### PR TITLE
💄 [Style]: core の関数内フェーズ区切りに空行挿入 (031)

### DIFF
--- a/packages/core/src/lexer/bytes/index.ts
+++ b/packages/core/src/lexer/bytes/index.ts
@@ -125,6 +125,7 @@ export function skipWhitespaceAndComments(
 ): number {
   const limit = end ?? data.length;
   let i = pos;
+
   while (i < limit) {
     if (isPdfWhitespace(data[i])) {
       i++;
@@ -136,6 +137,7 @@ export function skipWhitespaceAndComments(
     }
     break;
   }
+
   return i;
 }
 
@@ -155,6 +157,7 @@ export function matchesBytesAt(
   if (offset + pattern.length > data.length) {
     return false;
   }
+
   for (let j = 0; j < pattern.length; j++) {
     if (data[offset + j] !== pattern[j]) {
       return false;

--- a/packages/core/src/lexer/tokenizer/index.ts
+++ b/packages/core/src/lexer/tokenizer/index.ts
@@ -233,6 +233,7 @@ export class Tokenizer {
    */
   private readHexString(offset: number): Token {
     let hex = "";
+
     while (this.pos < this.data.length) {
       const b = this.data[this.pos];
       if (b === AsciiGreaterThan) {
@@ -244,6 +245,7 @@ export class Tokenizer {
       }
       this.pos++;
     }
+
     return {
       type: TokenType.HexString,
       value: hex,
@@ -363,6 +365,7 @@ export class Tokenizer {
    */
   private readName(offset: number): Token {
     let name = "";
+
     while (this.pos < this.data.length) {
       const b = this.data[this.pos];
       if (isWhitespace(b) || isDelimiter(b)) {
@@ -375,6 +378,7 @@ export class Tokenizer {
         this.pos++;
       }
     }
+
     return { type: TokenType.Name, value: name, offset: ByteOffset.of(offset) };
   }
 
@@ -498,10 +502,12 @@ export class Tokenizer {
   tokenize(): Token[] {
     const tokens: Token[] = [];
     let token: Token;
+
     do {
       token = this.nextToken();
       tokens.push(token);
     } while (token.type !== TokenType.EOF);
+
     return tokens;
   }
 }

--- a/packages/core/src/objects/object-parser/direct-object/index.ts
+++ b/packages/core/src/objects/object-parser/direct-object/index.ts
@@ -185,6 +185,7 @@ function tryReadIndirectRef(
         }),
       );
     }
+
     const generationNumber = GenerationNumber.create(secondVal);
     if (!generationNumber.ok) {
       return some(
@@ -195,6 +196,7 @@ function tryReadIndirectRef(
         }),
       );
     }
+
     return some(
       ok({
         type: "indirect-ref",

--- a/packages/core/src/objects/object-parser/index.ts
+++ b/packages/core/src/objects/object-parser/index.ts
@@ -90,6 +90,7 @@ export const ObjectParser = {
         if (!lengthResult.ok) {
           return lengthResult;
         }
+
         if (lengthResult.value.kind === "indirect") {
           return err({
             code: "OBJECT_PARSE_STREAM_LENGTH",
@@ -98,6 +99,7 @@ export const ObjectParser = {
             offset: ByteOffset.add(baseOffset, ByteOffset.of(bt.position)),
           });
         }
+
         const streamResult = StreamObject.extract(
           data,
           baseOffset,
@@ -108,6 +110,7 @@ export const ObjectParser = {
         if (!streamResult.ok) {
           return streamResult;
         }
+
         return ok(streamResult.value.object);
       }
       bt.pushBack(peekToken);
@@ -165,6 +168,7 @@ export const ObjectParser = {
         if (!lengthTyped.ok) {
           return lengthTyped;
         }
+
         const lengthResolved = await StreamObject.resolveLength(
           lengthTyped.value,
           baseOffset,
@@ -174,6 +178,7 @@ export const ObjectParser = {
         if (!lengthResolved.ok) {
           return lengthResolved;
         }
+
         const streamResult = StreamObject.extract(
           data,
           baseOffset,
@@ -184,6 +189,7 @@ export const ObjectParser = {
         if (!streamResult.ok) {
           return streamResult;
         }
+
         const endobjResult = IndirectObject.expectEndobjAfter(
           data,
           streamResult.value.afterEndstreamAbsPos,
@@ -191,6 +197,7 @@ export const ObjectParser = {
         if (!endobjResult.ok) {
           return endobjResult;
         }
+
         return ok({
           objectNumber,
           generationNumber,
@@ -204,6 +211,7 @@ export const ObjectParser = {
     if (!endobjResult.ok) {
       return endobjResult;
     }
+
     return ok({ objectNumber, generationNumber, body: value });
   },
 } as const;

--- a/packages/core/src/objects/object-parser/stream-object/index.ts
+++ b/packages/core/src/objects/object-parser/stream-object/index.ts
@@ -43,12 +43,14 @@ export const StreamObject = {
         offset: ByteOffset.add(baseOffset, ByteOffset.of(relPos)),
       });
     }
+
     if (lengthObj.type === "integer") {
       return ok({ kind: "direct", value: lengthObj.value });
     }
     if (lengthObj.type === "indirect-ref") {
       return ok({ kind: "indirect", ref: lengthObj });
     }
+
     return err({
       code: "OBJECT_PARSE_STREAM_LENGTH",
       message: `/Length has unexpected type: ${lengthObj.type}`,
@@ -75,6 +77,7 @@ export const StreamObject = {
     if (length.kind === "direct") {
       return ok(length.value);
     }
+
     if (resolver === undefined) {
       return err({
         code: "OBJECT_PARSE_STREAM_LENGTH",
@@ -83,6 +86,7 @@ export const StreamObject = {
         offset: ByteOffset.add(baseOffset, ByteOffset.of(relPos)),
       });
     }
+
     const objectNumber = ObjectNumber.create(length.ref.objectNumber);
     if (!objectNumber.ok) {
       return err({
@@ -91,6 +95,7 @@ export const StreamObject = {
         offset: ByteOffset.add(baseOffset, ByteOffset.of(relPos)),
       });
     }
+
     const generationNumber = GenerationNumber.create(
       length.ref.generationNumber,
     );
@@ -101,6 +106,7 @@ export const StreamObject = {
         offset: ByteOffset.add(baseOffset, ByteOffset.of(relPos)),
       });
     }
+
     const resolved = await resolver(objectNumber.value, generationNumber.value);
     if (!resolved.ok) {
       return err({
@@ -109,6 +115,7 @@ export const StreamObject = {
         offset: ByteOffset.add(baseOffset, ByteOffset.of(relPos)),
       });
     }
+
     if (resolved.value.type !== "integer") {
       return err({
         code: "TYPE_MISMATCH" as const,
@@ -117,6 +124,7 @@ export const StreamObject = {
         actual: resolved.value.type,
       });
     }
+
     return ok(resolved.value.value);
   },
 
@@ -216,6 +224,7 @@ export const StreamObject = {
         offset: afterEndstreamAbsPos,
       });
     }
+
     return ok({
       object: { type: "stream", dictionary: dict, data: streamData },
       afterEndstreamAbsPos,
@@ -239,6 +248,7 @@ function matchesAsciiAt(
   if (start < 0 || start + text.length > data.length) {
     return false;
   }
+
   for (let i = 0; i < text.length; i++) {
     if (data[start + i] !== text.charCodeAt(i)) {
       return false;

--- a/packages/core/src/objects/object-parser/string-decoder/index.ts
+++ b/packages/core/src/objects/object-parser/string-decoder/index.ts
@@ -20,6 +20,7 @@ export function decodeHexString(hex: string): Result<Uint8Array, string> {
     }
     bytes[i / 2] = parseInt(chunk, 16);
   }
+
   return ok(bytes);
 }
 
@@ -40,5 +41,6 @@ export function decodeLiteralString(str: string): Result<Uint8Array, string> {
     }
     bytes[i] = codeUnit;
   }
+
   return ok(bytes);
 }

--- a/packages/core/src/objects/object-store/index.ts
+++ b/packages/core/src/objects/object-store/index.ts
@@ -108,6 +108,7 @@ export class ObjectStore {
         actual: result.value.type,
       });
     }
+
     return ok(result.value as Extract<PdfObject, { type: T }>);
   }
 

--- a/packages/core/src/xref/stream/parser/index.ts
+++ b/packages/core/src/xref/stream/parser/index.ts
@@ -48,12 +48,14 @@ function decodeIntBE(
   if (width === 0) {
     return ok(0);
   }
+
   const value = data
     .subarray(offset, offset + width)
     .reduce((acc, byte) => acc * BYTE_BASE + byte, 0);
   if (value > Number.MAX_SAFE_INTEGER) {
     return failXRefStream("decoded integer exceeds safe integer range");
   }
+
   return ok(value);
 }
 

--- a/packages/core/src/xref/stream/trailer/index.ts
+++ b/packages/core/src/xref/stream/trailer/index.ts
@@ -46,5 +46,6 @@ export function buildXRefStreamTrailerDict(
   if (!result.ok) {
     return err(mapErr(result.error));
   }
+
   return result;
 }

--- a/packages/core/src/xref/trailer/dict-builder/index.ts
+++ b/packages/core/src/xref/trailer/dict-builder/index.ts
@@ -108,6 +108,7 @@ export function trailerDictBuilder(): TrailerDictBuilderChain {
           offset: _rootOffset,
         });
       }
+
       const root = {
         objectNumber: ObjectNumber.of(_root.objectNumber),
         generationNumber: rootGenResult.value,
@@ -182,6 +183,7 @@ export function trailerDictBuilder(): TrailerDictBuilderChain {
             offset: _infoOffset,
           });
         }
+
         result.info = {
           objectNumber: ObjectNumber.of(_info.objectNumber),
           generationNumber: infoGenResult.value,
@@ -220,6 +222,7 @@ export function trailerDictBuilder(): TrailerDictBuilderChain {
           }
           idPair[i] = elem.value;
         }
+
         result.id = idPair;
       }
 

--- a/packages/core/src/xref/trailer/parser/index.ts
+++ b/packages/core/src/xref/trailer/parser/index.ts
@@ -65,11 +65,13 @@ function hexStringToBytes(hex: string): Uint8Array | undefined {
   if (!/^[0-9A-Fa-f]*$/.test(hex)) {
     return undefined;
   }
+
   const padded = hex.length % 2 === 1 ? `${hex}0` : hex;
   const bytes = new Uint8Array(padded.length / 2);
   for (let i = 0; i < padded.length; i += 2) {
     bytes[i / 2] = parseInt(padded.substring(i, i + 2), 16);
   }
+
   return bytes;
 }
 
@@ -88,6 +90,7 @@ function literalStringToBytes(str: string): Uint8Array | undefined {
     }
     bytes[i] = codeUnit;
   }
+
   return bytes;
 }
 
@@ -123,6 +126,7 @@ function skipNestedArray(
   if (depth >= MAX_NESTING_DEPTH) {
     return failNestingTooDeep(entryOffset);
   }
+
   while (true) {
     const token = tokens.next();
     if (token.type === TokenType.ArrayEnd) {
@@ -184,6 +188,7 @@ function skipNestedDict(
   if (depth >= MAX_NESTING_DEPTH) {
     return failNestingTooDeep(entryOffset);
   }
+
   while (true) {
     const keyToken = tokens.next();
     if (keyToken.type === TokenType.DictEnd) {
@@ -457,6 +462,7 @@ function readIdArray(
       offset,
     });
   }
+
   const elements: PdfValue[] = [];
   while (true) {
     const token = tokens.next();
@@ -529,6 +535,7 @@ function skipValue(
     }
     tokens.pushBack(second);
   }
+
   return ok(undefined);
 }
 
@@ -642,6 +649,7 @@ function buildTrailerDict(
   if (!result.ok) {
     return err(mapErr(result.error));
   }
+
   return result;
 }
 


### PR DESCRIPTION
## Summary

`packages/core/src` の関数内で、フェーズ区切り（入力検証 → 本体 → return 等）に空行が入っていない箇所に空行を手動挿入。ロジック変更・識別子変更・コメント変更は一切なし（書式整備のみ）。

## スコープ

- 対象: `packages/core/src/**`（`@pdfmod/react` は対象外、docs も対象外）
- 作業順: utils → ext → pdf → lexer → xref → objects → root
- **utils / ext / pdf / root** は、対象関数がすべて単一フェーズまたは 1 行 arrow function のため変更なし
- **lexer / xref / objects** の 3 モジュールに空行追加

## 変更ファイル（11 files / 46 insertions / 0 deletions）

| モジュール | 主な対象関数 |
|---|---|
| lexer | `skipWhitespaceAndComments`, `matchesBytesAt`, `readHexString`, `readName`, `tokenize` |
| xref | `trailerDictBuilder.build`, `hexStringToBytes`, `literalStringToBytes`, `skipNestedArray`, `skipNestedDict`, `readIdArray`, `skipValue`, `buildTrailerDict`, `decodeIntBE`, `buildXRefStreamTrailerDict` |
| objects | `ObjectParser.parse/parseIndirectObject`, `StreamObject.readLength/resolveLength/extract`, `matchesAsciiAt`, `tryReadIndirectRef`, `getAs`, `decodeHexString`, `decodeLiteralString` |

## 手本ファイルは未変更（触っていない）

- `packages/core/src/xref/startxref/scanner/index.ts`
- `packages/core/src/xref/table/parser/index.ts`
- `packages/core/src/xref/merger/index.ts`
- `packages/core/src/objects/lru-cache/index.ts` の `get` / `set`

## 判断メモ（§3.3 拡張適用）

`trailerDictBuilder.build()` 内で plan §3.3 は `/Root` の `const root = {...}` 前のみ空行を明示していたが、同一構造の **/Info** (`result.info = {...}`) と **/ID** (`result.id = idPair`) にも同じパターンで空行を追加（整合性優先）。

## テスト方針

テストファイルはすべて `test(...)` が 3-10 行の短い blocks で構成されておりフェーズ区切りの対象ではないため、目視確認のみで変更なし。

## 検証結果

- [x] `pnpm test`: 77 test files / 756 tests pass（main と同数）
- [x] `pnpm lint`: 0 warnings, 0 errors
- [x] `pnpm typecheck`: 両パッケージ成功
- [x] `pnpm format:check`: No fixes applied
- [x] `git diff -w --ignore-blank-lines origin/main..HEAD`: 空（= 空白以外の変更なし）
- [x] コミットはモジュール単位で 3 コミット（lexer / xref / objects）

## Test plan

- [x] レビュー時は各コミットを `git show <sha>` で確認（モジュール単位）
- [x] `git diff -w --ignore-blank-lines origin/main..HEAD` が空であることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)