### PR TITLE
✨ [New Feature]: #18 PdfWarningCode に DocumentInfoParser 用の警告コード 4 件を追加

### DIFF
--- a/packages/core/src/pdf/errors/warning/index.ts
+++ b/packages/core/src/pdf/errors/warning/index.ts
@@ -21,7 +21,8 @@ export type PdfWarningCode =
   | "DATE_PARSE_FAILED"
   | "MISSING_KIDS"
   | "PAGE_TREE_TOO_DEEP"
-  | "RESOURCES_RESOLVE_FAILED";
+  | "RESOURCES_RESOLVE_FAILED"
+  | "INFO_RESOLVE_FAILED";
 
 /**
  * 回復可能なPDF問題の警告。

--- a/packages/core/src/pdf/errors/warning/index.ts
+++ b/packages/core/src/pdf/errors/warning/index.ts
@@ -22,7 +22,8 @@ export type PdfWarningCode =
   | "MISSING_KIDS"
   | "PAGE_TREE_TOO_DEEP"
   | "RESOURCES_RESOLVE_FAILED"
-  | "INFO_RESOLVE_FAILED";
+  | "INFO_RESOLVE_FAILED"
+  | "INFO_NOT_DICTIONARY";
 
 /**
  * 回復可能なPDF問題の警告。

--- a/packages/core/src/pdf/errors/warning/index.ts
+++ b/packages/core/src/pdf/errors/warning/index.ts
@@ -24,7 +24,8 @@ export type PdfWarningCode =
   | "RESOURCES_RESOLVE_FAILED"
   | "INFO_RESOLVE_FAILED"
   | "INFO_NOT_DICTIONARY"
-  | "STRING_DECODE_FAILED";
+  | "STRING_DECODE_FAILED"
+  | "TRAPPED_INVALID";
 
 /**
  * 回復可能なPDF問題の警告。

--- a/packages/core/src/pdf/errors/warning/index.ts
+++ b/packages/core/src/pdf/errors/warning/index.ts
@@ -23,7 +23,8 @@ export type PdfWarningCode =
   | "PAGE_TREE_TOO_DEEP"
   | "RESOURCES_RESOLVE_FAILED"
   | "INFO_RESOLVE_FAILED"
-  | "INFO_NOT_DICTIONARY";
+  | "INFO_NOT_DICTIONARY"
+  | "STRING_DECODE_FAILED";
 
 /**
  * 回復可能なPDF問題の警告。

--- a/packages/core/src/pdf/errors/warning/warning.type.test.ts
+++ b/packages/core/src/pdf/errors/warning/warning.type.test.ts
@@ -35,3 +35,8 @@ test("PdfWarningCode に STRING_DECODE_FAILED が含まれる", () => {
   const code: PdfWarningCode = "STRING_DECODE_FAILED";
   expect(code).toBe("STRING_DECODE_FAILED");
 });
+
+test("PdfWarningCode に TRAPPED_INVALID が含まれる", () => {
+  const code: PdfWarningCode = "TRAPPED_INVALID";
+  expect(code).toBe("TRAPPED_INVALID");
+});

--- a/packages/core/src/pdf/errors/warning/warning.type.test.ts
+++ b/packages/core/src/pdf/errors/warning/warning.type.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from "vitest";
-import type { PdfWarning } from "../../../index";
+import type { PdfWarning, PdfWarningCode } from "../../../index";
 
 test("PdfWarningは全フィールドを持てる", () => {
   const warning: PdfWarning = {
@@ -19,4 +19,9 @@ test("PdfWarningのoffsetとrecoveryは省略可能", () => {
   };
   expect(warning.offset).toBeUndefined();
   expect(warning.recovery).toBeUndefined();
+});
+
+test("PdfWarningCode に INFO_RESOLVE_FAILED が含まれる", () => {
+  const code: PdfWarningCode = "INFO_RESOLVE_FAILED";
+  expect(code).toBe("INFO_RESOLVE_FAILED");
 });

--- a/packages/core/src/pdf/errors/warning/warning.type.test.ts
+++ b/packages/core/src/pdf/errors/warning/warning.type.test.ts
@@ -30,3 +30,8 @@ test("PdfWarningCode に INFO_NOT_DICTIONARY が含まれる", () => {
   const code: PdfWarningCode = "INFO_NOT_DICTIONARY";
   expect(code).toBe("INFO_NOT_DICTIONARY");
 });
+
+test("PdfWarningCode に STRING_DECODE_FAILED が含まれる", () => {
+  const code: PdfWarningCode = "STRING_DECODE_FAILED";
+  expect(code).toBe("STRING_DECODE_FAILED");
+});

--- a/packages/core/src/pdf/errors/warning/warning.type.test.ts
+++ b/packages/core/src/pdf/errors/warning/warning.type.test.ts
@@ -25,3 +25,8 @@ test("PdfWarningCode に INFO_RESOLVE_FAILED が含まれる", () => {
   const code: PdfWarningCode = "INFO_RESOLVE_FAILED";
   expect(code).toBe("INFO_RESOLVE_FAILED");
 });
+
+test("PdfWarningCode に INFO_NOT_DICTIONARY が含まれる", () => {
+  const code: PdfWarningCode = "INFO_NOT_DICTIONARY";
+  expect(code).toBe("INFO_NOT_DICTIONARY");
+});


### PR DESCRIPTION
## 概要

DocumentInfoParser 実装 (#18) で必要となる新警告コード 4 件を `PdfWarningCode` union に追加する。後続 PR (PDFDocEncoding / decodePdfString / Trapped / parser 本体) がすべて新警告コードを参照するため、最初に union を確定して衝突を避ける。

`DATE_PARSE_FAILED` は既に予約済みのため再利用（本 PR では変更なし）。

## 変更内容

### 🎯 変更の種類

- [x] ✨ 新機能 (New feature)
- [x] 🚨 テスト追加/修正 (Tests)

### 📝 詳細な変更内容

#### 追加された警告コード

| コード | 用途 | 後続 PR |
|---|---|---|
| `INFO_RESOLVE_FAILED` | `/Info` IndirectRef の resolve 失敗 | PR 6 |
| `INFO_NOT_DICTIONARY` | `/Info` の解決値が辞書でない | PR 6 |
| `STRING_DECODE_FAILED` | UTF-16BE 例外 / PDFDocEncoding 未割当 / PdfString 期待箇所での型不一致 | PR 2, 3, 6 |
| `TRAPPED_INVALID` | `/Trapped` 未知 Name 値 / 非 Name 型 | PR 5, 6 |

#### 変更されたファイル

- `packages/core/src/pdf/errors/warning/index.ts` — `PdfWarningCode` union に 4 件追加
- `packages/core/src/pdf/errors/warning/warning.type.test.ts` — 各コードが型レベルで assignable であることを検証する test を追加

## 📊 システム図

### 警告コード union の構造変化

```mermaid
flowchart LR
    subgraph before[Before]
        A1[既存 14 コード<br/>EOF_NOT_FOUND<br/>...<br/>RESOURCES_RESOLVE_FAILED]
    end
    subgraph after[After]
        B1[既存 14 コード]
        B2[INFO_RESOLVE_FAILED]:::new
        B3[INFO_NOT_DICTIONARY]:::new
        B4[STRING_DECODE_FAILED]:::new
        B5[TRAPPED_INVALID]:::new
        B1 --> B2 --> B3 --> B4 --> B5
    end
    before --> after

    classDef new fill:#ffe4b5,stroke:#d97706,stroke-width:2px
```

### 後続 PR との依存関係

```mermaid
flowchart TD
    PR1[PR 1: warning-codes<br/>本 PR]:::current
    PR2[PR 2: pdf-doc-encoding]
    PR3[PR 3: decode-pdf-string]
    PR4[PR 4: parse-pdf-date<br/>warning 不要]
    PR5[PR 5: document-metadata]
    PR6[PR 6: document-info-parser]
    PR7[PR 7: root-export]

    PR1 --> PR2
    PR1 --> PR3
    PR1 --> PR5
    PR1 --> PR6
    PR2 --> PR3
    PR2 --> PR6
    PR3 --> PR6
    PR4 --> PR6
    PR5 --> PR6
    PR6 --> PR7

    classDef current fill:#bfdbfe,stroke:#2563eb,stroke-width:2px
```

## 📋 関連 Issue

- Refs #18

## 🧪 テスト

### テスト実行方法

```bash
pnpm test
pnpm --filter @pdfmod/core typecheck
```

### テスト項目

- [x] 単体テスト (型レベル assignable 検証)

### テスト結果

- `pnpm test`: 全 84 ファイル / 960 tests パス
- `pnpm --filter @pdfmod/core typecheck`: パス（tsc --noEmit エラーなし）
- biome / oxlint: 警告なし
- Codex 自動レビュー (review-001.md): **問題なし**

## 🔍 レビューポイント

- 4 件のコードがそれぞれ独立コミットになっている（1 コード = 1 コミットの粒度）
- 既存 union からの削除はなく、追加のみ（破壊的変更なし）
- 型レベルテストはトップレベル `test()` のみで `describe` 不使用、条件分岐なし

## ⚠️ 破壊的変更

- [ ] この変更は既存の API に破壊的変更を含みます

なし — union への追加のみで既存コードの再エクスポート・削除は行っていない。

## 📚 追加情報

### 参考資料

- 実装計画: `.specs/036-document-info-parser/implementation-plan.md` §4.5
- PR 分割インデックス: `.specs/036-document-info-parser/split/README.md`
- PR 1 タスク: `.specs/036-document-info-parser/split/tasks-01-warning-codes.md`

### 注意事項

- この PR は #18 の実装を 7 PR に分割した最初の PR。後続 PR で実際の警告 push 処理が追加される
- スペック branch (`spec/036-document-info-parser`) を直接利用しており、後続 PR も同 branch に積み上げる方針

## ✅ チェックリスト

- [x] コードレビューの準備ができている
- [x] テストが正常に実行される
- [x] コミットメッセージが適切な形式で書かれている
- [x] 関連する Issue を本文に記載
- [x] セルフレビューを実施した
- [x] 破壊的変更なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)