### PR TITLE
✨ spec-003 PR-2: PdfDocument.load に verifyHeader を実装

### DIFF
--- a/packages/core/src/document/pdf-document.error.test.ts
+++ b/packages/core/src/document/pdf-document.error.test.ts
@@ -20,9 +20,7 @@ test("`%PDF-` シグネチャ不在の入力は INVALID_HEADER を返す", async
 });
 
 test("不明な PDF バージョン (`%PDF-9.9`) は INVALID_HEADER を返す", async () => {
-  const result = await PdfDocument.load(
-    new TextEncoder().encode("%PDF-9.9\n%\xe2\xe3\xcf\xd3\n"),
-  );
+  const result = await PdfDocument.load(new TextEncoder().encode("%PDF-9.9\n"));
 
   expect(result.ok).toBe(false);
   assert(!result.ok);

--- a/packages/core/src/document/pdf-document.error.test.ts
+++ b/packages/core/src/document/pdf-document.error.test.ts
@@ -1,0 +1,42 @@
+import { assert, expect, test } from "vitest";
+import { PdfDocument } from "./pdf-document";
+
+test("空入力は INVALID_HEADER を返す", async () => {
+  const result = await PdfDocument.load(new Uint8Array());
+
+  expect(result.ok).toBe(false);
+  assert(!result.ok);
+  assert(!(result.error instanceof RangeError));
+  expect(result.error.code).toBe("INVALID_HEADER");
+});
+
+test("`%PDF-` シグネチャ不在の入力は INVALID_HEADER を返す", async () => {
+  const result = await PdfDocument.load(new TextEncoder().encode("not a pdf"));
+
+  expect(result.ok).toBe(false);
+  assert(!result.ok);
+  assert(!(result.error instanceof RangeError));
+  expect(result.error.code).toBe("INVALID_HEADER");
+});
+
+test("不明な PDF バージョン (`%PDF-9.9`) は INVALID_HEADER を返す", async () => {
+  const result = await PdfDocument.load(
+    new TextEncoder().encode("%PDF-9.9\n%\xe2\xe3\xcf\xd3\n"),
+  );
+
+  expect(result.ok).toBe(false);
+  assert(!result.ok);
+  assert(!(result.error instanceof RangeError));
+  expect(result.error.code).toBe("INVALID_HEADER");
+});
+
+test("TAB 終端の `%PDF-1.7` は INVALID_HEADER を返さない", async () => {
+  const result = await PdfDocument.load(
+    new TextEncoder().encode("%PDF-1.7\trest of file"),
+  );
+
+  expect(result.ok).toBe(false);
+  assert(!result.ok);
+  assert(!(result.error instanceof RangeError));
+  expect(result.error.code).not.toBe("INVALID_HEADER");
+});

--- a/packages/core/src/document/pdf-document.ts
+++ b/packages/core/src/document/pdf-document.ts
@@ -49,7 +49,7 @@ const verifyHeader = (data: Uint8Array): Result<PdfVersion, PdfParseError> => {
   if (headerOffset < 0) {
     return err({
       code: "INVALID_HEADER",
-      message: "%PDF- signature not found in first 1024 bytes",
+      message: `%PDF- signature not found in first ${HEADER_SCAN_LIMIT} bytes`,
       offset: ByteOffset.of(0),
     });
   }

--- a/packages/core/src/document/pdf-document.ts
+++ b/packages/core/src/document/pdf-document.ts
@@ -1,10 +1,84 @@
+import { isPdfWhitespace, matchesBytesAt } from "../lexer/bytes/index";
 import type { ObjectStore } from "../objects/object-store/index";
-import type { PdfError, PdfWarning } from "../pdf/errors/index";
-import type { PdfVersion } from "../pdf/version/index";
+import type { PdfError, PdfParseError, PdfWarning } from "../pdf/errors/index";
+import { ByteOffset } from "../pdf/types/index";
+import { PdfVersion } from "../pdf/version/index";
 import { fromNullable, type Option } from "../utils/option/index";
-import { err, type Result } from "../utils/result/index";
+import { err, ok, type Result } from "../utils/result/index";
 import type { DocumentMetadata } from "./document-metadata";
 import type { ResolvedPage } from "./page-tree/resolved-page";
+
+const PDF_HEADER_SIGNATURE: number[] = Array.from(
+  new TextEncoder().encode("%PDF-"),
+);
+const HEADER_SCAN_LIMIT = 1024;
+const VERSION_MAX_LEN = 8;
+
+/**
+ * `data` の先頭 `HEADER_SCAN_LIMIT` バイト以内で `%PDF-` の位置を探す。
+ *
+ * @param data - PDF のバイト列
+ * @returns 見つかれば 0 以上のオフセット、見つからなければ -1
+ */
+const findHeaderOffset = (data: Uint8Array): number => {
+  const scanEnd = Math.min(data.length, HEADER_SCAN_LIMIT);
+  for (let i = 0; i <= scanEnd - PDF_HEADER_SIGNATURE.length; i++) {
+    if (matchesBytesAt(data, i, PDF_HEADER_SIGNATURE)) {
+      return i;
+    }
+  }
+  return -1;
+};
+
+/**
+ * PDF ヘッダ (`%PDF-x.y`) を検証して `PdfVersion` を返す。
+ *
+ * @param data - PDF のバイト列
+ * @returns ヘッダが有効なら `Ok<PdfVersion>`、不正なら `Err<PdfParseError>`
+ */
+const verifyHeader = (data: Uint8Array): Result<PdfVersion, PdfParseError> => {
+  if (data.length < PDF_HEADER_SIGNATURE.length) {
+    return err({
+      code: "INVALID_HEADER",
+      message: "PDF data too short to contain %PDF- header",
+      offset: ByteOffset.of(0),
+    });
+  }
+
+  const headerOffset = findHeaderOffset(data);
+  if (headerOffset < 0) {
+    return err({
+      code: "INVALID_HEADER",
+      message: "%PDF- signature not found in first 1024 bytes",
+      offset: ByteOffset.of(0),
+    });
+  }
+
+  // signature 直後から PDF whitespace (NUL/TAB/LF/FF/CR/SPACE) までを
+  // version 文字列として読み取る。
+  const versionStart = headerOffset + PDF_HEADER_SIGNATURE.length;
+  let versionEnd = versionStart;
+  while (
+    versionEnd < data.length &&
+    versionEnd - versionStart < VERSION_MAX_LEN &&
+    !isPdfWhitespace(data[versionEnd])
+  ) {
+    versionEnd++;
+  }
+  const versionStr = new TextDecoder("ascii").decode(
+    data.subarray(versionStart, versionEnd),
+  );
+
+  const created = PdfVersion.create(versionStr);
+  if (!created.ok) {
+    return err({
+      code: "INVALID_HEADER",
+      message: `Unknown PDF version: "${versionStr}"`,
+      offset: ByteOffset.of(headerOffset),
+    });
+  }
+  return ok(created.value);
+};
 
 /**
  * `PdfDocument.load` が返しうるエラーの判別共用体。
@@ -37,10 +111,10 @@ interface PdfDocumentFields {
 /**
  * PDF ドキュメントを表すエンティティ。
  *
- * 本クラスは PR-1 時点では skeleton 実装であり、`load` は常に
- * `NOT_IMPLEMENTED` Err、`getPage` は空配列を参照して `None` を返す。
- * `INVALID_HEADER` を意図的に返さないのは、PR-2 の Red テスト (T-010)
- * が「空入力 → `INVALID_HEADER`」を期待して fail を観察できるようにするため。
+ * 本クラスは PR-2 時点でも本体未実装で、`load` は `verifyHeader` が
+ * Ok を返した場合でも下流が未実装のため `NOT_IMPLEMENTED` Err を返す。
+ * Cycle 1 (PR-2) では `verifyHeader` 部分のみ実装し、L-001 系
+ * (`INVALID_HEADER`) を担保する。
  */
 export class PdfDocument {
   readonly version!: PdfVersion;
@@ -56,14 +130,19 @@ export class PdfDocument {
   /**
    * PDF バイト列を読み込み、`PdfDocument` を構築する。
    *
-   * @param _data - PDF のバイト列
+   * @param data - PDF のバイト列
    * @param _options - 読み込みオプション
    * @returns 成功時は `Ok<PdfDocument>`、失敗時は `Err<PdfDocumentLoadError>`
    */
   static async load(
-    _data: Uint8Array,
+    data: Uint8Array,
     _options?: LoadOptions,
   ): Promise<Result<PdfDocument, PdfDocumentLoadError>> {
+    const headerResult = verifyHeader(data);
+    if (!headerResult.ok) {
+      return headerResult;
+    }
+
     return err({
       code: "NOT_IMPLEMENTED",
       message: "PdfDocument.load is not yet implemented",

--- a/packages/core/src/document/pdf-document.ts
+++ b/packages/core/src/document/pdf-document.ts
@@ -31,6 +31,25 @@ const findHeaderOffset = (data: Uint8Array): number => {
 };
 
 /**
+ * version 文字列の終端位置を返す。
+ * `versionStart` から最大 `VERSION_MAX_LEN` バイト以内で、
+ * 最初に現れる PDF whitespace の位置 (見つからなければ走査上限) を返す。
+ *
+ * @param data - PDF のバイト列
+ * @param versionStart - signature 直後の version 文字列開始位置
+ * @returns version 文字列の終端 (whitespace の位置、または走査上限)
+ */
+const findVersionEnd = (data: Uint8Array, versionStart: number): number => {
+  const scanLimit = Math.min(data.length, versionStart + VERSION_MAX_LEN);
+  for (let i = versionStart; i < scanLimit; i++) {
+    if (isPdfWhitespace(data[i])) {
+      return i;
+    }
+  }
+  return scanLimit;
+};
+
+/**
  * PDF ヘッダ (`%PDF-x.y`) を検証して `PdfVersion` を返す。
  *
  * @param data - PDF のバイト列
@@ -57,14 +76,7 @@ const verifyHeader = (data: Uint8Array): Result<PdfVersion, PdfParseError> => {
   // signature 直後から PDF whitespace (NUL/TAB/LF/FF/CR/SPACE) までを
   // version 文字列として読み取る。
   const versionStart = headerOffset + PDF_HEADER_SIGNATURE.length;
-  let versionEnd = versionStart;
-  while (
-    versionEnd < data.length &&
-    versionEnd - versionStart < VERSION_MAX_LEN &&
-    !isPdfWhitespace(data[versionEnd])
-  ) {
-    versionEnd++;
-  }
+  const versionEnd = findVersionEnd(data, versionStart);
   const versionStr = new TextDecoder("ascii").decode(
     data.subarray(versionStart, versionEnd),
   );

--- a/packages/core/src/document/pdf-document.ts
+++ b/packages/core/src/document/pdf-document.ts
@@ -73,8 +73,8 @@ const verifyHeader = (data: Uint8Array): Result<PdfVersion, PdfParseError> => {
   if (!created.ok) {
     return err({
       code: "INVALID_HEADER",
-      message: `Unknown PDF version: "${versionStr}"`,
-      offset: ByteOffset.of(headerOffset),
+      message: `Invalid PDF version "${versionStr}": ${created.error}`,
+      offset: ByteOffset.of(versionStart),
     });
   }
   return ok(created.value);


### PR DESCRIPTION
## 概要

`PdfDocument.load` に PDF ヘッダ (`%PDF-x.y`) 検証を行う `verifyHeader` ローカル関数を実装。L-001 系 4 ケース (空入力 / `%PDF-` 不在 / 不明バージョン / TAB 終端 OK) をエラーテストで担保する。`load` 本体は本 PR では引き続き `NOT_IMPLEMENTED` を返し、後続 PR (spec-004) でパイプライン全体を実装予定。

## 変更内容

### 🎯 変更の種類

- [x] ✨ 新機能 (New feature)
- [x] 🚨 テスト追加/修正 (Tests)

### 📝 詳細な変更内容

#### 追加された機能・修正

- `verifyHeader(data: Uint8Array): Result<PdfVersion, PdfParseError>` を `pdf-document.ts` 内ローカル関数として追加
  - `data.length < 5` (`%PDF-` の長さ) で `INVALID_HEADER`
  - 先頭 1024 バイト以内 (ISO 32000-1 §7.5.2) で `%PDF-` バイトシーケンスを線形検索
  - `%PDF-` 不在で `INVALID_HEADER`
  - signature 直後から PDF whitespace (NUL/TAB/LF/FF/CR/SPACE) までを ASCII 文字列として切り出し、`PdfVersion.create` に渡す
  - サポート外バージョン (`%PDF-9.9` など) は `INVALID_HEADER` に変換
- `load` 先頭で `verifyHeader(data)` を呼び出し、Err は早期 return

#### 変更されたファイル

- `packages/core/src/document/pdf-document.ts` (修正): verifyHeader 実装、load との連結
- `packages/core/src/document/pdf-document.error.test.ts` (新規): L-001 系 4 ケース

## 📊 システム図

### load() のフロー（PR-2 時点）

```mermaid
flowchart TD
    Start([PdfDocument.load]) --> VH[verifyHeader]:::new
    VH -->|len < 5| ErrShort[Err INVALID_HEADER<br/>data too short]:::new
    VH -->|`%PDF-` 不在| ErrNotFound[Err INVALID_HEADER<br/>signature not found]:::new
    VH -->|version 不正| ErrVersion[Err INVALID_HEADER<br/>Unknown PDF version]:::new
    VH -->|Ok PdfVersion| TODO[Err NOT_IMPLEMENTED<br/>下流は spec-004 で実装]
    ErrShort --> End([return])
    ErrNotFound --> End
    ErrVersion --> End
    TODO --> End

    classDef new fill:#ffe4b5,stroke:#d97706,stroke-width:2px
```

## 📋 関連 Issue

- spec: `.plugin-workspace/.specs/003-pdf-document-verify-header/`
- 親 spec: `001-pdf-document-load`
- 前 PR: #109 (spec-002 PR-1 skeleton, MERGED)

implementation-plan.md には GitHub Issue 番号は記載なし。

## 🧪 テスト

### テスト実行方法

```bash
pnpm --filter @pdfmod/core test pdf-document.error.test.ts
pnpm typecheck
pnpm lint
```

### テスト項目

- [x] 単体テスト (Unit tests) — L-001 系 4 ケース

### テスト結果

- `pdf-document.error.test.ts` 4 tests passed
- `@pdfmod/core` 全テスト 1365 passed
- `pnpm typecheck` clean
- `pnpm lint` clean (`.pnpm-store` の broken symlink 警告は環境由来)
- Codex CLI レビュー: 問題なし (`.plugin-workspace/.specs/003-pdf-document-verify-header/code-review/review-001.md`)

## 🔍 レビューポイント

- **`PDF_HEADER_SIGNATURE` の構築方法**: oxlint の `no-magic-numbers` を避けるため `Array.from(new TextEncoder().encode("%PDF-"))` でランタイム構築している。リテラル `[0x25, ...]` 直書きと比較して trade-off があれば指摘ください。
- **`findHeaderOffset` の分離**: 計画段階では verifyHeader 内インラインだったが、責務が単一になるよう関数化した。
- **TAB 終端ケースのテスト assertion**: 下流が未実装のため exact code でなく `not.toBe("INVALID_HEADER")` で確認している（plan §6 注記の方針）。
- **`assert(!result.ok)` / `assert(!(error instanceof RangeError))` の二重 narrowing**: overview.md §5.1.1 方針 A に従い vitest の `assert` を利用。

## ✅ チェックリスト

- [x] コードレビューの準備ができている
- [x] テストが正常に実行される
- [x] コミットメッセージが適切な形式で書かれている
- [x] セルフレビューを実施した
- [x] 破壊的変更なし