### PR TITLE
✨ spec-002 PR-1: PdfDocument skeleton を追加

### DIFF
--- a/packages/core/src/document/pdf-document.test.helpers.ts
+++ b/packages/core/src/document/pdf-document.test.helpers.ts
@@ -1,0 +1,92 @@
+/**
+ * `PdfDocument.load` の振る舞いテストで使う最小限の PDF バイト列ビルダー群。
+ *
+ * 本ファイルは PR-1 (skeleton) 時点では関数本体は空 (`new Uint8Array()`) であり、
+ * PR-2 以降の Red/Green サイクルで段階的に本実装に差し替えていく。
+ *
+ * 方針 A (overview.md §5.1.1): error / boundary テストで `result.error.code`
+ * を読む際は `assert(!(result.error instanceof RangeError));` で narrowing する。
+ * 本ファイルには narrowing 用 helper (`expectPdfError` 等) は置かない。
+ */
+
+/**
+ * `/Info` 由来のメタデータフィールド。
+ * `buildSinglePagePdfWithInfo` に渡す入力構造を表す。
+ */
+export interface InfoFields {
+  readonly title?: string;
+  readonly author?: string;
+}
+
+/**
+ * 1 ページのみを持つ最小構成の PDF を生成する。
+ *
+ * @returns 1 ページの最小 PDF を表すバイト列
+ */
+export const buildMinimalSinglePagePdf = (): Uint8Array => new Uint8Array();
+
+/**
+ * 1 ページ + `/Info` 辞書を持つ PDF を生成する。
+ *
+ * @param _info - `/Info` に格納するフィールド
+ * @returns `/Info` 付き PDF を表すバイト列
+ */
+export const buildSinglePagePdfWithInfo = (_info: InfoFields): Uint8Array =>
+  new Uint8Array();
+
+/**
+ * 2 ページの PDF を生成する。
+ *
+ * @returns 2 ページ PDF を表すバイト列
+ */
+export const buildTwoPagePdf = (): Uint8Array => new Uint8Array();
+
+/**
+ * `/Catalog` を欠く不正な PDF を生成する。
+ *
+ * @returns `/Catalog` 不在の PDF を表すバイト列
+ */
+export const buildPdfWithoutCatalog = (): Uint8Array => new Uint8Array();
+
+/**
+ * `/MediaBox` を欠く不正な PDF を生成する。
+ *
+ * @returns `/MediaBox` 不在の PDF を表すバイト列
+ */
+export const buildPdfWithoutMediaBox = (): Uint8Array => new Uint8Array();
+
+/**
+ * `startxref` の値が壊れた PDF を生成する。
+ *
+ * @returns `startxref` 破損 PDF を表すバイト列
+ */
+export const buildPdfWithCorruptStartXRef = (): Uint8Array => new Uint8Array();
+
+/**
+ * xref が破損し、かつ trailer も復元できない PDF を生成する。
+ *
+ * @returns xref/trailer ともに破損した PDF を表すバイト列
+ */
+export const buildPdfWithCorruptXRefAndNoTrailer = (): Uint8Array =>
+  new Uint8Array();
+
+/**
+ * ヘッダのみで本体を持たない PDF を生成する。
+ *
+ * @returns ヘッダのみの PDF を表すバイト列
+ */
+export const buildPdfHeaderOnly = (): Uint8Array => new Uint8Array();
+
+/**
+ * `/Info` の参照が壊れた PDF を生成する。
+ *
+ * @returns `/Info` 参照不正の PDF を表すバイト列
+ */
+export const buildPdfWithInvalidInfoRef = (): Uint8Array => new Uint8Array();
+
+/**
+ * インクリメンタルアップデートを含む PDF を生成する。
+ *
+ * @returns インクリメンタルアップデート付き PDF を表すバイト列
+ */
+export const buildPdfWithIncrementalUpdate = (): Uint8Array => new Uint8Array();

--- a/packages/core/src/document/pdf-document.ts
+++ b/packages/core/src/document/pdf-document.ts
@@ -73,7 +73,7 @@ export class PdfDocument {
   /**
    * 指定インデックスのページを取得する。
    *
-   * @param _index - 0-origin のページインデックス
+   * @param index - 0-origin のページインデックス
    * @returns 該当ページがあれば `Some<ResolvedPage>`、なければ `None`
    */
   getPage(index: number): Option<ResolvedPage> {

--- a/packages/core/src/document/pdf-document.ts
+++ b/packages/core/src/document/pdf-document.ts
@@ -38,9 +38,9 @@ interface PdfDocumentInit {
  * PDF ドキュメントを表すエンティティ。
  *
  * 本クラスは PR-1 時点では skeleton 実装であり、`load` は常に
- * `ROOT_NOT_FOUND` Err、`getPage` は `none` を返す。`INVALID_HEADER` を
- * 意図的に返さないのは、PR-2 の Red テスト (T-010) が「空入力 →
- * `INVALID_HEADER`」を期待して fail を観察できるようにするため。
+ * `NOT_IMPLEMENTED` Err、`getPage` は空配列を参照して `None` を返す。
+ * `INVALID_HEADER` を意図的に返さないのは、PR-2 の Red テスト (T-010)
+ * が「空入力 → `INVALID_HEADER`」を期待して fail を観察できるようにするため。
  */
 export class PdfDocument {
   readonly version!: PdfVersion;
@@ -65,7 +65,7 @@ export class PdfDocument {
     _options?: LoadOptions,
   ): Promise<Result<PdfDocument, PdfDocumentLoadError>> {
     return err({
-      code: "ROOT_NOT_FOUND",
+      code: "NOT_IMPLEMENTED",
       message: "PdfDocument.load is not yet implemented",
     });
   }

--- a/packages/core/src/document/pdf-document.ts
+++ b/packages/core/src/document/pdf-document.ts
@@ -24,10 +24,10 @@ export interface LoadOptions {
 }
 
 /**
- * `PdfDocument` の private constructor に渡す初期化情報。
+ * `PdfDocument` の private constructor が instance に assign する fields。
  * 公開 API ではないため `internal` 扱いで、PR-3 の本実装で使用する。
  */
-interface PdfDocumentInit {
+interface PdfDocumentFields {
   readonly version: PdfVersion;
   readonly pages: readonly ResolvedPage[];
   readonly metadata: DocumentMetadata;
@@ -49,7 +49,7 @@ export class PdfDocument {
   readonly resolver!: ObjectStore;
   readonly #pages: readonly ResolvedPage[] = [];
 
-  private constructor(_init: PdfDocumentInit) {
+  private constructor(_fields: PdfDocumentFields) {
     // PR-3 で fields を assign する。skeleton では直接呼び出されない。
   }
 

--- a/packages/core/src/document/pdf-document.ts
+++ b/packages/core/src/document/pdf-document.ts
@@ -1,0 +1,82 @@
+import type { ObjectStore } from "../objects/object-store/index";
+import type { PdfError, PdfWarning } from "../pdf/errors/index";
+import type { PdfVersion } from "../pdf/version/index";
+import { fromNullable, type Option } from "../utils/option/index";
+import { err, type Result } from "../utils/result/index";
+import type { DocumentMetadata } from "./document-metadata";
+import type { ResolvedPage } from "./page-tree/resolved-page";
+
+/**
+ * `PdfDocument.load` が返しうるエラーの判別共用体。
+ * - {@link PdfError}: PDF 構造に由来する致命的エラー
+ * - `RangeError`: 入力サイズや索引の境界違反
+ */
+export type PdfDocumentLoadError = PdfError | RangeError;
+
+/**
+ * `PdfDocument.load` 呼び出し時のオプション。
+ */
+export interface LoadOptions {
+  /** ObjectStore のキャッシュ容量上限（未指定時は実装側のデフォルト） */
+  readonly cacheCapacity?: number;
+  /** 回復可能な警告を受け取るコールバック */
+  readonly onWarning?: (warning: PdfWarning) => void;
+}
+
+/**
+ * `PdfDocument` の private constructor に渡す初期化情報。
+ * 公開 API ではないため `internal` 扱いで、PR-3 の本実装で使用する。
+ */
+interface PdfDocumentInit {
+  readonly version: PdfVersion;
+  readonly pages: readonly ResolvedPage[];
+  readonly metadata: DocumentMetadata;
+  readonly resolver: ObjectStore;
+}
+
+/**
+ * PDF ドキュメントを表すエンティティ。
+ *
+ * 本クラスは PR-1 時点では skeleton 実装であり、`load` は常に
+ * `ROOT_NOT_FOUND` Err、`getPage` は `none` を返す。`INVALID_HEADER` を
+ * 意図的に返さないのは、PR-2 の Red テスト (T-010) が「空入力 →
+ * `INVALID_HEADER`」を期待して fail を観察できるようにするため。
+ */
+export class PdfDocument {
+  readonly version!: PdfVersion;
+  readonly pageCount: number = 0;
+  readonly metadata!: DocumentMetadata;
+  readonly resolver!: ObjectStore;
+  readonly #pages: readonly ResolvedPage[] = [];
+
+  private constructor(_init: PdfDocumentInit) {
+    // PR-3 で fields を assign する。skeleton では直接呼び出されない。
+  }
+
+  /**
+   * PDF バイト列を読み込み、`PdfDocument` を構築する。
+   *
+   * @param _data - PDF のバイト列
+   * @param _options - 読み込みオプション
+   * @returns 成功時は `Ok<PdfDocument>`、失敗時は `Err<PdfDocumentLoadError>`
+   */
+  static async load(
+    _data: Uint8Array,
+    _options?: LoadOptions,
+  ): Promise<Result<PdfDocument, PdfDocumentLoadError>> {
+    return err({
+      code: "ROOT_NOT_FOUND",
+      message: "PdfDocument.load is not yet implemented",
+    });
+  }
+
+  /**
+   * 指定インデックスのページを取得する。
+   *
+   * @param _index - 0-origin のページインデックス
+   * @returns 該当ページがあれば `Some<ResolvedPage>`、なければ `None`
+   */
+  getPage(index: number): Option<ResolvedPage> {
+    return fromNullable(this.#pages[index]);
+  }
+}


### PR DESCRIPTION
## 概要

`PdfDocument` クラスと test helper 関数のシグネチャを skeleton として追加し、後続 PR (verifyHeader / pipeline) の足場を作る。spec-002 (`docs/specs/.../001-pdf-document-load`) の最初の子 spec の PR-1。

## 変更内容

### 🎯 変更の種類

- [x] ✨ 新機能 (New feature)

### 📝 詳細な変更内容

#### 追加された機能・修正

- `PdfDocument` クラス (private constructor + `static async load` + `getPage`) の最小骨格を新規追加
- `LoadOptions` interface と `PdfDocumentLoadError = PdfError | RangeError` を export
- `load` は常に `ROOT_NOT_FOUND` Err を返す TODO 実装。`INVALID_HEADER` 以外を返すことで、PR-2 の T-010 (空入力 → `INVALID_HEADER` を期待する Red テスト) を fail として観察できる状態に保つ
- `getPage` は内部 `#pages` を `fromNullable` 経由で参照（skeleton では空配列）
- `pdf-document.test.helpers.ts` に 10 種の PDF バイト列ビルダー (`buildMinimalSinglePagePdf` / `buildSinglePagePdfWithInfo` / `buildTwoPagePdf` / `buildPdfWithoutCatalog` / `buildPdfWithoutMediaBox` / `buildPdfWithCorruptStartXRef` / `buildPdfWithCorruptXRefAndNoTrailer` / `buildPdfHeaderOnly` / `buildPdfWithInvalidInfoRef` / `buildPdfWithIncrementalUpdate`) と `InfoFields` interface を stub として export

#### 変更されたファイル

- (新規) `packages/core/src/document/pdf-document.ts`
- (新規) `packages/core/src/document/pdf-document.test.helpers.ts`

#### 削除されたファイル・機能

- なし

## 📊 システム図

### 後続 PR との関係

```mermaid
flowchart TD
    PR1[PR-1: skeleton]:::current
    PR2[PR-2: verifyHeader]
    PR3[PR-3: full pipeline]

    PR1 -->|空 stub を順次差し替え| PR2
    PR2 -->|本実装| PR3

    subgraph PR1_files [本PRで追加]
        A[pdf-document.ts<br/>クラス骨格 / load=Err / getPage=None]
        B[pdf-document.test.helpers.ts<br/>10 ビルダー stub]
    end

    PR1 --- PR1_files

    classDef current fill:#ffe4b5,stroke:#d97706,stroke-width:2px
```

### `PdfDocument.load` の現状フロー

```mermaid
flowchart TD
    Input[Uint8Array data] --> Load[PdfDocument.load]
    Load --> Err{常に Err}
    Err --> Code[code: ROOT_NOT_FOUND]:::new
    Code --> Out[Result&lt;PdfDocument, PdfDocumentLoadError&gt;]

    classDef new fill:#ffe4b5,stroke:#d97706,stroke-width:2px
```

## 📋 関連 Issue

- spec: `.plugin-workspace/.specs/002-pdf-document-skeleton/`
- 親 spec: `.plugin-workspace/.specs/001-pdf-document-load/`
- 関連 Issue: なし（implementation-plan.md で未指定）

## 🧪 テスト

### テスト実行方法

```bash
pnpm --filter @pdfmod/core typecheck
pnpm lint
pnpm --filter @pdfmod/core test
```

### テスト項目

- [x] 単体テスト (Unit tests) — 既存テスト 1361 件全 pass
- [ ] 統合テスト — 本 PR では追加しない (PR-2 以降)

### テスト結果

- ✅ `pnpm --filter @pdfmod/core typecheck` 通過
- ✅ `pnpm lint` (biome + oxlint) エラー 0
- ✅ `pnpm --filter @pdfmod/core test` 1361 / 1361 passed
- ✅ `import { PdfDocument } from "./pdf-document";` がコンパイル可能

## 🔍 レビューポイント

- `load` が `INVALID_HEADER` ではなく `ROOT_NOT_FOUND` を返している意図 — PR-2 の Red テストで fail を観察するため (実装計画 §4 を参照)
- plan からの軽微な調整: 未使用 import `ByteOffset` を削除し、`ObjectStore` を `import type` に変更 (biome `noUnusedImports` 対応)
- `getPage` を `return none` から `fromNullable(this.#pages[index])` に変更 (biome `noUnusedPrivateClassMembers` 対応、空配列なので挙動は plan と同一)

## ⚠️ 破壊的変更

- [ ] この変更は既存の API に破壊的変更を含みます

## ✅ チェックリスト

- [x] コードレビューの準備ができている
- [x] テストが正常に実行される
- [x] コミットメッセージが適切な形式で書かれている
- [x] セルフレビューを実施した
- [x] Codex CLI による一括コードレビューを実施 (`code-review/review-001.md`、結果: 問題なし)

🤖 Generated with [Claude Code](https://claude.com/claude-code)