### PR TITLE
♻️ [Refactoring]: インライン整数判定を NumberEx.isSafeIntegerAtLeastZero へ置換 (#028)

### DIFF
--- a/packages/core/src/objects/object-parser/index.ts
+++ b/packages/core/src/objects/object-parser/index.ts
@@ -1,4 +1,5 @@
 import type { PdfError, PdfParseError } from "../../errors/index";
+import { NumberEx } from "../../ext/number/index";
 import { Tokenizer } from "../../lexer/tokenizer/index";
 import { ByteOffset } from "../../types/byte-offset/index";
 import { TokenType } from "../../types/index";
@@ -26,7 +27,7 @@ function validateOffset(
   offset: ByteOffset,
 ): Result<ByteOffset, PdfParseError> {
   const n = offset as number;
-  if (!Number.isSafeInteger(n) || n < 0) {
+  if (!NumberEx.isSafeIntegerAtLeastZero(n)) {
     return err({
       code: "OBJECT_PARSE_UNEXPECTED_TOKEN",
       message: `Offset ${n} is invalid; expected a non-negative safe integer within [0, ${data.length})`,

--- a/packages/core/src/objects/object-parser/stream-object/index.ts
+++ b/packages/core/src/objects/object-parser/stream-object/index.ts
@@ -1,4 +1,5 @@
 import type { PdfError, PdfParseError } from "../../../errors/index";
+import { NumberEx } from "../../../ext/number/index";
 import { isPdfTokenBoundary } from "../../../lexer/bytes/index";
 import { ByteOffset } from "../../../types/byte-offset/index";
 import { GenerationNumber } from "../../../types/generation-number/index";
@@ -136,7 +137,7 @@ export const StreamObject = {
     dict: PdfDictionary,
     length: number,
   ): Result<StreamExtractResult, PdfParseError> {
-    if (!Number.isSafeInteger(length) || length < 0) {
+    if (!NumberEx.isSafeIntegerAtLeastZero(length)) {
       return err({
         code: "OBJECT_PARSE_STREAM_LENGTH",
         message: `/Length value is invalid: ${length}`,

--- a/packages/core/src/objects/object-stream-extractor/body/index.ts
+++ b/packages/core/src/objects/object-stream-extractor/body/index.ts
@@ -1,4 +1,5 @@
 import type { PdfError } from "../../../errors/index";
+import { NumberEx } from "../../../ext/number/index";
 import { ByteOffset } from "../../../types/byte-offset/index";
 import type { ObjectNumber } from "../../../types/object-number/index";
 import type { PdfValue } from "../../../types/pdf-types/index";
@@ -32,7 +33,7 @@ export const ObjectStreamBody = {
     streamObjNum: ObjectNumber,
     indexInStream: number,
   ): Promise<Result<PdfValue, PdfError>> {
-    if (!Number.isSafeInteger(indexInStream) || indexInStream < 0) {
+    if (!NumberEx.isSafeIntegerAtLeastZero(indexInStream)) {
       return err({
         code: "OBJECT_STREAM_INVALID",
         message: `indexInStream must be a non-negative safe integer, got ${indexInStream}`,

--- a/packages/core/src/objects/object-stream-extractor/header/index.ts
+++ b/packages/core/src/objects/object-stream-extractor/header/index.ts
@@ -32,14 +32,14 @@ export const ObjectStreamHeader = {
     first: number,
     n: number,
   ): Result<readonly ObjectStreamHeaderEntry[], PdfParseError> {
-    if (!Number.isSafeInteger(first) || first < 0 || first > data.length) {
+    if (!NumberEx.isSafeIntegerAtLeastZero(first) || first > data.length) {
       return err({
         code: "OBJECT_STREAM_HEADER_INVALID",
         message: `ObjStm header range is invalid: first=${first}, length=${data.length}`,
       });
     }
 
-    if (!Number.isSafeInteger(n) || n < 0) {
+    if (!NumberEx.isSafeIntegerAtLeastZero(n)) {
       return err({
         code: "OBJECT_STREAM_HEADER_INVALID",
         message: `ObjStm header n is invalid: ${n}`,

--- a/packages/core/src/types/byte-offset/index.ts
+++ b/packages/core/src/types/byte-offset/index.ts
@@ -1,3 +1,4 @@
+import { NumberEx } from "../../ext/number/index";
 import type { Result } from "../../utils/result/index";
 import { err, ok } from "../../utils/result/index";
 import type { Brand } from "../brand/index";
@@ -8,7 +9,7 @@ type ByteOffset = Brand<number, typeof ByteOffsetBrand>;
 
 const ByteOffset = {
   create(n: number): Result<ByteOffset, string> {
-    if (!Number.isSafeInteger(n) || n < 0) {
+    if (!NumberEx.isSafeIntegerAtLeastZero(n)) {
       return err(
         `Invalid ByteOffset: ${n} (must be a non-negative safe integer)`,
       );

--- a/packages/core/src/types/object-number/index.ts
+++ b/packages/core/src/types/object-number/index.ts
@@ -1,3 +1,4 @@
+import { NumberEx } from "../../ext/number/index";
 import type { Result } from "../../utils/result/index";
 import { err, ok } from "../../utils/result/index";
 import type { Brand } from "../brand/index";
@@ -8,7 +9,7 @@ type ObjectNumber = Brand<number, typeof ObjectNumberBrand>;
 
 const ObjectNumber = {
   create(n: number): Result<ObjectNumber, string> {
-    if (!Number.isSafeInteger(n) || n < 0) {
+    if (!NumberEx.isSafeIntegerAtLeastZero(n)) {
       return err(
         `Invalid ObjectNumber: ${n} (must be a non-negative safe integer)`,
       );

--- a/packages/core/src/xref/stream/parser/index.ts
+++ b/packages/core/src/xref/stream/parser/index.ts
@@ -1,4 +1,5 @@
 import type { PdfParseError } from "../../../errors/index";
+import { NumberEx } from "../../../ext/number/index";
 import type { ByteOffset } from "../../../types/byte-offset/index";
 import { ByteOffset as ByteOffsetNs } from "../../../types/byte-offset/index";
 import { GenerationNumber } from "../../../types/generation-number/index";
@@ -145,7 +146,7 @@ function decodeEntry(
       if (!streamObjResult.ok) {
         return failXRefStream(streamObjResult.error, absField2Offset);
       }
-      if (!Number.isSafeInteger(field3) || field3 < 0) {
+      if (!NumberEx.isSafeIntegerAtLeastZero(field3)) {
         return failXRefStream(
           `invalid indexInStream: ${field3}`,
           absField3Offset,
@@ -182,7 +183,7 @@ export function decodeXRefStreamEntries(
     return failXRefStream("/W array must have exactly 3 elements");
   }
   for (let i = 0; i < W_ARRAY_LENGTH; i++) {
-    if (!Number.isSafeInteger(w[i]) || w[i] < 0) {
+    if (!NumberEx.isSafeIntegerAtLeastZero(w[i])) {
       return failXRefStream(
         "/W array element must be non-negative safe integer",
       );
@@ -194,7 +195,7 @@ export function decodeXRefStreamEntries(
     }
   }
 
-  if (!Number.isSafeInteger(size) || size < 0) {
+  if (!NumberEx.isSafeIntegerAtLeastZero(size)) {
     return failXRefStream("invalid /Size value");
   }
 
@@ -215,12 +216,12 @@ export function decodeXRefStreamEntries(
     const firstObj = index[i];
     const count = index[i + 1];
 
-    if (!Number.isSafeInteger(firstObj) || firstObj < 0) {
+    if (!NumberEx.isSafeIntegerAtLeastZero(firstObj)) {
       return failXRefStream(
         "/Index firstObj must be non-negative safe integer",
       );
     }
-    if (!Number.isSafeInteger(count) || count < 0) {
+    if (!NumberEx.isSafeIntegerAtLeastZero(count)) {
       return failXRefStream("/Index count must be non-negative safe integer");
     }
     if (firstObj + count > size) {

--- a/packages/core/src/xref/trailer/dict-builder/index.ts
+++ b/packages/core/src/xref/trailer/dict-builder/index.ts
@@ -1,4 +1,5 @@
 import type { PdfParseError, PdfParseErrorCode } from "../../../errors/index";
+import { NumberEx } from "../../../ext/number/index";
 import {
   ByteOffset as BO,
   type ByteOffset,
@@ -83,7 +84,7 @@ export function trailerDictBuilder(
           offset: _rootOffset,
         });
       }
-      if (!Number.isSafeInteger(_root.objectNumber) || _root.objectNumber < 0) {
+      if (!NumberEx.isSafeIntegerAtLeastZero(_root.objectNumber)) {
         return err({
           code: "ROOT_NOT_FOUND",
           message:
@@ -91,10 +92,7 @@ export function trailerDictBuilder(
           offset: _rootOffset,
         });
       }
-      if (
-        !Number.isSafeInteger(_root.generationNumber) ||
-        _root.generationNumber < 0
-      ) {
+      if (!NumberEx.isSafeIntegerAtLeastZero(_root.generationNumber)) {
         return err({
           code: "ROOT_NOT_FOUND",
           message:
@@ -125,8 +123,7 @@ export function trailerDictBuilder(
       }
       if (
         _size.type !== "integer" ||
-        !Number.isSafeInteger(_size.value as number) ||
-        (_size.value as number) < 0
+        !NumberEx.isSafeIntegerAtLeastZero(_size.value as number)
       ) {
         return err({
           code: "SIZE_NOT_FOUND",
@@ -142,8 +139,7 @@ export function trailerDictBuilder(
       if (_prev) {
         if (
           _prev.type !== "integer" ||
-          !Number.isSafeInteger(_prev.value as number) ||
-          (_prev.value as number) < 0
+          !NumberEx.isSafeIntegerAtLeastZero(_prev.value as number)
         ) {
           return err({
             code: optionalFieldErrorCode,
@@ -163,10 +159,7 @@ export function trailerDictBuilder(
             offset: _infoOffset,
           });
         }
-        if (
-          !Number.isSafeInteger(_info.objectNumber) ||
-          _info.objectNumber < 0
-        ) {
+        if (!NumberEx.isSafeIntegerAtLeastZero(_info.objectNumber)) {
           return err({
             code: optionalFieldErrorCode,
             message:
@@ -174,10 +167,7 @@ export function trailerDictBuilder(
             offset: _infoOffset,
           });
         }
-        if (
-          !Number.isSafeInteger(_info.generationNumber) ||
-          _info.generationNumber < 0
-        ) {
+        if (!NumberEx.isSafeIntegerAtLeastZero(_info.generationNumber)) {
           return err({
             code: optionalFieldErrorCode,
             message:


### PR DESCRIPTION
## 概要

`packages/core` 内に散在していたインライン判定 `!Number.isSafeInteger(n) || n < 0` を、既存の `NumberEx.isSafeIntegerAtLeastZero(n)` ユーティリティに置き換えるリファクタリング。振る舞いは厳密等価。

## 変更内容

### 🎯 変更の種類

- [x] ♻️ リファクタリング (Refactoring)

### 📝 詳細な変更内容

#### 変更されたファイル（8ファイル / 18箇所）

| # | ファイル | 置換数 | パターン |
|---|---------|-------|---------|
| 1 | `types/object-number/index.ts` | 1 | A |
| 2 | `types/byte-offset/index.ts` | 1 | A |
| 3 | `objects/object-parser/index.ts` | 1 | A |
| 4 | `objects/object-parser/stream-object/index.ts` | 1 | A |
| 5 | `objects/object-stream-extractor/body/index.ts` | 1 | A |
| 6 | `objects/object-stream-extractor/header/index.ts` | 2 | A + C（追加条件 `first > data.length` 保持） |
| 7 | `xref/stream/parser/index.ts` | 5 | A（`field3` / `w[i]` / `size` / `firstObj` / `count`） |
| 8 | `xref/trailer/dict-builder/index.ts` | 6 | A + B（`as number` キャスト保持） |

- A: 引数がそのまま `number` — `!Number.isSafeInteger(n) || n < 0` → `!NumberEx.isSafeIntegerAtLeastZero(n)`
- B: `as number` キャストを含むため、キャストを 1 回に集約して保持
- C: 追加条件（`first > data.length`）は必ず保持

#### スキップ対象（意図的に置き換えない）

`Number.isInteger` 使用箇所や、累積加算後のオーバーフロー検知用途で単独 `isSafeInteger` を使っている 7 箇所は挙動が異なるため対象外（`generation-number` / `lru-cache` / `xref/startxref/scanner` / `xref/table/parser` / `xref/stream/parser` L202/L233/L243）。

## 📊 システム図

### 置換パターン

```mermaid
flowchart LR
    A["BEFORE: !Number.isSafeInteger(n) || n < 0"] -->|"NumberEx import 追加、判定を関数呼び出しに集約"| B["AFTER: !NumberEx.isSafeIntegerAtLeastZero(n)"]
    C["ext/number/index.ts (依存ゼロの純粋ユーティリティ)"] -.->|import| B
    style B fill:#dff0d8
    style C fill:#f5f5f5
```

### レイヤ依存（循環なし）

```
               ┌──────────────────────────────┐
               │      ext/number/index.ts     │
               │  (imports ゼロの純粋ユーティリティ) │
               └──────────────────────────────┘
                     ▲        ▲        ▲
                     │        │        │
          ┌──────────┘        │        └──────────┐
          │                   │                   │
  types/ [NEW 依存]   objects/ [NEW 依存]   xref/ [NEW 依存]
```

## 📋 関連 Issue

- Refs: `.specs/028-refactor-use-existing-number-utils/`

## 🧪 テスト

### テスト実行方法

```bash
pnpm --filter @pdfmod/core typecheck
pnpm --filter @pdfmod/core test
pnpm lint
```

### テスト項目

- [x] 単体テスト (Unit tests) — 既存 739 tests 全 Green
- [x] 手動テスト — `rg 'Number\.isSafeInteger' packages/core/src` で残存 9 箇所（全てスキップ対象）を突合

### テスト結果

- `typecheck`: pass
- `test`: **73 files / 739 tests passed**
- `lint`: 既存警告のみ（新規エラー/警告なし）
- Copilot コードレビュー: **問題なし**（1 回目で確定）
- 残存 `Number.isSafeInteger` 箇所: 期待どおり 9 箇所のみ（NumberEx 定義本体 2 + オーバーフロー検知 7）

## 🔍 レビューポイント

- `objects/object-stream-extractor/header/index.ts` で `first > data.length` の追加条件が保持されていること
- `xref/trailer/dict-builder/index.ts` L128/L145 相当の箇所で `_size.value as number` / `_prev.value as number` のキャストが保持されていること（2 回 → 1 回に集約）
- `types/*` から `ext/number` への依存方向（循環なし、`ext/number` は imports ゼロ）

## ⚠️ 破壊的変更

- [ ] なし

## ✅ チェックリスト

- [x] コードレビューの準備ができている
- [x] テストが正常に実行される（739 tests green）
- [x] コミットメッセージが適切な形式で書かれている（5 コミットにモジュール単位で分割）
- [x] セルフレビューを実施した（Copilot レビューで「問題なし」）
- [x] 破壊的変更はなし（振る舞い厳密等価）
