### PR TITLE
🚨 [Tests]: spec-006 PR-5 2-page / Info 付き PDF の coverage

### DIFF
--- a/packages/core/src/document/pdf-document.behavior.test.ts
+++ b/packages/core/src/document/pdf-document.behavior.test.ts
@@ -1,6 +1,10 @@
 import { assert, expect, test } from "vitest";
 import { PdfDocument } from "./pdf-document";
-import { buildMinimalSinglePagePdf } from "./pdf-document.test.helpers";
+import {
+  buildMinimalSinglePagePdf,
+  buildSinglePagePdfWithInfo,
+  buildTwoPagePdf,
+} from "./pdf-document.test.helpers";
 
 test("最小 1-page PDF を load すると pageCount=1 を返す", async () => {
   const result = await PdfDocument.load(buildMinimalSinglePagePdf());
@@ -23,4 +27,28 @@ test("最小 1-page PDF の getPage(0) は Some(ResolvedPage) を返す", async 
   const page = result.value.getPage(0);
   assert(page.some);
   expect(page.value.mediaBox).toEqual([0, 0, 612, 792]);
+});
+
+test("2-page PDF を load すると pageCount=2 を返す", async () => {
+  const result = await PdfDocument.load(buildTwoPagePdf());
+
+  assert(result.ok);
+  expect(result.value.pageCount).toBe(2);
+});
+
+test.each([
+  { label: "title のみ", info: { title: "Hello" } },
+  { label: "author のみ", info: { author: "Alice" } },
+  {
+    label: "title + author",
+    info: { title: "MyTitle", author: "Bob" },
+  },
+])("/Info 付き PDF ($label) を load すると metadata に値が抽出される", async ({
+  info,
+}) => {
+  const result = await PdfDocument.load(buildSinglePagePdfWithInfo(info));
+
+  assert(result.ok);
+  expect(result.value.metadata.title).toBe(info.title);
+  expect(result.value.metadata.author).toBe(info.author);
 });

--- a/packages/core/src/document/pdf-document.test.helpers.ts
+++ b/packages/core/src/document/pdf-document.test.helpers.ts
@@ -98,16 +98,19 @@ const toPdfString = (s: string): string => {
 };
 
 /**
- * 1 0 obj 〜 N 0 obj の本体配列と trailer 補助エントリを与え、
+ * 1 0 obj 〜 N 0 obj の本体配列と trailer 追加エントリを与え、
  * テキスト xref 形式の PDF バイト列を組み立てる。
  *
+ * `trailerEntries` は `/Root 1 0 R` の **後ろに追記される** 追加エントリ（例: `/Info 4 0 R`）の配列。
+ * 区切りスペースは本関数が付与するため、呼び出し側は先頭スペースを含めない。
+ *
  * @param objectBodies - 各オブジェクトの本体（`<< ... >>` 等）
- * @param trailerExtras - trailer 辞書に追記するエントリ（先頭スペース込み）。例: `" /Info 4 0 R"`
+ * @param trailerEntries - trailer 辞書に追記するエントリ。例: `["/Info 4 0 R"]`
  * @returns 組み立てた PDF バイト列
  */
 const assembleTextPdf = (
   objectBodies: readonly string[],
-  trailerExtras = "",
+  trailerEntries: readonly string[] = [],
 ): Uint8Array => {
   const encoder = new TextEncoder();
   const objs = objectBodies.map(
@@ -128,6 +131,8 @@ const assembleTextPdf = (
     ...offsets.map((o) => `${padOffset10(o)} 00000 n \n`),
   ];
   const xref = `xref\n0 ${size}\n${xrefRows.join("")}`;
+  const trailerExtras =
+    trailerEntries.length === 0 ? "" : ` ${trailerEntries.join(" ")}`;
   const trailer = `trailer\n<< /Size ${size} /Root 1 0 R${trailerExtras} >>\nstartxref\n${xrefOffset}\n%%EOF\n`;
 
   return encoder.encode(PDF_HEADER + objs.join("") + xref + trailer);
@@ -162,7 +167,7 @@ export const buildSinglePagePdfWithInfo = (info: InfoFields): Uint8Array => {
   const infoBody = `<< ${fields.join(" ")} >>`;
   return assembleTextPdf(
     [CATALOG_BODY, PAGES_BODY_SINGLE, PAGE_BODY, infoBody],
-    " /Info 4 0 R",
+    ["/Info 4 0 R"],
   );
 };
 

--- a/packages/core/src/document/pdf-document.test.helpers.ts
+++ b/packages/core/src/document/pdf-document.test.helpers.ts
@@ -36,14 +36,63 @@ const PAGE_BODY = "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] >>";
 const padOffset10 = (n: number): string =>
   n.toString(DECIMAL_RADIX).padStart(XREF_OFFSET_DIGITS, "0");
 
+const ASCII_MAX = 0x7f;
+const HEX_BYTE_DIGITS = 2;
+const HEX_RADIX = 16;
+const UTF16_HIGH_BYTE_SHIFT = 8;
+const BYTE_MASK = 0xff;
+const UTF16_BE_BOM_HEX = "feff";
+
 /**
- * ASCII 文字列を PDF の literal string `(...)` 形式へエンコードする。
- * `\\` `(` `)` のみエスケープする最小実装。非 ASCII 文字は本 helper の対象外。
+ * 入力文字列が ASCII (U+0000〜U+007F) のみで構成されているかを判定する。
  *
- * @param s - エンコード対象の ASCII 文字列
- * @returns PDF literal string 表記
+ * @param s - 判定対象の文字列
+ * @returns すべて ASCII なら true
  */
-const toLiteralString = (s: string): string => {
+const isAscii = (s: string): boolean => {
+  for (let i = 0; i < s.length; i++) {
+    if (s.charCodeAt(i) > ASCII_MAX) {
+      return false;
+    }
+  }
+  return true;
+};
+
+/**
+ * 文字列を UTF-16BE BOM 付き hex string `<feff...>` 形式へエンコードする。
+ * PDF の string object として非 ASCII 文字を扱う標準的な表現。
+ *
+ * @param s - エンコード対象の文字列
+ * @returns hex string 表記
+ */
+const toUtf16BeHexString = (s: string): string => {
+  const hexParts: string[] = [UTF16_BE_BOM_HEX];
+  for (let i = 0; i < s.length; i++) {
+    const cu = s.charCodeAt(i);
+    const high = (cu >> UTF16_HIGH_BYTE_SHIFT) & BYTE_MASK;
+    const low = cu & BYTE_MASK;
+    hexParts.push(
+      high.toString(HEX_RADIX).padStart(HEX_BYTE_DIGITS, "0"),
+      low.toString(HEX_RADIX).padStart(HEX_BYTE_DIGITS, "0"),
+    );
+  }
+  return `<${hexParts.join("")}>`;
+};
+
+/**
+ * 任意の文字列を PDF の string object 表記へエンコードする。
+ * - 入力が ASCII のみ: literal string `(...)`（`\\` `(` `)` のみエスケープ）
+ * - 非 ASCII を含む: UTF-16BE BOM 付き hex string `<feff...>`
+ *
+ * いずれの形式も `decodePdfString` 側で復号可能。
+ *
+ * @param s - エンコード対象の文字列
+ * @returns PDF string object 表記
+ */
+const toPdfString = (s: string): string => {
+  if (!isAscii(s)) {
+    return toUtf16BeHexString(s);
+  }
   const escaped = s.replace(/[\\()]/g, (c) => `\\${c}`);
   return `(${escaped})`;
 };
@@ -105,10 +154,10 @@ export const buildMinimalSinglePagePdf = (): Uint8Array =>
 export const buildSinglePagePdfWithInfo = (info: InfoFields): Uint8Array => {
   const fields: string[] = [];
   if (info.title !== undefined) {
-    fields.push(`/Title ${toLiteralString(info.title)}`);
+    fields.push(`/Title ${toPdfString(info.title)}`);
   }
   if (info.author !== undefined) {
-    fields.push(`/Author ${toLiteralString(info.author)}`);
+    fields.push(`/Author ${toPdfString(info.author)}`);
   }
   const infoBody = `<< ${fields.join(" ")} >>`;
   return assembleTextPdf(

--- a/packages/core/src/document/pdf-document.test.helpers.ts
+++ b/packages/core/src/document/pdf-document.test.helpers.ts
@@ -21,14 +21,68 @@ export interface InfoFields {
 const XREF_OFFSET_DIGITS = 10;
 const DECIMAL_RADIX = 10;
 
+const PDF_HEADER = "%PDF-1.7\n";
+const CATALOG_BODY = "<< /Type /Catalog /Pages 2 0 R >>";
+const PAGES_BODY_SINGLE = "<< /Type /Pages /Kids [3 0 R] /Count 1 >>";
+const PAGES_BODY_TWO = "<< /Type /Pages /Kids [3 0 R 4 0 R] /Count 2 >>";
+const PAGE_BODY = "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] >>";
+
 /**
- * 10 桁ゼロ埋めでオフセットを表現する。xref テーブルの 18 バイト本体規約に従う。
+ * 10 桁ゼロ埋めでオフセットを表現する。xref テーブルの 20 バイト本体規約に従う。
  *
  * @param n - 0 以上の整数オフセット値
  * @returns 10 桁ゼロ埋め文字列
  */
 const padOffset10 = (n: number): string =>
   n.toString(DECIMAL_RADIX).padStart(XREF_OFFSET_DIGITS, "0");
+
+/**
+ * ASCII 文字列を PDF の literal string `(...)` 形式へエンコードする。
+ * `\\` `(` `)` のみエスケープする最小実装。非 ASCII 文字は本 helper の対象外。
+ *
+ * @param s - エンコード対象の ASCII 文字列
+ * @returns PDF literal string 表記
+ */
+const toLiteralString = (s: string): string => {
+  const escaped = s.replace(/[\\()]/g, (c) => `\\${c}`);
+  return `(${escaped})`;
+};
+
+/**
+ * 1 0 obj 〜 N 0 obj の本体配列と trailer 補助エントリを与え、
+ * テキスト xref 形式の PDF バイト列を組み立てる。
+ *
+ * @param objectBodies - 各オブジェクトの本体（`<< ... >>` 等）
+ * @param trailerExtras - trailer 辞書に追記するエントリ（先頭スペース込み）。例: `" /Info 4 0 R"`
+ * @returns 組み立てた PDF バイト列
+ */
+const assembleTextPdf = (
+  objectBodies: readonly string[],
+  trailerExtras = "",
+): Uint8Array => {
+  const encoder = new TextEncoder();
+  const objs = objectBodies.map(
+    (body, i) => `${i + 1} 0 obj\n${body}\nendobj\n`,
+  );
+
+  const offsets: number[] = [];
+  let cursor = encoder.encode(PDF_HEADER).length;
+  for (const obj of objs) {
+    offsets.push(cursor);
+    cursor += encoder.encode(obj).length;
+  }
+  const xrefOffset = cursor;
+
+  const size = objectBodies.length + 1;
+  const xrefRows = [
+    "0000000000 65535 f \n",
+    ...offsets.map((o) => `${padOffset10(o)} 00000 n \n`),
+  ];
+  const xref = `xref\n0 ${size}\n${xrefRows.join("")}`;
+  const trailer = `trailer\n<< /Size ${size} /Root 1 0 R${trailerExtras} >>\nstartxref\n${xrefOffset}\n%%EOF\n`;
+
+  return encoder.encode(PDF_HEADER + objs.join("") + xref + trailer);
+};
 
 /**
  * 1 ページのみを持つ最小構成の PDF を生成する。
@@ -38,49 +92,41 @@ const padOffset10 = (n: number): string =>
  *
  * @returns 1 ページの最小 PDF を表すバイト列
  */
-export const buildMinimalSinglePagePdf = (): Uint8Array => {
-  const encoder = new TextEncoder();
-
-  const header = "%PDF-1.7\n";
-  const obj1 = "1 0 obj\n<< /Type /Catalog /Pages 2 0 R >>\nendobj\n";
-  const obj2 = "2 0 obj\n<< /Type /Pages /Kids [3 0 R] /Count 1 >>\nendobj\n";
-  const obj3 =
-    "3 0 obj\n<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] >>\nendobj\n";
-
-  const offset1 = encoder.encode(header).length;
-  const offset2 = offset1 + encoder.encode(obj1).length;
-  const offset3 = offset2 + encoder.encode(obj2).length;
-  const xrefOffset = offset3 + encoder.encode(obj3).length;
-
-  const xref =
-    "xref\n" +
-    "0 4\n" +
-    "0000000000 65535 f \n" +
-    `${padOffset10(offset1)} 00000 n \n` +
-    `${padOffset10(offset2)} 00000 n \n` +
-    `${padOffset10(offset3)} 00000 n \n`;
-  const trailer =
-    "trailer\n<< /Size 4 /Root 1 0 R >>\n" +
-    `startxref\n${xrefOffset}\n%%EOF\n`;
-
-  return encoder.encode(header + obj1 + obj2 + obj3 + xref + trailer);
-};
+export const buildMinimalSinglePagePdf = (): Uint8Array =>
+  assembleTextPdf([CATALOG_BODY, PAGES_BODY_SINGLE, PAGE_BODY]);
 
 /**
  * 1 ページ + `/Info` 辞書を持つ PDF を生成する。
+ * `/Info` には `info` で指定された Title / Author のみ収録する。
  *
- * @param _info - `/Info` に格納するフィールド
+ * @param info - `/Info` に格納するフィールド
  * @returns `/Info` 付き PDF を表すバイト列
  */
-export const buildSinglePagePdfWithInfo = (_info: InfoFields): Uint8Array =>
-  new Uint8Array();
+export const buildSinglePagePdfWithInfo = (info: InfoFields): Uint8Array => {
+  const fields: string[] = [];
+  if (info.title !== undefined) {
+    fields.push(`/Title ${toLiteralString(info.title)}`);
+  }
+  if (info.author !== undefined) {
+    fields.push(`/Author ${toLiteralString(info.author)}`);
+  }
+  const infoBody = `<< ${fields.join(" ")} >>`;
+  return assembleTextPdf(
+    [CATALOG_BODY, PAGES_BODY_SINGLE, PAGE_BODY, infoBody],
+    " /Info 4 0 R",
+  );
+};
 
 /**
  * 2 ページの PDF を生成する。
  *
+ * Catalog (1 0 obj) / Pages (2 0 obj, /Count 2) / Page1 (3 0 obj) / Page2 (4 0 obj)
+ * の 4 オブジェクト構成。
+ *
  * @returns 2 ページ PDF を表すバイト列
  */
-export const buildTwoPagePdf = (): Uint8Array => new Uint8Array();
+export const buildTwoPagePdf = (): Uint8Array =>
+  assembleTextPdf([CATALOG_BODY, PAGES_BODY_TWO, PAGE_BODY, PAGE_BODY]);
 
 /**
  * `/Catalog` を欠く不正な PDF を生成する。


### PR DESCRIPTION
## 概要

spec-006 (PR-5: 2-page / Info coverage) として、2-page PDF と `/Info` 辞書付き PDF の振る舞いカバレッジを追加する。`PdfDocument.load` パイプラインは PR-3 (#111) で完成済みのため、本 PR は **fixture 本実装と behavior テストの追加のみ** で、`pdf-document.ts` には変更なし。

## 変更の種類

- 🚨 テスト追加 / fixture 本実装

## 詳細な変更内容

### `packages/core/src/document/pdf-document.test.helpers.ts`
- 既存スケルトンだった `buildTwoPagePdf` / `buildSinglePagePdfWithInfo` を本実装。
- 共通の組み立てヘルパー `assembleTextPdf(objectBodies, trailerExtras)` を追加し、オフセット計算と xref/trailer 生成を一本化。
- ASCII literal string エンコード `toLiteralString` を追加（`\\` `(` `)` のみエスケープ）。
- 既存 `buildMinimalSinglePagePdf` も `assembleTextPdf` 経由に書き換え（出力バイト列は等価）。

### `packages/core/src/document/pdf-document.behavior.test.ts`
- `buildTwoPagePdf()` を使った `pageCount === 2` ケースを追加。
- `buildSinglePagePdfWithInfo({ title?, author? })` を使った `metadata.title` / `metadata.author` 抽出のパラメータ化テストを追加（title のみ / author のみ / 両方の 3 ケース）。

## 📊 システム図

```mermaid
flowchart TD
    Helpers["pdf-document.test.helpers.ts"]
    Asm["assembleTextPdf<br/>共通ヘルパー [NEW]"]
    Lit["toLiteralString<br/>literal string エンコード [NEW]"]
    Min["buildMinimalSinglePagePdf<br/>(共通化に置換)"]
    Two["buildTwoPagePdf<br/>本実装 [NEW]"]
    Info["buildSinglePagePdfWithInfo<br/>本実装 [NEW]"]

    Helpers --> Asm
    Helpers --> Lit
    Asm --> Min
    Asm --> Two
    Asm --> Info
    Lit --> Info

    Behavior["pdf-document.behavior.test.ts"]
    PageCount["pageCount=2 テスト [NEW]"]
    Metadata["metadata.title/author<br/>パラメータ化テスト [NEW]"]
    Behavior --> PageCount
    Behavior --> Metadata
    Two --> PageCount
    Info --> Metadata

    classDef new fill:#ffe4b5,stroke:#d97706,stroke-width:2px
    class Asm,Lit,Two,Info,PageCount,Metadata new
```

## 関連 Issue

- spec: `.plugin-workspace/.specs/006-pdf-document-coverage-twopage-info/`
- 親 spec: 001-pdf-document-load (PR-3 #111 でパイプライン完成)
- 直前 PR: #112 (spec-005 behavior/boundary)

## 🧪 テスト

### 実行方法

\`\`\`bash
pnpm --filter @pdfmod/core test
pnpm run lint
pnpm run typecheck
\`\`\`

### 結果

- 単体/統合テスト: ✅ 1377 passed (97 files) — `pdf-document.behavior.test.ts` 7 cases pass
- Lint (oxlint + biome): ✅ pass
- Type check: ✅ pass (core / react)

### Codex レビュー

`.plugin-workspace/.specs/006-pdf-document-coverage-twopage-info/code-review/review-001.md` — 1 回目で「問題なし」。

## 🔍 レビューポイント

- `assembleTextPdf` への共通化により `buildMinimalSinglePagePdf` の出力が変わっていないこと（既存テスト 5 件すべて pass を確認済み）。
- `toLiteralString` のエスケープ範囲は `\\` `(` `)` のみ。今回のテストは ASCII 入力 (`Hello` / `Alice` / `MyTitle` / `Bob`) で十分なため最小実装。非 ASCII / UTF-16BE は将来必要になった時点で拡張する想定。
- 変更は test 配下のみで `pdf-document.ts` 等プロダクションコードに変更なし (V-004: 変更ファイル数 1〜2 を満たす)。

## ✅ チェックリスト

- [x] テスト追加 / pass
- [x] Lint / typecheck pass
- [x] Codex レビュー実施 (問題なし)
- [x] spec の DoD (Coverage green / 変更ファイル数 1〜2) 充足
- [x] セルフレビュー実施