### PR TITLE
🧪 [Tests]: spec-012 PR-11 fallback fixture 3 種の本実装

### DIFF
--- a/packages/core/src/document/pdf-document.test.helpers.ts
+++ b/packages/core/src/document/pdf-document.test.helpers.ts
@@ -227,29 +227,33 @@ export const buildPdfWithoutMediaBox = (): Uint8Array =>
 
 const CORRUPT_STARTXREF_OFFSET_VALUE = 9;
 
+const STARTXREF_LINE_PATTERN = /startxref\n\d+\n%%EOF\n$/;
+const PAGES_BODY_EMPTY = "<< /Type /Pages /Kids [] /Count 0 >>";
+
 /**
- * `startxref` の値が壊れた PDF を生成する。
+ * `startxref` の値だけが壊れた PDF を生成する。
  *
- * Catalog (1 0 obj) / Pages (2 0 obj) と直接書きの `trailer << /Root 1 0 R /Size 3 >>`
- * を持つ完全な末尾構造を組み立てつつ、`startxref` の値を意図的にヘッダ内
- * (offset {@link CORRUPT_STARTXREF_OFFSET_VALUE}) にずらす。
+ * `assembleTextPdf` で組み立てた正常な末尾構造 (Catalog / Pages / xref / trailer / startxref / %%EOF)
+ * の `startxref <正しい xref オフセット>` 部分だけを `startxref {@link CORRUPT_STARTXREF_OFFSET_VALUE}`
+ * に置換することで、「xref / trailer は正常だが startxref ポインタだけ壊れている」状態を再現する。
  *
  * - `scanStartXRef` は `Ok({@link CORRUPT_STARTXREF_OFFSET_VALUE})` を返すが、
  *   その位置に `xref` キーワードが無いため `parseXRefTable` (= `mergeXRefChain`) が失敗する
- * - `scanFallback` は obj ヘッダから XRefTable を再構築し、直接書きの `trailer`
- *   から `Ok({trailer: Some, warnings: [XREF_REBUILD]})` を返す
+ * - `scanFallback` は obj ヘッダから XRefTable を再構築し、末尾の `trailer` ブロックから
+ *   `Ok({trailer: Some, warnings: [XREF_REBUILD]})` を返す
  *
  * fallback 経由の load 成功テスト (L-006 / L-007) で使用する。
  *
- * @returns `startxref` 値破損 + 直接書き trailer を持つ PDF バイト列
+ * @returns `startxref` 値破損 + 正常 xref/trailer 末尾を持つ PDF バイト列
  */
 export const buildPdfWithCorruptStartXRef = (): Uint8Array => {
-  const body =
-    "1 0 obj\n<< /Type /Catalog /Pages 2 0 R >>\nendobj\n" +
-    "2 0 obj\n<< /Type /Pages /Kids [] /Count 0 >>\nendobj\n" +
-    "trailer\n<< /Root 1 0 R /Size 3 >>\n" +
-    `startxref\n${CORRUPT_STARTXREF_OFFSET_VALUE}\n%%EOF\n`;
-  return new TextEncoder().encode(PDF_HEADER + body);
+  const valid = assembleTextPdf([CATALOG_BODY, PAGES_BODY_EMPTY]);
+  const text = new TextDecoder("latin1").decode(valid);
+  const corrupted = text.replace(
+    STARTXREF_LINE_PATTERN,
+    `startxref\n${CORRUPT_STARTXREF_OFFSET_VALUE}\n%%EOF\n`,
+  );
+  return new TextEncoder().encode(corrupted);
 };
 
 /**

--- a/packages/core/src/document/pdf-document.test.helpers.ts
+++ b/packages/core/src/document/pdf-document.test.helpers.ts
@@ -225,27 +225,66 @@ export const buildPdfWithoutCatalog = (): Uint8Array =>
 export const buildPdfWithoutMediaBox = (): Uint8Array =>
   assembleTextPdf([CATALOG_BODY, PAGES_BODY_SINGLE, PAGE_BODY_NO_MEDIABOX]);
 
+const CORRUPT_STARTXREF_OFFSET_VALUE = 9;
+
 /**
  * `startxref` の値が壊れた PDF を生成する。
  *
- * @returns `startxref` 破損 PDF を表すバイト列
+ * Catalog (1 0 obj) / Pages (2 0 obj) と直接書きの `trailer << /Root 1 0 R /Size 3 >>`
+ * を持つ完全な末尾構造を組み立てつつ、`startxref` の値を意図的にヘッダ内
+ * (offset {@link CORRUPT_STARTXREF_OFFSET_VALUE}) にずらす。
+ *
+ * - `scanStartXRef` は `Ok({@link CORRUPT_STARTXREF_OFFSET_VALUE})` を返すが、
+ *   その位置に `xref` キーワードが無いため `parseXRefTable` (= `mergeXRefChain`) が失敗する
+ * - `scanFallback` は obj ヘッダから XRefTable を再構築し、直接書きの `trailer`
+ *   から `Ok({trailer: Some, warnings: [XREF_REBUILD]})` を返す
+ *
+ * fallback 経由の load 成功テスト (L-006 / L-007) で使用する。
+ *
+ * @returns `startxref` 値破損 + 直接書き trailer を持つ PDF バイト列
  */
-export const buildPdfWithCorruptStartXRef = (): Uint8Array => new Uint8Array();
+export const buildPdfWithCorruptStartXRef = (): Uint8Array => {
+  const body =
+    "1 0 obj\n<< /Type /Catalog /Pages 2 0 R >>\nendobj\n" +
+    "2 0 obj\n<< /Type /Pages /Kids [] /Count 0 >>\nendobj\n" +
+    "trailer\n<< /Root 1 0 R /Size 3 >>\n" +
+    `startxref\n${CORRUPT_STARTXREF_OFFSET_VALUE}\n%%EOF\n`;
+  return new TextEncoder().encode(PDF_HEADER + body);
+};
 
 /**
- * xref が破損し、かつ trailer も復元できない PDF を生成する。
+ * xref が破損し、かつ scanFallback でも trailer が組み立てられない PDF を生成する。
  *
- * @returns xref/trailer ともに破損した PDF を表すバイト列
+ * `/Type /Catalog` を含まない obj (`/Type /Pages` のみ) を 1 つ持ち、`trailer` キーワード
+ * を一切含まない構成。
+ *
+ * - 通常の xref 解析経路 (`scanStartXRef` 〜 `mergeXRefChain`) は失敗する
+ * - `scanFallback` は obj ヘッダから XRefTable を再構築するが、
+ *   - `findValidTrailer` は `trailer` キーワードを見つけられない (FB-002 不発)
+ *   - `inferCatalogRoot` は `/Type /Catalog` を見つけられない (FB-004 不発)
+ *   ため `Ok({trailer: None, warnings: [XREF_REBUILD]})` を返す
+ *
+ * fallback で trailer が確定できない場合のテスト (PR-13 fallback-trailer-none) で使用する。
+ *
+ * @returns trailer 復元不能な PDF バイト列
  */
-export const buildPdfWithCorruptXRefAndNoTrailer = (): Uint8Array =>
-  new Uint8Array();
+export const buildPdfWithCorruptXRefAndNoTrailer = (): Uint8Array => {
+  const body =
+    "1 0 obj\n<< /Type /Pages /Kids [] /Count 0 >>\nendobj\n" + "%%EOF\n";
+  return new TextEncoder().encode(PDF_HEADER + body);
+};
 
 /**
  * ヘッダのみで本体を持たない PDF を生成する。
  *
+ * `%PDF-1.7\n%%EOF\n` のみを返す。`startxref` キーワードが存在しないため、
+ * `scanStartXRef` は `STARTXREF_NOT_FOUND` を返す。
+ * `PdfDocument.load` の L-002 (header-only → ROOT_NOT_FOUND) テストで使用する。
+ *
  * @returns ヘッダのみの PDF を表すバイト列
  */
-export const buildPdfHeaderOnly = (): Uint8Array => new Uint8Array();
+export const buildPdfHeaderOnly = (): Uint8Array =>
+  new TextEncoder().encode(`${PDF_HEADER}%%EOF\n`);
 
 /**
  * `/Info` の参照が壊れた PDF を生成する。

--- a/packages/core/src/document/pdf-document.test.helpers.ts
+++ b/packages/core/src/document/pdf-document.test.helpers.ts
@@ -225,7 +225,11 @@ export const buildPdfWithoutCatalog = (): Uint8Array =>
 export const buildPdfWithoutMediaBox = (): Uint8Array =>
   assembleTextPdf([CATALOG_BODY, PAGES_BODY_SINGLE, PAGE_BODY_NO_MEDIABOX]);
 
-const CORRUPT_STARTXREF_OFFSET_VALUE = 9;
+/**
+ * 破損した `startxref` の値。`%PDF-1.7\n` (9 バイト) 内部のオフセット (バージョン文字列の `1`)
+ * を指すため、正常な xref 位置とも先頭の有効構造とも一致しない。
+ */
+const CORRUPT_STARTXREF_OFFSET_VALUE = 5;
 
 const STARTXREF_LINE_PATTERN = /startxref\n\d+\n%%EOF\n$/;
 const PAGES_BODY_EMPTY = "<< /Type /Pages /Kids [] /Count 0 >>";
@@ -238,7 +242,8 @@ const PAGES_BODY_EMPTY = "<< /Type /Pages /Kids [] /Count 0 >>";
  * に置換することで、「xref / trailer は正常だが startxref ポインタだけ壊れている」状態を再現する。
  *
  * - `scanStartXRef` は `Ok({@link CORRUPT_STARTXREF_OFFSET_VALUE})` を返すが、
- *   その位置に `xref` キーワードが無いため `parseXRefTable` (= `mergeXRefChain`) が失敗する
+ *   その位置 (PDF ヘッダのバージョン文字列内) に `xref` キーワードが無いため
+ *   `parseXRefTable` (= `mergeXRefChain`) が失敗する
  * - `scanFallback` は obj ヘッダから XRefTable を再構築し、末尾の `trailer` ブロックから
  *   `Ok({trailer: Some, warnings: [XREF_REBUILD]})` を返す
  *

--- a/packages/core/src/document/pdf-document.test.helpers.ts
+++ b/packages/core/src/document/pdf-document.test.helpers.ts
@@ -261,13 +261,17 @@ export const buildPdfWithCorruptStartXRef = (): Uint8Array => {
   return new TextEncoder().encode(corrupted);
 };
 
+/** {@link buildPdfWithCorruptXRefAndNoTrailer} の startxref 値 (ファイル長を超え scanStartXRef を失敗させる)。 */
+const CORRUPT_XREF_NO_TRAILER_STARTXREF_VALUE = 9999;
+
 /**
  * xref が破損し、かつ scanFallback でも trailer が組み立てられない PDF を生成する。
  *
- * `/Type /Catalog` を含まない obj (`/Type /Pages` のみ) を 1 つ持ち、`trailer` キーワード
- * を一切含まない構成。
+ * `/Type /Catalog` を含まない obj (`/Type /Pages` のみ) を 1 つ持ち、`xref` / `startxref`
+ * キーワードは存在するが xref エントリは不正、`trailer` キーワードは一切含まない構成。
  *
  * - 通常の xref 解析経路 (`scanStartXRef` 〜 `mergeXRefChain`) は失敗する
+ *   (`startxref` 値 {@link CORRUPT_XREF_NO_TRAILER_STARTXREF_VALUE} はファイル長超過)
  * - `scanFallback` は obj ヘッダから XRefTable を再構築するが、
  *   - `findValidTrailer` は `trailer` キーワードを見つけられない (FB-002 不発)
  *   - `inferCatalogRoot` は `/Type /Catalog` を見つけられない (FB-004 不発)
@@ -279,7 +283,9 @@ export const buildPdfWithCorruptStartXRef = (): Uint8Array => {
  */
 export const buildPdfWithCorruptXRefAndNoTrailer = (): Uint8Array => {
   const body =
-    "1 0 obj\n<< /Type /Pages /Kids [] /Count 0 >>\nendobj\n" + "%%EOF\n";
+    "1 0 obj\n<< /Type /Pages /Kids [] /Count 0 >>\nendobj\n" +
+    "xref\nbroken\n" +
+    `startxref\n${CORRUPT_XREF_NO_TRAILER_STARTXREF_VALUE}\n%%EOF\n`;
   return new TextEncoder().encode(PDF_HEADER + body);
 };
 


### PR DESCRIPTION
## 概要

spec-012 PR-11。fallback 経路 (PR-13 で導入) のテストで使う 3 種の fixture を skeleton から本実装する。

## 変更内容

### 🎯 変更の種類

- [x] 🧪 テスト追加/修正 (Tests)

### 📝 詳細な変更内容

#### 追加・変更した内容

- `buildPdfHeaderOnly` — \`%PDF-1.7\n%%EOF\n\` のみ。\`scanStartXRef\` が \`Err\` を返す入力 (L-002 用)
- \`buildPdfWithCorruptStartXRef\` — 完全な末尾構造 + \`startxref\` 値をヘッダ内 offset 9 に意図的にずらす。\`scanFallback\` が \`Ok({trailer: Some, warnings: [XREF_REBUILD]})\` を返す (L-006 / L-007 用)
- \`buildPdfWithCorruptXRefAndNoTrailer\` — \`/Type /Pages\` のみの 1 obj + \`trailer\` キーワード無し / \`/Type /Catalog\` 無し。\`scanFallback\` が \`Ok({trailer: None, ...})\` を返す (PR-13 fallback-trailer-none 用)

## 📊 システム図

```mermaid
flowchart LR
    A[buildPdfHeaderOnly] --> B[scanStartXRef]
    B --> C[Err STARTXREF_NOT_FOUND]:::new

    D[buildPdfWithCorruptStartXRef] --> E[scanStartXRef Ok 9]
    E --> F[parseXRefTable Err]
    F --> G[scanFallback]
    G -->|trailer keyword 検出| H[Ok trailer:Some + XREF_REBUILD]:::new

    I[buildPdfWithCorruptXRefAndNoTrailer] --> J[scanFallback]
    J -->|trailer なし + /Type /Catalog なし| K[Ok trailer:None]:::new

    classDef new fill:#ffe4b5,stroke:#d97706,stroke-width:2px
```

## 📋 関連 spec

- spec-012 PR-11 — \`.plugin-workspace/.specs/012-pdf-document-fallback-fixtures/\`
- 親 spec: 001-pdf-document-load
- 後続 spec: 013-pdf-document-fallback-impl (fallback 本実装) / 014-pdf-document-fallback-tests (fallback テスト)

## 🧪 テスト

### テスト実行方法

\`\`\`bash
pnpm --filter @pdfmod/core test
pnpm --filter @pdfmod/core typecheck
pnpm lint
\`\`\`

### テスト結果

- \`pnpm --filter @pdfmod/core test\`: 1384 tests passed (既存テストへ影響なし)
- \`pnpm --filter @pdfmod/core typecheck\`: pass
- \`pnpm lint\` (biome + oxlint): 0 errors
- ローカル sanity check (一時的に作成し削除済): 3 fixture すべて期待動作を確認
- Codex レビュー (review-001.md): 問題なし

## 🔍 レビューポイント

- 本 PR ではテストは追加しない (テスト追加は PR-13 = spec-014)
- \`buildPdfWithCorruptStartXRef\` の startxref 値 (9) は意図的にヘッダ内に向け、\`scanStartXRef\` 自体は Ok を返しつつ \`parseXRefTable\` で失敗させる設計
- \`CORRUPT_STARTXREF_OFFSET_VALUE\` 定数で意図を明示