### PR TITLE
♻️ #101 PdfTrapped (旧 TrappedState) を Brand + create() factory 化

### DIFF
--- a/packages/core/src/document/document-metadata.parse.test.ts
+++ b/packages/core/src/document/document-metadata.parse.test.ts
@@ -1,7 +1,7 @@
 import { expect, test } from "vitest";
 import type { PdfWarning } from "../pdf/errors/warning/index";
 import type { PdfValue } from "../pdf/types/pdf-types/index";
-import { parseTrappedName } from "./document-metadata";
+import { parseTrappedName, TrappedState } from "./document-metadata";
 
 const makeName = (value: string): PdfValue => ({ type: "name", value });
 
@@ -12,7 +12,10 @@ test.each([
 ])("/Trapped Name '%s' は TrappedState '%s' に解釈される", (literal) => {
   const warnings: PdfWarning[] = [];
   const result = parseTrappedName(makeName(literal), warnings);
-  expect(result).toBe(literal);
+  expect(TrappedState.create(literal)).toStrictEqual({
+    ok: true,
+    value: result,
+  });
   expect(warnings).toHaveLength(0);
 });
 

--- a/packages/core/src/document/document-metadata.parse.test.ts
+++ b/packages/core/src/document/document-metadata.parse.test.ts
@@ -1,7 +1,7 @@
 import { expect, test } from "vitest";
 import type { PdfWarning } from "../pdf/errors/warning/index";
 import type { PdfValue } from "../pdf/types/pdf-types/index";
-import { parseTrappedName, TrappedState } from "./document-metadata";
+import { PdfTrapped, parseTrappedName } from "./document-metadata";
 
 const makeName = (value: string): PdfValue => ({ type: "name", value });
 
@@ -9,10 +9,10 @@ test.each([
   ["True"] as const,
   ["False"] as const,
   ["Unknown"] as const,
-])("/Trapped Name '%s' は TrappedState '%s' に解釈される", (literal) => {
+])("/Trapped Name '%s' は PdfTrapped '%s' に解釈される", (literal) => {
   const warnings: PdfWarning[] = [];
   const result = parseTrappedName(makeName(literal), warnings);
-  expect(TrappedState.create(literal)).toStrictEqual({
+  expect(PdfTrapped.create(literal)).toStrictEqual({
     ok: true,
     value: result,
   });

--- a/packages/core/src/document/document-metadata.ts
+++ b/packages/core/src/document/document-metadata.ts
@@ -1,21 +1,40 @@
 import type { PdfWarning } from "../pdf/errors/warning/index";
 import type { PdfValue } from "../pdf/types/pdf-types/index";
+import type { Brand } from "../utils/brand/index";
+import type { Result } from "../utils/result/index";
+import { err, ok } from "../utils/result/index";
+
+declare const TrappedStateBrand: unique symbol;
 
 /**
- * /Trapped の許可値（ISO 32000-2:2020 § 14.3.3）。
+ * /Trapped 値を表すブランド型（ISO 32000-2:2020 § 14.3.3）。
+ * `TrappedState.create` を通じてのみ構築可能で、"True" / "False" / "Unknown" のみ受理する。
  */
-export type TrappedState = "True" | "False" | "Unknown";
+type TrappedState = Brand<
+  "True" | "False" | "Unknown",
+  typeof TrappedStateBrand
+>;
 
 const TRAPPED_ALLOWED = ["True", "False", "Unknown"] as const;
 
-/**
- * 文字列が {@link TrappedState} の許可リテラルに該当するかを判定する型ガード。
- *
- * @param value - 判定対象の文字列
- * @returns "True" / "False" / "Unknown" のいずれかなら true
- */
-const isTrappedLiteral = (value: string): value is TrappedState =>
-  (TRAPPED_ALLOWED as readonly string[]).includes(value);
+const TrappedState = {
+  /**
+   * 文字列から `TrappedState` を構築する。
+   *
+   * @param s - "True" / "False" / "Unknown" のいずれか（大文字小文字区別）
+   * @returns 集合に属すれば `Ok<TrappedState>`、属さなければ `Err<string>`
+   */
+  create(s: string): Result<TrappedState, string> {
+    if (!(TRAPPED_ALLOWED as readonly string[]).includes(s)) {
+      return err(
+        `Invalid TrappedState: "${s}" (supported: ${TRAPPED_ALLOWED.join(", ")})`,
+      );
+    }
+    return ok(s as TrappedState);
+  },
+} as const;
+
+export { TrappedState };
 
 /**
  * PdfValue の診断用要約を生成する。
@@ -99,12 +118,13 @@ export const parseTrappedName = (
     });
     return undefined;
   }
-  if (!isTrappedLiteral(value.value)) {
+  const result = TrappedState.create(value.value);
+  if (!result.ok) {
     warnings.push({
       code: "TRAPPED_INVALID",
       message: `/Trapped value '${value.value}' is not in {True, False, Unknown}`,
     });
     return undefined;
   }
-  return value.value;
+  return result.value;
 };

--- a/packages/core/src/document/document-metadata.ts
+++ b/packages/core/src/document/document-metadata.ts
@@ -4,37 +4,34 @@ import type { Brand } from "../utils/brand/index";
 import type { Result } from "../utils/result/index";
 import { err, ok } from "../utils/result/index";
 
-declare const TrappedStateBrand: unique symbol;
+declare const PdfTrappedBrand: unique symbol;
 
 /**
  * /Trapped 値を表すブランド型（ISO 32000-2:2020 § 14.3.3）。
- * `TrappedState.create` を通じてのみ構築可能で、"True" / "False" / "Unknown" のみ受理する。
+ * `PdfTrapped.create` を通じてのみ構築可能で、"True" / "False" / "Unknown" のみ受理する。
  */
-type TrappedState = Brand<
-  "True" | "False" | "Unknown",
-  typeof TrappedStateBrand
->;
+type PdfTrapped = Brand<"True" | "False" | "Unknown", typeof PdfTrappedBrand>;
 
 const TRAPPED_ALLOWED = ["True", "False", "Unknown"] as const;
 
-const TrappedState = {
+const PdfTrapped = {
   /**
-   * 文字列から `TrappedState` を構築する。
+   * 文字列から `PdfTrapped` を構築する。
    *
    * @param s - "True" / "False" / "Unknown" のいずれか（大文字小文字区別）
-   * @returns 集合に属すれば `Ok<TrappedState>`、属さなければ `Err<string>`
+   * @returns 集合に属すれば `Ok<PdfTrapped>`、属さなければ `Err<string>`
    */
-  create(s: string): Result<TrappedState, string> {
+  create(s: string): Result<PdfTrapped, string> {
     if (!(TRAPPED_ALLOWED as readonly string[]).includes(s)) {
       return err(
-        `Invalid TrappedState: "${s}" (supported: ${TRAPPED_ALLOWED.join(", ")})`,
+        `Invalid PdfTrapped: "${s}" (supported: ${TRAPPED_ALLOWED.join(", ")})`,
       );
     }
-    return ok(s as TrappedState);
+    return ok(s as PdfTrapped);
   },
 } as const;
 
-export { TrappedState };
+export { PdfTrapped };
 
 /**
  * PdfValue の診断用要約を生成する。
@@ -90,11 +87,11 @@ export interface DocumentMetadata {
   /** /ModDate — 最終更新日時 */
   readonly modDate?: Date;
   /** /Trapped — 印刷品質に関するトラッピング情報 */
-  readonly trapped?: TrappedState;
+  readonly trapped?: PdfTrapped;
 }
 
 /**
- * /Trapped の Name 値を {@link TrappedState} リテラルに解釈する。
+ * /Trapped の Name 値を {@link PdfTrapped} リテラルに解釈する。
  *
  * - value が undefined → undefined（警告なし）
  * - value が PdfName で値が "True" / "False" / "Unknown" → 該当 literal
@@ -102,12 +99,12 @@ export interface DocumentMetadata {
  *
  * @param value - /Trapped の値（解決済みの PdfValue または undefined）
  * @param warnings - 警告蓄積先（mutable）
- * @returns TrappedState または undefined
+ * @returns PdfTrapped または undefined
  */
 export const parseTrappedName = (
   value: PdfValue | undefined,
   warnings: PdfWarning[],
-): TrappedState | undefined => {
+): PdfTrapped | undefined => {
   if (value === undefined) {
     return undefined;
   }
@@ -118,7 +115,7 @@ export const parseTrappedName = (
     });
     return undefined;
   }
-  const result = TrappedState.create(value.value);
+  const result = PdfTrapped.create(value.value);
   if (!result.ok) {
     warnings.push({
       code: "TRAPPED_INVALID",

--- a/packages/core/src/document/document-metadata.validation.test.ts
+++ b/packages/core/src/document/document-metadata.validation.test.ts
@@ -1,12 +1,12 @@
 import { expect, test } from "vitest";
-import { TrappedState } from "./document-metadata";
+import { PdfTrapped } from "./document-metadata";
 
 test.each([
   ["True"],
   ["False"],
   ["Unknown"],
-])("TrappedState.create returns Ok for %s", (s) => {
-  const result = TrappedState.create(s);
+])("PdfTrapped.create returns Ok for %s", (s) => {
+  const result = PdfTrapped.create(s);
   expect(result).toStrictEqual({ ok: true, value: s });
 });
 
@@ -16,15 +16,15 @@ test.each([
   ["false"],
   ["unknown"],
   [""],
-])("TrappedState.create returns Err for %s", (s) => {
-  const result = TrappedState.create(s);
+])("PdfTrapped.create returns Err for %s", (s) => {
+  const result = PdfTrapped.create(s);
   expect(result.ok).toBe(false);
 });
 
-test("TrappedState.create Err message lists supported values", () => {
-  const result = TrappedState.create("Yes");
+test("PdfTrapped.create Err message lists supported values", () => {
+  const result = PdfTrapped.create("Yes");
   expect(result).toStrictEqual({
     ok: false,
-    error: 'Invalid TrappedState: "Yes" (supported: True, False, Unknown)',
+    error: 'Invalid PdfTrapped: "Yes" (supported: True, False, Unknown)',
   });
 });

--- a/packages/core/src/document/document-metadata.validation.test.ts
+++ b/packages/core/src/document/document-metadata.validation.test.ts
@@ -1,0 +1,30 @@
+import { expect, test } from "vitest";
+import { TrappedState } from "./document-metadata";
+
+test.each([
+  ["True"],
+  ["False"],
+  ["Unknown"],
+])("TrappedState.create returns Ok for %s", (s) => {
+  const result = TrappedState.create(s);
+  expect(result).toStrictEqual({ ok: true, value: s });
+});
+
+test.each([
+  ["Yes"],
+  ["true"],
+  ["false"],
+  ["unknown"],
+  [""],
+])("TrappedState.create returns Err for %s", (s) => {
+  const result = TrappedState.create(s);
+  expect(result.ok).toBe(false);
+});
+
+test("TrappedState.create Err message lists supported values", () => {
+  const result = TrappedState.create("Yes");
+  expect(result).toStrictEqual({
+    ok: false,
+    error: 'Invalid TrappedState: "Yes" (supported: True, False, Unknown)',
+  });
+});


### PR DESCRIPTION
## 概要

`TrappedState` を他のカテゴリ系型 (`PdfVersion` / `ByteOffset` / `GenerationNumber` / `ObjectNumber`) と同じく **Brand 型 + companion `create()` factory** 形式に揃えるリファクタリング。リテラル union 直書きを排し、`PdfVersion` パターンに完全に揃える。

caller は `parseTrappedName` 自身のみ (PR #100 が初出、root export 未実施) のため後方互換不要、実質非破壊的変更。

## 変更内容

### 🎯 変更の種類

- [x] ♻️ リファクタリング (Refactoring)
- [x] 🚨 テスト追加/修正 (Tests)

### 📝 詳細な変更内容

#### 追加された機能・修正

- `TrappedState` を `Brand<"True"|"False"|"Unknown", typeof TrappedStateBrand>` に置換
- companion `const TrappedState = { create(s): Result<TrappedState, string> } as const` を追加
- エラーメッセージ書式を PdfVersion パターンに揃える: `Invalid TrappedState: "Yes" (supported: True, False, Unknown)`
- `parseTrappedName` 内部の検証を `TrappedState.create(value.value)` 経由に書き換え
- `document-metadata.validation.test.ts` を新規 (Ok 3 / Err 5 / メッセージ書式 1 ケース)

#### 変更されたファイル

- `packages/core/src/document/document-metadata.ts`
- `packages/core/src/document/document-metadata.parse.test.ts`
- `packages/core/src/document/document-metadata.validation.test.ts` (新規)

#### 削除されたファイル・機能

- `isTrappedLiteral` (内部型ガード関数、外部参照ゼロ確認済み)
- 旧 `export type TrappedState = "True" | "False" | "Unknown"` (新しい `export { TrappedState }` に統合)

## 📊 システム図

### TrappedState.create() の検証フロー

```mermaid
flowchart TD
    Input([s: string]) --> Check{TRAPPED_ALLOWED に s が含まれるか}
    Check -->|Yes| OK["ok({ ok: true, value: s as TrappedState })"]
    Check -->|No| ERR["err('Invalid TrappedState: \"...\" (supported: True, False, Unknown)')"]
    OK --> Out1([Result.Ok])
    ERR --> Out2([Result.Err])

    classDef new fill:#ffe4b5,stroke:#d97706,stroke-width:2px
    class OK,ERR new
```

### parseTrappedName のフロー (リファクタ後)

```mermaid
flowchart TD
    Input([PdfValue or undefined]) --> A{value === undefined}
    A -->|Yes| RetUndef1([return undefined])
    A -->|No| B{value.type !== 'name'}
    B -->|Yes| Warn1["warnings.push TRAPPED_INVALID + summarize"]
    Warn1 --> RetUndef2([return undefined])
    B -->|No| Create["TrappedState.create value.value"]:::new
    Create --> C{result.ok}
    C -->|No| Warn2["warnings.push TRAPPED_INVALID"]
    Warn2 --> RetUndef3([return undefined])
    C -->|Yes| RetVal([return result.value]):::new

    classDef new fill:#ffe4b5,stroke:#d97706,stroke-width:2px
```

## 📋 関連 Issue

- Closes #101
- Refs #18 (DocumentInfoParser 親 Issue)
- Refs #100 (TrappedState 初出 PR、マージ済み)

## 🧪 テスト

### テスト実行方法

```bash
pnpm --filter @pdfmod/core test document-metadata
pnpm --filter @pdfmod/core typecheck
pnpm lint
```

### テスト項目

- [x] 単体テスト (Unit tests)

### テスト結果

- `pnpm --filter @pdfmod/core test`: **1268 passed (87 files)**
- `pnpm --filter @pdfmod/core typecheck`: エラーゼロ
- `pnpm lint`: 違反ゼロ (既存の `.pnpm-store` broken symlink 警告のみ)
- `grep -rn "isTrappedLiteral" packages/`: 0 件
- `grep -rn "export type TrappedState" packages/`: 0 件

新規 `document-metadata.validation.test.ts` (9 ケース):
- `TrappedState.create("True"|"False"|"Unknown")` → Ok
- `TrappedState.create("Yes"|"true"|"false"|"unknown"|"")` → Err
- エラーメッセージ書式の検証

## 🔍 レビューポイント

- **PdfVersion パターン踏襲**: `Brand<T, B>` + `unique symbol` + 同名 const/type companion + `as const` ロックの規約に揃えていること
- **公開 API の不変性**: `parseTrappedName` のシグネチャ・警告メッセージ (`/Trapped value '...' is not in {True, False, Unknown}`)・`TRAPPED_INVALID` warning code・`DocumentMetadata.trapped` の型はすべて維持
- **キャストの局所化**: `as TrappedState` は `TrappedState.create()` 内部の `ok(s as TrappedState)` 1 箇所のみ
- **テストルール準拠**: parse.test.ts の比較は `expect(TrappedState.create(literal)).toStrictEqual({ ok: true, value: result })` に変更し、`if`/`else` を使わず Brand 経由比較を実現

## ✅ チェックリスト

- [x] コードレビューの準備ができている
- [x] テストが正常に実行される
- [x] コミットメッセージが適切な形式で書かれている
- [x] 関連する Issue を PR の「Development」に Linked する想定
- [x] PR 本文に `Closes #101` で Issue が記載されている
- [x] セルフレビューを実施した
- [x] 破壊的変更なし (caller は parseTrappedName 自身のみ、root export 未実施)