### PR TITLE
♻️ mergeXRefChain の可読性を改善

### DIFF
--- a/packages/core/src/xref/merger/index.ts
+++ b/packages/core/src/xref/merger/index.ts
@@ -37,6 +37,34 @@ function resolveMaxDepth(maxDepth: number | undefined): number {
 }
 
 /**
+ * 収集済みの xref チェーンをマージし、統合結果を返す。
+ * chain は newest-first の順序で渡される。[...chain].reverse() で oldest から走査し、
+ * newer が older を上書きする形でエントリを統合する。chain は破壊しない。
+ *
+ * @precondition chain は非空であること（呼び出し元で最低1回の parseCallback 成功を保証）
+ */
+function mergeCollectedChain(
+  chain: ReadonlyArray<{ xref: XRefTable; trailer: TrailerDict }>,
+): { mergedXRef: XRefTable; latestTrailer: TrailerDict } {
+  const mergedEntries = new Map<ObjectNumber, XRefEntry>();
+  let maxSize = 0;
+
+  for (const { xref } of [...chain].reverse()) {
+    for (const [objNum, entry] of xref.entries) {
+      mergedEntries.set(objNum, entry);
+    }
+    maxSize = Math.max(maxSize, xref.size);
+  }
+
+  const latestTrailer = chain[0].trailer;
+
+  return {
+    mergedXRef: { entries: mergedEntries, size: maxSize },
+    latestTrailer: { ...latestTrailer, size: maxSize },
+  };
+}
+
+/**
  * /Prevチェーンを辿り、全xrefテーブルをマージする。
  * 新しいエントリが古いものを上書きし、最新のトレイラ辞書を返す。
  *
@@ -56,14 +84,14 @@ export function mergeXRefChain(
   PdfParseError
 > {
   const maxDepth = resolveMaxDepth(options?.maxDepth);
-  const visited = new Set<ByteOffset>();
+  const traversedOffsets = new Set<ByteOffset>();
   const chain: Array<{ xref: XRefTable; trailer: TrailerDict }> = [];
 
   let currentOffset: ByteOffset = startOffset;
   let depth = 0;
 
-  for (;;) {
-    if (visited.has(currentOffset)) {
+  while (true) {
+    if (traversedOffsets.has(currentOffset)) {
       return failPrevChain(
         "XREF_PREV_CHAIN_CYCLE",
         `Circular /Prev reference detected at offset ${String(currentOffset)}`,
@@ -79,7 +107,7 @@ export function mergeXRefChain(
       );
     }
 
-    visited.add(currentOffset);
+    traversedOffsets.add(currentOffset);
 
     const parseResult = parseCallback(currentOffset);
     if (!parseResult.ok) {
@@ -97,22 +125,5 @@ export function mergeXRefChain(
     currentOffset = trailer.prev;
   }
 
-  chain.reverse();
-
-  const mergedEntries = new Map<ObjectNumber, XRefEntry>();
-  let maxSize = 0;
-
-  for (const { xref } of chain) {
-    for (const [objNum, entry] of xref.entries) {
-      mergedEntries.set(objNum, entry);
-    }
-    maxSize = Math.max(maxSize, xref.size);
-  }
-
-  const latestTrailer = chain[chain.length - 1].trailer;
-
-  return ok({
-    mergedXRef: { entries: mergedEntries, size: maxSize },
-    latestTrailer: { ...latestTrailer, size: maxSize },
-  });
+  return ok(mergeCollectedChain(chain));
 }


### PR DESCRIPTION
## 概要

`mergeXRefChain` 関数の可読性を改善するリファクタリング。振る舞い変更なし。

## 変更の種類

♻️ リファクタリング

## 詳細な変更内容

### 変更

- `for(;;)` → `while (true)` に統一（コードベース内の他ループと同一スタイル）
- マージフェーズを `mergeCollectedChain` ヘルパー関数に分離
- `chain.reverse()` の破壊的操作を `[...chain].reverse()` に変更（`ReadonlyArray` で型保証）
- `latestTrailer` を `chain[0]`（newest-first の先頭）から取得するよう変更
- `visited` → `traversedOffsets` にリネーム（PDF走査の文脈に合わせた命名）

### データフロー（変更後）

```
mergeXRefChain
  ├── while (true) ループ: /Prev チェーン走査
  │     ├── 循環検出 (traversedOffsets)
  │     ├── 深度制限チェック
  │     ├── parseCallback 実行
  │     └── chain に蓄積 (newest-first)
  │
  └── mergeCollectedChain(chain)  ← [NEW] ヘルパーに分離
        ├── [...chain].reverse() で oldest→newest 走査
        ├── entries を Map に統合（newer が older を上書き）
        └── latestTrailer = chain[0]（newest-first の先頭）
```

## テスト

- `pnpm --filter @pdfmod/core test`: 475 tests passed (44 files)
- `pnpm --filter @pdfmod/core typecheck`: passed
- Codex レビュー: 問題なし

## チェックリスト

- [x] セルフレビュー実施
- [x] テスト正常実行
- [x] 公開APIシグネチャ未変更
- [x] `throw` 未使用（Result型パターン維持）
- [x] エラーコード・メッセージ未変更
- [x] `for(;;)` が対象ファイルに残っていないこと確認