### PR TITLE
✨ [New Feature]: #19 fallback xref scanner を xref/index 経由で公開

### DIFF
--- a/packages/core/src/xref/fallback/index.ts
+++ b/packages/core/src/xref/fallback/index.ts
@@ -1,0 +1,1 @@
+export { type FallbackScanResult, scanFallback } from "./fallback-scanner";

--- a/packages/core/src/xref/fallback/index.ts
+++ b/packages/core/src/xref/fallback/index.ts
@@ -1,1 +1,2 @@
-export { type FallbackScanResult, scanFallback } from "./fallback-scanner";
+export type { FallbackScanResult } from "./fallback-scanner";
+export { scanFallback } from "./fallback-scanner";

--- a/packages/core/src/xref/index.ts
+++ b/packages/core/src/xref/index.ts
@@ -4,7 +4,8 @@
  * およびtrailer辞書解析機能を提供する。
  */
 
-export { type FallbackScanResult, scanFallback } from "./fallback/index";
+export type { FallbackScanResult } from "./fallback/index";
+export { scanFallback } from "./fallback/index";
 export { mergeXRefChain } from "./merger/index";
 export { scanStartXRef } from "./startxref/index";
 export {

--- a/packages/core/src/xref/index.ts
+++ b/packages/core/src/xref/index.ts
@@ -4,6 +4,7 @@
  * およびtrailer辞書解析機能を提供する。
  */
 
+export { type FallbackScanResult, scanFallback } from "./fallback/index";
 export { mergeXRefChain } from "./merger/index";
 export { scanStartXRef } from "./startxref/index";
 export {

--- a/packages/core/src/xref/index.ts
+++ b/packages/core/src/xref/index.ts
@@ -1,7 +1,7 @@
 /**
  * PDF相互参照テーブル処理モジュール。
  * startxrefオフセットの走査、xrefテーブル解析、xrefストリームデコード、
- * およびtrailer辞書解析機能を提供する。
+ * trailer辞書解析、および xref 破損時のフォールバックスキャン機能を提供する。
  */
 
 export type { FallbackScanResult } from "./fallback/index";


### PR DESCRIPTION
## Summary
- `scanFallback` / `FallbackScanResult` を `xref/fallback/index.ts` 経由で `xref/index.ts` から re-export。

## Changes
- [NEW] `packages/core/src/xref/fallback/index.ts`
- [MODIFY] `packages/core/src/xref/index.ts`

## Why
- 既存 `parseXRefTable` / `parseTrailer` / `scanStartXRef` と同様、xref 関連 API は `xref/index.ts` 経由でサブパッケージ層から公開する一貫性を保つ。

## Test plan
- [x] `pnpm --filter @pdfmod/core test` グリーン (1361 tests passed)
- [x] `pnpm --filter @pdfmod/core typecheck` クリーン

## Refs
- Issue: #19
- Depends on: PR #107 (PR 3)