### PR TITLE
✨ [New Feature]: #18 DocumentInfoParser を root export に追加 (PR 7/7)

### DIFF
--- a/packages/core/src/document/index.ts
+++ b/packages/core/src/document/index.ts
@@ -1,5 +1,9 @@
 export type { ParsedCatalog, ResolveRef } from "./catalog-parser";
 export { CatalogParser } from "./catalog-parser";
+export type { ParsedDocumentInfo } from "./document-info-parser";
+export { DocumentInfoParser } from "./document-info-parser";
+export type { DocumentMetadata } from "./document-metadata";
+export { PdfTrapped } from "./document-metadata";
 export type {
   InheritedAttrs,
   PageRotate,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -6,9 +6,11 @@
  */
 
 export type {
+  DocumentMetadata,
   InheritedAttrs,
   PageRotate,
   ParsedCatalog,
+  ParsedDocumentInfo,
   PdfRectangle,
   ResolvedPage,
   ResolveInheritedOutcome,
@@ -17,8 +19,10 @@ export type {
 } from "./document/index";
 export {
   CatalogParser,
+  DocumentInfoParser,
   InheritanceResolver,
   PageTreeWalker,
+  PdfTrapped,
 } from "./document/index";
 export { NumberEx } from "./ext/number/index";
 export { Tokenizer } from "./lexer/index";

--- a/packages/core/src/namespace-export.runtime.test.ts
+++ b/packages/core/src/namespace-export.runtime.test.ts
@@ -2,6 +2,7 @@ import { expect, test } from "vitest";
 import {
   ByteOffset,
   CatalogParser,
+  DocumentInfoParser,
   GenerationNumber,
   InheritanceResolver,
   LRUCache,
@@ -11,6 +12,7 @@ import {
   ObjectStreamBody,
   ObjectStreamHeader,
   PageTreeWalker,
+  PdfTrapped,
   PdfVersion,
   parseTrailer,
   parseXRefTable,
@@ -36,6 +38,8 @@ test.each([
   { name: "CatalogParser.parse", value: CatalogParser.parse },
   { name: "PageTreeWalker.walk", value: PageTreeWalker.walk },
   { name: "InheritanceResolver.resolve", value: InheritanceResolver.resolve },
+  { name: "DocumentInfoParser.parse", value: DocumentInfoParser.parse },
+  { name: "PdfTrapped.create", value: PdfTrapped.create },
 ])("$nameがルートからexportされている", ({ value }) => {
   expect(typeof value).toBe("function");
 });


### PR DESCRIPTION
## Summary

DocumentInfoParser (#18) の最終 PR。PR 1〜6 で実装した DocumentInfoParser 系シンボルを `@pdfmod/core` ルートから export し、`namespace-export.runtime.test.ts` を同期する。

これにより外部から `import { DocumentInfoParser, PdfTrapped, DocumentMetadata, ParsedDocumentInfo } from \"@pdfmod/core\"` が可能になる。

## Changes

- [MODIFY] `packages/core/src/document/index.ts`: 4 シンボル re-export 追加
  - value: `DocumentInfoParser`, `PdfTrapped`
  - type: `DocumentMetadata`, `ParsedDocumentInfo`
- [MODIFY] `packages/core/src/index.ts`: 同 4 シンボルを root から re-export（アルファベット昇順）
- [MODIFY] `packages/core/src/namespace-export.runtime.test.ts`: `DocumentInfoParser.parse` / `PdfTrapped.create` を `test.each` リストに追加

## 計画書からの差分

計画書 (split/tasks-07-root-export.md) では `TrappedState` / `ParseDocumentInfoResult` という名前だったが、PR 6 マージ前後のリネームで以下になった:
- `TrappedState` → `PdfTrapped`（Brand 型 + companion object に変更され value+type の両方を export）
- `ParseDocumentInfoResult` → `ParsedDocumentInfo`

また、計画書では `namespace-export.type.test.ts` への型サンプル + 構造アサーション追加が含まれていたが、本リポジトリの方針「型で保証される制約を runtime expect で再確認するテストは書かない」に基づき本 PR では追加していない。型 export の到達性は tsc が保証する。代わりに value-bearing な `DocumentInfoParser.parse` / `PdfTrapped.create` を runtime test.each に追加することで export 反映を担保している。

## Why

PR 6 までで本体実装が完了したため、最終 PR として外部公開 API を整える。Issue #18 の DoD §8.4「公開 API」を満たす。

## Test plan

- [x] \`pnpm --filter @pdfmod/core test namespace-export\` パス（30 tests）
- [x] \`pnpm test\` 全プロジェクトパス（93 ファイル / 1315 tests）
- [x] \`pnpm typecheck\` パス
- [x] \`pnpm lint\` パス
- [x] Codex レビュー「問題なし」（review-011.md）

## Refs

- Closes #18
- Depends on PR #100 (PR 5: document-metadata) ・ PR #103 (PR 6: document-info-parser)
- Implementation plan: \`.specs/036-document-info-parser/implementation-plan.md\` §4.6〜§4.9
- Split index: \`.specs/036-document-info-parser/split/README.md\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)