### PR TITLE
feat(#19): フォールバック XRef 再構築 (FB-001 + FB-003) を追加

### DIFF
--- a/docs/pdf-parsing-pipeline/error-handling-spec.md
+++ b/docs/pdf-parsing-pipeline/error-handling-spec.md
@@ -252,7 +252,9 @@ packages/core/src/
 │   ├── index.ts          # 再エクスポート
 │   └── result.ts         # Result<T, E> 型 + ok/err/map/flatMap/unwrapOr
 ├── xref/
-│   └── fallback-scanner.ts   # フォールバックXRefスキャナ
+│   └── fallback/
+│       ├── fallback-scanner.ts   # フォールバックXRefスキャナ
+│       └── object-scanner.ts     # `\d+ \d+ obj` ヘッダのバイト走査ヘルパー
 ```
 
 ## 関連仕様

--- a/packages/core/src/xref/fallback/fallback-scanner.behavior.test.ts
+++ b/packages/core/src/xref/fallback/fallback-scanner.behavior.test.ts
@@ -75,6 +75,21 @@ test("XRefTable.size は max(objectNumber) + 1 で計算される", () => {
   expect(result.value.xrefTable.entries.size).toBe(3);
 });
 
+test("MAX_SAFE_INTEGER のオブジェクト番号は size 超過のため skip され、recovery に size-overflow が記録される", () => {
+  const maxSafeInt = String(Number.MAX_SAFE_INTEGER);
+  const body = `1 0 obj\n<<>>\nendobj\n${maxSafeInt} 0 obj\n<<>>\nendobj\n`;
+  const data = encode(body);
+  const result = scanFallback(data);
+  assert(result.ok);
+  expect(Number.isSafeInteger(result.value.xrefTable.size)).toBe(true);
+  expect(result.value.xrefTable.size).toBe(2);
+  expect(result.value.xrefTable.entries.size).toBe(1);
+  expect(result.value.warnings).toHaveLength(1);
+  const warning = result.value.warnings[0];
+  expect(warning.code).toBe("XREF_REBUILD");
+  expect(warning.recovery).toContain("size-overflow");
+});
+
 test("skip 候補があっても warnings は XREF_REBUILD 1 件のみで recovery に集約される", () => {
   const overflow = "9".repeat(21);
   const body =

--- a/packages/core/src/xref/fallback/fallback-scanner.behavior.test.ts
+++ b/packages/core/src/xref/fallback/fallback-scanner.behavior.test.ts
@@ -1,0 +1,109 @@
+import { assert, expect, test } from "vitest";
+import {
+  ByteOffset,
+  GenerationNumber,
+  ObjectNumber,
+} from "../../pdf/types/index";
+import { scanFallback } from "./fallback-scanner";
+
+function encode(s: string): Uint8Array {
+  return new TextEncoder().encode(s);
+}
+
+test("`1 0 obj` 1 件含むデータから XRefTable を構築する (FB-001)", () => {
+  const data = encode("1 0 obj\n<<>>\nendobj\n");
+  const result = scanFallback(data);
+  assert(result.ok);
+  const { xrefTable, trailer, warnings } = result.value;
+  expect(xrefTable.entries.size).toBe(1);
+  expect(xrefTable.size).toBe(2);
+  expect(xrefTable.entries.get(ObjectNumber.of(1))).toEqual({
+    type: 1,
+    offset: ByteOffset.of(0),
+    generationNumber: GenerationNumber.of(0),
+  });
+  expect(trailer).toBeUndefined();
+  expect(warnings).toHaveLength(1);
+  expect(warnings[0].code).toBe("XREF_REBUILD");
+});
+
+test("`obj` 皆無のデータでは空 XRefTable と XREF_REBUILD warning 1 件を返す", () => {
+  const data = encode("%PDF-1.7\n%%EOF\n");
+  const result = scanFallback(data);
+  assert(result.ok);
+  const { xrefTable, warnings } = result.value;
+  expect(xrefTable.entries.size).toBe(0);
+  expect(xrefTable.size).toBe(0);
+  expect(warnings).toHaveLength(1);
+  expect(warnings[0].code).toBe("XREF_REBUILD");
+});
+
+test.each([
+  ["empty", new Uint8Array(0)],
+  ["1KB 未満", new Uint8Array(512)],
+])("境界条件 %s でもエラーにならず空 XRefTable を返す", (_label, data) => {
+  const result = scanFallback(data);
+  assert(result.ok);
+  expect(result.value.xrefTable.entries.size).toBe(0);
+  expect(result.value.xrefTable.size).toBe(0);
+  expect(result.value.warnings).toHaveLength(1);
+  expect(result.value.warnings[0].code).toBe("XREF_REBUILD");
+});
+
+test("同一オブジェクト番号の重複は末尾優先で採用される (FB-003)", () => {
+  const body = "1 0 obj\n<<>>\nendobj\n1 0 obj\n<</Late true>>\nendobj\n";
+  const data = encode(body);
+  const result = scanFallback(data);
+  assert(result.ok);
+  const entry = result.value.xrefTable.entries.get(ObjectNumber.of(1));
+  const lastOffset = body.lastIndexOf("1 0 obj");
+  expect(entry).toEqual({
+    type: 1,
+    offset: ByteOffset.of(lastOffset),
+    generationNumber: GenerationNumber.of(0),
+  });
+  expect(result.value.xrefTable.entries.size).toBe(1);
+  expect(result.value.xrefTable.size).toBe(2);
+});
+
+test("XRefTable.size は max(objectNumber) + 1 で計算される", () => {
+  const body = "1 0 obj\nx\nendobj\n5 0 obj\nx\nendobj\n3 0 obj\nx\nendobj\n";
+  const data = encode(body);
+  const result = scanFallback(data);
+  assert(result.ok);
+  expect(result.value.xrefTable.size).toBe(6);
+  expect(result.value.xrefTable.entries.size).toBe(3);
+});
+
+test("skip 候補があっても warnings は XREF_REBUILD 1 件のみで recovery に集約される", () => {
+  const overflow = "9".repeat(21);
+  const body =
+    "1 0 obj\n<<>>\nendobj\n" +
+    `${overflow} 0 obj\n<<>>\nendobj\n` +
+    "2 70000 obj\n<<>>\nendobj\n";
+  const data = encode(body);
+  const result = scanFallback(data);
+  assert(result.ok);
+  expect(result.value.warnings).toHaveLength(1);
+  const warning = result.value.warnings[0];
+  expect(warning.code).toBe("XREF_REBUILD");
+  expect(warning.recovery).toBeDefined();
+  expect(warning.recovery).toContain("2");
+  expect(warning.recovery).toContain("object-number-invalid");
+  expect(warning.recovery).toContain("generation-invalid");
+});
+
+test.each([
+  ["empty", new Uint8Array(0)],
+  ["random 512 bytes", new Uint8Array(512).fill(0x41)],
+  ["single obj", new TextEncoder().encode("1 0 obj\n<<>>\nendobj\n")],
+  [
+    "skip mixed",
+    new TextEncoder().encode(
+      "1 0 obj\n<<>>\nendobj\n2 70000 obj\n<<>>\nendobj\n",
+    ),
+  ],
+])("任意の入力 %s で常に ok を返す", (_label, data) => {
+  const result = scanFallback(data);
+  expect(result.ok).toBe(true);
+});

--- a/packages/core/src/xref/fallback/fallback-scanner.ts
+++ b/packages/core/src/xref/fallback/fallback-scanner.ts
@@ -2,8 +2,8 @@ import type { PdfError, PdfWarning } from "../../pdf/errors/index";
 import type {
   ObjectNumber,
   TrailerDict,
+  XRefEntry,
   XRefTable,
-  XRefUsedEntry,
 } from "../../pdf/types/index";
 import type { Result } from "../../utils/result/index";
 import { ok } from "../../utils/result/index";
@@ -36,7 +36,7 @@ export interface FallbackScanResult {
  * @returns 再構築した XRefTable
  */
 function rebuildXRefTable(hits: readonly ObjectHit[]): XRefTable {
-  const entries = new Map<ObjectNumber, XRefUsedEntry>();
+  const entries = new Map<ObjectNumber, XRefEntry>();
   let maxObjectNumber = -1;
   for (const hit of hits) {
     entries.set(hit.objectNumber, {

--- a/packages/core/src/xref/fallback/fallback-scanner.ts
+++ b/packages/core/src/xref/fallback/fallback-scanner.ts
@@ -111,7 +111,7 @@ function formatRecoveryMessage(
  * @param sizeOverflowCount - `xrefTable.size` 超過のため skip した hit 数
  * @returns `XREF_REBUILD` コードを持つ単一の警告
  */
-function buildRebuildWarning(
+function formatRebuildWarning(
   report: ObjectScanReport,
   sizeOverflowCount: number,
 ): PdfWarning {
@@ -136,6 +136,6 @@ export function scanFallback(
 ): Result<FallbackScanResult, PdfError> {
   const report = scanObjectHeaders(data);
   const { xrefTable, sizeOverflowCount } = rebuildXRefTable(report.hits);
-  const warning = buildRebuildWarning(report, sizeOverflowCount);
+  const warning = formatRebuildWarning(report, sizeOverflowCount);
   return ok({ xrefTable, trailer: undefined, warnings: [warning] });
 }

--- a/packages/core/src/xref/fallback/fallback-scanner.ts
+++ b/packages/core/src/xref/fallback/fallback-scanner.ts
@@ -81,7 +81,7 @@ type FallbackSkipReason = ObjectScanSkipped["reason"] | "size-overflow";
  * skip 候補（object-scanner 由来 + size 超過）の件数・理由カテゴリから
  * `recovery` 用の文字列を組み立てる。skip が無ければ `undefined` を返す。
  */
-function buildSkippedRecovery(
+function formatRecoveryMessage(
   skipped: readonly ObjectScanSkipped[],
   sizeOverflowCount: number,
 ): string | undefined {
@@ -115,7 +115,7 @@ function buildRebuildWarning(
   report: ObjectScanReport,
   sizeOverflowCount: number,
 ): PdfWarning {
-  const recovery = buildSkippedRecovery(report.skipped, sizeOverflowCount);
+  const recovery = formatRecoveryMessage(report.skipped, sizeOverflowCount);
   const acceptedHits = report.hits.length - sizeOverflowCount;
   const message = `Reconstructed xref by scanning ${acceptedHits} objects`;
   if (recovery === undefined) {

--- a/packages/core/src/xref/fallback/fallback-scanner.ts
+++ b/packages/core/src/xref/fallback/fallback-scanner.ts
@@ -1,0 +1,106 @@
+import type { PdfError, PdfWarning } from "../../pdf/errors/index";
+import type {
+  ObjectNumber,
+  TrailerDict,
+  XRefTable,
+  XRefUsedEntry,
+} from "../../pdf/types/index";
+import type { Result } from "../../utils/result/index";
+import { ok } from "../../utils/result/index";
+import {
+  type ObjectHit,
+  type ObjectScanReport,
+  type ObjectScanSkipped,
+  scanObjectHeaders,
+} from "./object-scanner";
+
+/**
+ * フォールバック XRef スキャン結果。
+ *
+ * - `xrefTable`: 復元した XRef テーブル（空でも返す）
+ * - `trailer`: trailer 直接取得 / Catalog 推定 / 取得不可（undefined）の三状態。本 PR 範囲では常に `undefined`。
+ * - `warnings`: `XREF_REBUILD` を 1 件含む。skip 件数・理由カテゴリは同 warning の `recovery` に集約。
+ */
+export interface FallbackScanResult {
+  readonly xrefTable: XRefTable;
+  readonly trailer: TrailerDict | undefined;
+  readonly warnings: readonly PdfWarning[];
+}
+
+/**
+ * ObjectHit 列から XRefTable を再構築する (FB-001 + FB-003)。
+ * 先頭→末尾順に `Map.set` するため、同一オブジェクト番号は末尾候補が勝つ。
+ * `size` は `max(objectNumber) + 1`。hits が空の場合は size=0 の空 table。
+ *
+ * @param hits - object-scanner が検出した ObjectHit 列
+ * @returns 再構築した XRefTable
+ */
+function rebuildXRefTable(hits: readonly ObjectHit[]): XRefTable {
+  const entries = new Map<ObjectNumber, XRefUsedEntry>();
+  let maxObjectNumber = -1;
+  for (const hit of hits) {
+    entries.set(hit.objectNumber, {
+      type: 1,
+      offset: hit.offset,
+      generationNumber: hit.generation,
+    });
+    if (hit.objectNumber > maxObjectNumber) {
+      maxObjectNumber = hit.objectNumber;
+    }
+  }
+  return { entries, size: maxObjectNumber + 1 };
+}
+
+/**
+ * `ObjectScanSkipped` を理由カテゴリごとに集計し、`recovery` 用の文字列を組み立てる。
+ * 例: `"Skipped 2 invalid candidates: 1 object-number-invalid, 1 generation-invalid"`
+ * skipped が空の場合は `undefined` を返す。
+ */
+function summarizeSkippedRecovery(
+  skipped: readonly ObjectScanSkipped[],
+): string | undefined {
+  if (skipped.length === 0) {
+    return undefined;
+  }
+  const counts = new Map<ObjectScanSkipped["reason"], number>();
+  for (const entry of skipped) {
+    counts.set(entry.reason, (counts.get(entry.reason) ?? 0) + 1);
+  }
+  const parts: string[] = [];
+  for (const [reason, count] of counts) {
+    parts.push(`${count} ${reason}`);
+  }
+  return `Skipped ${skipped.length} invalid candidates: ${parts.join(", ")}`;
+}
+
+/**
+ * 再構築 1 回につき 1 件発行する `XREF_REBUILD` warning を組み立てる。
+ * skip 候補の件数・理由カテゴリは `recovery` フィールドに集約する。
+ *
+ * @param report - object-scanner の走査結果（hits 件数 / skipped 集計）
+ * @returns `XREF_REBUILD` コードを持つ単一の警告
+ */
+function buildRebuildWarning(report: ObjectScanReport): PdfWarning {
+  const recovery = summarizeSkippedRecovery(report.skipped);
+  const message = `Reconstructed xref by scanning ${report.hits.length} objects`;
+  if (recovery === undefined) {
+    return { code: "XREF_REBUILD", message };
+  }
+  return { code: "XREF_REBUILD", message, recovery };
+}
+
+/**
+ * xref 通常パース失敗時のフォールバックスキャナ (#19)。
+ * 本 PR 範囲では FB-001 + FB-003 のみ実装し、trailer は常に `undefined` を返す。
+ *
+ * @param data - PDF ファイル全体のバイト配列
+ * @returns 復元した XRef テーブルと warnings（trailer は後続 PR で実装）
+ */
+export function scanFallback(
+  data: Uint8Array,
+): Result<FallbackScanResult, PdfError> {
+  const report = scanObjectHeaders(data);
+  const xrefTable = rebuildXRefTable(report.hits);
+  const warning = buildRebuildWarning(report);
+  return ok({ xrefTable, trailer: undefined, warnings: [warning] });
+}

--- a/packages/core/src/xref/fallback/fallback-scanner.ts
+++ b/packages/core/src/xref/fallback/fallback-scanner.ts
@@ -78,10 +78,10 @@ function rebuildXRefTable(hits: readonly ObjectHit[]): RebuildResult {
 type FallbackSkipReason = ObjectScanSkipped["reason"] | "size-overflow";
 
 /**
- * skip 候補（object-scanner 由来 + size 超過）を理由カテゴリごとに集計し、
+ * skip 候補（object-scanner 由来 + size 超過）の件数・理由カテゴリから
  * `recovery` 用の文字列を組み立てる。skip が無ければ `undefined` を返す。
  */
-function summarizeSkippedRecovery(
+function buildSkippedRecovery(
   skipped: readonly ObjectScanSkipped[],
   sizeOverflowCount: number,
 ): string | undefined {
@@ -115,7 +115,7 @@ function buildRebuildWarning(
   report: ObjectScanReport,
   sizeOverflowCount: number,
 ): PdfWarning {
-  const recovery = summarizeSkippedRecovery(report.skipped, sizeOverflowCount);
+  const recovery = buildSkippedRecovery(report.skipped, sizeOverflowCount);
   const acceptedHits = report.hits.length - sizeOverflowCount;
   const message = `Reconstructed xref by scanning ${acceptedHits} objects`;
   if (recovery === undefined) {

--- a/packages/core/src/xref/fallback/fallback-scanner.ts
+++ b/packages/core/src/xref/fallback/fallback-scanner.ts
@@ -28,17 +28,38 @@ export interface FallbackScanResult {
 }
 
 /**
+ * `XRefTable.size` は `max(objectNumber) + 1` で算出するため、
+ * `objectNumber === MAX_SAFE_INTEGER` の hit は size を不正値に押し上げる。
+ * `parseXRefTable` 側の挙動（safe integer 超過は明示的に拒否）と整合させる。
+ */
+const MAX_OBJECT_NUMBER_FOR_SIZE = Number.MAX_SAFE_INTEGER - 1;
+
+/**
+ * size 超過 hit の集計結果。
+ */
+interface RebuildResult {
+  readonly xrefTable: XRefTable;
+  readonly sizeOverflowCount: number;
+}
+
+/**
  * ObjectHit 列から XRefTable を再構築する (FB-001 + FB-003)。
  * 先頭→末尾順に `Map.set` するため、同一オブジェクト番号は末尾候補が勝つ。
- * `size` は `max(objectNumber) + 1`。hits が空の場合は size=0 の空 table。
+ * `size = max(objectNumber) + 1`。`objectNumber > MAX_SAFE_INTEGER - 1` の hit は
+ * skip して safe integer を保証する（件数は呼び出し側で warning に集約する）。
  *
  * @param hits - object-scanner が検出した ObjectHit 列
- * @returns 再構築した XRefTable
+ * @returns 再構築した XRefTable と size 超過で skip した件数
  */
-function rebuildXRefTable(hits: readonly ObjectHit[]): XRefTable {
+function rebuildXRefTable(hits: readonly ObjectHit[]): RebuildResult {
   const entries = new Map<ObjectNumber, XRefEntry>();
   let maxObjectNumber = -1;
+  let sizeOverflowCount = 0;
   for (const hit of hits) {
+    if (hit.objectNumber > MAX_OBJECT_NUMBER_FOR_SIZE) {
+      sizeOverflowCount++;
+      continue;
+    }
     entries.set(hit.objectNumber, {
       type: 1,
       offset: hit.offset,
@@ -48,29 +69,38 @@ function rebuildXRefTable(hits: readonly ObjectHit[]): XRefTable {
       maxObjectNumber = hit.objectNumber;
     }
   }
-  return { entries, size: maxObjectNumber + 1 };
+  return {
+    xrefTable: { entries, size: maxObjectNumber + 1 },
+    sizeOverflowCount,
+  };
 }
 
+type FallbackSkipReason = ObjectScanSkipped["reason"] | "size-overflow";
+
 /**
- * `ObjectScanSkipped` を理由カテゴリごとに集計し、`recovery` 用の文字列を組み立てる。
- * 例: `"Skipped 2 invalid candidates: 1 object-number-invalid, 1 generation-invalid"`
- * skipped が空の場合は `undefined` を返す。
+ * skip 候補（object-scanner 由来 + size 超過）を理由カテゴリごとに集計し、
+ * `recovery` 用の文字列を組み立てる。skip が無ければ `undefined` を返す。
  */
 function summarizeSkippedRecovery(
   skipped: readonly ObjectScanSkipped[],
+  sizeOverflowCount: number,
 ): string | undefined {
-  if (skipped.length === 0) {
+  if (skipped.length === 0 && sizeOverflowCount === 0) {
     return undefined;
   }
-  const counts = new Map<ObjectScanSkipped["reason"], number>();
+  const counts = new Map<FallbackSkipReason, number>();
   for (const entry of skipped) {
     counts.set(entry.reason, (counts.get(entry.reason) ?? 0) + 1);
+  }
+  if (sizeOverflowCount > 0) {
+    counts.set("size-overflow", sizeOverflowCount);
   }
   const parts: string[] = [];
   for (const [reason, count] of counts) {
     parts.push(`${count} ${reason}`);
   }
-  return `Skipped ${skipped.length} invalid candidates: ${parts.join(", ")}`;
+  const total = skipped.length + sizeOverflowCount;
+  return `Skipped ${total} invalid candidates: ${parts.join(", ")}`;
 }
 
 /**
@@ -78,11 +108,16 @@ function summarizeSkippedRecovery(
  * skip 候補の件数・理由カテゴリは `recovery` フィールドに集約する。
  *
  * @param report - object-scanner の走査結果（hits 件数 / skipped 集計）
+ * @param sizeOverflowCount - `xrefTable.size` 超過のため skip した hit 数
  * @returns `XREF_REBUILD` コードを持つ単一の警告
  */
-function buildRebuildWarning(report: ObjectScanReport): PdfWarning {
-  const recovery = summarizeSkippedRecovery(report.skipped);
-  const message = `Reconstructed xref by scanning ${report.hits.length} objects`;
+function buildRebuildWarning(
+  report: ObjectScanReport,
+  sizeOverflowCount: number,
+): PdfWarning {
+  const recovery = summarizeSkippedRecovery(report.skipped, sizeOverflowCount);
+  const acceptedHits = report.hits.length - sizeOverflowCount;
+  const message = `Reconstructed xref by scanning ${acceptedHits} objects`;
   if (recovery === undefined) {
     return { code: "XREF_REBUILD", message };
   }
@@ -100,7 +135,7 @@ export function scanFallback(
   data: Uint8Array,
 ): Result<FallbackScanResult, PdfError> {
   const report = scanObjectHeaders(data);
-  const xrefTable = rebuildXRefTable(report.hits);
-  const warning = buildRebuildWarning(report);
+  const { xrefTable, sizeOverflowCount } = rebuildXRefTable(report.hits);
+  const warning = buildRebuildWarning(report, sizeOverflowCount);
   return ok({ xrefTable, trailer: undefined, warnings: [warning] });
 }


### PR DESCRIPTION
## 概要

xref 通常パース失敗時のフォールバックスキャナ `scanFallback` の **FB-001 (XRefTable 再構築)** と **FB-003 (同一オブジェクト番号の末尾優先)** を実装する。

PR1 (#105) で導入済みの `scanObjectHeaders` が返す `ObjectHit` 列を `Map<ObjectNumber, XRefUsedEntry>` に詰め、構造を失った PDF からでも XRefTable を復元する責務を担う。本 PR の範囲では trailer は `undefined` 固定で、trailer 探索 (FB-002) と Catalog 推定 (FB-004) は PR3 で追加する。

## 変更内容

### 🎯 変更の種類

- [x] ✨ 新機能 (New feature)
- [x] 🚨 テスト追加/修正 (Tests)

### 📝 詳細な変更内容

#### 追加された機能・修正

- `scanFallback(data: Uint8Array): Result<FallbackScanResult, PdfError>` を新設（関数 export、companion object 化しない）
- `FallbackScanResult { xrefTable, trailer, warnings }` 型を export（trailer は本 PR では `undefined` 固定）
- `rebuildXRefTable`: 先頭→末尾順に `Map.set` するため、同一オブジェクト番号は末尾候補が勝つ (FB-003)。`size = max(objectNumber) + 1`
- `summarizeSkippedRecovery` / `buildRebuildWarning`: 再構築 1 回につき `XREF_REBUILD` warning を 1 件のみ発行し、skip 候補の件数・理由カテゴリを `recovery` フィールドに集約

#### 変更されたファイル

- [NEW] `packages/core/src/xref/fallback/fallback-scanner.ts`
- [NEW] `packages/core/src/xref/fallback/fallback-scanner.behavior.test.ts`（11 tests, 正常系 / 境界 / FB-003 / size / skip 集約 / Result 整合 を `test.each` で集約）

#### 削除されたファイル・機能

- なし（破壊的変更なし、追加のみ）

## 📊 システム図

### フロー図

```mermaid
flowchart TD
    Start([scanFallback - data: Uint8Array]) --> Scan["scanObjectHeaders - PR1 既存"]
    Scan --> Hits{ObjectHit 列}
    Hits --> Rebuild["rebuildXRefTable - FB-001 + FB-003"]:::new
    Rebuild --> Map[(Map - 先頭→末尾順 set, 末尾優先)]:::new
    Map --> Size["size = max + 1"]:::new
    Size --> Warn["buildRebuildWarning - 1 件のみ発行 + recovery 集約"]:::new
    Warn --> Emit[("ok - xrefTable, trailer=undefined, warnings")]:::new
    Emit --> End([Result])

    classDef new fill:#ffe4b5,stroke:#d97706,stroke-width:2px
```

### データフロー

```
Uint8Array (PDF file)
    ↓
scanObjectHeaders(data)            [PR1 既存]
    ├─ hits: ObjectHit[]
    └─ skipped: ObjectScanSkipped[]
    ↓
rebuildXRefTable(hits)             [NEW: FB-001 + FB-003]
    ↓
Map<ObjectNumber, XRefUsedEntry>   先頭→末尾順 set → 末尾優先
    ↓
XRefTable { entries, size = max+1 }
    ↓
buildRebuildWarning(report)        [NEW]
    └─ recovery: "Skipped K invalid candidates: N object-number-invalid, M generation-invalid"
    ↓
ok({ xrefTable, trailer: undefined, warnings: [XREF_REBUILD] })
```

## 📋 関連 Issue

- Refs #19
- Spec: `docs/pdf-parsing-pipeline/error-handling-spec.md` §FB-001, §FB-003
- Depends on: #105 (PR 1 / 5)
- Spec doc: `.specs/038-fallback-xref-scanner/implementation-plan.md`

## 🧪 テスト

### テスト実行方法

```bash
pnpm --filter @pdfmod/core test src/xref/fallback/fallback-scanner
pnpm --filter @pdfmod/core typecheck
```

### テスト項目

- [x] 単体テスト (Unit tests)

### テスト結果

- `pnpm --filter @pdfmod/core test` 全 1343 テストグリーン（fallback-scanner.behavior 11 tests 含む）
- `pnpm --filter @pdfmod/core typecheck` クリーン
- `pnpm lint` (biome + oxlint) エラー 0

#### 網羅シナリオ（test.each で集約）

- ✅ FB-001: `\d+ \d+ obj` 検出 → `XRefTable` 構築 / `size = max + 1`
- ✅ FB-003: 同一オブジェクト番号重複時に末尾優先
- ✅ 空ファイル / 1KB 未満 / `obj` 皆無 → 空 `XRefTable` + warning 1 件
- ✅ skip 集約: safe-int 違反 + GenerationNumber 範囲外 を混在しても `warnings.length === 1`、`recovery` に件数・理由カテゴリ
- ✅ Result 整合: 任意の入力で常に `result.ok === true`

## 🔍 レビューポイント

- `rebuildXRefTable` の Map.set 順序が末尾優先（FB-003）の根拠になっている点 — `mergeXRefChain` の newer-overrides-older と同じ設計
- `summarizeSkippedRecovery` を caller ローカルに置いている（外からコールバックを受ける汎用 util にしない方針）
- skip 候補の理由カテゴリは `object-scanner.ObjectScanSkipped.reason` (`object-number-invalid` / `generation-invalid`) をそのまま利用
- 本 PR では trailer は `undefined` 固定。FB-002 / FB-004 は PR3 で追加するため、テストでも `expect(trailer).toBeUndefined()` で固定確認

## ⚠️ 破壊的変更

- [ ] この変更は既存の API に破壊的変更を含みます

なし。新規ファイル追加のみ。

## ✅ チェックリスト

- [x] コードレビューの準備ができている
- [x] テストが正常に実行される
- [x] コミットメッセージが適切な形式で書かれている
- [x] 関連する Issue (#19) が記載されている
- [x] セルフレビューを実施した（Codex review-004.md: 問題なし）
- [x] 破壊的変更なし

## 🤝 レビュアーへのお願い

- FB-001 / FB-003 の受入条件 (`error-handling-spec.md` §FB-001 / §FB-003) を満たしているか確認してください
- `XREF_REBUILD` warning が「再構築 1 回につき 1 件のみ」になっており、skip 詳細が `recovery` に集約されているか
- 後続 PR3 で trailer を入れる前提のため、`trailer: undefined` 固定を妥当と判断できるか