### PR TITLE
✨ [New Feature]: PdfPage クラスと width/height 算出ロジックを公開

### DIFF
--- a/packages/core/src/document/index.ts
+++ b/packages/core/src/document/index.ts
@@ -13,3 +13,5 @@ export type {
   WalkPageTreeResult,
 } from "./page-tree/index";
 export { InheritanceResolver, PageTreeWalker } from "./page-tree/index";
+export type { PdfPageRectangle } from "./pdf-page";
+export { PdfPage } from "./pdf-page";

--- a/packages/core/src/document/pdf-page.behavior.test.ts
+++ b/packages/core/src/document/pdf-page.behavior.test.ts
@@ -1,0 +1,174 @@
+import { expect, test } from "vitest";
+import { GenerationNumber } from "../pdf/types/generation-number/index";
+import type { IndirectRef } from "../pdf/types/indirect-ref/index";
+import { ObjectNumber } from "../pdf/types/object-number/index";
+import type { PdfDictionary } from "../pdf/types/pdf-types/index";
+import type {
+  PageRotate,
+  PdfRectangle,
+  ResolvedPage,
+} from "./page-tree/resolved-page";
+import { PdfPage } from "./pdf-page";
+
+const emptyDict: PdfDictionary = {
+  type: "dictionary",
+  entries: new Map(),
+};
+
+const makeRef = (objNum: number, genNum = 0): IndirectRef => ({
+  objectNumber: ObjectNumber.of(objNum),
+  generationNumber: GenerationNumber.of(genNum),
+});
+
+interface MakeResolvedPageArgs {
+  mediaBox?: PdfRectangle;
+  cropBox?: PdfRectangle;
+  rotate?: PageRotate;
+  userUnit?: number;
+  objectRef?: IndirectRef;
+}
+
+const makeResolvedPage = (args: MakeResolvedPageArgs = {}): ResolvedPage => {
+  const mediaBox = args.mediaBox ?? [0, 0, 100, 200];
+  return {
+    mediaBox,
+    cropBox: args.cropBox ?? mediaBox,
+    rotate: args.rotate ?? 0,
+    userUnit: args.userUnit ?? 1.0,
+    resources: emptyDict,
+    contents: null,
+    annots: null,
+    objectRef: args.objectRef ?? makeRef(1, 0),
+  };
+};
+
+test.each([
+  {
+    label: "PP-001 rotate=0  userUnit=1.0",
+    rotate: 0 as PageRotate,
+    userUnit: 1.0,
+    expectW: 100,
+    expectH: 200,
+  },
+  {
+    label: "PP-001 rotate=180 userUnit=1.0",
+    rotate: 180 as PageRotate,
+    userUnit: 1.0,
+    expectW: 100,
+    expectH: 200,
+  },
+  {
+    label: "PP-002 rotate=90  userUnit=1.0",
+    rotate: 90 as PageRotate,
+    userUnit: 1.0,
+    expectW: 200,
+    expectH: 100,
+  },
+  {
+    label: "PP-002 rotate=270 userUnit=1.0",
+    rotate: 270 as PageRotate,
+    userUnit: 1.0,
+    expectW: 200,
+    expectH: 100,
+  },
+  {
+    label: "PP-003 rotate=0   userUnit=2.0",
+    rotate: 0 as PageRotate,
+    userUnit: 2.0,
+    expectW: 200,
+    expectH: 400,
+  },
+  {
+    label: "PP-003 rotate=90  userUnit=0.5",
+    rotate: 90 as PageRotate,
+    userUnit: 0.5,
+    expectW: 100,
+    expectH: 50,
+  },
+  {
+    label: "PP-003 rotate=180 userUnit=2.0",
+    rotate: 180 as PageRotate,
+    userUnit: 2.0,
+    expectW: 200,
+    expectH: 400,
+  },
+  {
+    label: "PP-003 rotate=270 userUnit=0.5",
+    rotate: 270 as PageRotate,
+    userUnit: 0.5,
+    expectW: 100,
+    expectH: 50,
+  },
+])("$label のとき width/height が PP ルールどおり算出される", ({
+  rotate,
+  userUnit,
+  expectW,
+  expectH,
+}) => {
+  const page = PdfPage.from(makeResolvedPage({ rotate, userUnit }));
+  expect(page.width).toBe(expectW);
+  expect(page.height).toBe(expectH);
+});
+
+test("非原点 mediaBox でも rotate=0 のとき width = urx-llx, height = ury-lly", () => {
+  const page = PdfPage.from(
+    makeResolvedPage({
+      mediaBox: [10, 20, 110, 220],
+      rotate: 0,
+      userUnit: 1.0,
+    }),
+  );
+  expect(page.width).toBe(100);
+  expect(page.height).toBe(200);
+});
+
+test("非原点 mediaBox でも rotate=90 のとき width = ury-lly, height = urx-llx", () => {
+  const page = PdfPage.from(
+    makeResolvedPage({
+      mediaBox: [10, 20, 110, 220],
+      rotate: 90,
+      userUnit: 1.0,
+    }),
+  );
+  expect(page.width).toBe(200);
+  expect(page.height).toBe(100);
+});
+
+test("mediaBox プロパティが ResolvedPage.mediaBox の値と一致する", () => {
+  const mediaBox: PdfRectangle = [0, 0, 100, 200];
+  const page = PdfPage.from(makeResolvedPage({ mediaBox }));
+  expect(page.mediaBox).toEqual([0, 0, 100, 200]);
+});
+
+test("cropBox プロパティが ResolvedPage.cropBox の値と一致する（mediaBox と異なる場合）", () => {
+  const page = PdfPage.from(
+    makeResolvedPage({
+      mediaBox: [0, 0, 100, 200],
+      cropBox: [10, 20, 90, 180],
+    }),
+  );
+  expect(page.cropBox).toEqual([10, 20, 90, 180]);
+});
+
+test("cropBox プロパティが ResolvedPage.cropBox の値と一致する（mediaBox と参照同一の場合）", () => {
+  const mediaBox: PdfRectangle = [0, 0, 100, 200];
+  const page = PdfPage.from(makeResolvedPage({ mediaBox, cropBox: mediaBox }));
+  expect(page.cropBox).toEqual([0, 0, 100, 200]);
+  expect(page.cropBox).toBe(page.mediaBox);
+});
+
+test("rotate プロパティが ResolvedPage.rotate の値と一致する", () => {
+  const page = PdfPage.from(makeResolvedPage({ rotate: 270 }));
+  expect(page.rotate).toBe(270);
+});
+
+test("userUnit プロパティが ResolvedPage.userUnit の値と一致する", () => {
+  const page = PdfPage.from(makeResolvedPage({ userUnit: 1.5 }));
+  expect(page.userUnit).toBe(1.5);
+});
+
+test("ref プロパティが ResolvedPage.objectRef の値と一致する", () => {
+  const ref = makeRef(7, 2);
+  const page = PdfPage.from(makeResolvedPage({ objectRef: ref }));
+  expect(page.ref).toBe(ref);
+});

--- a/packages/core/src/document/pdf-page.ts
+++ b/packages/core/src/document/pdf-page.ts
@@ -1,0 +1,93 @@
+import type { IndirectRef } from "../pdf/types/indirect-ref/index";
+import {
+  PAGE_ROTATE_90,
+  PAGE_ROTATE_270,
+  type PageRotate,
+  type ResolvedPage,
+} from "./page-tree/resolved-page";
+
+/**
+ * `PdfPage` の `mediaBox` / `cropBox` で公開する readonly タプル型。
+ */
+export type PdfPageRectangle = readonly [number, number, number, number];
+
+/**
+ * `PdfPage` の private constructor が instance に assign する fields。
+ */
+interface PdfPageFields {
+  readonly mediaBox: PdfPageRectangle;
+  readonly cropBox: PdfPageRectangle;
+  readonly rotate: PageRotate;
+  readonly userUnit: number;
+  readonly ref: IndirectRef;
+  readonly width: number;
+  readonly height: number;
+}
+
+/**
+ * 1 ページを表すクラス。`ResolvedPage` をラップし、Rotate / userUnit を
+ * 考慮した width / height を算出して公開する。
+ *
+ * - PP-001: rotate ∈ {0, 180} → width = urx-llx, height = ury-lly
+ * - PP-002: rotate ∈ {90, 270} → width = ury-lly, height = urx-llx
+ * - PP-003: 上記に userUnit を乗算
+ */
+export class PdfPage {
+  readonly mediaBox: PdfPageRectangle;
+  readonly cropBox: PdfPageRectangle;
+  readonly rotate: PageRotate;
+  readonly userUnit: number;
+  readonly ref: IndirectRef;
+  readonly width: number;
+  readonly height: number;
+
+  private constructor(fields: PdfPageFields) {
+    this.mediaBox = fields.mediaBox;
+    this.cropBox = fields.cropBox;
+    this.rotate = fields.rotate;
+    this.userUnit = fields.userUnit;
+    this.ref = fields.ref;
+    this.width = fields.width;
+    this.height = fields.height;
+  }
+
+  /**
+   * `ResolvedPage` から `PdfPage` を構築する。
+   * `ResolvedPage` は上流（`PageTreeWalker` / `AttrResolver`）でバリデート
+   * 済みのため失敗パスはなく、直接 `PdfPage` を返す。
+   *
+   * @param resolved - 上流で正規化済みの `ResolvedPage`
+   * @returns 構築された `PdfPage`
+   */
+  static from(resolved: ResolvedPage): PdfPage {
+    const [llx, lly, urx, ury] = resolved.mediaBox;
+    const horizontal = urx - llx;
+    const vertical = ury - lly;
+
+    let baseWidth: number;
+    let baseHeight: number;
+    if (
+      resolved.rotate === PAGE_ROTATE_90 ||
+      resolved.rotate === PAGE_ROTATE_270
+    ) {
+      baseWidth = vertical;
+      baseHeight = horizontal;
+    } else {
+      baseWidth = horizontal;
+      baseHeight = vertical;
+    }
+
+    const width = baseWidth * resolved.userUnit;
+    const height = baseHeight * resolved.userUnit;
+
+    return new PdfPage({
+      mediaBox: resolved.mediaBox as PdfPageRectangle,
+      cropBox: resolved.cropBox as PdfPageRectangle,
+      rotate: resolved.rotate,
+      userUnit: resolved.userUnit,
+      ref: resolved.objectRef,
+      width,
+      height,
+    });
+  }
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -11,6 +11,7 @@ export type {
   PageRotate,
   ParsedCatalog,
   ParsedDocumentInfo,
+  PdfPageRectangle,
   PdfRectangle,
   ResolvedPage,
   ResolveInheritedOutcome,
@@ -22,6 +23,7 @@ export {
   DocumentInfoParser,
   InheritanceResolver,
   PageTreeWalker,
+  PdfPage,
   PdfTrapped,
 } from "./document/index";
 export { NumberEx } from "./ext/number/index";

--- a/packages/core/src/namespace-export.runtime.test.ts
+++ b/packages/core/src/namespace-export.runtime.test.ts
@@ -12,6 +12,7 @@ import {
   ObjectStreamBody,
   ObjectStreamHeader,
   PageTreeWalker,
+  PdfPage,
   PdfTrapped,
   PdfVersion,
   parseTrailer,
@@ -40,6 +41,7 @@ test.each([
   { name: "InheritanceResolver.resolve", value: InheritanceResolver.resolve },
   { name: "DocumentInfoParser.parse", value: DocumentInfoParser.parse },
   { name: "PdfTrapped.create", value: PdfTrapped.create },
+  { name: "PdfPage.from", value: PdfPage.from },
 ])("$nameがルートからexportされている", ({ value }) => {
   expect(typeof value).toBe("function");
 });

--- a/packages/core/src/namespace-export.type.test.ts
+++ b/packages/core/src/namespace-export.type.test.ts
@@ -2,6 +2,7 @@ import { expect, test } from "vitest";
 import type {
   InheritedAttrs,
   ParsedCatalog,
+  PdfPageRectangle,
   ResolvedPage,
   ResolveRef,
   WalkPageTreeResult,
@@ -72,6 +73,12 @@ test("ParsedCatalog型とResolveRef型が参照できる", () => {
   const resolver: ResolveRef = async () => Result.ok({ type: "null" as const });
   expect(parsed.version).toBe(version);
   expect(typeof resolver).toBe("function");
+});
+
+test("PdfPageRectangle 型がルートから参照できる", () => {
+  const rect: PdfPageRectangle = [0, 0, 612, 792];
+  expect(rect[2]).toBe(612);
+  expect(rect[3]).toBe(792);
 });
 
 test("ResolvedPage / InheritedAttrs / WalkPageTreeResult 型が参照できる", () => {


### PR DESCRIPTION
## 概要

spec-018 (Issue #49)。`@pdfmod/core` のパブリック API として `PdfPage` クラスを新規実装する。`ResolvedPage` をラップし、PP-001/002/003 ルール (Rotate / userUnit を考慮した width / height 算出) を提供する。`PdfDocument.getPage()` の戻り値型変更は別 issue にスコープアウト。

## 変更の種類

- ✨ [New Feature]: 新機能
- 🏷️ [Types]: 型定義の追加 (`PdfPageRectangle`)

## 追加した内容

- `packages/core/src/document/pdf-page.ts` — `PdfPage` クラス + `PdfPageRectangle` 型 + `static from(resolved): PdfPage`
- `packages/core/src/document/pdf-page.behavior.test.ts` — 16 件の behavior test
  - `test.each` で PP-001 (rotate 0/180) / PP-002 (rotate 90/270) / PP-003 (userUnit 乗算) を 8 ケース網羅
  - 非原点 mediaBox 境界値テスト 2 件
  - `mediaBox` / `cropBox` (mediaBox と異なる/参照同一) / `rotate` / `userUnit` / `ref` のプロパティ透過テスト 6 件

## 変更した内容

- `packages/core/src/document/index.ts` — `PdfPage` value-export と `PdfPageRectangle` type-export を追加
- `packages/core/src/index.ts` — ルートからの `PdfPage` / `PdfPageRectangle` 公開
- `packages/core/src/namespace-export.runtime.test.ts` — `PdfPage.from` の存在検証を追加

## システム図

### width / height 算出フロー

```mermaid
flowchart TD
    A[ResolvedPage] --> B[PdfPage.from]
    B --> C{rotate ∈ 90/270?}
    C -->|true| D["PP-002<br/>baseW = ury - lly<br/>baseH = urx - llx"]
    C -->|false| E["PP-001<br/>baseW = urx - llx<br/>baseH = ury - lly"]
    D --> F["PP-003<br/>width = baseW × userUnit<br/>height = baseH × userUnit"]
    E --> F
    F --> G[new PdfPage fields]
    G --> H[PdfPage immutable]
    style B fill:#e1f5ff
    style H fill:#d4edda
```

### 公開 API パッケージ構造

```mermaid
flowchart LR
    A["pdf-page.ts<br/>[NEW]"] --> B[document/index.ts]
    B --> C[src/index.ts]
    C --> D["@pdfmod/core<br/>PdfPage / PdfPageRectangle"]
    style A fill:#fff4d4
```

## 関連 spec / Issue

- spec: `.plugin-workspace/.specs/018-pdf-page-class/`
- Refs #49

## テスト

- `pnpm --filter @pdfmod/core test`: **1410/1410 passed** (99 files)
- `pnpm test:run` (monorepo): **1430/1430 passed** (103 files)
- `pnpm --filter @pdfmod/core typecheck` (`tsc --noEmit`): pass
- `pnpm lint` (biome + oxlint): エラーなし (`.pnpm-store` の broken symlink warning のみ、事前から存在)
- Codex レビュー: **問題なし** (1 回で通過)

## レビューポイント

- **設計判断 R1**: `mediaBox` / `cropBox` は型レベルの readonly のみ採用し、runtime での `slice()` コピーや `Object.freeze` は行わない (`as PdfPageRectangle` で narrow)。`ResolvedPage` は `PageTreeWalker` 内部で生成・パース後不変であることを前提とする。テストで `cropBox === mediaBox` の参照同一性を `toBe` で検証
- **PageRotate 定数の使用**: `90`/`270` のマジックナンバーを避け、`resolved-page.ts` の `PAGE_ROTATE_90` / `PAGE_ROTATE_270` を使用 (no-magic-numbers ルール準拠)
- **プライベート constructor + static factory**: `PdfDocument` と同じ `private constructor(fields)` + `static from(...)` パターンを踏襲
- **TDD サイクル**: PP-001 → PP-002 → PP-003 → プロパティ透過 → exports の順で Red → Green → Refactor を実施 (tasks.md 参照)
- **スコープ外**: `PdfDocument.getPage()` の戻り値型変更 (`Option<ResolvedPage>` → `Option<PdfPage>`) は別 issue