### PR TITLE
🚨 [Tests]: spec-007 PR-6 エラー伝搬 fixture (Catalog 不在 / MediaBox 欠落) 本実装

### DIFF
--- a/packages/core/src/document/pdf-document.test.helpers.ts
+++ b/packages/core/src/document/pdf-document.test.helpers.ts
@@ -26,6 +26,7 @@ const CATALOG_BODY = "<< /Type /Catalog /Pages 2 0 R >>";
 const PAGES_BODY_SINGLE = "<< /Type /Pages /Kids [3 0 R] /Count 1 >>";
 const PAGES_BODY_TWO = "<< /Type /Pages /Kids [3 0 R 4 0 R] /Count 2 >>";
 const PAGE_BODY = "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] >>";
+const PAGE_BODY_NO_MEDIABOX = "<< /Type /Page /Parent 2 0 R >>";
 
 /**
  * 10 桁ゼロ埋めでオフセットを表現する。xref テーブルの 20 バイト本体規約に従う。
@@ -98,6 +99,17 @@ const toPdfString = (s: string): string => {
 };
 
 /**
+ * `assembleTextPdf` のオプション。
+ */
+interface AssembleTextPdfOptions {
+  /**
+   * `true` のとき trailer 辞書から `/Root` を省略する。
+   * Catalog 不在を再現する error fixture 用途のフラグで、通常の正常系 fixture では省略する。
+   */
+  readonly omitRoot?: boolean;
+}
+
+/**
  * 1 0 obj 〜 N 0 obj の本体配列と trailer 追加エントリを与え、
  * テキスト xref 形式の PDF バイト列を組み立てる。
  *
@@ -106,11 +118,13 @@ const toPdfString = (s: string): string => {
  *
  * @param objectBodies - 各オブジェクトの本体（`<< ... >>` 等）
  * @param trailerEntries - trailer 辞書に追記するエントリ。例: `["/Info 4 0 R"]`
+ * @param options - 組み立てオプション（`omitRoot` で `/Root` の省略可）
  * @returns 組み立てた PDF バイト列
  */
 const assembleTextPdf = (
   objectBodies: readonly string[],
   trailerEntries: readonly string[] = [],
+  options: AssembleTextPdfOptions = {},
 ): Uint8Array => {
   const encoder = new TextEncoder();
   const objs = objectBodies.map(
@@ -131,9 +145,10 @@ const assembleTextPdf = (
     ...offsets.map((o) => `${padOffset10(o)} 00000 n \n`),
   ];
   const xref = `xref\n0 ${size}\n${xrefRows.join("")}`;
+  const rootEntry = options.omitRoot === true ? "" : " /Root 1 0 R";
   const trailerExtras =
     trailerEntries.length === 0 ? "" : ` ${trailerEntries.join(" ")}`;
-  const trailer = `trailer\n<< /Size ${size} /Root 1 0 R${trailerExtras} >>\nstartxref\n${xrefOffset}\n%%EOF\n`;
+  const trailer = `trailer\n<< /Size ${size}${rootEntry}${trailerExtras} >>\nstartxref\n${xrefOffset}\n%%EOF\n`;
 
   return encoder.encode(PDF_HEADER + objs.join("") + xref + trailer);
 };
@@ -185,16 +200,28 @@ export const buildTwoPagePdf = (): Uint8Array =>
 /**
  * `/Catalog` を欠く不正な PDF を生成する。
  *
- * @returns `/Catalog` 不在の PDF を表すバイト列
+ * trailer 辞書から `/Root` を省略することで、ヘッダ / startxref / xref テーブル
+ * までは妥当なまま、trailer 解析段階で `ROOT_NOT_FOUND` 系のエラーになる入力を作る。
+ * `PdfDocument.load` のエラー伝搬テスト (L-003) で使用する。
+ *
+ * @returns `/Root` を欠く trailer を持つ PDF バイト列
  */
-export const buildPdfWithoutCatalog = (): Uint8Array => new Uint8Array();
+export const buildPdfWithoutCatalog = (): Uint8Array =>
+  assembleTextPdf([CATALOG_BODY, PAGES_BODY_SINGLE, PAGE_BODY], [], {
+    omitRoot: true,
+  });
 
 /**
  * `/MediaBox` を欠く不正な PDF を生成する。
  *
- * @returns `/MediaBox` 不在の PDF を表すバイト列
+ * Page leaf にも親 Pages ノードにも `/MediaBox` が無い構成にすることで、
+ * `PageTreeWalker.walk` (継承解決) が `MEDIABOX_NOT_FOUND` を返す入力になる。
+ * `PdfDocument.load` のエラー伝搬テスト (L-004) で使用する。
+ *
+ * @returns ページ・親いずれも `/MediaBox` を持たない PDF バイト列
  */
-export const buildPdfWithoutMediaBox = (): Uint8Array => new Uint8Array();
+export const buildPdfWithoutMediaBox = (): Uint8Array =>
+  assembleTextPdf([CATALOG_BODY, PAGES_BODY_SINGLE, PAGE_BODY_NO_MEDIABOX]);
 
 /**
  * `startxref` の値が壊れた PDF を生成する。

--- a/packages/core/src/document/pdf-document.test.helpers.ts
+++ b/packages/core/src/document/pdf-document.test.helpers.ts
@@ -113,7 +113,9 @@ interface AssembleTextPdfOptions {
  * 1 0 obj 〜 N 0 obj の本体配列と trailer 追加エントリを与え、
  * テキスト xref 形式の PDF バイト列を組み立てる。
  *
- * `trailerEntries` は `/Root 1 0 R` の **後ろに追記される** 追加エントリ（例: `/Info 4 0 R`）の配列。
+ * `trailerEntries` は trailer 辞書の必須エントリ（`/Size`、および `omitRoot` が
+ * false の場合は `/Root 1 0 R`）の **後ろに追記される** 追加エントリ
+ * （例: `/Info 4 0 R`）の配列。`omitRoot: true` のときは `/Size` の直後に追記される。
  * 区切りスペースは本関数が付与するため、呼び出し側は先頭スペースを含めない。
  *
  * @param objectBodies - 各オブジェクトの本体（`<< ... >>` 等）


### PR DESCRIPTION
## 概要

spec-007 (PR-6: エラー伝搬 fixture) として、`buildPdfWithoutCatalog` / `buildPdfWithoutMediaBox` を skeleton から本実装に差し替える。次 PR (spec-008 / PR-7) のエラー伝搬テスト L-003 / L-004 で利用する fixture の準備で、本 PR ではテスト追加なし・`pdf-document.ts` への変更もなし。

## 変更の種類

- 🚨 テスト fixture 本実装（プロダクションコード変更なし）

## 詳細な変更内容

### `packages/core/src/document/pdf-document.test.helpers.ts`

- `buildPdfWithoutCatalog`: 既存 skeleton (`new Uint8Array()`) を本実装に差し替え。trailer 辞書から `/Root` を省略した PDF バイト列を生成する。これにより `parseTrailer` が `ROOT_NOT_FOUND` を返し、`PdfDocument.load` 全体としても `ROOT_NOT_FOUND` 系のエラーを伝搬する入力になる。
- `buildPdfWithoutMediaBox`: 既存 skeleton を本実装に差し替え。Page leaf にも親 Pages ノードにも `/MediaBox` が無い構成 (`PAGE_BODY_NO_MEDIABOX = "<< /Type /Page /Parent 2 0 R >>"`) を追加し、`PageTreeWalker.walk` の継承解決が `MEDIABOX_NOT_FOUND` を返す入力にする。
- `assembleTextPdf` に `AssembleTextPdfOptions.omitRoot` を追加。デフォルト `false` で既存の正常系 fixture (`buildMinimalSinglePagePdf` / `buildSinglePagePdfWithInfo` / `buildTwoPagePdf`) の出力は不変。`omitRoot: true` のときのみ trailer から `/Root 1 0 R` を抜いた文字列を生成する。

## 📊 システム図

```mermaid
flowchart TD
    Helpers["pdf-document.test.helpers.ts"]
    Asm["assembleTextPdf<br/>+ omitRoot オプション [UPDATED]"]
    NoCatalog["buildPdfWithoutCatalog<br/>本実装 [NEW]"]
    NoMB["buildPdfWithoutMediaBox<br/>本実装 [NEW]"]
    NoMBBody["PAGE_BODY_NO_MEDIABOX<br/>定数 [NEW]"]

    Helpers --> Asm
    Helpers --> NoMBBody
    Asm --> NoCatalog
    Asm --> NoMB
    NoMBBody --> NoMB

    subgraph Load["PdfDocument.load (PR-3 で完成済)"]
      direction LR
      VH[verifyHeader] --> SX[scanStartXRef]
      SX --> XR[parseXRefTable]
      XR --> PT[parseTrailer]
      PT --> CP[CatalogParser.parse]
      CP --> PTW[PageTreeWalker.walk]
    end

    NoCatalog -. "ROOT_NOT_FOUND を発生<br/>(L-003 で検証予定)" .-> PT
    NoMB -. "MEDIABOX_NOT_FOUND を発生<br/>(L-004 で検証予定)" .-> PTW

    classDef new fill:#ffe4b5,stroke:#d97706,stroke-width:2px
    class Asm,NoCatalog,NoMB,NoMBBody new
```

## 関連 Issue

- spec: `.plugin-workspace/.specs/007-pdf-document-error-fixtures/`
- 親 spec: 001-pdf-document-load
- 直前 PR: #113 (spec-006 PR-5 2-page / Info coverage)
- 後続 PR: spec-008 (PR-7) でこの fixture を使ったエラー伝搬テスト L-003 / L-004 を追加予定

## 🧪 テスト

### 実行方法

```bash
pnpm --filter @pdfmod/core test
pnpm lint
pnpm typecheck
```

### 結果

- 単体/統合テスト: ✅ 1377 passed (97 files) — 既存テスト全 pass、出力バイト列の等価性を担保
- Lint (oxlint + biome): ✅ 0 errors（pnpm-store の broken symlink 警告 3 件は本変更と無関係）
- Type check: ✅ pass (core / react)

## 🔍 レビューポイント

- `assembleTextPdf` のシグネチャに 3 番目のオプション引数を追加したが、デフォルト値で既存呼び出しは不変。正常系 fixture (`buildMinimalSinglePagePdf` / `buildSinglePagePdfWithInfo` / `buildTwoPagePdf`) の出力が変わっていないことを既存テスト 1377 件で担保。
- `buildPdfWithoutCatalog` の方針として「trailer に `/Root` を含めない」 / 「`/Root` を解決できない objectNumber にする」の 2 通りが implementation-plan.md §5.1 で示されているが、PR-7 が `error.code` の `ROOT_NOT_FOUND` 系判定を要求するため**前者 (`/Root` 省略)** を採用。後者では `OBJECT_NOT_FOUND` 系のエラーになり PR-7 の assert に合わない。
- 本 PR ではテスト未追加。L-003 / L-004 の green 担保は spec-008 (PR-7) で行う。
- 変更は test helper 1 ファイルのみ (V-004: 変更ファイル数 1〜2 を満たす)。

## ✅ チェックリスト

- [x] fixture 本実装 (`buildPdfWithoutCatalog` / `buildPdfWithoutMediaBox`)
- [x] テスト pass / Lint / typecheck pass
- [x] spec の DoD (テスト未追加・CI green・変更ファイル数 1〜2) 充足
- [x] セルフレビュー実施