### PR TITLE
🧪 [Tests]: spec-015 PR-14 /Info 不正参照 fixture + L-009 INFO_RESOLVE_FAILED warning

### DIFF
--- a/packages/core/src/document/pdf-document.test.helpers.ts
+++ b/packages/core/src/document/pdf-document.test.helpers.ts
@@ -302,12 +302,50 @@ export const buildPdfWithCorruptXRefAndNoTrailer = (): Uint8Array => {
 export const buildPdfHeaderOnly = (): Uint8Array =>
   new TextEncoder().encode(`${PDF_HEADER}%%EOF\n`);
 
+/** {@link buildPdfWithInvalidInfoRef} で trailer `/Info` が指す壊れたオブジェクト番号。Catalog/Pages/Page の次に予約する。 */
+const INVALID_INFO_REF_OBJECT_NUMBER = 4;
+
 /**
- * `/Info` の参照が壊れた PDF を生成する。
+ * `/Info` の参照は xref に存在するが、解決すると obj ヘッダ不一致でエラーになる PDF を生成する。
  *
- * @returns `/Info` 参照不正の PDF を表すバイト列
+ * trailer に `/Info {@link INVALID_INFO_REF_OBJECT_NUMBER} 0 R` を持たせ、xref には当該
+ * オブジェクト番号のエントリを含めるが、その offset は別オブジェクト (Catalog 1 0 R) の
+ * 開始位置を指すように細工する。`object-store` の inline reader は要求された
+ * `4 0 obj` を期待しつつ実際には `1 0 obj` ヘッダを読むため、`OBJECT_PARSE_UNEXPECTED_TOKEN`
+ * のエラーを返す。`DocumentInfoParser.parse` はこれを `INFO_RESOLVE_FAILED` warning に
+ * 変換し、`EMPTY_METADATA` を返す。
+ *
+ * `PdfDocument.load` の L-009 (`/Info` 不正参照 → warning + 空 metadata) テストで使用する。
+ *
+ * @returns `/Info` 参照不正 + 正常な Catalog/Pages/Page を持つ PDF バイト列
  */
-export const buildPdfWithInvalidInfoRef = (): Uint8Array => new Uint8Array();
+export const buildPdfWithInvalidInfoRef = (): Uint8Array => {
+  const encoder = new TextEncoder();
+  const objectBodies = [CATALOG_BODY, PAGES_BODY_SINGLE, PAGE_BODY];
+  const objs = objectBodies.map(
+    (body, i) => `${i + 1} 0 obj\n${body}\nendobj\n`,
+  );
+
+  const offsets: number[] = [];
+  let cursor = encoder.encode(PDF_HEADER).length;
+  for (const obj of objs) {
+    offsets.push(cursor);
+    cursor += encoder.encode(obj).length;
+  }
+  const xrefOffset = cursor;
+
+  const size = INVALID_INFO_REF_OBJECT_NUMBER + 1;
+  const catalogOffset = offsets[0];
+  const xrefRows = [
+    "0000000000 65535 f \n",
+    ...offsets.map((o) => `${padOffset10(o)} 00000 n \n`),
+    `${padOffset10(catalogOffset)} 00000 n \n`,
+  ];
+  const xref = `xref\n0 ${size}\n${xrefRows.join("")}`;
+  const trailer = `trailer\n<< /Size ${size} /Root 1 0 R /Info ${INVALID_INFO_REF_OBJECT_NUMBER} 0 R >>\nstartxref\n${xrefOffset}\n%%EOF\n`;
+
+  return encoder.encode(PDF_HEADER + objs.join("") + xref + trailer);
+};
 
 const INCREMENTAL_UPDATE_NEW_PAGE_WIDTH = 200;
 const INCREMENTAL_UPDATE_NEW_PAGE_HEIGHT = 300;

--- a/packages/core/src/document/pdf-document.warning.test.ts
+++ b/packages/core/src/document/pdf-document.warning.test.ts
@@ -46,5 +46,5 @@ test("/Info の参照が不正な PDF を load すると INFO_RESOLVE_FAILED war
 
   assert(result.ok);
   expect(Object.keys(result.value.metadata)).toHaveLength(0);
-  expect(seen.filter((w) => w.code === "INFO_RESOLVE_FAILED")).toHaveLength(1);
+  expect(seen.map((w) => w.code)).toEqual(["INFO_RESOLVE_FAILED"]);
 });

--- a/packages/core/src/document/pdf-document.warning.test.ts
+++ b/packages/core/src/document/pdf-document.warning.test.ts
@@ -4,6 +4,7 @@ import { PdfDocument } from "./pdf-document";
 import {
   buildMinimalSinglePagePdf,
   buildPdfWithCorruptStartXRef,
+  buildPdfWithInvalidInfoRef,
 } from "./pdf-document.test.helpers";
 
 test("/Info を持たない PDF を load すると metadata はキー数 0 の空オブジェクト (L-005)", async () => {
@@ -35,4 +36,15 @@ test("xref 破損 PDF を onWarning 指定で load すると XREF_REBUILD warnin
 
   assert(result.ok);
   expect(seen.map((w) => w.code)).toEqual(["XREF_REBUILD"]);
+});
+
+test("/Info の参照が不正な PDF を load すると INFO_RESOLVE_FAILED warning + 空 metadata になる (L-009)", async () => {
+  const seen: PdfWarning[] = [];
+  const result = await PdfDocument.load(buildPdfWithInvalidInfoRef(), {
+    onWarning: (w) => seen.push(w),
+  });
+
+  assert(result.ok);
+  expect(Object.keys(result.value.metadata)).toHaveLength(0);
+  expect(seen.filter((w) => w.code === "INFO_RESOLVE_FAILED")).toHaveLength(1);
 });


### PR DESCRIPTION
## 概要

spec-015 PR-14。PR-12 で完成した `DocumentInfoParser` warning 配線の追加カバレッジ。`/Info` の参照解決が失敗したときに `INFO_RESOLVE_FAILED` warning が 1 件発行され、`metadata` が空オブジェクトになる経路をテストする。

## 変更の種類

- 🧪 Tests: テスト追加（fixture 本実装 + warning カバレッジ）

## 追加した内容

### `pdf-document.test.helpers.ts`
- `buildPdfWithInvalidInfoRef` を skeleton から本実装に差し替え
  - xref に object 4 のエントリを含めつつ、offset を object 1 (Catalog) を指すよう細工
  - object-store の inline reader が `4 0 obj` を期待しつつ `1 0 obj` を読むため `OBJECT_PARSE_UNEXPECTED_TOKEN` を返す
  - `DocumentInfoParser.parse` がこれを `INFO_RESOLVE_FAILED` warning に変換し `EMPTY_METADATA` を返す

### `pdf-document.warning.test.ts`
- L-009: `buildPdfWithInvalidInfoRef` を `onWarning` 付きで `load` し、Ok / 空 metadata / `INFO_RESOLVE_FAILED` warning が 1 件観測されることを検証

## システム図

\`\`\`mermaid
flowchart TD
    A[PdfDocument.load] --> B[trailer 解析]
    B --> C{trailer に /Info あり?}
    C -->|なし| D["空 metadata + 空 warnings<br/>(L-005)"]
    C -->|あり| E["resolveRef(trailerDict.info)"]
    E --> F{resolved.ok?}
    F -->|err| G["INFO_RESOLVE_FAILED warning<br/>+ 空 metadata<br/>[L-009 NEW]"]
    F -->|ok / type ≠ dictionary| H[INFO_NOT_DICTIONARY warning]
    F -->|ok / dictionary| I[metadata 抽出]

    style G fill:#fef3c7
\`\`\`

## 関連 spec / Issue

- spec: \`.plugin-workspace/.specs/015-pdf-document-info-resolve-failed/\`
- 親 spec: \`.plugin-workspace/.specs/001-pdf-document-load/\`
- 前 PR: spec-014 PR-13 (#121, fallback warning + L-002/L-006/L-007/fallback-trailer-none)
- タスク: T-061 / T-062

## テスト

- \`pnpm test:run\`: 1409 tests pass (102 files、新規 1 件追加: warning 5 件)
- \`pnpm typecheck\`: pass
- \`pnpm lint\`: 0 errors（broken symlink 警告のみ、変更ファイル外）
- Codex レビュー: 問題なし（\`code-review/review-001.md\`）

## レビューポイント

- fixture の細工: 単純に xref 範囲外を指すと object-store は \`ok({type:"null"})\` を返して \`INFO_NOT_DICTIONARY\` 経路に流れる。\`INFO_RESOLVE_FAILED\` を直接発火させるため、xref エントリは存在するが offset が別オブジェクトを指すよう細工している点
- describe 不使用・フラット test 列挙の規約に準拠
- 変更ファイル数 2（V-004 制約: 1〜2）

🤖 Generated with [Claude Code](https://claude.com/claude-code)