### PR TITLE
🧪 [Tests]: spec-011 PR-10 warning テストファイル新設 + L-005

### DIFF
--- a/packages/core/src/document/pdf-document.warning.test.ts
+++ b/packages/core/src/document/pdf-document.warning.test.ts
@@ -1,0 +1,16 @@
+import { assert, expect, test } from "vitest";
+import { PdfDocument } from "./pdf-document";
+import { buildMinimalSinglePagePdf } from "./pdf-document.test.helpers";
+
+test("/Info を持たない PDF を load すると metadata はキー数 0 の空オブジェクト (L-005)", async () => {
+  const result = await PdfDocument.load(buildMinimalSinglePagePdf());
+
+  assert(result.ok);
+  expect(Object.keys(result.value.metadata)).toHaveLength(0);
+});
+
+test("/Info を持たない PDF を onWarning 未指定で load すると Ok を返す (L-005)", async () => {
+  const result = await PdfDocument.load(buildMinimalSinglePagePdf());
+
+  assert(result.ok);
+});

--- a/packages/core/src/document/pdf-document.warning.test.ts
+++ b/packages/core/src/document/pdf-document.warning.test.ts
@@ -9,8 +9,10 @@ test("/Info を持たない PDF を load すると metadata はキー数 0 の�
   expect(Object.keys(result.value.metadata)).toHaveLength(0);
 });
 
-test("/Info を持たない PDF を onWarning 未指定で load すると Ok を返す (L-005)", async () => {
-  const result = await PdfDocument.load(buildMinimalSinglePagePdf());
+test("/Info を持たない PDF を options 指定 + onWarning 未指定で load すると Ok を返す (L-005)", async () => {
+  const result = await PdfDocument.load(buildMinimalSinglePagePdf(), {
+    cacheCapacity: 1,
+  });
 
   assert(result.ok);
 });


### PR DESCRIPTION
## 概要

spec-011 PR-10 の実装。`pdf-document.warning.test.ts` を新設し、`/Info` を持たない最小 PDF で `metadata` が空オブジェクト + `onWarning` 未指定でも `load` が Ok を返す silent success を担保する (L-005)。

## 変更内容

### 🎯 変更の種類

- [x] 🚨 テスト追加/修正 (Tests)

### 📝 詳細な変更内容

#### 追加された機能・修正

- `/Info` を持たない PDF を `PdfDocument.load` した結果、`metadata` のキー数が 0 の空オブジェクトであることを検証するテスト
- `onWarning` 未指定でも `load` が Ok を返すこと (silent success) を検証するテスト

#### 変更されたファイル

- (新規) `packages/core/src/document/pdf-document.warning.test.ts` (+16 行)

## 📊 システム図

### データフロー

```mermaid
flowchart LR
    A[buildMinimalSinglePagePdf] -->|/Info なし| B[PdfDocument.load]
    B --> C[DocumentInfoParser.parse]
    C -->|/Info 不在| D[EMPTY_METADATA + 空 warnings]
    D --> E[Ok PdfDocument]
    E -->|metadata| F[Object.keys length 0]:::new
    E -->|onWarning 未指定| G[silent success]:::new

    classDef new fill:#ffe4b5,stroke:#d97706,stroke-width:2px
```

## 📋 関連 Issue

- Refs spec-001 (parent) / spec-011 PR-10

## 🧪 テスト

### テスト実行方法

```bash
pnpm --filter @pdfmod/core test src/document/pdf-document.warning.test.ts
```

### テスト項目

- [x] 単体テスト (Unit tests)

### テスト結果

- 新規 2 件 含む `pnpm --filter @pdfmod/core test`: 1384 tests passed
- `pnpm --filter @pdfmod/core typecheck`: pass
- `pnpm lint` (biome + oxlint): 0 errors
- Codex レビュー (review-001.md): 問題なし

## 🔍 レビューポイント

- describe 不使用・フラット test 列挙の規約に準拠
- spy パターンは L-007 で本格導入予定で、本 PR は metadata 空 + silent success の確認に留める
- `pdf-document.ts` 側の変更なし (既存 `options?.onWarning?.()` のオプショナルチェーンに依存)

## ✅ チェックリスト

- [x] コードレビューの準備ができている
- [x] テストが正常に実行される
- [x] コミットメッセージが適切な形式で書かれている
- [x] セルフレビューを実施した