### PR TITLE
✨ [New Feature]: #50 PdfDocument / LoadOptions / PdfDocumentLoadError を @pdfmod/core から公開

### DIFF
--- a/packages/core/src/document/index.ts
+++ b/packages/core/src/document/index.ts
@@ -13,5 +13,7 @@ export type {
   WalkPageTreeResult,
 } from "./page-tree/index";
 export { InheritanceResolver, PageTreeWalker } from "./page-tree/index";
+export type { LoadOptions, PdfDocumentLoadError } from "./pdf-document";
+export { PdfDocument } from "./pdf-document";
 export type { PdfPageRectangle } from "./pdf-page";
 export { PdfPage } from "./pdf-page";

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -8,9 +8,11 @@
 export type {
   DocumentMetadata,
   InheritedAttrs,
+  LoadOptions,
   PageRotate,
   ParsedCatalog,
   ParsedDocumentInfo,
+  PdfDocumentLoadError,
   PdfPageRectangle,
   PdfRectangle,
   ResolvedPage,
@@ -23,6 +25,7 @@ export {
   DocumentInfoParser,
   InheritanceResolver,
   PageTreeWalker,
+  PdfDocument,
   PdfPage,
   PdfTrapped,
 } from "./document/index";

--- a/packages/core/src/namespace-export.runtime.test.ts
+++ b/packages/core/src/namespace-export.runtime.test.ts
@@ -12,6 +12,7 @@ import {
   ObjectStreamBody,
   ObjectStreamHeader,
   PageTreeWalker,
+  PdfDocument,
   PdfPage,
   PdfTrapped,
   PdfVersion,
@@ -42,6 +43,7 @@ test.each([
   { name: "DocumentInfoParser.parse", value: DocumentInfoParser.parse },
   { name: "PdfTrapped.create", value: PdfTrapped.create },
   { name: "PdfPage.from", value: PdfPage.from },
+  { name: "PdfDocument.load", value: PdfDocument.load },
 ])("$nameがルートからexportされている", ({ value }) => {
   expect(typeof value).toBe("function");
 });

--- a/packages/core/src/namespace-export.type.test.ts
+++ b/packages/core/src/namespace-export.type.test.ts
@@ -1,7 +1,9 @@
 import { expect, test } from "vitest";
 import type {
   InheritedAttrs,
+  LoadOptions,
   ParsedCatalog,
+  PdfDocumentLoadError,
   PdfPageRectangle,
   ResolvedPage,
   ResolveRef,
@@ -99,4 +101,18 @@ test("ResolvedPage / InheritedAttrs / WalkPageTreeResult 型が参照できる",
   const res: WalkPageTreeResult = { pages: [page], warnings: [] };
   expect(res.pages.length).toBe(1);
   expect(inh.mediaBox?.[2]).toBe(612);
+});
+
+test("LoadOptions 型がルートから参照できる", () => {
+  const options: LoadOptions = {
+    cacheCapacity: 16,
+    onWarning: () => {},
+  };
+  expect(options.cacheCapacity).toBe(16);
+  expect(typeof options.onWarning).toBe("function");
+});
+
+test("PdfDocumentLoadError 型がルートから参照できる", () => {
+  const error: PdfDocumentLoadError = new RangeError("cacheCapacity");
+  expect(error.message).toBe("cacheCapacity");
 });


### PR DESCRIPTION
## 概要

`@pdfmod/core` の Phase 1+2 で実装済みの `PdfDocument` クラスとその関連型を、ルート (`packages/core/src/index.ts`) および `document` barrel (`packages/core/src/document/index.ts`) から公開する。

利用者は以下のように import できるようになる:

```ts
import { PdfDocument } from "@pdfmod/core";
import type { LoadOptions, PdfDocumentLoadError } from "@pdfmod/core";

const result = await PdfDocument.load(bytes, { cacheCapacity: 16 });
```

## 変更の種類

- ✨ 新機能（公開 API 表面の追加）
- 🚨 テスト（namespace-export 検証拡張）

## 詳細な変更内容

### 追加した 3 シンボル

| シンボル | 種別 | 出元 |
| --- | --- | --- |
| `PdfDocument` | class (value) | `./document/pdf-document` |
| `LoadOptions` | interface (type) | `./document/pdf-document` |
| `PdfDocumentLoadError` | type | `./document/pdf-document` |

### 変更ファイル

- `packages/core/src/index.ts` — type ブロックに `LoadOptions` / `PdfDocumentLoadError`、value ブロックに `PdfDocument` をアルファベット順で追加
- `packages/core/src/document/index.ts` — `pdf-document` からの type / value re-export を追加
- `packages/core/src/namespace-export.runtime.test.ts` — `test.each` 末尾に `PdfDocument.load` 行を追加
- `packages/core/src/namespace-export.type.test.ts` — `LoadOptions` / `PdfDocumentLoadError` の type import と参照可能性を確認する最小テスト 2 件を追加

## システム図

```mermaid
flowchart LR
  A["利用者: from @pdfmod/core"] --> B["src/index.ts"]
  B --> C["src/document/index.ts"]
  C --> D["src/document/pdf-document.ts"]
  D --> D1["class PdfDocument (NEW export)"]
  D --> D2["interface LoadOptions (NEW export)"]
  D --> D3["type PdfDocumentLoadError (NEW export)"]
```

## 関連Issue

- Refs #50
- 親: #20

## テスト

- [x] `pnpm --filter @pdfmod/core build` 成功
- [x] `pnpm --filter @pdfmod/core test` 全 pass（99 ファイル / 1414 件）
- [x] `pnpm --filter @pdfmod/core typecheck` 成功
- [x] `pnpm lint` 通過（`.pnpm-store/` 配下の broken symlink 警告のみで実害なし）
- [x] `dist/index.d.ts` に `PdfDocument` / `LoadOptions` / `PdfDocumentLoadError` が出現
- [x] Codex 一括レビュー: 問題なし

### Definition of Done

- [x] value/type ブロック分離・アルファベット順を維持
- [x] `throw` 新規追加なし
- [x] テストにセクションコメント追加なし
- [x] フラット構造（`describe` 不使用）維持
- [x] 型で保証される制約の runtime 再確認テストは書いていない

## レビューポイント

- `packages/core/src/document/index.ts` で `pdf-document` の type / value 行が `page-tree` と `pdf-page` の間にアルファベット順で挿入されているか
- `namespace-export.type.test.ts` の `PdfDocumentLoadError` テストは `RangeError` 枝のみで参照可能性を確認しており、`instanceof` などの runtime 型再確認は意図的に避けている

## スコープ外（次の spec で扱う）

本 PR では `pdf-document.e2e.test.ts` の追加（公開 API 経由 E2E、metadata / pageCount / page(n) / 破損 PDF / 暗号化 PDF / XRefStream）は **扱わない**。別 spec / 別 PR で対応する（`feedback_one_pr_at_a_time`）。