### PR TITLE
✨ [Feature]: #18 PR4 PDF 日時パース (parsePdfDate)

### DIFF
--- a/packages/core/src/document/parse-pdf-date.parse.test.ts
+++ b/packages/core/src/document/parse-pdf-date.parse.test.ts
@@ -1,0 +1,6 @@
+import { expect, test } from "vitest";
+import { parsePdfDate } from "./parse-pdf-date";
+
+test("D: prefix が欠落した文字列は undefined を返す", () => {
+  expect(parsePdfDate("20230101")).toBeUndefined();
+});

--- a/packages/core/src/document/parse-pdf-date.parse.test.ts
+++ b/packages/core/src/document/parse-pdf-date.parse.test.ts
@@ -1,7 +1,10 @@
 import { expect, test } from "vitest";
 import { parsePdfDate } from "./parse-pdf-date";
 
-test("D: prefix が欠落した文字列は undefined を返す", () => {
+// 本プロジェクトでは `D:` prefix を必須とする厳格仕様を採用している
+// （ISO 32000-2:2020 § 7.9.4 では省略可能だが、PDF 日時オブジェクトを
+// 誤認しないため `D:` で前置されたものだけを受理する）。
+test("D: prefix が欠落した文字列は undefined を返す（本実装の厳格仕様）", () => {
   expect(parsePdfDate("20230101")).toBeUndefined();
 });
 

--- a/packages/core/src/document/parse-pdf-date.parse.test.ts
+++ b/packages/core/src/document/parse-pdf-date.parse.test.ts
@@ -4,3 +4,89 @@ import { parsePdfDate } from "./parse-pdf-date";
 test("D: prefix が欠落した文字列は undefined を返す", () => {
   expect(parsePdfDate("20230101")).toBeUndefined();
 });
+
+interface LocalParts {
+  readonly y: number;
+  readonly mo: number;
+  readonly d: number;
+  readonly h: number;
+  readonly mi: number;
+  readonly s: number;
+}
+
+const VALID_TZ_NONE: ReadonlyArray<readonly [string, LocalParts]> = [
+  ["D:2023", { y: 2023, mo: 0, d: 1, h: 0, mi: 0, s: 0 }],
+  ["D:202306", { y: 2023, mo: 5, d: 1, h: 0, mi: 0, s: 0 }],
+  ["D:20230615", { y: 2023, mo: 5, d: 15, h: 0, mi: 0, s: 0 }],
+  ["D:20230615120530", { y: 2023, mo: 5, d: 15, h: 12, mi: 5, s: 30 }],
+  ["D:1000", { y: 1000, mo: 0, d: 1, h: 0, mi: 0, s: 0 }],
+  ["D:9999", { y: 9999, mo: 0, d: 1, h: 0, mi: 0, s: 0 }],
+  ["D:20240229", { y: 2024, mo: 1, d: 29, h: 0, mi: 0, s: 0 }],
+];
+
+test.each(
+  VALID_TZ_NONE,
+)("TZ なし日時 %s をローカル時刻として解釈する", (raw, expected) => {
+  const result = parsePdfDate(raw);
+  expect(result).toBeDefined();
+  const date = result as Date;
+  expect(date.getFullYear()).toBe(expected.y);
+  expect(date.getMonth()).toBe(expected.mo);
+  expect(date.getDate()).toBe(expected.d);
+  expect(date.getHours()).toBe(expected.h);
+  expect(date.getMinutes()).toBe(expected.mi);
+  expect(date.getSeconds()).toBe(expected.s);
+});
+
+const VALID_TZ_AWARE: ReadonlyArray<readonly [string, LocalParts]> = [
+  ["D:2023Z", { y: 2023, mo: 0, d: 1, h: 0, mi: 0, s: 0 }],
+  ["D:202306+09'00'", { y: 2023, mo: 4, d: 31, h: 15, mi: 0, s: 0 }],
+  ["D:20230615+09'00'", { y: 2023, mo: 5, d: 14, h: 15, mi: 0, s: 0 }],
+  ["D:2023061512+09'00'", { y: 2023, mo: 5, d: 15, h: 3, mi: 0, s: 0 }],
+  ["D:202306151205+09'00'", { y: 2023, mo: 5, d: 15, h: 3, mi: 5, s: 0 }],
+  ["D:20230101000000Z", { y: 2023, mo: 0, d: 1, h: 0, mi: 0, s: 0 }],
+  ["D:20230615120530Z", { y: 2023, mo: 5, d: 15, h: 12, mi: 5, s: 30 }],
+  ["D:20230615120530+09'00'", { y: 2023, mo: 5, d: 15, h: 3, mi: 5, s: 30 }],
+  ["D:20230615120530-05'00'", { y: 2023, mo: 5, d: 15, h: 17, mi: 5, s: 30 }],
+  ["D:20230615120530-05'30'", { y: 2023, mo: 5, d: 15, h: 17, mi: 35, s: 30 }],
+];
+
+test.each(
+  VALID_TZ_AWARE,
+)("TZ あり日時 %s を UTC として解釈する", (raw, expected) => {
+  const result = parsePdfDate(raw);
+  expect(result).toBeDefined();
+  const date = result as Date;
+  expect(date.getUTCFullYear()).toBe(expected.y);
+  expect(date.getUTCMonth()).toBe(expected.mo);
+  expect(date.getUTCDate()).toBe(expected.d);
+  expect(date.getUTCHours()).toBe(expected.h);
+  expect(date.getUTCMinutes()).toBe(expected.mi);
+  expect(date.getUTCSeconds()).toBe(expected.s);
+});
+
+const INVALID_INPUTS: ReadonlyArray<readonly [string]> = [
+  ["20230101"],
+  ["D:abcd"],
+  ["D:20231345"],
+  ["D:20230231"],
+  ["D:20230229"],
+  ["D:20230231000000+09'00'"],
+  ["D:20230101246000"],
+  ["D:20230101000061"],
+  ["D:20230101000000+25'00'"],
+  ["D:0050"],
+  ["D:0999"],
+  ["D:00500101"],
+  ["D:10000"],
+  ["D:"],
+  ["D:202"],
+  ["D:2023011"],
+  ["D:2023+"],
+  ["D:20230101000000+09'00'extra"],
+  ["D:20230101000000+09'00"],
+];
+
+test.each(INVALID_INPUTS)("不正な PDF 日時 %s は undefined を返す", (raw) => {
+  expect(parsePdfDate(raw)).toBeUndefined();
+});

--- a/packages/core/src/document/parse-pdf-date.ts
+++ b/packages/core/src/document/parse-pdf-date.ts
@@ -1,3 +1,35 @@
+/** PDF 日時の YYYY 部分が受理される最小値（`Date.UTC` の 0..99 年自動補正回避）。 */
+const YEAR_MIN = 1000;
+/** PDF 日時の YYYY 部分が受理される最大値。 */
+const YEAR_MAX = 9999;
+/** 月の最小値（1 月）。 */
+const MONTH_MIN = 1;
+/** 月の最大値（12 月）。 */
+const MONTH_MAX = 12;
+/** 日の最小値。 */
+const DAY_MIN = 1;
+/** 日の最大値（31 日。実在チェックは probe で行う）。 */
+const DAY_MAX = 31;
+/** 時の最大値（23 時）。 */
+const HOUR_MAX = 23;
+/** 分・秒の最大値（59）。 */
+const MINUTE_MAX = 59;
+/** タイムゾーン分単位の係数（1 時間 = 60 分）。 */
+const MINUTES_PER_HOUR = 60;
+/** 1 分のミリ秒数。 */
+const MS_PER_MINUTE = 60_000;
+
+/**
+ * `D:YYYY[MM[DD[HH[mm[SS]]]]][TZ]` 形式の正規表現。
+ *
+ * - YYYY は 4 桁固定、必須
+ * - MM, DD, HH, mm, SS は 2 桁単位で末尾から段階的に省略可能
+ * - TZ は `Z` または `+HH'mm'` / `-HH'mm'`
+ * - 末尾 `$` アンカで trailing garbage を拒否
+ */
+const DATE_PATTERN =
+  /^D:(\d{4})(\d{2})?(\d{2})?(\d{2})?(\d{2})?(\d{2})?(?:(Z)|([+-])(\d{2})'(\d{2})')?$/;
+
 /**
  * PDF 日時文字列をパースした各成分。
  * 範囲検証済み。`tzSign` が `"+"` / `"-"` のときのみ `tzHour` / `tzMin` が意味を持つ。
@@ -15,23 +47,192 @@ interface ParsedDateParts {
 }
 
 /**
+ * 数値が `[min, max]` の範囲内かを判定する。
+ *
+ * @param value - 検証対象
+ * @param min - 下限（inclusive）
+ * @param max - 上限（inclusive）
+ * @returns 範囲内なら true
+ */
+const inRange = (value: number, min: number, max: number): boolean => {
+  return value >= min && value <= max;
+};
+
+/**
+ * オプショナルな 2 桁キャプチャを数値に変換する。未マッチ時は `fallback` を返す。
+ *
+ * @param captured - 正規表現のキャプチャ結果（未マッチ時 `undefined`）
+ * @param fallback - 未マッチ時に使うデフォルト値
+ * @returns 数値
+ */
+const numOrDefault = (
+  captured: string | undefined,
+  fallback: number,
+): number => {
+  if (captured === undefined) {
+    return fallback;
+  }
+  return Number(captured);
+};
+
+/**
  * "D:..." 文字列を {@link ParsedDateParts} に分解し各成分の数値範囲を検証する。
+ *
+ * `RegExp.exec` は標準 API として `null` を返すため、`if (!match)` で
+ * `undefined` に正規化する（プロジェクト内で以後 `null` を扱わない）。
  *
  * @param raw - PDF 日時文字列
  * @returns 成功時は分解された各成分。形式不正・範囲外時は `undefined`
  */
 const extractDateParts = (raw: string): ParsedDateParts | undefined => {
-  if (!raw.startsWith("D:")) {
+  const match = DATE_PATTERN.exec(raw);
+  if (!match) {
     return undefined;
   }
-  return undefined;
+
+  const [
+    ,
+    yearStr,
+    monthStr,
+    dayStr,
+    hourStr,
+    minStr,
+    secStr,
+    zMark,
+    sign,
+    tzHourStr,
+    tzMinStr,
+  ] = match;
+
+  const year = Number(yearStr);
+  if (!inRange(year, YEAR_MIN, YEAR_MAX)) {
+    return undefined;
+  }
+
+  const month = numOrDefault(monthStr, MONTH_MIN);
+  if (!inRange(month, MONTH_MIN, MONTH_MAX)) {
+    return undefined;
+  }
+
+  const day = numOrDefault(dayStr, DAY_MIN);
+  if (!inRange(day, DAY_MIN, DAY_MAX)) {
+    return undefined;
+  }
+
+  const hour = numOrDefault(hourStr, 0);
+  if (!inRange(hour, 0, HOUR_MAX)) {
+    return undefined;
+  }
+
+  const min = numOrDefault(minStr, 0);
+  if (!inRange(min, 0, MINUTE_MAX)) {
+    return undefined;
+  }
+
+  const sec = numOrDefault(secStr, 0);
+  if (!inRange(sec, 0, MINUTE_MAX)) {
+    return undefined;
+  }
+
+  if (zMark === "Z") {
+    return {
+      year,
+      month,
+      day,
+      hour,
+      min,
+      sec,
+      tzSign: "Z",
+      tzHour: 0,
+      tzMin: 0,
+    };
+  }
+
+  if (sign === "+" || sign === "-") {
+    const tzHour = Number(tzHourStr);
+    if (!inRange(tzHour, 0, HOUR_MAX)) {
+      return undefined;
+    }
+    const tzMin = Number(tzMinStr);
+    if (!inRange(tzMin, 0, MINUTE_MAX)) {
+      return undefined;
+    }
+    return {
+      year,
+      month,
+      day,
+      hour,
+      min,
+      sec,
+      tzSign: sign,
+      tzHour,
+      tzMin,
+    };
+  }
+
+  return {
+    year,
+    month,
+    day,
+    hour,
+    min,
+    sec,
+    tzSign: undefined,
+    tzHour: 0,
+    tzMin: 0,
+  };
+};
+
+/**
+ * `Date.UTC` で構築した probe の UTC 成分が入力成分と一致するかを検証する。
+ *
+ * 一致しない場合、自動繰り上がり（`2/31` → `3/3` など）が発生したことを意味する。
+ * TZ 付き／なし共通でこの検証を実施することで、TZ 付き不在日 `D:20230231000000+09'00'`
+ * もこの段階で弾く（review-002 反映）。
+ *
+ * @param parsed - 検証対象の各成分
+ * @returns probe の UTC ミリ秒。成分一致しない場合 `undefined`
+ */
+const buildProbeMs = (parsed: ParsedDateParts): number | undefined => {
+  const probeMs = Date.UTC(
+    parsed.year,
+    parsed.month - 1,
+    parsed.day,
+    parsed.hour,
+    parsed.min,
+    parsed.sec,
+  );
+  const probe = new Date(probeMs);
+  if (
+    probe.getUTCFullYear() !== parsed.year ||
+    probe.getUTCMonth() !== parsed.month - 1 ||
+    probe.getUTCDate() !== parsed.day ||
+    probe.getUTCHours() !== parsed.hour ||
+    probe.getUTCMinutes() !== parsed.min ||
+    probe.getUTCSeconds() !== parsed.sec
+  ) {
+    return undefined;
+  }
+  return probeMs;
 };
 
 /**
  * PDF 日時文字列 `D:YYYY[MM[DD[HH[mm[SS]]]]][TZ]` を `Date` にパースする。
  *
+ * 受理パターン:
+ *   - YYYY (1000-9999, 4 桁固定, 必須)
+ *   - MM, DD, HH, mm, SS は末尾から段階的に省略可
+ *   - TZ は `Z` / `+HH'mm'` / `-HH'mm'` / 省略
+ *   - trailing garbage 禁止、TZ 末尾 `'` 必須
+ *
+ * 検証フロー:
+ *   1. `DATE_PATTERN` 正規表現で構文と各成分の範囲を検証（`extractDateParts`）
+ *   2. `Date.UTC` で probe ms を構築し、UTC 成分一致検証で自動繰り上がりを弾く
+ *   3. TZ なし → `new Date(local)`、TZ "Z" → `new Date(probeMs)`、
+ *      TZ ± → `new Date(probeMs + offsetMs)` で最終 Date を返す
+ *
  * 警告は本関数では push せず、caller 側で `parsePdfDate(raw) === undefined`
- * を検出して `DATE_PARSE_FAILED` を push する想定（既存 `resolveResources` と同形）。
+ * を検出して `DATE_PARSE_FAILED` を push する想定。
  *
  * @param raw - PDF 日時文字列
  * @returns 成功時は `Date`、失敗時は `undefined`
@@ -41,5 +242,33 @@ export const parsePdfDate = (raw: string): Date | undefined => {
   if (parsed === undefined) {
     return undefined;
   }
-  return undefined;
+
+  const probeMs = buildProbeMs(parsed);
+  if (probeMs === undefined) {
+    return undefined;
+  }
+
+  if (parsed.tzSign === undefined) {
+    return new Date(
+      parsed.year,
+      parsed.month - 1,
+      parsed.day,
+      parsed.hour,
+      parsed.min,
+      parsed.sec,
+    );
+  }
+
+  if (parsed.tzSign === "Z") {
+    return new Date(probeMs);
+  }
+
+  // '+09:00' は UTC より 9h 早いので、UTC ms から TZ オフセットを引く（符号反転）
+  let sign = 1;
+  if (parsed.tzSign === "+") {
+    sign = -1;
+  }
+  const offsetMs =
+    sign * (parsed.tzHour * MINUTES_PER_HOUR + parsed.tzMin) * MS_PER_MINUTE;
+  return new Date(probeMs + offsetMs);
 };

--- a/packages/core/src/document/parse-pdf-date.ts
+++ b/packages/core/src/document/parse-pdf-date.ts
@@ -1,0 +1,45 @@
+/**
+ * PDF 日時文字列をパースした各成分。
+ * 範囲検証済み。`tzSign` が `"+"` / `"-"` のときのみ `tzHour` / `tzMin` が意味を持つ。
+ */
+interface ParsedDateParts {
+  readonly year: number;
+  readonly month: number;
+  readonly day: number;
+  readonly hour: number;
+  readonly min: number;
+  readonly sec: number;
+  readonly tzSign: "+" | "-" | "Z" | undefined;
+  readonly tzHour: number;
+  readonly tzMin: number;
+}
+
+/**
+ * "D:..." 文字列を {@link ParsedDateParts} に分解し各成分の数値範囲を検証する。
+ *
+ * @param raw - PDF 日時文字列
+ * @returns 成功時は分解された各成分。形式不正・範囲外時は `undefined`
+ */
+const extractDateParts = (raw: string): ParsedDateParts | undefined => {
+  if (!raw.startsWith("D:")) {
+    return undefined;
+  }
+  return undefined;
+};
+
+/**
+ * PDF 日時文字列 `D:YYYY[MM[DD[HH[mm[SS]]]]][TZ]` を `Date` にパースする。
+ *
+ * 警告は本関数では push せず、caller 側で `parsePdfDate(raw) === undefined`
+ * を検出して `DATE_PARSE_FAILED` を push する想定（既存 `resolveResources` と同形）。
+ *
+ * @param raw - PDF 日時文字列
+ * @returns 成功時は `Date`、失敗時は `undefined`
+ */
+export const parsePdfDate = (raw: string): Date | undefined => {
+  const parsed = extractDateParts(raw);
+  if (parsed === undefined) {
+    return undefined;
+  }
+  return undefined;
+};

--- a/packages/core/src/document/parse-pdf-date.ts
+++ b/packages/core/src/document/parse-pdf-date.ts
@@ -22,6 +22,10 @@ const MS_PER_MINUTE = 60_000;
 /**
  * `D:YYYY[MM[DD[HH[mm[SS]]]]][TZ]` 形式の正規表現。
  *
+ * - **`D:` prefix は必須**（本プロジェクト固有の厳格仕様）。
+ *   ISO 32000-2:2020 § 7.9.4 では `D:` は省略可能とされているが、本プロジェクトでは
+ *   `D:YYYY...` 形式に統一して期待する PDF 日時オブジェクトを誤認しないようにする。
+ *   `D:` を欠いた `20230101` のような入力は `undefined` で弾く（DI-004(a)）。
  * - YYYY は 4 桁固定、必須
  * - MM, DD, HH, mm, SS は 2 桁単位で末尾から段階的に省略可能
  * - TZ は `Z` または `+HH'mm'` / `-HH'mm'`
@@ -249,7 +253,7 @@ export const parsePdfDate = (raw: string): Date | undefined => {
   }
 
   if (parsed.tzSign === undefined) {
-    return new Date(
+    const local = new Date(
       parsed.year,
       parsed.month - 1,
       parsed.day,
@@ -257,6 +261,21 @@ export const parsePdfDate = (raw: string): Date | undefined => {
       parsed.min,
       parsed.sec,
     );
+    // ローカル DST ギャップ（例: 春の 02:30 が 03:30 に繰り上がる）で
+    // 「存在しないローカル時刻」を入力された場合、`new Date(...)` が
+    // 自動補正して別時刻になる。各成分が入力と一致するか検証して
+    // 一致しない場合は undefined にして弾く。
+    if (
+      local.getFullYear() !== parsed.year ||
+      local.getMonth() !== parsed.month - 1 ||
+      local.getDate() !== parsed.day ||
+      local.getHours() !== parsed.hour ||
+      local.getMinutes() !== parsed.min ||
+      local.getSeconds() !== parsed.sec
+    ) {
+      return undefined;
+    }
+    return local;
   }
 
   if (parsed.tzSign === "Z") {


### PR DESCRIPTION
## 概要

PDF 日時 `D:YYYYMMDDHHmmSSOHH'mm'` を `Date` にパースする pure 関数 `parsePdfDate` を実装（DocumentInfoParser の準備、PR 4/7）。

- 戻り値は `Date | undefined`（Result 型ではない、review-002）
- year は **1000-9999 のみ受理**（`Date.UTC(0..99, ...)` の 1900+ 自動補正回避、review-003）
- TZ 付き／なし共通で UTC 成分一致検証（自動繰り上がり / TZ 付き不在日を弾く、review-002）
- 正規表現 `DATE_PATTERN` で構文を完全一致（trailing garbage / TZ 末尾 \`'\` 欠落を拒否、review-004）
- 省略レベル + TZ の任意組み合わせ受理（`D:2023Z` / `D:202306+09'00'` / `D:2023061512+09'00'` 等、review-004 / 005）

## 変更内容

### 🎯 変更の種類

- [x] ✨ 新機能 (New feature)
- [x] 🚨 テスト追加/修正 (Tests)

### 📝 詳細な変更内容

#### 追加された機能・修正

- `parsePdfDate(raw): Date | undefined` を新規実装
- `extractDateParts(raw): ParsedDateParts | undefined` で `DATE_PATTERN` 正規表現ベースの構文＋範囲検証
- `buildProbeMs(parsed): number | undefined` で `Date.UTC` 経由の UTC 成分一致検証
- `numOrDefault` / `inRange` ヘルパで可読性確保
- 36 ケースの単体テスト（正常 TZ なし 7 + 正常 TZ あり 10 + 異常 19）

#### 変更されたファイル

- [NEW] `packages/core/src/document/parse-pdf-date.ts` (+274 行)
- [NEW] `packages/core/src/document/parse-pdf-date.parse.test.ts` (+92 行)

#### 削除されたファイル・機能

- なし

## 📊 システム図

### フロー図

\`\`\`mermaid
flowchart TD
    Start([parsePdfDate raw]) --> Extract[extractDateParts]:::new
    Extract --> ExtractCheck{構文/範囲 OK?}
    ExtractCheck -->|No| ReturnUndef1[return undefined]:::warn
    ExtractCheck -->|Yes| Probe[buildProbeMs Date.UTC]:::new
    Probe --> ProbeCheck{UTC 成分一致?}
    ProbeCheck -->|No 自動繰り上がり| ReturnUndef2[return undefined]:::warn
    ProbeCheck -->|Yes| TzCheck{tzSign?}
    TzCheck -->|undefined| LocalDate[new Date local]:::green
    TzCheck -->|Z| UtcDate[new Date probeMs]:::green
    TzCheck -->|+/-| OffsetDate[new Date probeMs + offsetMs]:::green

    classDef new fill:#ffe4b5,stroke:#d97706,stroke-width:2px
    classDef green fill:#d4edda,stroke:#155724
    classDef warn fill:#f8d7da,stroke:#721c24
\`\`\`

### データフロー

\`\`\`
入力文字列 raw
    ↓
extractDateParts(raw)
    ├─→ DATE_PATTERN.exec(raw)
    │     null → undefined（境界で正規化）
    ├─→ year (1000-9999) / month (1-12) / day (1-31)
    │   hour (0-23) / min (0-59) / sec (0-59)
    │   tzSign / tzHour (0-23) / tzMin (0-59) を範囲検証
    └─→ ParsedDateParts | undefined
            ↓
buildProbeMs(parsed)
    ├─→ Date.UTC(...) で probeMs 構築
    ├─→ new Date(probeMs).getUTC* が parsed と一致するか検証
    │     不一致 (2/31 や非うるう年 2/29 等) → undefined
    └─→ probeMs (number) | undefined
            ↓
最終 Date 構築
    ├─→ tzSign undefined → new Date(local components)
    ├─→ tzSign "Z"        → new Date(probeMs)
    └─→ tzSign "+"/"-"   → new Date(probeMs + offsetMs)
\`\`\`

## 📋 関連 Issue

- Refs #18

依存関係: なし（警告 push を行わない pure 関数のため、PR 1 にも依存しない）

後続: PR 6 で `readDateField` から呼び出し、`DATE_PARSE_FAILED` 警告は caller 側で push。

## 🧪 テスト

### テスト実行方法

\`\`\`bash
pnpm --filter @pdfmod/core test parse-pdf-date
pnpm test
pnpm --filter @pdfmod/core typecheck
\`\`\`

### テスト項目

- [x] 単体テスト (Unit tests) — 37 ケース
- [ ] 統合テスト — `DocumentInfoParser.parse` 経由の検証は **PR 6** で実施
- [ ] E2E テスト
- [ ] 手動テスト

### テスト結果

\`\`\`
Test Files  82 passed (82)
     Tests  1238 passed (1238)
\`\`\`

#### 正常系テーブル A (TZ なし、ローカル成分検証、7 ケース)
- `D:2023` / `D:202306` / `D:20230615` / `D:20230615120530`
- `D:1000` / `D:9999`（year 境界）
- `D:20240229`（うるう年）

#### 正常系テーブル B (TZ あり/Z、UTC 成分検証、10 ケース)
- `D:2023Z` / `D:202306+09'00'` / `D:20230615+09'00'`
- `D:2023061512+09'00'` / `D:202306151205+09'00'`（review-005）
- `D:20230101000000Z` / `D:20230615120530Z`
- `D:20230615120530+09'00'` / `-05'00'` / `-05'30'`

#### 異常系 (19 ケース、すべて undefined)
- D: 欠落 / 数値不正 / 月=13 / 2/31 / 非うるう年 2/29
- TZ 付き 2/31 / 24時 / 61秒 / TZ時25
- year 範囲外 (`0050` / `0999` / `00500101` / `10000`)
- 構文不正 (`D:` / `D:202` / `D:2023011` / `D:2023+`)
- trailing garbage / TZ 末尾 `'` 欠落

## 🔍 レビューポイント

- **year 範囲制限 (1000-9999)**: `Date.UTC(0..99, ...)` の 1900+ 自動補正により `D:0050` が 1950 年として通ってしまうのを未然に弾く
- **probe + UTC 成分一致検証**: TZ 付き／なし共通で `Date.UTC` の自動繰り上がり（2/31 → 3/3 等）を検出
- **DATE_PATTERN の `$` アンカ**: trailing garbage を構造的に拒否
- **`if (!match)` 形式**: `RegExp.exec` の `null` を境界で `undefined` に正規化（プロジェクト内で `null` 不使用）
- 警告 push は行わない pure 関数。caller (PR 6) で `parsePdfDate(raw) === undefined` を検出して `DATE_PARSE_FAILED` を push する設計

## ⚠️ 破壊的変更

- [ ] この変更は既存の API に破壊的変更を含みます

新規ファイル追加のみのため破壊的変更なし。

## 📚 追加情報

### 参考資料

- 実装計画: `.specs/036-document-info-parser/implementation-plan.md` §4.2
- PR 分割インデックス: `.specs/036-document-info-parser/split/README.md`
- PR 4 詳細タスク: `.specs/036-document-info-parser/split/tasks-04-parse-pdf-date.md`
- Codex review-002 / -003 / -004 / -005 すべて反映済み（review-004 結果: 問題なし）
- ISO 32000-2:2020 § 7.9.4 PDF 日時フォーマット仕様

### 注意事項

- 警告コードへの依存はないが、`DATE_PARSE_FAILED` 警告と組み合わせて使うのは PR 6 の `readDateField`
- PR 3 (decode-pdf-string, #95) とは独立に進行可能

## ✅ チェックリスト

- [x] コードレビューの準備ができている
- [x] テストが正常に実行される（1238 passed）
- [x] ドキュメントが更新されている（implementation-plan.md 既存、変更なし）
- [x] コミットメッセージが適切な形式で書かれている（2 コミット）
- [x] 関連する Issue が PR の本文に Refs #18 として記載されている
- [x] セルフレビューを実施した（Codex review-004: 問題なし）
- [x] 破壊的変更なし