### PR TITLE
✨ [New Feature]: spec-013 PR-12 PdfDocument.load fallback 経路 + emitWarnings 実装

### DIFF
--- a/docs/implementation/index.md
+++ b/docs/implementation/index.md
@@ -1,0 +1,16 @@
+# 実装ドキュメント
+
+`@pdfmod/core` 各モジュールの **実装側の動作・契約・既知制約** を記すドキュメント群。
+仕様 (理想形) は [pdf-parsing-pipeline/](../pdf-parsing-pipeline/index.md) を参照。本フォルダは「実装が現時点で何をしていて、何をしていないか」を把握するためのリファレンス。
+
+## ドキュメント一覧
+
+| ドキュメント | 説明 |
+|:---|:---|
+| [pdf-document-load-fallback.md](./pdf-document-load-fallback.md) | `PdfDocument.load` の fallback recovery 経路。`scanStartXRef` / `mergeXRefChain` 失敗時の `scanFallback` 呼び出し、`XREF_REBUILD` warning 契約、`resolveXRefStructure` / `emitWarnings` ローカル関数の役割、ISO 32000-1 §7.5 との対応 |
+
+## 配置ルール
+
+- **spec (理想形・公開 API 設計)**: [`docs/pdf-parsing-pipeline/`](../pdf-parsing-pipeline/) 配下
+- **実装 (内部の振る舞い・degraded recovery などの実装事情)**: 本フォルダ配下
+- 1 機能で spec / 実装の両方がある場合は両側にファイルを置き、相互リンクで紐付ける

--- a/docs/implementation/pdf-document-load-fallback.md
+++ b/docs/implementation/pdf-document-load-fallback.md
@@ -1,7 +1,7 @@
 # PdfDocument.load の fallback recovery 経路
 
-> **機能**: [PDF解析パイプライン](./index.md)
-> **関連 spec**: ISO 32000-1:2008 §7.5 (File Structure)
+> **カテゴリ**: 実装ドキュメント
+> **関連 spec**: ISO 32000-1:2008 §7.5 (File Structure) / [pdf-parsing-pipeline](../pdf-parsing-pipeline/index.md)
 > **実装**: `packages/core/src/document/pdf-document.ts`
 > **ステータス**: 下書き (spec-013 PR-12 で実装)
 
@@ -114,7 +114,7 @@ merge-failure 経路で trailer 復元できなかった時に合成 `ROOT_NOT_F
 ## 関連ドキュメント
 
 - [xref-fallback-scanner.md](../xref-fallback-scanner.md) — `scanFallback` 実装の詳細
-- [xref-merger-spec.md](./xref-merger-spec.md) — `mergeXRefChain` (`/Prev` 連鎖マージ) の仕様
-- [startxref-scanner.md](./startxref-scanner.md) — `scanStartXRef` の仕様
-- [xref-parser-spec.md](./xref-parser-spec.md) — xref テーブル解析
-- [error-handling-spec.md](./error-handling-spec.md) — `PdfError` / `PdfWarning` 階層
+- [xref-merger-spec.md](../pdf-parsing-pipeline/xref-merger-spec.md) — `mergeXRefChain` (`/Prev` 連鎖マージ) の仕様
+- [startxref-scanner.md](../pdf-parsing-pipeline/startxref-scanner.md) — `scanStartXRef` の仕様
+- [xref-parser-spec.md](../pdf-parsing-pipeline/xref-parser-spec.md) — xref テーブル解析
+- [error-handling-spec.md](../pdf-parsing-pipeline/error-handling-spec.md) — `PdfError` / `PdfWarning` 階層

--- a/docs/pdf-parsing-pipeline/document-load-fallback.md
+++ b/docs/pdf-parsing-pipeline/document-load-fallback.md
@@ -1,0 +1,120 @@
+# PdfDocument.load の fallback recovery 経路
+
+> **機能**: [PDF解析パイプライン](./index.md)
+> **関連 spec**: ISO 32000-1:2008 §7.5 (File Structure)
+> **実装**: `packages/core/src/document/pdf-document.ts`
+> **ステータス**: 下書き (spec-013 PR-12 で実装)
+
+## 概要
+
+`PdfDocument.load` は ヘッダ検証 → startxref 走査 → xref/trailer 解析 → ObjectStore 生成 → カタログ解析 → ページツリー走査 → /Info メタデータ抽出 を直列に実行する。
+本ドキュメントは、その中の **xref/trailer 解析段階で正規パスが破綻したときの fallback recovery** を対象とする。
+
+正規パスは ISO 32000-1 §7.5.5 の `startxref` → `xref` → `trailer` → `/Root` チェーン。fallback はこの構造が破損している PDF を可能な限り読み込むための recovery 層で、Acrobat 等の reader が現実世界の壊れた PDF に対して暗黙に行う「本文の `obj` ヘッダを線形走査して xref を再構築する」挙動を、`onWarning` 契約で明示的に表現する。
+
+## 解決経路
+
+`resolveXRefStructure(data, emitWarnings)` ローカル関数が xref と trailer を 1 つの「xref 構造」として解決する。
+
+```
+scanStartXRef(data)
+├─ Err  → scanFallback ─┬─ trailer.Some → emitWarnings(XREF_REBUILD) → Ok({xref, trailer})
+│                       └─ trailer.None → Err({code: "ROOT_NOT_FOUND"})  (§7.5.5 必須エントリ違反)
+└─ Ok   → mergeXRefChain
+          ├─ Ok   → Ok({xref: mergedXRef, trailer: latestTrailer})
+          └─ Err  → scanFallback ─┬─ trailer.Some → emitWarnings(XREF_REBUILD) → Ok({xref, trailer})
+                                  └─ trailer.None → 元の mergeResult Err を伝搬
+```
+
+### fallback 発火条件
+
+ISO 32000-1 §7.5.5 に基づく正規パスの破綻 2 種類でのみ発火する:
+
+| トリガー | 仕様上の意味 | 典型例 |
+|:---|:---|:---|
+| `scanStartXRef` Err | `%%EOF` 直前の `startxref <offset>` が見つからない or 不正 (§7.5.5) | ヘッダのみで本体無し / ファイル末尾切り捨て |
+| `mergeXRefChain` Err | xref テーブル / trailer 辞書が malformed、`/Prev` cycle、`/Root` 必須エントリ欠落 (§7.5.4 / §7.5.5) | xref offset が壊れている / `/Prev` の循環参照 / trailer 辞書から `/Root` が欠落 |
+
+`CatalogParser` (§7.7.2) / `PageTreeWalker` (§7.7.3) / `DocumentInfoParser` (§14.3.3) の Err では fallback **しない**。これらは xref 構造が正しく解決された後の論理的なエラーで、recovery しても結果は変わらない。
+
+### scanFallback の詳細
+
+`packages/core/src/xref/fallback/` 配下。詳細は [xref-fallback-scanner.md](../xref-fallback-scanner.md) 参照。本ドキュメントでは `PdfDocument.load` から見た契約のみ記す。
+
+- 戻り値型: `Result<FallbackScanResult, PdfError>`。現状実装は常に `Ok` を返すが、将来拡張に備えて `if (!fb.ok) return fb;` で Err 伝搬経路を温存している。
+- `FallbackScanResult.xrefTable`: 線形走査で集めた `N G obj` ヘッダから合成した xref (`type=n` のみ)
+- `FallbackScanResult.trailer`: `Option<TrailerDict>`
+  - 末尾近くに valid な `trailer << ... >>` ブロックがあれば直接利用
+  - 無ければ本体の `/Type /Catalog` を含む dict object を最末尾優先で探し、最小 trailer (`/Root`, `/Size`) を合成 (§7.5.5 必須エントリ)
+  - どちらも見つからなければ `None`
+- `FallbackScanResult.warnings`: `XREF_REBUILD` 1 件 (skip 件数 / 理由カテゴリは `recovery` に集約)
+
+## warning 契約 (`XREF_REBUILD`)
+
+`onWarning` は ISO 32000-1 仕様にない本ライブラリ拡張の「回復可能な警告」通知点。fallback を通過した場合、`PdfDocument.load` は xref/trailer の再構築が行われたことを `XREF_REBUILD` warning で呼び出し側に通知する。
+
+### 発火タイミング
+
+```
+scanFallback Ok
+├─ trailer.Some  → emitWarnings(XREF_REBUILD) を発火してから ROOT 解決へ進む
+└─ trailer.None  → emitWarnings は呼ばない (load は失敗を返すため、recovery 通知は契約違反)
+```
+
+`trailer.None` で warning を発火しないのは、warning が「**復元成功** + 注意してね」を意味する契約だから。`load()` が `Err` を返すケースで recovery warning を出すと、呼び出し側は「復元できた」と誤解する。
+
+### emitWarnings ローカル関数
+
+`load()` 内クロージャで定義し、`options?.onWarning` をラップ。同じ関数を 3 箇所から呼ぶ:
+
+| 呼び出し元 | 仕様上の対応箇所 | 通知内容 |
+|:---|:---|:---|
+| `resolveXRefStructure` の fallback 経路 | §7.5.4 / §7.5.5 違反からの復元 | `XREF_REBUILD` (1 件) |
+| `PageTreeWalker.walk` 後 | §7.7.3 ページ木走査時の異常 | walk 内で蓄積された warnings |
+| `DocumentInfoParser.parse` 後 | §14.3.3 Document Information Dictionary 解析時の異常 | parse 内で蓄積された warnings |
+
+`options?.onWarning` 未登録なら早期 return で配列イテレーションを省略する。
+
+```ts
+type EmitWarnings = (warnings: readonly PdfWarning[]) => void;
+
+const emitWarnings: EmitWarnings = (warnings) => {
+  if (!options?.onWarning) return;
+  for (const w of warnings) options.onWarning(w);
+};
+```
+
+汎用 callback util にはせず、`load` ローカルにスコープして caller ローカル原則を満たす形にしている。
+
+## エラー契約
+
+| 経路 | 戻り値 | 意味 |
+|:---|:---|:---|
+| scanStartXRef Err → fallback Ok / trailer Some | `Ok` + `XREF_REBUILD` warning | degraded recovery 成功 |
+| scanStartXRef Err → fallback Ok / trailer None | `Err({code:"ROOT_NOT_FOUND", message:"fallback xref scan could not reconstruct trailer", offset:0})` | ヘッダのみで本体無し等の確定パス (L-002) |
+| scanStartXRef Ok → mergeXRefChain Ok | `Ok` (warning なし) | 正規パス成功 |
+| scanStartXRef Ok → mergeXRefChain Err → fallback Ok / trailer Some | `Ok` + `XREF_REBUILD` warning | degraded recovery 成功 |
+| scanStartXRef Ok → mergeXRefChain Err → fallback Ok / trailer None | **元の mergeResult Err をそのまま伝搬** | 真の失敗原因 (CIRCULAR_REFERENCE / 不正 xref 等) を温存 |
+| scanFallback Err (将来) | scanFallback の Err をそのまま伝搬 | scanFallback 自体の失敗 |
+
+merge-failure 経路で trailer 復元できなかった時に合成 `ROOT_NOT_FOUND` を被せると、CIRCULAR_REFERENCE などの根本原因が消えて caller を混乱させるため、元の Err を温存する仕様にしている。一方 `scanStartXRef` Err 経路では「そもそも xref に到達できない」という意味で `ROOT_NOT_FOUND` を返すのが妥当 (spec hearing-notes §4 で確定)。
+
+## 仕様との乖離 (既知制約)
+
+`scanFallback` は `obj` ヘッダから xref を再構築する都合で、ISO 32000-1 §7.5 の意味論を完全には再現できない:
+
+| 仕様 | fallback での扱い |
+|:---|:---|
+| §7.5.4 `type=f` 自由エントリ (削除済みオブジェクト) | **再現不能**。`obj` ヘッダしか見ないため、incremental update で削除されたオブジェクトが fallback 経由では「生き返る」ことがある |
+| §7.5.6 `/Prev` 連鎖 (新 revision で旧エントリ上書き) | **再現不能**。最新 revision を線形スキャンで合成するのみ |
+| §7.5.8 圧縮オブジェクト (xref stream) | scanFallback 自体は対応するが、xref/fallback layer のスコープ |
+
+これらは degraded recovery の trade-off として設計上受け入れている。`XREF_REBUILD` warning が出ているときは「復元はできたが上記の制約があり得る」状態として呼び出し側で扱う。仕様準拠が必要な caller は warning を error として扱えばよい。
+
+## 関連ドキュメント
+
+- [xref-fallback-scanner.md](../xref-fallback-scanner.md) — `scanFallback` 実装の詳細
+- [xref-merger-spec.md](./xref-merger-spec.md) — `mergeXRefChain` (`/Prev` 連鎖マージ) の仕様
+- [startxref-scanner.md](./startxref-scanner.md) — `scanStartXRef` の仕様
+- [xref-parser-spec.md](./xref-parser-spec.md) — xref テーブル解析
+- [error-handling-spec.md](./error-handling-spec.md) — `PdfError` / `PdfWarning` 階層

--- a/docs/pdf-parsing-pipeline/index.md
+++ b/docs/pdf-parsing-pipeline/index.md
@@ -99,9 +99,14 @@ PdfDocument (ページ一覧 + メタデータ)
 | [object-resolver-spec.md](./object-resolver-spec.md) | インダイレクト参照のオブジェクト解決、LRUキャッシュ、ObjectParser |
 | [page-tree-spec.md](./page-tree-spec.md) | ページツリー走査、属性継承解決、ドキュメント構造構築 |
 | [document-api-spec.md](./document-api-spec.md) | PdfDocument / PdfPage パブリックAPI |
-| [document-load-fallback.md](./document-load-fallback.md) | PdfDocument.load の fallback recovery 経路 (`XREF_REBUILD` warning 契約 / `resolveXRefStructure` / `emitWarnings`) |
 | [object-stream-spec.md](./object-stream-spec.md) | オブジェクトストリーム（ObjStm）のPDF仕様、内部構造、制約事項 |
 | [error-handling-spec.md](./error-handling-spec.md) | エラー体系、寛容処理、フォールバックメカニズム |
+
+## 実装ドキュメント
+
+実装側の動作・契約を記すドキュメントは [docs/implementation/](../implementation/) を参照:
+
+- [pdf-document-load-fallback.md](../implementation/pdf-document-load-fallback.md) — `PdfDocument.load` の fallback recovery 経路 (`XREF_REBUILD` warning 契約 / `resolveXRefStructure` / `emitWarnings`)
 
 ## 非機能要件
 

--- a/docs/pdf-parsing-pipeline/index.md
+++ b/docs/pdf-parsing-pipeline/index.md
@@ -99,6 +99,7 @@ PdfDocument (ページ一覧 + メタデータ)
 | [object-resolver-spec.md](./object-resolver-spec.md) | インダイレクト参照のオブジェクト解決、LRUキャッシュ、ObjectParser |
 | [page-tree-spec.md](./page-tree-spec.md) | ページツリー走査、属性継承解決、ドキュメント構造構築 |
 | [document-api-spec.md](./document-api-spec.md) | PdfDocument / PdfPage パブリックAPI |
+| [document-load-fallback.md](./document-load-fallback.md) | PdfDocument.load の fallback recovery 経路 (`XREF_REBUILD` warning 契約 / `resolveXRefStructure` / `emitWarnings`) |
 | [object-stream-spec.md](./object-stream-spec.md) | オブジェクトストリーム（ObjStm）のPDF仕様、内部構造、制約事項 |
 | [error-handling-spec.md](./error-handling-spec.md) | エラー体系、寛容処理、フォールバックメカニズム |
 

--- a/packages/core/src/document/pdf-document.test.helpers.ts
+++ b/packages/core/src/document/pdf-document.test.helpers.ts
@@ -202,14 +202,16 @@ export const buildTwoPagePdf = (): Uint8Array =>
 /**
  * `/Catalog` を欠く不正な PDF を生成する。
  *
- * trailer 辞書から `/Root` を省略することで、ヘッダ / startxref / xref テーブル
- * までは妥当なまま、trailer 解析段階で `ROOT_NOT_FOUND` 系のエラーになる入力を作る。
+ * trailer 辞書から `/Root` を省略し、かつ本体にも `/Type /Catalog` を含めない
+ * ことで、scanFallback でも `/Root` を再構築できない状態を作る。ヘッダ /
+ * startxref / xref テーブルまでは妥当だが、`mergeXRefChain` 失敗 →
+ * `scanFallback` 失敗 (`trailer = None`) を経て `ROOT_NOT_FOUND` が返る。
  * `PdfDocument.load` のエラー伝搬テスト (L-003) で使用する。
  *
- * @returns `/Root` を欠く trailer を持つ PDF バイト列
+ * @returns `/Root` を欠き、本体に `/Type /Catalog` も持たない PDF バイト列
  */
 export const buildPdfWithoutCatalog = (): Uint8Array =>
-  assembleTextPdf([CATALOG_BODY, PAGES_BODY_SINGLE, PAGE_BODY], [], {
+  assembleTextPdf(["<< /Type /Pages /Kids [] /Count 0 >>"], [], {
     omitRoot: true,
   });
 

--- a/packages/core/src/document/pdf-document.test.helpers.ts
+++ b/packages/core/src/document/pdf-document.test.helpers.ts
@@ -25,6 +25,7 @@ const PDF_HEADER = "%PDF-1.7\n";
 const CATALOG_BODY = "<< /Type /Catalog /Pages 2 0 R >>";
 const PAGES_BODY_SINGLE = "<< /Type /Pages /Kids [3 0 R] /Count 1 >>";
 const PAGES_BODY_TWO = "<< /Type /Pages /Kids [3 0 R 4 0 R] /Count 2 >>";
+const PAGES_BODY_EMPTY = "<< /Type /Pages /Kids [] /Count 0 >>";
 const PAGE_BODY = "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] >>";
 const PAGE_BODY_NO_MEDIABOX = "<< /Type /Page /Parent 2 0 R >>";
 
@@ -212,9 +213,7 @@ export const buildTwoPagePdf = (): Uint8Array =>
  * @returns `/Root` を欠き、本体に `/Type /Catalog` も持たない PDF バイト列
  */
 export const buildPdfWithoutCatalog = (): Uint8Array =>
-  assembleTextPdf(["<< /Type /Pages /Kids [] /Count 0 >>"], [], {
-    omitRoot: true,
-  });
+  assembleTextPdf([PAGES_BODY_EMPTY], [], { omitRoot: true });
 
 /**
  * `/MediaBox` を欠く不正な PDF を生成する。
@@ -235,7 +234,6 @@ export const buildPdfWithoutMediaBox = (): Uint8Array =>
 const CORRUPT_STARTXREF_OFFSET_VALUE = 5;
 
 const STARTXREF_LINE_PATTERN = /startxref\n\d+\n%%EOF\n$/;
-const PAGES_BODY_EMPTY = "<< /Type /Pages /Kids [] /Count 0 >>";
 
 /**
  * `startxref` の値だけが壊れた PDF を生成する。

--- a/packages/core/src/document/pdf-document.test.helpers.ts
+++ b/packages/core/src/document/pdf-document.test.helpers.ts
@@ -205,7 +205,8 @@ export const buildTwoPagePdf = (): Uint8Array =>
  * trailer 辞書から `/Root` を省略し、かつ本体にも `/Type /Catalog` を含めない
  * ことで、scanFallback でも `/Root` を再構築できない状態を作る。ヘッダ /
  * startxref / xref テーブルまでは妥当だが、`mergeXRefChain` 失敗 →
- * `scanFallback` 失敗 (`trailer = None`) を経て `ROOT_NOT_FOUND` が返る。
+ * `scanFallback` は `Ok({trailer: None, ...})` を返し、`PdfDocument.load`
+ * 側の trailer 不在分岐で `ROOT_NOT_FOUND` が返る。
  * `PdfDocument.load` のエラー伝搬テスト (L-003) で使用する。
  *
  * @returns `/Root` を欠き、本体に `/Type /Catalog` も持たない PDF バイト列

--- a/packages/core/src/document/pdf-document.ts
+++ b/packages/core/src/document/pdf-document.ts
@@ -178,12 +178,7 @@ const resolveXRefAndTrailer = (
     return fb;
   }
   if (!fb.value.trailer.some) {
-    return err({
-      code: "ROOT_NOT_FOUND",
-      message:
-        "fallback xref scan could not reconstruct trailer after merge failure",
-      offset: ByteOffset.of(0),
-    });
+    return mergeResult;
   }
   emitWarnings(fb.value.warnings);
   return ok({ xref: fb.value.xrefTable, trailer: fb.value.trailer.value });

--- a/packages/core/src/document/pdf-document.ts
+++ b/packages/core/src/document/pdf-document.ts
@@ -140,7 +140,7 @@ type EmitWarnings = (warnings: readonly PdfWarning[]) => void;
  *
  * @param data - PDF のバイト列
  * @param emitWarnings - fallback 復元時の警告通知コールバック
- * @returns 成功時は `Ok<{ xref, trailer }>`、失敗時は `Err<PdfParseError>`
+ * @returns 成功時は `Ok<{ xref, trailer }>`、失敗時は `Err<PdfError>`
  */
 const resolveXRefAndTrailer = (
   data: Uint8Array,
@@ -152,7 +152,6 @@ const resolveXRefAndTrailer = (
     if (!fb.ok) {
       return fb;
     }
-    emitWarnings(fb.value.warnings);
     if (!fb.value.trailer.some) {
       return err({
         code: "ROOT_NOT_FOUND",
@@ -160,6 +159,7 @@ const resolveXRefAndTrailer = (
         offset: ByteOffset.of(0),
       });
     }
+    emitWarnings(fb.value.warnings);
     return ok({ xref: fb.value.xrefTable, trailer: fb.value.trailer.value });
   }
 
@@ -177,7 +177,6 @@ const resolveXRefAndTrailer = (
   if (!fb.ok) {
     return fb;
   }
-  emitWarnings(fb.value.warnings);
   if (!fb.value.trailer.some) {
     return err({
       code: "ROOT_NOT_FOUND",
@@ -186,6 +185,7 @@ const resolveXRefAndTrailer = (
       offset: ByteOffset.of(0),
     });
   }
+  emitWarnings(fb.value.warnings);
   return ok({ xref: fb.value.xrefTable, trailer: fb.value.trailer.value });
 };
 

--- a/packages/core/src/document/pdf-document.ts
+++ b/packages/core/src/document/pdf-document.ts
@@ -142,7 +142,7 @@ type EmitWarnings = (warnings: readonly PdfWarning[]) => void;
  * @param emitWarnings - fallback 復元時の警告通知コールバック
  * @returns 成功時は `Ok<{ xref, trailer }>`、失敗時は `Err<PdfError>`
  */
-const resolveXRefAndTrailer = (
+const resolveXRefStructure = (
   data: Uint8Array,
   emitWarnings: EmitWarnings,
 ): Result<{ xref: XRefTable; trailer: TrailerDict }, PdfError> => {
@@ -267,7 +267,7 @@ export class PdfDocument {
       }
     };
 
-    const xrefResolution = resolveXRefAndTrailer(data, emitWarnings);
+    const xrefResolution = resolveXRefStructure(data, emitWarnings);
     if (!xrefResolution.ok) {
       return xrefResolution;
     }

--- a/packages/core/src/document/pdf-document.ts
+++ b/packages/core/src/document/pdf-document.ts
@@ -6,6 +6,7 @@ import { ByteOffset } from "../pdf/types/index";
 import { PdfVersion } from "../pdf/version/index";
 import { none, type Option, some } from "../utils/option/index";
 import { err, ok, type Result } from "../utils/result/index";
+import { scanFallback } from "../xref/fallback/index";
 import { mergeXRefChain } from "../xref/merger/index";
 import { scanStartXRef } from "../xref/startxref/index";
 import { parseXRefTable } from "../xref/table/index";
@@ -126,24 +127,66 @@ const parseXRefAt = (
   });
 };
 
+/** PdfWarning 配列を消費するローカルコールバック型。 */
+type EmitWarnings = (warnings: readonly PdfWarning[]) => void;
+
 /**
- * `data` から startxref 走査と /Prev チェーンマージを行い、
- * 統合済み xref と最新 trailer 辞書を返す。
+ * startxref → /Prev チェーンマージ → 失敗時は scanFallback の順で
+ * xref テーブルと trailer 辞書を解決する。
+ *
+ * - `scanStartXRef` Err / `mergeXRefChain` Err のいずれか発生時のみ
+ *   `scanFallback` を呼び、成功した警告は `emitWarnings` で通知する。
+ * - fallback でも trailer を再構築できなければ `ROOT_NOT_FOUND` を返す。
  *
  * @param data - PDF のバイト列
- * @returns 成功時は `Ok<{ mergedXRef, latestTrailer }>`、失敗時は `Err<PdfParseError>`
+ * @param emitWarnings - fallback 復元時の警告通知コールバック
+ * @returns 成功時は `Ok<{ xref, trailer }>`、失敗時は `Err<PdfParseError>`
  */
-const loadXRefStructure = (
+const resolveXRefAndTrailer = (
   data: Uint8Array,
-): Result<
-  { mergedXRef: XRefTable; latestTrailer: TrailerDict },
-  PdfParseError
-> => {
+  emitWarnings: EmitWarnings,
+): Result<{ xref: XRefTable; trailer: TrailerDict }, PdfError> => {
   const startXRefResult = scanStartXRef(data);
   if (!startXRefResult.ok) {
-    return startXRefResult;
+    const fb = scanFallback(data);
+    if (!fb.ok) {
+      return fb;
+    }
+    emitWarnings(fb.value.warnings);
+    if (!fb.value.trailer.some) {
+      return err({
+        code: "ROOT_NOT_FOUND",
+        message: "fallback xref scan could not reconstruct trailer",
+        offset: ByteOffset.of(0),
+      });
+    }
+    return ok({ xref: fb.value.xrefTable, trailer: fb.value.trailer.value });
   }
-  return mergeXRefChain(startXRefResult.value, (off) => parseXRefAt(data, off));
+
+  const mergeResult = mergeXRefChain(startXRefResult.value, (off) =>
+    parseXRefAt(data, off),
+  );
+  if (mergeResult.ok) {
+    return ok({
+      xref: mergeResult.value.mergedXRef,
+      trailer: mergeResult.value.latestTrailer,
+    });
+  }
+
+  const fb = scanFallback(data);
+  if (!fb.ok) {
+    return fb;
+  }
+  emitWarnings(fb.value.warnings);
+  if (!fb.value.trailer.some) {
+    return err({
+      code: "ROOT_NOT_FOUND",
+      message:
+        "fallback xref scan could not reconstruct trailer after merge failure",
+      offset: ByteOffset.of(0),
+    });
+  }
+  return ok({ xref: fb.value.xrefTable, trailer: fb.value.trailer.value });
 };
 
 /**
@@ -178,7 +221,9 @@ interface PdfDocumentFields {
  * `load` は ヘッダ検証 → startxref 走査 → xref/trailer 解析 → ObjectStore 生成
  * → カタログ解析 → ページツリー走査 → /Info メタデータ抽出 を直列に実行する。
  *
- * fallback 経路と onWarning 通知は本 PR では未実装で、後続 PR で追加する。
+ * `scanStartXRef` / `mergeXRefChain` の失敗時は `scanFallback` で
+ * xref/trailer の再構築を試み、復元できた場合は `XREF_REBUILD`
+ * 警告を `onWarning` に通知してから処理を続行する。
  */
 export class PdfDocument {
   readonly version: PdfVersion;
@@ -212,14 +257,29 @@ export class PdfDocument {
     }
     const headerVersion = headerResult.value;
 
-    const xrefResult = loadXRefStructure(data);
-    if (!xrefResult.ok) {
-      return xrefResult;
+    /**
+     * `options.onWarning` が登録されていれば各警告を順に通知する。
+     * 未登録なら早期 return で配列イテレーションを省く。
+     *
+     * @param warnings - 通知対象の警告配列
+     */
+    const emitWarnings: EmitWarnings = (warnings) => {
+      if (!options?.onWarning) {
+        return;
+      }
+      for (const w of warnings) {
+        options.onWarning(w);
+      }
+    };
+
+    const xrefResolution = resolveXRefAndTrailer(data, emitWarnings);
+    if (!xrefResolution.ok) {
+      return xrefResolution;
     }
-    const { mergedXRef, latestTrailer } = xrefResult.value;
+    const { xref, trailer: latestTrailer } = xrefResolution.value;
 
     const storeResult = ObjectStore.create(
-      { xref: mergedXRef, data },
+      { xref, data },
       { cacheCapacity: options?.cacheCapacity },
     );
     if (!storeResult.ok) {
@@ -245,9 +305,7 @@ export class PdfDocument {
     if (!walkResult.ok) {
       return walkResult;
     }
-    for (const w of walkResult.value.warnings) {
-      options?.onWarning?.(w);
-    }
+    emitWarnings(walkResult.value.warnings);
 
     const infoResult = await DocumentInfoParser.parse(
       latestTrailer,
@@ -256,9 +314,7 @@ export class PdfDocument {
     if (!infoResult.ok) {
       return infoResult;
     }
-    for (const w of infoResult.value.warnings) {
-      options?.onWarning?.(w);
-    }
+    emitWarnings(infoResult.value.warnings);
 
     return ok(
       new PdfDocument({


### PR DESCRIPTION
## 概要

spec-013 PR-12。`PdfDocument.load` に fallback xref scan 経路を実装し、`scanStartXRef` Err / `mergeXRefChain` Err 時に `scanFallback` で xref/trailer を再構築する。あわせて 3 箇所に分散していた warning 通知を `load` ローカルの `emitWarnings` 関数に集約。warning テスト追加は spec-014 PR-13 に保留。

## 変更の種類

- ✨ New Feature（fallback 経路実装）
- ♻️ Refactoring（emitWarnings ローカル関数化）

## 追加した内容

- `resolveXRefAndTrailer` ローカル関数: startxref → /Prev チェーンマージ → 失敗時は scanFallback の順で xref/trailer を解決
- `EmitWarnings` 型エイリアス + `load` 内ローカルの `emitWarnings` 関数: `options?.onWarning` 早期 return ガードを内包

## 変更した内容

- `load` の warning 通知を 3 箇所すべて `emitWarnings(...)` 経由に置換（fallback / page-tree / document-info）
- `buildPdfWithoutCatalog` fixture: 本体から `/Type /Catalog` を除き `[<< /Type /Pages /Kids [] /Count 0 >>]` のみに変更。fallback の `inferCatalogRoot` で `/Root` が再構築されないようにし、L-003 (ROOT_NOT_FOUND) のテスト意図を維持
- `loadXRefStructure` を削除し `resolveXRefAndTrailer` に置換（戻り値型を `PdfParseError` → `PdfError` に拡張）

## システム図

```mermaid
flowchart TD
    A[PdfDocument.load] --> B[verifyHeader]
    B --> C[resolveXRefAndTrailer]
    C --> D{scanStartXRef}
    D -->|Err| E[scanFallback]
    D -->|Ok| F{mergeXRefChain}
    F -->|Ok| K[xref + trailer Ok]
    F -->|Err| E
    E --> G{fb.ok?}
    G -->|Err| H[Err 伝搬]
    G -->|Ok| I[emitWarnings XREF_REBUILD]
    I --> J{trailer.some?}
    J -->|None| L[Err ROOT_NOT_FOUND]
    J -->|Some| K
    K --> M[ObjectStore.create]
    M --> N[CatalogParser.parse]
    N --> O[PageTreeWalker.walk]
    O --> P[emitWarnings walk warnings]
    P --> Q[DocumentInfoParser.parse]
    Q --> R[emitWarnings info warnings]
    R --> S[Ok PdfDocument]

    style E fill:#ffe7a0
    style I fill:#ffe7a0
    style P fill:#ffe7a0
    style R fill:#ffe7a0
    style L fill:#ffd0d0
```

凡例: 黄色 = fallback / emitWarnings 通知（NEW）、赤 = 復元失敗時の ROOT_NOT_FOUND 経路（NEW）。

## 関連 spec / Issue

- spec: `.plugin-workspace/.specs/013-pdf-document-fallback-impl/`
- 親 spec: `.plugin-workspace/.specs/001-pdf-document-load/`
- 直前 PR: #119 (spec-012 PR-11 fallback fixture)
- 後続 spec: 014-pdf-document-fallback-tests（warning 通知の挙動テストを追加予定）

## テスト

- `pnpm --filter @pdfmod/core typecheck`: ✓ pass
- `pnpm --filter @pdfmod/core test`: ✓ 98 files / 1384 tests passed
- `pnpm lint` (biome + oxlint): ✓ 0 warnings / 0 errors（pnpm-store 由来の symlink 警告 3 件は無関係）
- Codex レビュー (spec-implement-codex): ✓ 「問題なし」（review-001.md 参照）

本 PR では warning 通知の振る舞いテストは追加していない。spec の実装計画に従い PR-13 (spec-014) で本格追加予定。手元検証としては `buildPdfWithCorruptStartXRef` / `buildPdfHeaderOnly` / `buildPdfWithCorruptXRefAndNoTrailer` (PR-11 fixture) を使った既存契約は変わらず green を維持。

## レビューポイント

- `resolveXRefAndTrailer` の 2 経路（scanStartXRef Err / mergeXRefChain Err）でほぼ同じブロックが繰り返されているが、`feedback_no_callback_util` を踏まえて意図的にインライン展開している（fallback ロジックを汎用 util にしない）。同様の理由で `emitWarnings` も `load` ローカルにスコープしている。
- `scanFallback` Err の伝搬経路は現状到達不能（scanFallback は常に Ok を返す）だが、将来拡張に備えて `if (!fb.ok) return fb;` を保持している（implementation-plan §5.2）。
- `buildPdfWithoutCatalog` の意味変更は L-003 の test 意図を守るためであり、L-002（startxref 検出失敗）は PR-11 で追加された別 fixture でカバー済み。

🤖 Generated with [Claude Code](https://claude.com/claude-code)