### PR TITLE
🧪 [Tests]: spec-016 PR-15 cacheCapacity 境界テスト追加 (L-008)

### DIFF
--- a/packages/core/src/document/pdf-document.boundary.test.ts
+++ b/packages/core/src/document/pdf-document.boundary.test.ts
@@ -29,6 +29,8 @@ test("load は cacheCapacity 未指定で既定値により Ok を返す (L-008)
   const result = await PdfDocument.load(buildMinimalSinglePagePdf());
 
   assert(result.ok);
+  expect(result.value.pageCount).toBe(1);
+  expect(result.value.getPage(0).some).toBe(true);
 });
 
 test.each([

--- a/packages/core/src/document/pdf-document.boundary.test.ts
+++ b/packages/core/src/document/pdf-document.boundary.test.ts
@@ -28,7 +28,7 @@ test("getPage(0) は Some を返す (DA-002)", async () => {
 test("load は cacheCapacity 未指定で既定値により Ok を返す (L-008)", async () => {
   const result = await PdfDocument.load(buildMinimalSinglePagePdf());
 
-  expect(result.ok).toBe(true);
+  assert(result.ok);
 });
 
 test.each([

--- a/packages/core/src/document/pdf-document.boundary.test.ts
+++ b/packages/core/src/document/pdf-document.boundary.test.ts
@@ -24,3 +24,22 @@ test("getPage(0) は Some を返す (DA-002)", async () => {
   assert(result.ok);
   expect(result.value.getPage(0).some).toBe(true);
 });
+
+test("load は cacheCapacity 未指定で既定値により Ok を返す (L-008)", async () => {
+  const result = await PdfDocument.load(buildMinimalSinglePagePdf());
+
+  expect(result.ok).toBe(true);
+});
+
+test.each([
+  { label: "cacheCapacity = 0", cacheCapacity: 0 },
+  { label: "cacheCapacity = -1", cacheCapacity: -1 },
+  { label: "cacheCapacity = 1.5", cacheCapacity: 1.5 },
+])("load は $label で RangeError を返す", async ({ cacheCapacity }) => {
+  const result = await PdfDocument.load(buildMinimalSinglePagePdf(), {
+    cacheCapacity,
+  });
+
+  assert(!result.ok);
+  expect(result.error).toBeInstanceOf(RangeError);
+});


### PR DESCRIPTION
## 概要

spec-016 PR-15 (Cycle 9 最終)。`PdfDocument.load` の `cacheCapacity` 境界条件 (`undefined` で既定値, `0` / `-1` / `1.5` で `RangeError`) を boundary テストで担保する。`ObjectStore.create` の Err 伝搬は T-022 (PR-3) で実装済みのため本 PR はテスト追加のみ。

## 変更の種類

- 🧪 [Tests]: テスト追加

## 追加した内容

`packages/core/src/document/pdf-document.boundary.test.ts`:

- L-008 カバレッジ: `cacheCapacity` 未指定で `load` Ok を返すテスト
- パラメータ化テスト (`test.each`): `cacheCapacity = 0 / -1 / 1.5` で `result.error` が `RangeError` のインスタンスであることを assert

## システム図

```mermaid
flowchart TD
  A["PdfDocument.load(data, options)"] --> B["verifyHeader"]
  B --> C["resolveXRefStructure"]
  C --> D["ObjectStore.create<br/>{ cacheCapacity }"]
  D -->|"Ok"| E["CatalogParser.parse"]
  D -->|"Err: RangeError"| X["return Err&lt;RangeError&gt;"]
  E --> F["PageTreeWalker.walk"]
  F --> G["DocumentInfoParser.parse"]
  G --> H["Ok&lt;PdfDocument&gt;"]

  style D fill:#fff4cc,stroke:#d9a800
  style X fill:#ffe0e0,stroke:#c00

  subgraph Coverage["本 PR のテスト追加範囲 [NEW]"]
    T1["cacheCapacity 未指定 → Ok<br/>(L-008)"]
    T2["cacheCapacity = 0 → RangeError"]
    T3["cacheCapacity = -1 → RangeError"]
    T4["cacheCapacity = 1.5 → RangeError"]
  end
  style Coverage fill:#e8f5e9,stroke:#2e7d32
```

## 関連 spec / Issue

- spec: `.plugin-workspace/.specs/016-pdf-document-cache-capacity/`
- 親 spec: `001-pdf-document-load`
- 前 PR: spec-015 (#122 マージ済み)
- 次 spec: `017-pdf-document-final-refactor` (任意)

## テスト

- `pnpm --filter @pdfmod/core test`: **1393 tests passed (98 files)**
- `pnpm --filter @pdfmod/core typecheck`: ✅ パス
- lint (oxlint / biome): 0 warnings, 0 errors
- Codex レビュー (`code-review/review-001.md`): **問題なし** (1 回で確定)

## レビューポイント

- `result.error instanceof RangeError` の逆方向 narrowing を採用しており、`PdfDocumentLoadError = PdfError | RangeError` の判別共用体の `RangeError` 分岐をテストできているか
- `test.each` のパラメータ化で `0` / `-1` / `1.5` の 3 ケースをフラットに列挙できているか (describe 不使用)
- Err 伝搬本体は T-022 で実装済みのためテストのみで完結している点