### PR TITLE
🧪 [Tests]: spec-008 PR-7 エラー伝搬テスト (L-003 / L-004) を追加

### DIFF
--- a/packages/core/src/document/pdf-document.error.test.ts
+++ b/packages/core/src/document/pdf-document.error.test.ts
@@ -43,7 +43,7 @@ test("TAB 終端の `%PDF-1.7` は INVALID_HEADER を返さない", async () => 
   expect(result.error.code).not.toBe("INVALID_HEADER");
 });
 
-test("Catalog (`/Root`) を欠く trailer は ROOT_NOT_FOUND を返す", async () => {
+test("trailer 辞書が `/Root` を欠く PDF は ROOT_NOT_FOUND を返す", async () => {
   const result = await PdfDocument.load(buildPdfWithoutCatalog());
 
   expect(result.ok).toBe(false);

--- a/packages/core/src/document/pdf-document.error.test.ts
+++ b/packages/core/src/document/pdf-document.error.test.ts
@@ -1,5 +1,9 @@
 import { assert, expect, test } from "vitest";
 import { PdfDocument } from "./pdf-document";
+import {
+  buildPdfWithoutCatalog,
+  buildPdfWithoutMediaBox,
+} from "./pdf-document.test.helpers";
 
 test("空入力は INVALID_HEADER を返す", async () => {
   const result = await PdfDocument.load(new Uint8Array());
@@ -37,4 +41,22 @@ test("TAB 終端の `%PDF-1.7` は INVALID_HEADER を返さない", async () => 
   assert(!result.ok);
   assert(!(result.error instanceof RangeError));
   expect(result.error.code).not.toBe("INVALID_HEADER");
+});
+
+test("Catalog (`/Root`) を欠く trailer は ROOT_NOT_FOUND を返す", async () => {
+  const result = await PdfDocument.load(buildPdfWithoutCatalog());
+
+  expect(result.ok).toBe(false);
+  assert(!result.ok);
+  assert(!(result.error instanceof RangeError));
+  expect(result.error.code).toBe("ROOT_NOT_FOUND");
+});
+
+test("Page にも親 Pages にも MediaBox が無い PDF は MEDIABOX_NOT_FOUND を返す", async () => {
+  const result = await PdfDocument.load(buildPdfWithoutMediaBox());
+
+  expect(result.ok).toBe(false);
+  assert(!result.ok);
+  assert(!(result.error instanceof RangeError));
+  expect(result.error.code).toBe("MEDIABOX_NOT_FOUND");
 });


### PR DESCRIPTION
## 概要

spec-008 (`.plugin-workspace/.specs/008-pdf-document-error-tests/`) — PR-7 のエラー伝搬カバレッジテストを追加。`PdfDocument.load` 内のパイプライン直列化 (`if (!result.ok) return result;`) が **trailer dict-builder** / **PageTreeWalker** の `Err` をそのまま伝搬することを確認する。

## 変更内容

### 🎯 変更の種類

- [x] 🚨 テスト追加/修正 (Tests)

### 📝 詳細な変更内容

#### 追加された機能・修正

- `pdf-document.error.test.ts` に L-003 ケースを追加: `buildPdfWithoutCatalog()` (trailer から `/Root` を省略) 入力で `result.error.code === "ROOT_NOT_FOUND"` を assert
  - **発生段階**: trailer dict-builder の必須 `/Root` 検証 (`packages/core/src/xref/trailer/dict-builder/index.ts`)。CatalogParser には到達しない
- `pdf-document.error.test.ts` に L-004 ケースを追加: `buildPdfWithoutMediaBox()` 入力で `result.error.code === "MEDIABOX_NOT_FOUND"` を assert
  - **発生段階**: PageTreeWalker (継承解決) の MediaBox 検証
- いずれも overview.md §5.1.1 方針 A の narrowing 慣用句 `assert(!(result.error instanceof RangeError))` を `code` 参照前に挿入

#### 変更されたファイル

- `packages/core/src/document/pdf-document.error.test.ts` (+22 行)

#### 削除されたファイル・機能

- なし

## 📊 システム図

```mermaid
flowchart TD
    Input[Uint8Array] --> Load[PdfDocument.load]
    Load --> H[verifyHeader]
    H -->|Ok| X[xref pipeline]
    X --> T[trailer dict-builder]
    T -->|Ok| C[CatalogParser]
    C -->|Ok| W[PageTreeWalker]
    W -->|Ok| Doc([PdfDocument])

    H -->|Err INVALID_HEADER| ErrH([Err]):::existing
    T -->|Err ROOT_NOT_FOUND| ErrT([Err]):::new
    W -->|Err MEDIABOX_NOT_FOUND| ErrW([Err]):::new

    classDef new fill:#ffe4b5,stroke:#d97706,stroke-width:2px
    classDef existing fill:#e5e7eb,stroke:#6b7280
```

`[NEW]` で示した経路 (L-003: trailer / L-004: PageTreeWalker) を本 PR で test カバレッジに追加。`pdf-document.ts` 自体は無変更。

## 📋 関連 Issue

- Refs spec: `.plugin-workspace/.specs/008-pdf-document-error-tests/`
- 親 spec: 001-pdf-document-load (overview.md §9 PR-7)
- 前段 PR: #114 (spec-007 エラー fixture 本実装)

## 🧪 テスト

### テスト実行方法

```bash
pnpm --filter @pdfmod/core test -- --run pdf-document.error
```

### テスト項目

- [x] 単体テスト (Unit tests)

### テスト結果

- `pdf-document.error.test.ts`: 6 tests passed
- 全体: 97 files / 1379 tests passed
- `pnpm lint`: クリーン (biome / oxlint)
- `pnpm typecheck`: クリーン

## 🔍 レビューポイント

- L-003 は **trailer 段階** の `ROOT_NOT_FOUND` 伝搬カバレッジ。`buildPdfWithoutCatalog()` は trailer 辞書から `/Root` を省略する fixture で、エラーは trailer dict-builder で発生する (CatalogParser には到達しない)。仕様書側の表現は「Catalog 解決失敗」だが、実装ルート上は trailer 段階で fail-fast する。
- L-004 は **PageTreeWalker** 段階の `MEDIABOX_NOT_FOUND` 伝搬カバレッジ。
- `assert(!(result.error instanceof RangeError))` を `code` 参照直前に挟む方針 A の narrowing 慣用句に準拠。
- 変更ファイル数 1 (V-004 の 1〜2 ファイル制約)。

## ✅ チェックリスト

- [x] コードレビューの準備ができている
- [x] テストが正常に実行される
- [x] コミットメッセージが適切な形式で書かれている
- [x] セルフレビュー実施 (Codex CLI レビュー: review-001.md → 問題なし)

🤖 Generated with [Claude Code](https://claude.com/claude-code)