### PR TITLE
🧪 [Tests]: spec-014 PR-13 fallback warning + L-002/L-006/L-007/fallback-trailer-none

### DIFF
--- a/packages/core/src/document/pdf-document.error.test.ts
+++ b/packages/core/src/document/pdf-document.error.test.ts
@@ -1,6 +1,8 @@
 import { assert, expect, test } from "vitest";
 import { PdfDocument } from "./pdf-document";
 import {
+  buildPdfHeaderOnly,
+  buildPdfWithCorruptXRefAndNoTrailer,
   buildPdfWithoutCatalog,
   buildPdfWithoutMediaBox,
 } from "./pdf-document.test.helpers";
@@ -59,4 +61,22 @@ test("Page にも親 Pages にも MediaBox が無い PDF は MEDIABOX_NOT_FOUND 
   assert(!result.ok);
   assert(!(result.error instanceof RangeError));
   expect(result.error.code).toBe("MEDIABOX_NOT_FOUND");
+});
+
+test("ヘッダのみで本体を持たない PDF は ROOT_NOT_FOUND を返す (L-002)", async () => {
+  const result = await PdfDocument.load(buildPdfHeaderOnly());
+
+  expect(result.ok).toBe(false);
+  assert(!result.ok);
+  assert(!(result.error instanceof RangeError));
+  expect(result.error.code).toBe("ROOT_NOT_FOUND");
+});
+
+test("xref 破損かつ fallback で trailer を確定できない PDF は ROOT_NOT_FOUND を返す", async () => {
+  const result = await PdfDocument.load(buildPdfWithCorruptXRefAndNoTrailer());
+
+  expect(result.ok).toBe(false);
+  assert(!result.ok);
+  assert(!(result.error instanceof RangeError));
+  expect(result.error.code).toBe("ROOT_NOT_FOUND");
 });

--- a/packages/core/src/document/pdf-document.warning.test.ts
+++ b/packages/core/src/document/pdf-document.warning.test.ts
@@ -1,6 +1,10 @@
 import { assert, expect, test } from "vitest";
+import type { PdfWarning } from "../pdf/errors/warning/index";
 import { PdfDocument } from "./pdf-document";
-import { buildMinimalSinglePagePdf } from "./pdf-document.test.helpers";
+import {
+  buildMinimalSinglePagePdf,
+  buildPdfWithCorruptStartXRef,
+} from "./pdf-document.test.helpers";
 
 test("/Info を持たない PDF を load すると metadata はキー数 0 の空オブジェクト (L-005)", async () => {
   const result = await PdfDocument.load(buildMinimalSinglePagePdf());
@@ -15,4 +19,20 @@ test("/Info を持たない PDF を options 指定 + onWarning 未指定で load
   });
 
   assert(result.ok);
+});
+
+test("xref 破損 PDF を onWarning 未指定で load すると Ok を返す (L-006)", async () => {
+  const result = await PdfDocument.load(buildPdfWithCorruptStartXRef());
+
+  assert(result.ok);
+});
+
+test("xref 破損 PDF を onWarning 指定で load すると XREF_REBUILD warning が観測される (L-007)", async () => {
+  const seen: PdfWarning[] = [];
+  const result = await PdfDocument.load(buildPdfWithCorruptStartXRef(), {
+    onWarning: (w) => seen.push(w),
+  });
+
+  assert(result.ok);
+  expect(seen.some((w) => w.code === "XREF_REBUILD")).toBe(true);
 });

--- a/packages/core/src/document/pdf-document.warning.test.ts
+++ b/packages/core/src/document/pdf-document.warning.test.ts
@@ -34,5 +34,5 @@ test("xref 破損 PDF を onWarning 指定で load すると XREF_REBUILD warnin
   });
 
   assert(result.ok);
-  expect(seen.some((w) => w.code === "XREF_REBUILD")).toBe(true);
+  expect(seen.map((w) => w.code)).toEqual(["XREF_REBUILD"]);
 });


### PR DESCRIPTION
## 概要

spec-014 PR-13。PR-12 で実装した fallback 経路に対するカバレッジテストを追加する。`pdf-document.error.test.ts` と `pdf-document.warning.test.ts` の 2 ファイルにテストケースを追加するのみで、実装コードへの変更はなし。

## 変更の種類

- 🧪 Tests: テスト追加

## 追加した内容

### `pdf-document.error.test.ts`
- L-002: ヘッダのみで本体を持たない PDF (`buildPdfHeaderOnly`) で `ROOT_NOT_FOUND` を返す
- fallback-trailer-none: xref 破損 + fallback でも trailer 確定不能な PDF (`buildPdfWithCorruptXRefAndNoTrailer`) で `ROOT_NOT_FOUND` を返す

### `pdf-document.warning.test.ts`
- L-006: xref 破損 PDF (`buildPdfWithCorruptStartXRef`) を `onWarning` 未指定で `load` → silent success (`Ok`)
- L-007: 同 PDF を `onWarning` 指定で `load` すると `XREF_REBUILD` warning が観測される

## システム図

```mermaid
flowchart TD
    A[PdfDocument.load] --> B{xref 解析}
    B -->|成功| C[trailer 取得]
    B -->|失敗| D[scanFallback]
    D --> E{trailer 復元}
    E -->|Some + warning| F["XREF_REBUILD warning 発行<br/>[L-006/L-007]"]
    E -->|None| G["ROOT_NOT_FOUND<br/>[fallback-trailer-none]"]
    C --> H[Catalog 解決]
    F --> H
    H -->|/Root 不在| I["ROOT_NOT_FOUND<br/>[L-002 / L-003]"]
    H -->|OK| J[Ok]

    style F fill:#fef3c7
    style G fill:#fee2e2
    style I fill:#fee2e2
```

## 関連 spec / Issue

- spec: \`.plugin-workspace/.specs/014-pdf-document-fallback-tests/\`
- 親 spec: \`.plugin-workspace/.specs/001-pdf-document-load/\`
- 前 PR: spec-013 PR-12 (fallback 経路実装、#120 でマージ済み)
- タスク: T-050 / T-071 / T-073 / T-081

## テスト

- \`pnpm test:run\`: 1408 tests pass (102 files、新規 4 件追加: error 8 / warning 4)
- \`pnpm typecheck\`: pass
- \`pnpm lint\`: 0 errors（broken symlink 警告のみ、変更ファイル外）
- Codex レビュー: 問題なし（\`code-review/review-001.md\`）

## レビューポイント

- L-002 / fallback-trailer-none テストで方針 A の narrowing (\`assert(!(result.error instanceof RangeError));\`) を踏襲
- describe 不使用・フラット test 列挙の規約に準拠
- spy パターンは caller ローカル配列に push（callback util を作らない方針）
- 変更ファイル数 2（V-004 制約: 1〜2）

🤖 Generated with [Claude Code](https://claude.com/claude-code)