### PR TITLE
🧪 [Tests]: spec-009 PR-8 incremental update fixture を本実装

### DIFF
--- a/packages/core/src/document/pdf-document.test.helpers.ts
+++ b/packages/core/src/document/pdf-document.test.helpers.ts
@@ -257,6 +257,60 @@ export const buildPdfWithInvalidInfoRef = (): Uint8Array => new Uint8Array();
 /**
  * インクリメンタルアップデートを含む PDF を生成する。
  *
+ * 旧 xref (旧 trailer の `/Root 1 0 R`) と、`/Prev` で旧 xref を指す新 xref +
+ * 新 trailer (新 `/Root 4 0 R`) を持つ incremental update PDF を組み立てる。
+ *
+ * - 旧セクション: Catalog (1 0 R) / Pages (2 0 R) / Page (3 0 R) と
+ *   `xref 0 4` 形式の単一サブセクション、`/Size 4 /Root 1 0 R` の旧 trailer。
+ * - 新セクション: 新 Catalog (4 0 R, `/Pages 2 0 R` を再利用) と
+ *   `0 1` + `4 1` の 2 サブセクション形式の新 xref、
+ *   `/Size 5 /Root 4 0 R /Prev <oldXrefOffset>` の新 trailer。
+ *
+ * `mergeXRefChain` は startxref から新 xref を読み、`/Prev` を辿って旧 xref
+ * を merge し、最新 trailer の `/Root` (= 新 Catalog 4 0 R) を採用する。
+ *
  * @returns インクリメンタルアップデート付き PDF を表すバイト列
  */
-export const buildPdfWithIncrementalUpdate = (): Uint8Array => new Uint8Array();
+export const buildPdfWithIncrementalUpdate = (): Uint8Array => {
+  const encoder = new TextEncoder();
+
+  const oldObjBodies = [CATALOG_BODY, PAGES_BODY_SINGLE, PAGE_BODY];
+  const oldObjs = oldObjBodies.map(
+    (body, i) => `${i + 1} 0 obj\n${body}\nendobj\n`,
+  );
+
+  const oldOffsets: number[] = [];
+  let cursor = encoder.encode(PDF_HEADER).length;
+  for (const obj of oldObjs) {
+    oldOffsets.push(cursor);
+    cursor += encoder.encode(obj).length;
+  }
+  const oldXrefOffset = cursor;
+
+  const oldSize = oldObjBodies.length + 1;
+  const oldXrefRows = [
+    "0000000000 65535 f \n",
+    ...oldOffsets.map((o) => `${padOffset10(o)} 00000 n \n`),
+  ];
+  const oldXref = `xref\n0 ${oldSize}\n${oldXrefRows.join("")}`;
+  const oldTrailer = `trailer\n<< /Size ${oldSize} /Root 1 0 R >>\nstartxref\n${oldXrefOffset}\n%%EOF\n`;
+  const oldTail = oldXref + oldTrailer;
+  cursor += encoder.encode(oldTail).length;
+
+  const newCatalogBody = "<< /Type /Catalog /Pages 2 0 R >>";
+  const newObj = `4 0 obj\n${newCatalogBody}\nendobj\n`;
+  const newObjOffset = cursor;
+  cursor += encoder.encode(newObj).length;
+  const newXrefOffset = cursor;
+
+  const newSize = oldSize + 1;
+  const newXref =
+    `xref\n` +
+    `0 1\n0000000000 65535 f \n` +
+    `4 1\n${padOffset10(newObjOffset)} 00000 n \n`;
+  const newTrailer = `trailer\n<< /Size ${newSize} /Root 4 0 R /Prev ${oldXrefOffset} >>\nstartxref\n${newXrefOffset}\n%%EOF\n`;
+
+  return encoder.encode(
+    PDF_HEADER + oldObjs.join("") + oldTail + newObj + newXref + newTrailer,
+  );
+};


### PR DESCRIPTION
## 概要

spec-009 PR-8: `buildPdfWithIncrementalUpdate` を本実装し、PR-9 (spec-010) の L-010 テストで使う incremental update PDF fixture を準備する。

## 変更内容

### 🎯 変更の種類

- [x] 🚨 テスト追加/修正 (Tests)

### 📝 詳細な変更内容

#### 追加された機能・修正

- `buildPdfWithIncrementalUpdate` を空実装から本実装に置き換え
- 旧 xref (Catalog 1 0 R / Pages 2 0 R / Page 3 0 R + `/Size 4 /Root 1 0 R`) の後ろに、新 Catalog (4 0 R) と `/Prev` で旧 xref を指す新 xref + `/Size 5 /Root 4 0 R /Prev <oldXrefOffset>` の新 trailer を配置する
- 新 xref は `0 1` + `4 1` の 2 サブセクション形式

#### 変更されたファイル

- `packages/core/src/document/pdf-document.test.helpers.ts`

#### 削除されたファイル・機能

- なし

## 📊 システム図

### incremental update PDF レイアウト

```mermaid
flowchart TD
    Header["%PDF-1.7"] --> Obj1["1 0 obj — Catalog (旧, /Pages 2 0 R)"]
    Obj1 --> Obj2["2 0 obj — Pages (/Kids [3 0 R])"]
    Obj2 --> Obj3["3 0 obj — Page (MediaBox)"]
    Obj3 --> XrefOld["旧 xref (0 4 サブセクション)"]
    XrefOld --> TrailerOld["旧 trailer<br/>/Size 4 /Root 1 0 R"]
    TrailerOld --> StartXrefOld["startxref &lt;oldXrefOffset&gt; %%EOF"]
    StartXrefOld --> Obj4["4 0 obj — 新 Catalog (/Pages 2 0 R)"]:::new
    Obj4 --> XrefNew["新 xref (0 1 + 4 1 サブセクション)"]:::new
    XrefNew --> TrailerNew["新 trailer<br/>/Size 5 /Root 4 0 R<br/>/Prev &lt;oldXrefOffset&gt;"]:::new
    TrailerNew --> StartXrefNew["startxref &lt;newXrefOffset&gt; %%EOF"]:::new

    classDef new fill:#ffe4b5,stroke:#d97706,stroke-width:2px
```

### mergeXRefChain 走査フロー

```mermaid
flowchart LR
    StartXref["scanStartXRef → 末尾 startxref<br/>(= newXrefOffset)"]
    StartXref --> ParseNew["parseXRefAt(newXrefOffset)<br/>→ 新 xref + 新 trailer"]
    ParseNew --> Prev{"trailer.prev?"}
    Prev -->|あり: oldXrefOffset| ParseOld["parseXRefAt(oldXrefOffset)<br/>→ 旧 xref + 旧 trailer"]
    ParseOld --> Merge["chain merge (oldest→newest 上書き)"]
    Merge --> Result["latestTrailer = 新 trailer (/Root 4 0 R)<br/>mergedXRef: obj 1〜4 すべて含む"]
```

## 📋 関連 Issue

- 関連 Issue 番号は implementation-plan.md に記載なし

## 🧪 テスト

### テスト実行方法

```bash
pnpm --filter @pdfmod/core typecheck
pnpm --filter @pdfmod/core test
```

### テスト項目

- [x] 単体テスト (Unit tests) — 既存スイート全体を実行

### テスト結果

- typecheck: 通過
- test: 1379 / 1379 passed
- Codex レビュー (1 回): 「問題なし」

> 本 PR ではテストは追加しない。fixture を使う L-010 テストの追加は次の spec (010-pdf-document-incremental-test / PR-9) で行う。

## 🔍 レビューポイント

- 旧 xref → 新 xref の `/Prev` チェーンが正しく辿れる byte レイアウトになっているか（オフセット計算が `cursor` 累積で完結している点）
- 新 xref の `0 1` + `4 1` 2 サブセクション表記が `parseXRefTable` のサブセクションループ仕様に整合しているか
- 新 trailer の `/Root 4 0 R` を最新として採用するため、新 Catalog が旧 Catalog と異なる object number になっている点

## ✅ チェックリスト

- [x] コードレビューの準備ができている
- [x] テストが正常に実行される (1379 passed)
- [x] ドキュメント更新は不要（fixture 関数の JSDoc を充実）
- [x] コミットメッセージが適切な形式で書かれている
- [x] セルフレビューを実施した
- [x] 破壊的変更なし