### PR TITLE
🧪 spec-005 PR-4 PdfDocument behavior + boundary テスト追加

### DIFF
--- a/packages/core/src/document/pdf-document.behavior.test.ts
+++ b/packages/core/src/document/pdf-document.behavior.test.ts
@@ -24,15 +24,3 @@ test("最小 1-page PDF の getPage(0) は Some(ResolvedPage) を返す", async 
   assert(page.some);
   expect(page.value.mediaBox).toEqual([0, 0, 612, 792]);
 });
-
-test.each([
-  { label: "負のインデックス", index: -1 },
-  { label: "ページ数以上のインデックス", index: 1 },
-  { label: "整数でないインデックス", index: 0.5 },
-  { label: "NaN", index: Number.NaN },
-])("getPage($label) は None を返す", async ({ index }) => {
-  const result = await PdfDocument.load(buildMinimalSinglePagePdf());
-
-  assert(result.ok);
-  expect(result.value.getPage(index).some).toBe(false);
-});

--- a/packages/core/src/document/pdf-document.boundary.test.ts
+++ b/packages/core/src/document/pdf-document.boundary.test.ts
@@ -1,0 +1,22 @@
+import { assert, expect, test } from "vitest";
+import { PdfDocument } from "./pdf-document";
+import { buildMinimalSinglePagePdf } from "./pdf-document.test.helpers";
+
+test.each([
+  { label: "負のインデックス", index: -1 },
+  { label: "ページ数以上のインデックス", index: 1 },
+  { label: "整数でないインデックス", index: 1.5 },
+  { label: "NaN", index: Number.NaN },
+])("getPage($label) は None を返す", async ({ index }) => {
+  const result = await PdfDocument.load(buildMinimalSinglePagePdf());
+
+  assert(result.ok);
+  expect(result.value.getPage(index).some).toBe(false);
+});
+
+test("getPage(0) は Some を返す (DA-002)", async () => {
+  const result = await PdfDocument.load(buildMinimalSinglePagePdf());
+
+  assert(result.ok);
+  expect(result.value.getPage(0).some).toBe(true);
+});

--- a/packages/core/src/document/pdf-document.boundary.test.ts
+++ b/packages/core/src/document/pdf-document.boundary.test.ts
@@ -3,14 +3,18 @@ import { PdfDocument } from "./pdf-document";
 import { buildMinimalSinglePagePdf } from "./pdf-document.test.helpers";
 
 test.each([
-  { label: "負のインデックス", index: -1 },
-  { label: "ページ数以上のインデックス", index: 1 },
-  { label: "整数でないインデックス", index: 1.5 },
-  { label: "NaN", index: Number.NaN },
-])("getPage($label) は None を返す", async ({ index }) => {
+  { label: "負のインデックス", getIndex: () => -1 },
+  {
+    label: "ページ数以上のインデックス",
+    getIndex: (document: PdfDocument) => document.pageCount,
+  },
+  { label: "整数でないインデックス", getIndex: () => 1.5 },
+  { label: "NaN", getIndex: () => Number.NaN },
+])("getPage($label) は None を返す", async ({ getIndex }) => {
   const result = await PdfDocument.load(buildMinimalSinglePagePdf());
 
   assert(result.ok);
+  const index = getIndex(result.value);
   expect(result.value.getPage(index).some).toBe(false);
 });
 


### PR DESCRIPTION
## 概要

spec-005 (`.specs/archive/005-pdf-document-behavior-boundary/`) の PR-4 を実施。`PdfDocument.load` の最小 1-page 振る舞いと `getPage` 範囲外ガードを担保するテストを 2 ファイルに分離・追加した。`pdf-document.ts` 本体への変更はなし (PR-3 状態のまま)。

## 変更内容

### 🎯 変更の種類

- [x] 🚨 テスト追加/修正 (Tests)

### 📝 詳細な変更内容

#### 追加された機能・修正

- `pdf-document.boundary.test.ts` を新規作成し、`getPage` の範囲外ケース (DA-001) をパラメータ化テストで網羅
  - `getPage(-1)` → `Option.none`
  - `getPage(pageCount)` → `Option.none` (1-page で `getPage(1)`)
  - `getPage(1.5)` → `Option.none` (非整数)
  - `getPage(NaN)` → `Option.none`
- DA-002 の `getPage(0).some === true` を boundary に単独テストとして追加 (T-042)

#### 変更されたファイル

- `packages/core/src/document/pdf-document.behavior.test.ts` — 末尾の boundary 用 `test.each` ブロックを削除し behavior に専念
- `packages/core/src/document/pdf-document.boundary.test.ts` — 新規

#### 削除されたファイル・機能

- なし

## 📊 システム図

### テスト分割フロー

```mermaid
flowchart LR
    A[buildMinimalSinglePagePdf] --> B[PdfDocument.load]
    B --> C{behavior.test.ts}
    B --> D{boundary.test.ts}:::new
    C --> C1[pageCount === 1]
    C --> C2[version === '1.7']
    C --> C3[getPage 0 → Some]
    D --> D1[test.each: -1 / 1 / 1.5 / NaN → None]:::new
    D --> D2[getPage 0 → Some / DA-002]:::new

    classDef new fill:#ffe4b5,stroke:#d97706,stroke-width:2px
```

## 📋 関連 Issue

- Refs spec-005 (`.plugin-workspace/.specs/archive/005-pdf-document-behavior-boundary/`)
- 親 spec: 001-pdf-document-load (DA-001 / DA-002 / V-004)

## 🧪 テスト

### テスト実行方法

```bash
pnpm --filter @pdfmod/core test -- --run packages/core/src/document/pdf-document.behavior.test.ts packages/core/src/document/pdf-document.boundary.test.ts
```

### テスト項目

- [x] 単体テスト (Unit tests)
- [x] 統合テスト (Integration tests) — `PdfDocument.load` パイプラインを通す

### テスト結果

- 全 1373 テスト pass
- `pdf-document.behavior.test.ts`: 3 tests pass
- `pdf-document.boundary.test.ts`: 5 tests pass
- lint: 0 warnings 0 errors / typecheck pass

### Codex レビュー

- review-001: Low 1 件 (`index: 0.5` → `1.5` に変更 / 計画書 §5.2 と一致) → 修正済み
- review-002: 問題なし

## 🔍 レビューポイント

- 受入条件 (V-004) の「変更ファイル数 1〜2」を満たしているか (本 PR は 2 ファイル)
- DA-001 の 4 値 (-1 / pageCount / 非整数 / NaN) が網羅されているか
- behavior と boundary の責務分割 (テストコロケーション + describe 不使用)

## ⚠️ 破壊的変更

- [ ] この変更は既存の API に破壊的変更を含みます

なし。

## ✅ チェックリスト

- [x] コードレビューの準備ができている
- [x] テストが正常に実行される
- [x] コミットメッセージが適切な形式で書かれている
- [x] セルフレビューを実施した
- [x] 破壊的変更なしを確認