### PR TITLE
✨ #18 PR6: DocumentInfoParser companion object 本体

### DIFF
--- a/packages/core/src/document/document-info-parser.behavior.test.ts
+++ b/packages/core/src/document/document-info-parser.behavior.test.ts
@@ -1,0 +1,258 @@
+import { expect, test, vi } from "vitest";
+import type { PdfError } from "../pdf/errors/error/index";
+import type {
+  IndirectRef,
+  PdfObject,
+  PdfStream,
+  PdfValue,
+} from "../pdf/types/pdf-types/index";
+import type { Result } from "../utils/result/index";
+import { DocumentInfoParser } from "./document-info-parser";
+import {
+  literalString,
+  makeInfoDict,
+  makeRef,
+  makeResolverWithInfo,
+  makeTrailerNoInfo,
+  makeTrailerWithInfo,
+  unwrapOk,
+  utf16BeString,
+} from "./document-info-parser.test.helpers";
+
+const failingResolver = (
+  error: PdfError,
+): ((ref: IndirectRef) => Promise<Result<PdfObject, PdfError>>) => {
+  return async () => ({ ok: false, error });
+};
+
+test("/Info が trailer に無い場合は空 metadata と空 warnings を返し resolver を呼ばない", async () => {
+  const resolver = vi.fn();
+  const result = await DocumentInfoParser.parse(makeTrailerNoInfo(), resolver);
+  const { metadata, warnings } = unwrapOk(result);
+  expect(metadata).toEqual({});
+  expect(warnings).toHaveLength(0);
+  expect(resolver).not.toHaveBeenCalled();
+});
+
+test("/Info に ASCII Title のみがある場合 metadata.title が抽出される", async () => {
+  const dict = makeInfoDict([["Title", literalString("Hello")]]);
+  const resolver = makeResolverWithInfo(dict);
+  const result = await DocumentInfoParser.parse(
+    makeTrailerWithInfo(makeRef(2)),
+    resolver,
+  );
+  const { metadata, warnings } = unwrapOk(result);
+  expect(metadata.title).toBe("Hello");
+  expect(warnings).toHaveLength(0);
+});
+
+test("/Info の Title / Author / Subject / Keywords / Creator / Producer が全て抽出される", async () => {
+  const dict = makeInfoDict([
+    ["Title", literalString("MyTitle")],
+    ["Author", literalString("Alice")],
+    ["Subject", literalString("Subject1")],
+    ["Keywords", literalString("k1,k2")],
+    ["Creator", literalString("CreatorApp")],
+    ["Producer", literalString("ProducerApp")],
+  ]);
+  const result = await DocumentInfoParser.parse(
+    makeTrailerWithInfo(makeRef(2)),
+    makeResolverWithInfo(dict),
+  );
+  const { metadata, warnings } = unwrapOk(result);
+  expect(metadata.title).toBe("MyTitle");
+  expect(metadata.author).toBe("Alice");
+  expect(metadata.subject).toBe("Subject1");
+  expect(metadata.keywords).toBe("k1,k2");
+  expect(metadata.creator).toBe("CreatorApp");
+  expect(metadata.producer).toBe("ProducerApp");
+  expect(warnings).toHaveLength(0);
+});
+
+test("/Title が UTF-16BE BOM 付き多言語文字列の場合に正しくデコードされる", async () => {
+  const dict = makeInfoDict([["Title", utf16BeString("日本語")]]);
+  const result = await DocumentInfoParser.parse(
+    makeTrailerWithInfo(makeRef(2)),
+    makeResolverWithInfo(dict),
+  );
+  const { metadata } = unwrapOk(result);
+  expect(metadata.title).toBe("日本語");
+});
+
+test("/Title が UTF-16BE 補助平面 🚀 を含む場合に正しくデコードされる", async () => {
+  const dict = makeInfoDict([["Title", utf16BeString("🚀 Launch")]]);
+  const result = await DocumentInfoParser.parse(
+    makeTrailerWithInfo(makeRef(2)),
+    makeResolverWithInfo(dict),
+  );
+  const { metadata } = unwrapOk(result);
+  expect(metadata.title).toBe("🚀 Launch");
+});
+
+test("/Title が PdfString 以外 (PdfInteger) の場合 undefined + STRING_DECODE_FAILED", async () => {
+  const integerValue: PdfValue = { type: "integer", value: 42 };
+  const dict = makeInfoDict([["Title", integerValue]]);
+  const result = await DocumentInfoParser.parse(
+    makeTrailerWithInfo(makeRef(2)),
+    makeResolverWithInfo(dict),
+  );
+  const { metadata, warnings } = unwrapOk(result);
+  expect(metadata.title).toBeUndefined();
+  expect(warnings).toHaveLength(1);
+  expect(warnings[0].code).toBe("STRING_DECODE_FAILED");
+  expect(warnings[0].message).toContain("Title");
+  expect(warnings[0].message).toContain("integer");
+});
+
+test("/CreationDate が D:20230615120530+09'00' の場合 UTC 換算 Date が抽出される", async () => {
+  const dict = makeInfoDict([
+    ["CreationDate", literalString("D:20230615120530+09'00'")],
+  ]);
+  const result = await DocumentInfoParser.parse(
+    makeTrailerWithInfo(makeRef(2)),
+    makeResolverWithInfo(dict),
+  );
+  const { metadata, warnings } = unwrapOk(result);
+  expect(metadata.creationDate).toBeDefined();
+  expect((metadata.creationDate as Date).getUTCHours()).toBe(3);
+  expect((metadata.creationDate as Date).getUTCMinutes()).toBe(5);
+  expect((metadata.creationDate as Date).getUTCSeconds()).toBe(30);
+  expect(warnings).toHaveLength(0);
+});
+
+test("/ModDate が D:20240101000000Z の場合 UTC Date が抽出される", async () => {
+  const dict = makeInfoDict([["ModDate", literalString("D:20240101000000Z")]]);
+  const result = await DocumentInfoParser.parse(
+    makeTrailerWithInfo(makeRef(2)),
+    makeResolverWithInfo(dict),
+  );
+  const { metadata, warnings } = unwrapOk(result);
+  expect(metadata.modDate).toBeDefined();
+  expect((metadata.modDate as Date).getUTCFullYear()).toBe(2024);
+  expect(warnings).toHaveLength(0);
+});
+
+test("/CreationDate が不正フォーマット D:abcd の場合 undefined + DATE_PARSE_FAILED", async () => {
+  const dict = makeInfoDict([["CreationDate", literalString("D:abcd")]]);
+  const result = await DocumentInfoParser.parse(
+    makeTrailerWithInfo(makeRef(2)),
+    makeResolverWithInfo(dict),
+  );
+  const { metadata, warnings } = unwrapOk(result);
+  expect(metadata.creationDate).toBeUndefined();
+  expect(warnings).toHaveLength(1);
+  expect(warnings[0].code).toBe("DATE_PARSE_FAILED");
+  expect(warnings[0].message).toContain("CreationDate");
+});
+
+test("/CreationDate が PdfString 以外 (PdfInteger) の場合 undefined + DATE_PARSE_FAILED", async () => {
+  const integerValue: PdfValue = { type: "integer", value: 0 };
+  const dict = makeInfoDict([["CreationDate", integerValue]]);
+  const result = await DocumentInfoParser.parse(
+    makeTrailerWithInfo(makeRef(2)),
+    makeResolverWithInfo(dict),
+  );
+  const { metadata, warnings } = unwrapOk(result);
+  expect(metadata.creationDate).toBeUndefined();
+  expect(warnings).toHaveLength(1);
+  expect(warnings[0].code).toBe("DATE_PARSE_FAILED");
+  expect(warnings[0].message).toContain("CreationDate");
+});
+
+const VALID_TRAPPED: ReadonlyArray<readonly ["True" | "False" | "Unknown"]> = [
+  ["True"],
+  ["False"],
+  ["Unknown"],
+];
+
+test.each(
+  VALID_TRAPPED,
+)("/Trapped Name '%s' が metadata.trapped に格納される", async (name) => {
+  const trappedValue: PdfValue = { type: "name", value: name };
+  const dict = makeInfoDict([["Trapped", trappedValue]]);
+  const result = await DocumentInfoParser.parse(
+    makeTrailerWithInfo(makeRef(2)),
+    makeResolverWithInfo(dict),
+  );
+  const { metadata, warnings } = unwrapOk(result);
+  expect(metadata.trapped).toBe(name);
+  expect(warnings).toHaveLength(0);
+});
+
+test("/Trapped が未知 Name 'Yes' の場合 undefined + TRAPPED_INVALID", async () => {
+  const trappedValue: PdfValue = { type: "name", value: "Yes" };
+  const dict = makeInfoDict([["Trapped", trappedValue]]);
+  const result = await DocumentInfoParser.parse(
+    makeTrailerWithInfo(makeRef(2)),
+    makeResolverWithInfo(dict),
+  );
+  const { metadata, warnings } = unwrapOk(result);
+  expect(metadata.trapped).toBeUndefined();
+  expect(warnings).toHaveLength(1);
+  expect(warnings[0].code).toBe("TRAPPED_INVALID");
+});
+
+test("resolver が err を返した場合 INFO_RESOLVE_FAILED + 空 metadata", async () => {
+  const infoRef = makeRef(2);
+  const resolver = failingResolver({
+    code: "OBJECT_PARSE_UNEXPECTED_TOKEN",
+    message: "object parse failed",
+  });
+  const result = await DocumentInfoParser.parse(
+    makeTrailerWithInfo(infoRef),
+    resolver,
+  );
+  const { metadata, warnings } = unwrapOk(result);
+  expect(metadata).toEqual({});
+  expect(warnings).toHaveLength(1);
+  expect(warnings[0].code).toBe("INFO_RESOLVE_FAILED");
+  expect(warnings[0].message).toContain("OBJECT_PARSE_UNEXPECTED_TOKEN");
+  expect(warnings[0].message).toContain("2");
+});
+
+test("/Info が dictionary 以外 (stream) に解決された場合 INFO_NOT_DICTIONARY + 空 metadata", async () => {
+  const stream: PdfStream = {
+    type: "stream",
+    dictionary: { type: "dictionary", entries: new Map() },
+    data: new Uint8Array(),
+  };
+  const result = await DocumentInfoParser.parse(
+    makeTrailerWithInfo(makeRef(2)),
+    makeResolverWithInfo(stream),
+  );
+  const { metadata, warnings } = unwrapOk(result);
+  expect(metadata).toEqual({});
+  expect(warnings).toHaveLength(1);
+  expect(warnings[0].code).toBe("INFO_NOT_DICTIONARY");
+  expect(warnings[0].message).toContain("stream");
+});
+
+test("/Info に全フィールド（9 件）が揃った場合の統合抽出", async () => {
+  const trappedValue: PdfValue = { type: "name", value: "True" };
+  const dict = makeInfoDict([
+    ["Title", literalString("MyDoc")],
+    ["Author", literalString("Alice")],
+    ["Subject", literalString("Sample")],
+    ["Keywords", literalString("pdf,test")],
+    ["Creator", literalString("MyApp")],
+    ["Producer", literalString("ProducerLib")],
+    ["CreationDate", literalString("D:20230615120530Z")],
+    ["ModDate", literalString("D:20240101000000Z")],
+    ["Trapped", trappedValue],
+  ]);
+  const result = await DocumentInfoParser.parse(
+    makeTrailerWithInfo(makeRef(2)),
+    makeResolverWithInfo(dict),
+  );
+  const { metadata, warnings } = unwrapOk(result);
+  expect(metadata.title).toBe("MyDoc");
+  expect(metadata.author).toBe("Alice");
+  expect(metadata.subject).toBe("Sample");
+  expect(metadata.keywords).toBe("pdf,test");
+  expect(metadata.creator).toBe("MyApp");
+  expect(metadata.producer).toBe("ProducerLib");
+  expect((metadata.creationDate as Date).getUTCFullYear()).toBe(2023);
+  expect((metadata.modDate as Date).getUTCFullYear()).toBe(2024);
+  expect(metadata.trapped).toBe("True");
+  expect(warnings).toHaveLength(0);
+});

--- a/packages/core/src/document/document-info-parser.test.helpers.ts
+++ b/packages/core/src/document/document-info-parser.test.helpers.ts
@@ -64,10 +64,14 @@ export const makeTrailerNoInfo = (): TrailerDict => ({
 });
 
 /**
- * ASCII / Latin-1 範囲のテキストを literal byte 列で表現する。
- * 多言語は {@link utf16BeString} を使用すること。
+ * ASCII 範囲のテキストを literal byte 列で表現する。
  *
- * @param text - エンコード対象のテキスト
+ * `TextEncoder` は UTF-8 でエンコードするため、非 ASCII 文字を渡すとマルチバイト
+ * 列になり PDF の literal string バイト列と一致しなくなる。日本語・絵文字など
+ * 多言語の検証には必ず {@link utf16BeString} を使用すること（こちらは BOM 付き
+ * UTF-16BE で構築する）。
+ *
+ * @param text - エンコード対象のテキスト（ASCII 範囲のみ）
  * @returns PdfString
  */
 export const literalString = (text: string): PdfString => ({

--- a/packages/core/src/document/document-info-parser.test.helpers.ts
+++ b/packages/core/src/document/document-info-parser.test.helpers.ts
@@ -1,0 +1,141 @@
+import { expect } from "vitest";
+import type { PdfError } from "../pdf/errors/error/index";
+import { GenerationNumber } from "../pdf/types/generation-number/index";
+import { ObjectNumber } from "../pdf/types/object-number/index";
+import type {
+  IndirectRef,
+  PdfDictionary,
+  PdfObject,
+  PdfString,
+  PdfValue,
+  TrailerDict,
+} from "../pdf/types/pdf-types/index";
+import type { Result } from "../utils/result/index";
+
+const BOM_BYTE_0 = 0xfe;
+const BOM_BYTE_1 = 0xff;
+const BYTES_PER_CHAR_CODE = 2;
+const HIGH_BYTE_SHIFT = 8;
+const BYTE_MASK = 0xff;
+
+/**
+ * Result が Ok であることを `expect` で保証し、値を返す（テスト専用ヘルパ）。
+ *
+ * @param result - 検査対象
+ * @returns 成功値
+ */
+export const unwrapOk = <T>(result: Result<T, unknown>): T => {
+  expect(result.ok).toBe(true);
+  return (result as { ok: true; value: T }).value;
+};
+
+/**
+ * ブランド付き `IndirectRef` を手軽に作るヘルパ。
+ *
+ * @param objNum - オブジェクト番号
+ * @param genNum - 世代番号（既定: 0）
+ * @returns 構築された IndirectRef
+ */
+export const makeRef = (objNum: number, genNum = 0): IndirectRef => ({
+  objectNumber: ObjectNumber.of(objNum),
+  generationNumber: GenerationNumber.of(genNum),
+});
+
+/**
+ * `/Info` を含むトレーラ辞書を作る。
+ *
+ * @param info - `/Info` に設定する間接参照
+ * @returns 構築された TrailerDict
+ */
+export const makeTrailerWithInfo = (info: IndirectRef): TrailerDict => ({
+  root: makeRef(1),
+  size: 10,
+  info,
+});
+
+/**
+ * `/Info` を含まないトレーラ辞書を作る。
+ *
+ * @returns 構築された TrailerDict
+ */
+export const makeTrailerNoInfo = (): TrailerDict => ({
+  root: makeRef(1),
+  size: 10,
+});
+
+/**
+ * ASCII / Latin-1 範囲のテキストを literal byte 列で表現する。
+ * 多言語は {@link utf16BeString} を使用すること。
+ *
+ * @param text - エンコード対象のテキスト
+ * @returns PdfString
+ */
+export const literalString = (text: string): PdfString => ({
+  type: "string",
+  value: new TextEncoder().encode(text),
+  encoding: "literal",
+});
+
+/**
+ * UTF-16BE BOM 付き PdfString を生成する。
+ *
+ * `charCodeAt` をインデックスごとに呼ぶことで、サロゲートペア（補助平面文字 🚀 等）
+ * を保持する。`String.prototype.codePointAt` でコードポイント単位に集約してしまうと
+ * UTF-16 サロゲートが失われてしまうため、ここでは UTF-16 コードユニット単位で扱う。
+ *
+ * @param text - エンコード対象のテキスト
+ * @returns BOM 付き UTF-16BE バイト列を持つ PdfString
+ */
+export const utf16BeString = (text: string): PdfString => {
+  const codeUnits: number[] = [];
+  for (let i = 0; i < text.length; i++) {
+    codeUnits.push(text.charCodeAt(i));
+  }
+  const bytes = new Uint8Array(
+    BYTES_PER_CHAR_CODE + codeUnits.length * BYTES_PER_CHAR_CODE,
+  );
+  bytes[0] = BOM_BYTE_0;
+  bytes[1] = BOM_BYTE_1;
+  for (let i = 0; i < codeUnits.length; i++) {
+    bytes[BYTES_PER_CHAR_CODE + i * BYTES_PER_CHAR_CODE] =
+      (codeUnits[i] >> HIGH_BYTE_SHIFT) & BYTE_MASK;
+    bytes[BYTES_PER_CHAR_CODE + i * BYTES_PER_CHAR_CODE + 1] =
+      codeUnits[i] & BYTE_MASK;
+  }
+  return { type: "string", value: bytes, encoding: "literal" };
+};
+
+/**
+ * エントリマップから PdfDictionary を作る。
+ *
+ * @param entries - 辞書エントリ
+ * @returns 構築された PdfDictionary
+ */
+export const okDict = (entries: Map<string, PdfValue>): PdfDictionary => ({
+  type: "dictionary",
+  entries,
+});
+
+/**
+ * `[キー, PdfValue]` のリストから `/Info` 辞書を構築する。
+ *
+ * @param fields - キーと値のペア
+ * @returns 構築された PdfDictionary
+ */
+export const makeInfoDict = (
+  fields: ReadonlyArray<readonly [string, PdfValue]>,
+): PdfDictionary => okDict(new Map(fields));
+
+/**
+ * resolver の挙動を ok 値で固定するスタブ。
+ *
+ * @param info - 解決時に返す PdfObject
+ * @returns ResolveRef 互換の関数
+ */
+export const makeResolverWithInfo = (
+  info: PdfObject,
+): ((ref: IndirectRef) => Promise<Result<PdfObject, PdfError>>) => {
+  return async () => {
+    return { ok: true, value: info };
+  };
+};

--- a/packages/core/src/document/document-info-parser.ts
+++ b/packages/core/src/document/document-info-parser.ts
@@ -16,7 +16,7 @@ import { parsePdfDate } from "./pdf-date";
 /**
  * `DocumentInfoParser.parse` の戻り値。
  */
-export interface ParseDocumentInfoResult {
+export interface ParsedDocumentInfo {
   /** 抽出された /Info 由来メタデータ。/Info 不在 / 抽出失敗時は空オブジェクト */
   readonly metadata: DocumentMetadata;
   /** 抽出処理中に蓄積された警告 */
@@ -194,7 +194,7 @@ export const DocumentInfoParser = {
   async parse(
     trailerDict: TrailerDict,
     resolveRef: ResolveRef,
-  ): Promise<Result<ParseDocumentInfoResult, PdfError>> {
+  ): Promise<Result<ParsedDocumentInfo, PdfError>> {
     const warnings: PdfWarning[] = [];
     if (trailerDict.info === undefined) {
       return ok({ metadata: EMPTY_METADATA, warnings });

--- a/packages/core/src/document/document-info-parser.ts
+++ b/packages/core/src/document/document-info-parser.ts
@@ -5,6 +5,7 @@ import type {
   PdfValue,
   TrailerDict,
 } from "../pdf/types/pdf-types/index";
+import { stripUndefined } from "../utils/object";
 import type { Result } from "../utils/result/index";
 import { ok } from "../utils/result/index";
 import type { ResolveRef } from "./catalog-parser";
@@ -127,47 +128,17 @@ const extractMetadata = (
   warnings: PdfWarning[],
 ): DocumentMetadata => {
   const e = dict.entries;
-  const metadata: {
-    -readonly [K in keyof DocumentMetadata]: DocumentMetadata[K];
-  } = {};
-
-  const title = readStringField(e, "Title", warnings);
-  if (title !== undefined) {
-    metadata.title = title;
-  }
-  const author = readStringField(e, "Author", warnings);
-  if (author !== undefined) {
-    metadata.author = author;
-  }
-  const subject = readStringField(e, "Subject", warnings);
-  if (subject !== undefined) {
-    metadata.subject = subject;
-  }
-  const keywords = readStringField(e, "Keywords", warnings);
-  if (keywords !== undefined) {
-    metadata.keywords = keywords;
-  }
-  const creator = readStringField(e, "Creator", warnings);
-  if (creator !== undefined) {
-    metadata.creator = creator;
-  }
-  const producer = readStringField(e, "Producer", warnings);
-  if (producer !== undefined) {
-    metadata.producer = producer;
-  }
-  const creationDate = readDateField(e, "CreationDate", warnings);
-  if (creationDate !== undefined) {
-    metadata.creationDate = creationDate;
-  }
-  const modDate = readDateField(e, "ModDate", warnings);
-  if (modDate !== undefined) {
-    metadata.modDate = modDate;
-  }
-  const trapped = parseTrappedName(e.get("Trapped"), warnings);
-  if (trapped !== undefined) {
-    metadata.trapped = trapped;
-  }
-  return metadata;
+  return stripUndefined<DocumentMetadata>({
+    title: readStringField(e, "Title", warnings),
+    author: readStringField(e, "Author", warnings),
+    subject: readStringField(e, "Subject", warnings),
+    keywords: readStringField(e, "Keywords", warnings),
+    creator: readStringField(e, "Creator", warnings),
+    producer: readStringField(e, "Producer", warnings),
+    creationDate: readDateField(e, "CreationDate", warnings),
+    modDate: readDateField(e, "ModDate", warnings),
+    trapped: parseTrappedName(e.get("Trapped"), warnings),
+  });
 };
 
 /**

--- a/packages/core/src/document/document-info-parser.ts
+++ b/packages/core/src/document/document-info-parser.ts
@@ -104,7 +104,7 @@ const readDateField = (
   if (parsed === undefined) {
     warnings.push({
       code: "DATE_PARSE_FAILED",
-      message: `/${key} = ${JSON.stringify(raw)}`,
+      message: `/${key} failed to parse PDF date ${JSON.stringify(raw)}; expected pattern D:YYYYMMDDHHmmSSOHH'mm'`,
     });
     return undefined;
   }
@@ -203,7 +203,7 @@ export const DocumentInfoParser = {
     if (!resolved.ok) {
       warnings.push({
         code: "INFO_RESOLVE_FAILED",
-        message: `Failed to resolve /Info ${trailerDict.info.objectNumber} ${trailerDict.info.generationNumber}: cause=${resolved.error.code}`,
+        message: `Failed to resolve /Info ${trailerDict.info.objectNumber} ${trailerDict.info.generationNumber}: cause=${resolved.error.code}, message=${resolved.error.message}`,
       });
       return ok({ metadata: EMPTY_METADATA, warnings });
     }

--- a/packages/core/src/document/document-info-parser.ts
+++ b/packages/core/src/document/document-info-parser.ts
@@ -1,0 +1,220 @@
+import type { PdfError } from "../pdf/errors/error/index";
+import type { PdfWarning } from "../pdf/errors/warning/index";
+import type {
+  PdfDictionary,
+  PdfValue,
+  TrailerDict,
+} from "../pdf/types/pdf-types/index";
+import type { Result } from "../utils/result/index";
+import { ok } from "../utils/result/index";
+import type { ResolveRef } from "./catalog-parser";
+import { decodePdfString } from "./decode-pdf-string";
+import type { DocumentMetadata } from "./document-metadata";
+import { parseTrappedName } from "./document-metadata";
+import { parsePdfDate } from "./pdf-date";
+
+/**
+ * `DocumentInfoParser.parse` の戻り値。
+ */
+export interface ParseDocumentInfoResult {
+  /** 抽出された /Info 由来メタデータ。/Info 不在 / 抽出失敗時は空オブジェクト */
+  readonly metadata: DocumentMetadata;
+  /** 抽出処理中に蓄積された警告 */
+  readonly warnings: PdfWarning[];
+}
+
+/**
+ * `/Info` 不在・解決失敗時に返す共有空 metadata。
+ *
+ * `Object.freeze` で凍結することで、複数の `parse()` 呼び出し間で同じ参照を
+ * 返しても呼び出し側のミューテーションが他の結果に波及しないことを保証する。
+ */
+const EMPTY_METADATA: DocumentMetadata = Object.freeze({});
+
+/**
+ * テキストフィールド共通リーダ。値の型チェックと {@link decodePdfString} 呼び出しを束ねる。
+ *
+ * 分岐:
+ *  - 値が `undefined` → `undefined`（警告なし、未指定扱い）
+ *  - 値が PdfString 以外 → `undefined` + `STRING_DECODE_FAILED` 警告
+ *  - 値が PdfString → `decodePdfString` に委譲
+ *
+ * @param entries - /Info 辞書のエントリ
+ * @param key - 取得するキー（例: `"Title"`）
+ * @param warnings - 警告蓄積先（mutable）
+ * @returns 復号成功時は文字列、それ以外は `undefined`
+ */
+const readStringField = (
+  entries: Map<string, PdfValue>,
+  key: string,
+  warnings: PdfWarning[],
+): string | undefined => {
+  const value = entries.get(key);
+  if (value === undefined) {
+    return undefined;
+  }
+  if (value.type !== "string") {
+    warnings.push({
+      code: "STRING_DECODE_FAILED",
+      message: `/${key} expected PdfString but got ${value.type}`,
+    });
+    return undefined;
+  }
+  return decodePdfString(value, key, warnings);
+};
+
+/**
+ * 日時フィールド共通リーダ。値の型チェック → 文字列復号 → {@link parsePdfDate} を束ねる。
+ *
+ * `parsePdfDate` は警告 push を行わない pure 関数なので、`undefined` を検出した時点で
+ * 本リーダ（caller）が `DATE_PARSE_FAILED` 警告を push する（review-002 反映）。
+ *
+ * 分岐:
+ *  - 値が `undefined` → `undefined`（警告なし、未指定扱い）
+ *  - 値が PdfString 以外 → `undefined` + `DATE_PARSE_FAILED` 警告
+ *  - 文字列復号失敗 → `undefined`（警告は decodePdfString 側で push 済み）
+ *  - 日時パース失敗 → `undefined` + `DATE_PARSE_FAILED` 警告
+ *
+ * @param entries - /Info 辞書のエントリ
+ * @param key - 取得するキー（例: `"CreationDate"`）
+ * @param warnings - 警告蓄積先（mutable）
+ * @returns パース成功時は `Date`、それ以外は `undefined`
+ */
+const readDateField = (
+  entries: Map<string, PdfValue>,
+  key: string,
+  warnings: PdfWarning[],
+): Date | undefined => {
+  const value = entries.get(key);
+  if (value === undefined) {
+    return undefined;
+  }
+  if (value.type !== "string") {
+    warnings.push({
+      code: "DATE_PARSE_FAILED",
+      message: `/${key} expected PdfString but got ${value.type}`,
+    });
+    return undefined;
+  }
+  const raw = decodePdfString(value, key, warnings);
+  if (raw === undefined) {
+    return undefined;
+  }
+  const parsed = parsePdfDate(raw);
+  if (parsed === undefined) {
+    warnings.push({
+      code: "DATE_PARSE_FAILED",
+      message: `/${key} = ${JSON.stringify(raw)}`,
+    });
+    return undefined;
+  }
+  return parsed;
+};
+
+/**
+ * `/Info` 辞書から 9 フィールドを抽出して {@link DocumentMetadata} に詰め直す。
+ *
+ * テキスト 6 フィールド・日時 2 フィールド・Trapped を、それぞれ
+ * `readStringField` / `readDateField` / `parseTrappedName` に委譲する。
+ * 値が `undefined` のフィールドはオブジェクトに含めない（PR #98 review 反映）。
+ *
+ * @param dict - 解決済みの `/Info` 辞書
+ * @param warnings - 警告蓄積先（mutable）
+ * @returns 抽出されたメタデータ
+ */
+const extractMetadata = (
+  dict: PdfDictionary,
+  warnings: PdfWarning[],
+): DocumentMetadata => {
+  const e = dict.entries;
+  const metadata: {
+    -readonly [K in keyof DocumentMetadata]: DocumentMetadata[K];
+  } = {};
+
+  const title = readStringField(e, "Title", warnings);
+  if (title !== undefined) {
+    metadata.title = title;
+  }
+  const author = readStringField(e, "Author", warnings);
+  if (author !== undefined) {
+    metadata.author = author;
+  }
+  const subject = readStringField(e, "Subject", warnings);
+  if (subject !== undefined) {
+    metadata.subject = subject;
+  }
+  const keywords = readStringField(e, "Keywords", warnings);
+  if (keywords !== undefined) {
+    metadata.keywords = keywords;
+  }
+  const creator = readStringField(e, "Creator", warnings);
+  if (creator !== undefined) {
+    metadata.creator = creator;
+  }
+  const producer = readStringField(e, "Producer", warnings);
+  if (producer !== undefined) {
+    metadata.producer = producer;
+  }
+  const creationDate = readDateField(e, "CreationDate", warnings);
+  if (creationDate !== undefined) {
+    metadata.creationDate = creationDate;
+  }
+  const modDate = readDateField(e, "ModDate", warnings);
+  if (modDate !== undefined) {
+    metadata.modDate = modDate;
+  }
+  const trapped = parseTrappedName(e.get("Trapped"), warnings);
+  if (trapped !== undefined) {
+    metadata.trapped = trapped;
+  }
+  return metadata;
+};
+
+/**
+ * トレーラ辞書の `/Info` 間接参照を解決し、{@link DocumentMetadata} を抽出する
+ * companion object。ISO 32000-2:2020 § 14.3.3 (Document Information Dictionary) 準拠。
+ *
+ * 分岐:
+ *  - `/Info` 不在 → 空 metadata + 空 warnings の Ok
+ *  - resolver 失敗 → `INFO_RESOLVE_FAILED` 警告 + 空 metadata
+ *  - 解決値が dictionary 以外 → `INFO_NOT_DICTIONARY` 警告 + 空 metadata
+ *  - 辞書あり → 9 フィールドを抽出して返す
+ *
+ * 現状 `Result.err` 経路は使用していない（resolver は契約上 Promise を reject せず
+ * `err` を `Result.ok` に正規化して戻す）。
+ */
+export const DocumentInfoParser = {
+  /**
+   * `/Info` 辞書から PDF ドキュメントメタデータを抽出する。
+   *
+   * @param trailerDict - trailer parser 出力（`info` は IndirectRef または undefined）
+   * @param resolveRef - 間接参照を解決する関数
+   * @returns 抽出結果と警告を含む `Ok`
+   */
+  async parse(
+    trailerDict: TrailerDict,
+    resolveRef: ResolveRef,
+  ): Promise<Result<ParseDocumentInfoResult, PdfError>> {
+    const warnings: PdfWarning[] = [];
+    if (trailerDict.info === undefined) {
+      return ok({ metadata: EMPTY_METADATA, warnings });
+    }
+    const resolved = await resolveRef(trailerDict.info);
+    if (!resolved.ok) {
+      warnings.push({
+        code: "INFO_RESOLVE_FAILED",
+        message: `Failed to resolve /Info ${trailerDict.info.objectNumber} ${trailerDict.info.generationNumber}: cause=${resolved.error.code}`,
+      });
+      return ok({ metadata: EMPTY_METADATA, warnings });
+    }
+    if (resolved.value.type !== "dictionary") {
+      warnings.push({
+        code: "INFO_NOT_DICTIONARY",
+        message: `Trailer /Info did not resolve to a dictionary (got: ${resolved.value.type})`,
+      });
+      return ok({ metadata: EMPTY_METADATA, warnings });
+    }
+    const metadata = extractMetadata(resolved.value, warnings);
+    return ok({ metadata, warnings });
+  },
+} as const;

--- a/packages/core/src/utils/object.basic.test.ts
+++ b/packages/core/src/utils/object.basic.test.ts
@@ -1,0 +1,73 @@
+import { expect, test } from "vitest";
+import { stripUndefined } from "./object";
+
+interface SampleMetadata {
+  readonly title?: string;
+  readonly count?: number;
+  readonly active?: boolean;
+}
+
+test("全キーが値ありの場合はすべてのキーが残る", () => {
+  const result = stripUndefined<SampleMetadata>({
+    title: "hello",
+    count: 1,
+    active: true,
+  });
+  expect(result).toEqual({ title: "hello", count: 1, active: true });
+});
+
+test("undefined のキーは結果から除外される", () => {
+  const result = stripUndefined<SampleMetadata>({
+    title: "hello",
+    count: undefined,
+    active: true,
+  });
+  expect(result).toEqual({ title: "hello", active: true });
+  expect("count" in result).toBe(false);
+});
+
+test("全キーが undefined の場合は空オブジェクトを返す", () => {
+  const result = stripUndefined<SampleMetadata>({
+    title: undefined,
+    count: undefined,
+    active: undefined,
+  });
+  expect(result).toEqual({});
+  expect(Object.keys(result)).toHaveLength(0);
+});
+
+interface FalsyContainer {
+  readonly nullValue?: null;
+  readonly zero?: number;
+  readonly emptyString?: string;
+  readonly falseValue?: boolean;
+}
+
+test.each<[keyof FalsyContainer, FalsyContainer[keyof FalsyContainer]]>([
+  ["nullValue", null],
+  ["zero", 0],
+  ["emptyString", ""],
+  ["falseValue", false],
+])("falsy 値 (%s = %j) は undefined ではないので保持される", (key, value) => {
+  const input: { [K in keyof FalsyContainer]: FalsyContainer[K] | undefined } =
+    {
+      nullValue: undefined,
+      zero: undefined,
+      emptyString: undefined,
+      falseValue: undefined,
+      [key]: value,
+    };
+  const result = stripUndefined<FalsyContainer>(input);
+  expect(key in result).toBe(true);
+  expect(result[key]).toBe(value);
+});
+
+test("入力オブジェクトを破壊的に変更しない", () => {
+  const input: { title: string | undefined; count: number | undefined } = {
+    title: "hello",
+    count: undefined,
+  };
+  stripUndefined<{ title?: string; count?: number }>(input);
+  expect(input).toEqual({ title: "hello", count: undefined });
+  expect("count" in input).toBe(true);
+});

--- a/packages/core/src/utils/object.ts
+++ b/packages/core/src/utils/object.ts
@@ -1,0 +1,18 @@
+/**
+ * オブジェクトから値が `undefined` のキーを取り除いた新しいオブジェクトを返す。
+ *
+ * 入力は `T` の全キーを必須に持ち、各値は `T[K] | undefined`。
+ * 戻り値は `T` 型で、入力時に `undefined` だったキーは含まない（`"key" in result` は `false`）。
+ *
+ * `null` / `0` / `""` / `false` は値として保持される。除外されるのは `undefined` のみ。
+ *
+ * @typeParam T - 結果オブジェクトの型。optional プロパティを持つことを想定する。
+ * @param obj - 全キーを必須に持つオブジェクト。各値は対応する型または `undefined`。
+ * @returns `undefined` 値のキーを除いたオブジェクト。
+ */
+export const stripUndefined = <T extends object>(
+  obj: { [K in keyof T]: T[K] | undefined },
+): T =>
+  Object.fromEntries(
+    Object.entries(obj).filter(([, v]) => v !== undefined),
+  ) as T;


### PR DESCRIPTION
## 概要

`/Info` 辞書から `DocumentMetadata` を抽出する `DocumentInfoParser.parse(trailer, resolveRef)` companion object を実装します。Issue #18 の Spec 036 を 7 PR に分割した第 6 弾で、PR 2/3/4/5 で切り出した helper（`decodePdfString` / `parsePdfDate` / `parseTrappedName`）を統合し、警告ベースで回復可能な抽出フローを提供します。

## 変更内容

### 🎯 変更の種類

- [x] ✨ 新機能 (New feature)

### 📝 詳細な変更内容

#### 追加された機能・修正

- `DocumentInfoParser.parse(trailerDict, resolveRef): Promise<Result<ParseDocumentInfoResult, PdfError>>` を新規実装
- `/Info` 不在 → 空 metadata + 空 warnings の Ok 返却
- resolver 失敗 → `INFO_RESOLVE_FAILED` 警告 + 空 metadata（object/generation 番号と原因コードをメッセージに含める）
- 解決値が dictionary 以外 → `INFO_NOT_DICTIONARY` 警告 + 空 metadata
- 9 フィールド抽出: テキスト 6 (`Title` / `Author` / `Subject` / `Keywords` / `Creator` / `Producer`) は `decodePdfString` 委譲、日時 2 (`CreationDate` / `ModDate`) は `decodePdfString` + `parsePdfDate` 委譲（警告 push は caller 側で実施）、`Trapped` は `parseTrappedName` 委譲
- 値が `undefined` のフィールドは出力オブジェクトから省略（PR #98 review 反映）
- 共有 `EMPTY_METADATA` を `Object.freeze({})` で凍結（PR #98 review 反映）
- behavior テスト 17 件と test ヘルパファイルを新規作成

#### 変更されたファイル

- `packages/core/src/document/document-info-parser.ts` (NEW, 220 行)
- `packages/core/src/document/document-info-parser.behavior.test.ts` (NEW, 258 行)
- `packages/core/src/document/document-info-parser.test.helpers.ts` (NEW, 141 行)

#### 削除されたファイル・機能

なし

## 📊 システム図

### parse(trailerDict, resolveRef) フロー

\`\`\`mermaid
flowchart TD
    Start([parse]) --> CheckInfo{trailerDict.info\nundefined?}
    CheckInfo -->|Yes| EmptyOk[Ok: EMPTY_METADATA, []]:::new
    CheckInfo -->|No| Resolve[await resolveRef]
    Resolve --> ResolveOk{resolved.ok?}
    ResolveOk -->|No| InfoResolveFailed[push INFO_RESOLVE_FAILED]:::new
    InfoResolveFailed --> EmptyOk2[Ok: EMPTY_METADATA, warnings]:::new
    ResolveOk -->|Yes| TypeCheck{type === 'dictionary'?}
    TypeCheck -->|No| InfoNotDict[push INFO_NOT_DICTIONARY]:::new
    InfoNotDict --> EmptyOk3[Ok: EMPTY_METADATA, warnings]:::new
    TypeCheck -->|Yes| Extract[extractMetadata]:::new
    Extract --> OkResult[Ok: metadata, warnings]:::new

    classDef new fill:#ffe4b5,stroke:#d97706,stroke-width:2px
\`\`\`

### extractMetadata の helper 委譲構造

\`\`\`mermaid
flowchart LR
    Dict[/Info dict entries] --> ReadStr[readStringField x6]:::new
    Dict --> ReadDate[readDateField x2]:::new
    Dict --> ParseTrapped[parseTrappedName]
    ReadStr -->|PdfString以外| StrWarn[STRING_DECODE_FAILED]:::new
    ReadStr -->|OK| DecodePdfStr[decodePdfString]
    ReadDate -->|PdfString以外| DateWarn1[DATE_PARSE_FAILED]:::new
    ReadDate -->|OK| DecodeThen[decodePdfString → parsePdfDate]
    DecodeThen -->|undefined| DateWarn2[DATE_PARSE_FAILED caller push]:::new
    ParseTrapped -->|未知| TrappedWarn[TRAPPED_INVALID]
    DecodePdfStr --> Metadata[DocumentMetadata]
    DecodeThen --> Metadata
    ParseTrapped --> Metadata

    classDef new fill:#ffe4b5,stroke:#d97706,stroke-width:2px
\`\`\`

## 📋 関連 Issue

- Refs #18
- Depends on PR #93 (warning codes), #94 (pdf-doc-encoding), #95 (decode-pdf-string), #99 (parsePdfDate), #100 (DocumentMetadata)

## 🧪 テスト

### テスト実行方法

\`\`\`bash
pnpm --filter @pdfmod/core test document-info-parser
pnpm test:run
pnpm --filter @pdfmod/core typecheck
pnpm lint
\`\`\`

### テスト項目

- [x] 単体テスト (Unit tests)
- [x] 統合テスト (Integration tests) — 全 9 フィールド統合テスト含む

### テスト結果

- ✅ `document-info-parser.behavior.test.ts` 17 件 green
- ✅ 全パッケージ 1305 件 green
- ✅ typecheck エラーなし
- ✅ lint 警告なし

#### カバーした観点

| カテゴリ | テスト |
|---|---|
| DI-002 | /Info 不在 → 空 metadata + 空 warnings (resolver 未呼び出し検証) |
| DI-001 (a) | ASCII Title 単体抽出 |
| DI-001 (b) | テキスト 6 フィールド全抽出 |
| UTF-16BE | 多言語 (日本語) / 補助平面 (🚀) |
| 型不一致 | /Title 数値 → STRING_DECODE_FAILED |
| 日時 | `+09'00'` TZ / `Z` UTC / `D:abcd` 不正 / 数値型 |
| Trapped | True / False / Unknown / 未知 'Yes' |
| Resolver 異常 | err → INFO_RESOLVE_FAILED / 非辞書 (stream) → INFO_NOT_DICTIONARY |
| 統合 | 全 9 フィールド同時抽出 |

## 🔍 レビューポイント

- `EMPTY_METADATA` は `Object.freeze({})` で凍結し、複数 `parse()` 呼び出しから同一参照を返してもミューテーション波及がない設計（PR #98 review 反映）
- `extractMetadata` は値が `undefined` のフィールドをオブジェクトから省略（`metadata.title === undefined` ではなく `"title" in metadata === false`）
- `parsePdfDate` は警告 push を行わない pure 関数なので、`undefined` を検出した時点で `readDateField` (caller) 側で `DATE_PARSE_FAILED` 警告を push する設計
- import パスは `./pdf-date`（PR #99 で `parse-pdf-date.ts` から rename 済み）
- `Result.err` 経路は現状未使用（resolver は契約上 reject せず err を Ok 化）

## ⚠️ 破壊的変更

- [ ] この変更は既存の API に破壊的変更を含みます

なし。新規追加のみで既存 API には影響しません。なお root export (`packages/core/src/index.ts` / `document/index.ts`) は本 PR には含めず PR 7 に委譲しています。

## 📚 追加情報

### 参考資料

- 実装計画: `.specs/036-document-info-parser/implementation-plan.md` §4.2 / §4.3 / §4.4
- タスク仕様: `.specs/036-document-info-parser/split/tasks-06-document-info-parser.md`
- 過去レビュー: PR #98 (closed) — Copilot レビュー指摘 4 件のうち本 PR に該当する 2 件 (EMPTY_METADATA 共有 / extractMetadata 未指定キー出力) を反映
- Codex 自動レビューはサンドボックス制約により未実行 (詳細: `.specs/036-document-info-parser/code-review/review-010.md`)

## ✅ チェックリスト

- [x] コードレビューの準備ができている
- [x] テストが正常に実行される (1305/1305 pass)
- [x] コミットメッセージが適切な形式で書かれている
- [x] 関連する Issue (#18) が PR 本文に記載されている
- [x] セルフレビューを実施した
- [x] 破壊的変更なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)