### PR TITLE
♻️ [Refactoring]: spec-017 PR-16 pdf-document の最終 Refactor (Cycle 10)

### DIFF
--- a/packages/core/src/document/pdf-document.test.helpers.ts
+++ b/packages/core/src/document/pdf-document.test.helpers.ts
@@ -1,12 +1,5 @@
 /**
  * `PdfDocument.load` の振る舞いテストで使う最小限の PDF バイト列ビルダー群。
- *
- * 本ファイルは PR-1 (skeleton) 時点では関数本体は空 (`new Uint8Array()`) であり、
- * PR-2 以降の Red/Green サイクルで段階的に本実装に差し替えていく。
- *
- * 方針 A (overview.md §5.1.1): error / boundary テストで `result.error.code`
- * を読む際は `assert(!(result.error instanceof RangeError));` で narrowing する。
- * 本ファイルには narrowing 用 helper (`expectPdfError` 等) は置かない。
  */
 
 /**

--- a/packages/core/src/document/pdf-document.test.helpers.ts
+++ b/packages/core/src/document/pdf-document.test.helpers.ts
@@ -93,6 +93,19 @@ const toPdfString = (s: string): string => {
 };
 
 /**
+ * オブジェクト本体を `${objNum} 0 obj\n...\nendobj\n` 形式の indirect object 文字列に変換する。
+ *
+ * @param bodies - オブジェクト本体の配列（`<< ... >>` 等）
+ * @param startObjNum - 先頭オブジェクト番号（既定値 1）
+ * @returns indirect object 形式の文字列配列
+ */
+const formatIndirectObjects = (
+  bodies: readonly string[],
+  startObjNum = 1,
+): string[] =>
+  bodies.map((body, i) => `${i + startObjNum} 0 obj\n${body}\nendobj\n`);
+
+/**
  * `assembleTextPdf` のオプション。
  */
 interface AssembleTextPdfOptions {
@@ -123,9 +136,7 @@ const assembleTextPdf = (
   options: AssembleTextPdfOptions = {},
 ): Uint8Array => {
   const encoder = new TextEncoder();
-  const objs = objectBodies.map(
-    (body, i) => `${i + 1} 0 obj\n${body}\nendobj\n`,
-  );
+  const objs = formatIndirectObjects(objectBodies);
 
   const offsets: number[] = [];
   let cursor = encoder.encode(PDF_HEADER).length;
@@ -315,9 +326,7 @@ const INVALID_INFO_REF_OBJECT_NUMBER = 4;
 export const buildPdfWithInvalidInfoRef = (): Uint8Array => {
   const encoder = new TextEncoder();
   const objectBodies = [CATALOG_BODY, PAGES_BODY_SINGLE, PAGE_BODY];
-  const objs = objectBodies.map(
-    (body, i) => `${i + 1} 0 obj\n${body}\nendobj\n`,
-  );
+  const objs = formatIndirectObjects(objectBodies);
 
   const offsets: number[] = [];
   let cursor = encoder.encode(PDF_HEADER).length;
@@ -382,9 +391,7 @@ export const buildPdfWithIncrementalUpdate = (): Uint8Array => {
   const encoder = new TextEncoder();
 
   const oldObjBodies = [CATALOG_BODY, PAGES_BODY_SINGLE, PAGE_BODY];
-  const oldObjs = oldObjBodies.map(
-    (body, i) => `${i + 1} 0 obj\n${body}\nendobj\n`,
-  );
+  const oldObjs = formatIndirectObjects(oldObjBodies);
 
   const oldOffsets: number[] = [];
   let cursor = encoder.encode(PDF_HEADER).length;
@@ -413,9 +420,9 @@ export const buildPdfWithIncrementalUpdate = (): Uint8Array => {
     `<< /Type /Pages /Kids [${newPageObjNum} 0 R] /Count 1 >>`,
     `<< /Type /Page /Parent ${newPagesObjNum} 0 R /MediaBox [${mbX} ${mbY} ${mbW} ${mbH}] >>`,
   ];
-  const newObjs = newObjBodies.map(
-    (body, i) =>
-      `${i + INCREMENTAL_UPDATE_NEW_SECTION_FIRST_OBJ_NUM} 0 obj\n${body}\nendobj\n`,
+  const newObjs = formatIndirectObjects(
+    newObjBodies,
+    INCREMENTAL_UPDATE_NEW_SECTION_FIRST_OBJ_NUM,
   );
 
   const newOffsets: number[] = [];

--- a/packages/core/src/document/pdf-document.ts
+++ b/packages/core/src/document/pdf-document.ts
@@ -85,8 +85,6 @@ const verifyHeader = (data: Uint8Array): Result<PdfVersion, PdfParseError> => {
     });
   }
 
-  // signature 直後から PDF whitespace (NUL/TAB/LF/FF/CR/SPACE) までを
-  // version 文字列として読み取る。
   const versionStart = headerOffset + PDF_HEADER_SIGNATURE.length;
   const versionEnd = findVersionEnd(data, versionStart);
   const versionStr = new TextDecoder("ascii").decode(

--- a/packages/core/src/document/pdf-document.ts
+++ b/packages/core/src/document/pdf-document.ts
@@ -1,8 +1,11 @@
 import { isPdfWhitespace, matchesBytesAt } from "../lexer/bytes/index";
 import { ObjectStore } from "../objects/object-store/index";
 import type { PdfError, PdfParseError, PdfWarning } from "../pdf/errors/index";
-import type { TrailerDict, XRefTable } from "../pdf/types/index";
-import { ByteOffset } from "../pdf/types/index";
+import {
+  ByteOffset,
+  type TrailerDict,
+  type XRefTable,
+} from "../pdf/types/index";
 import { PdfVersion } from "../pdf/version/index";
 import { none, type Option, some } from "../utils/option/index";
 import { err, ok, type Result } from "../utils/result/index";


### PR DESCRIPTION
## 概要

spec-017 PR-16 (任意の最終 Refactor、Cycle 10)。`pdf-document.ts` および `pdf-document.test.helpers.ts` に対し、import 整理 / コメント整理 / fixture 共通化のクリーンアップを行う。**機能変更なし**、テスト追加・修正なし。

## 変更の種類

♻️ Refactoring

## 追加した内容

- `pdf-document.test.helpers.ts` に `formatIndirectObjects` 内部ヘルパを追加
  - `${objNum} 0 obj\n...\nendobj\n` 形式の indirect object 整形ロジックを 1 ヶ所に集約
  - `startObjNum` 引数で先頭オブジェクト番号を指定可能（incremental update fixture の新セクションでも再利用）

## 変更した内容

- `pdf-document.ts`:
  - `../pdf/types/index` の split import (`type { TrailerDict, XRefTable }` と `{ ByteOffset }`) を companion object パターンの一括 import に統合
  - `verifyHeader` 内の冗長な inline コメント (関数 JSDoc と重複) を削除
- `pdf-document.test.helpers.ts`:
  - PR-1 skeleton 時点の状態を述べる古い冒頭 JSDoc を簡潔化
  - `assembleTextPdf` / `buildPdfWithInvalidInfoRef` / `buildPdfWithIncrementalUpdate` の 4 ヶ所で重複していた obj 整形ロジックを `formatIndirectObjects` 呼び出しに置換

## 削除した内容

- 重複していた `objectBodies.map((body, i) => \`...\`)` パターン 4 ヶ所（共通ヘルパへ移行）
- `pdf-document.ts` の冗長な inline コメント
- `pdf-document.test.helpers.ts` 冒頭の古い PR-1 期 skeleton コメント

## システム図

リファクタのみで処理フローや構造に変更がないため省略。

## 関連 spec / Issue

- spec: \`.plugin-workspace/.specs/017-pdf-document-final-refactor/\`
- 親 spec: \`.plugin-workspace/.specs/001-pdf-document-load/\` (Cycle 10 の最終 PR)
- 前 spec PR: #123 (spec-016 PR-15 cacheCapacity 境界)

## テスト

本 PR ではテストの追加・修正は行わない (実装計画 §6 方針)。既存テストでの確認のみ:

- `pnpm --filter @pdfmod/core test`: **1393 / 1393 passed (98 files)**
- `pnpm --filter @pdfmod/core test pdf-document`: **32 / 32 passed**
- `pnpm --filter @pdfmod/core typecheck`: pass
- `pnpm lint`: 0 errors / 0 lint warnings (※ プロジェクト既存の `.pnpm-store` broken symlink に対する Biome warning 3 件は本変更と無関係)

### Codex レビュー結果

`code-review/review-001.md`: **問題なし** (1 ラウンドで合意)。

## レビューポイント

- companion object 一括 import が memory `feedback_companion_object_import.md` に沿っているか
- `formatIndirectObjects` ヘルパが trivial wrapper の禁則 (memory `feedback_no_trivial_wrapper.md`) に抵触しないか — 4 ヶ所での重複削減のため抽出済み (3 ヶ所以上の重複は OK の例外条件に該当)
- helpers.ts 内クローズドの caller-local 原則に準拠しているか (memory `feedback_no_callback_util.md`)
- 機能変更がないこと (既存テスト無修正で全 pass を維持していること)