### PR TITLE
♻️ [Refactoring]: PdfPage.from の不要な PdfPageRectangle キャストを削除

### DIFF
--- a/packages/core/src/document/pdf-page.ts
+++ b/packages/core/src/document/pdf-page.ts
@@ -81,8 +81,8 @@ export class PdfPage {
     const height = baseHeight * resolved.userUnit;
 
     return new PdfPage({
-      mediaBox: resolved.mediaBox as PdfPageRectangle,
-      cropBox: resolved.cropBox as PdfPageRectangle,
+      mediaBox: resolved.mediaBox,
+      cropBox: resolved.cropBox,
       rotate: resolved.rotate,
       userUnit: resolved.userUnit,
       ref: resolved.objectRef,


### PR DESCRIPTION
## 概要

`PdfPage.from` 内の `as PdfPageRectangle` キャストを削除する。`PdfRectangle`（mutable tuple）は `PdfPageRectangle`（readonly tuple）に TypeScript の型システム上そのまま代入可能なため、明示的な型アサーションは不要。

## 変更の種類

- ♻️ Refactoring

## 変更した内容

- `packages/core/src/document/pdf-page.ts`: `PdfPage.from` の `mediaBox` / `cropBox` 代入から `as PdfPageRectangle` を削除

## システム図

```mermaid
flowchart LR
    A["resolved.mediaBox<br/>PdfRectangle<br/>[number,number,number,number]"] -->|"以前: as PdfPageRectangle"| B["PdfPageFields.mediaBox<br/>readonly [number,number,number,number]"]
    A -->|"今回: 代入のみ [CHANGED]"| B
    style A fill:#e8f5e9
    style B fill:#fff3e0
```

mutable tuple は readonly tuple に共変的に代入できるため、キャストを介さなくても型エラーは発生しない。

## 関連 spec / Issue

- spec-049 PdfPage クラスのフォローアップ（小規模リファクタ）

## テスト

- `pnpm --filter @pdfmod/core typecheck` → エラーなし
- `pnpm --filter @pdfmod/core test pdf-page` → 16 tests passed
- `pnpm lint` → 0 errors

## レビューポイント

- `PdfRectangle` → `PdfPageRectangle` の代入が型システム上安全であること（mutable → readonly への共変代入）
- 後続で `PdfRectangle` 側に readonly 制約を加えるなどの破壊的変更があれば再検討が必要