### PR TITLE
✨ [New Feature]: #129 Token discriminated union 化と Operator バリアント基盤追加

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -81,6 +81,7 @@ export {
   GenerationNumber,
   IndirectRef,
   ObjectNumber,
+  Operator,
   PdfVersion,
   TokenType,
 } from "./pdf/index";

--- a/packages/core/src/lexer/tokenizer/tokenizer.basic.test.ts
+++ b/packages/core/src/lexer/tokenizer/tokenizer.basic.test.ts
@@ -122,20 +122,17 @@ test("不正数値 1.2.3 はキーワードにフォールバックする", () =
 
 test("ドット単独 . は Real (NaN) になる", () => {
   const tokens = tokenize(".");
-  expect(tokens[0].type).toBe(TokenType.Real);
-  expect(tokens[0].value).toBeNaN();
+  expect(tokens[0]).toMatchObject({ type: TokenType.Real, value: NaN });
 });
 
 test("符号単独 + は Integer (NaN) になる", () => {
   const tokens = tokenize("+");
-  expect(tokens[0].type).toBe(TokenType.Integer);
-  expect(tokens[0].value).toBeNaN();
+  expect(tokens[0]).toMatchObject({ type: TokenType.Integer, value: NaN });
 });
 
 test("符号単独 - は Integer (NaN) になる", () => {
   const tokens = tokenize("-");
-  expect(tokens[0].type).toBe(TokenType.Integer);
-  expect(tokens[0].value).toBeNaN();
+  expect(tokens[0]).toMatchObject({ type: TokenType.Integer, value: NaN });
 });
 
 test("空リテラル文字列 () をトークナイズする", () => {
@@ -219,10 +216,11 @@ test.each([
 
 test("Name の不正hexエスケープ /A#GG は #GG を16進デコードする", () => {
   const tokens = tokenize("/A#GG");
-  const name = tokens[0];
-  expect(name.type).toBe(TokenType.Name);
   // parseInt("GG", 16) = NaN → String.fromCharCode(NaN) = "\u0000"
-  expect(name.value).toBe("A\u0000");
+  expect(tokens[0]).toMatchObject({
+    type: TokenType.Name,
+    value: "A\u0000",
+  });
 });
 
 test.each([

--- a/packages/core/src/lexer/tokenizer/tokenizer.pdf-spec.test.ts
+++ b/packages/core/src/lexer/tokenizer/tokenizer.pdf-spec.test.ts
@@ -86,8 +86,10 @@ test("高位バイト(0xFF, 0x00)を含むバイト列をトークナイズす�
   ]);
   const tokenizer = new Tokenizer(bytes);
   const token = tokenizer.nextToken();
-  expect(token.type).toBe(TokenType.LiteralString);
-  expect(token.value).toBe("\xff\x00A");
+  expect(token).toMatchObject({
+    type: TokenType.LiteralString,
+    value: "\xff\x00A",
+  });
 });
 
 test("デリミタ直後の数値 [42] をトークナイズする", () => {

--- a/packages/core/src/namespace-export.runtime.test.ts
+++ b/packages/core/src/namespace-export.runtime.test.ts
@@ -11,6 +11,7 @@ import {
   ObjectStore,
   ObjectStreamBody,
   ObjectStreamHeader,
+  Operator,
   PageTreeWalker,
   PdfDocument,
   PdfPage,
@@ -72,4 +73,12 @@ test("ByteOffsetコンパニオンがルートからexportされている", () =
 test("TokenType enumがルートからexportされている", () => {
   expect(TokenType.Integer).toBeDefined();
   expect(TokenType.EOF).toBeDefined();
+  expect(TokenType.Operator).toBeDefined();
+});
+
+test("Operatorコンパニオンがルートからexportされている", () => {
+  const op = Operator.of("m", ByteOffset.of(42));
+  expect(op.type).toBe(TokenType.Operator);
+  expect(op.name).toBe("m");
+  expect(op.offset).toBe(42);
 });

--- a/packages/core/src/objects/object-parser/buffered-tokenizer/buffered-tokenizer.basic.test.ts
+++ b/packages/core/src/objects/object-parser/buffered-tokenizer/buffered-tokenizer.basic.test.ts
@@ -10,10 +10,9 @@ test("next() が Tokenizer のトークンを順次返す", () => {
   const first = bt.next();
   const second = bt.next();
   const third = bt.next();
-  expect(first.type).toBe(TokenType.Integer);
-  expect(first.value).toBe(1);
-  expect(second.value).toBe(2);
-  expect(third.value).toBe(3);
+  expect(first).toMatchObject({ type: TokenType.Integer, value: 1 });
+  expect(second).toMatchObject({ type: TokenType.Integer, value: 2 });
+  expect(third).toMatchObject({ type: TokenType.Integer, value: 3 });
 });
 
 test("pushBack() したトークンが次の next() で返される", () => {
@@ -23,7 +22,7 @@ test("pushBack() したトークンが次の next() で返される", () => {
   const again = bt.next();
   expect(again).toBe(first);
   const next = bt.next();
-  expect(next.value).toBe(99);
+  expect(next).toMatchObject({ type: TokenType.Integer, value: 99 });
 });
 
 test("複数 pushBack() 後の next() 順序は LIFO である", () => {

--- a/packages/core/src/objects/object-parser/direct-object/index.ts
+++ b/packages/core/src/objects/object-parser/direct-object/index.ts
@@ -2,7 +2,7 @@ import type { PdfParseError } from "../../../pdf/errors/index";
 import { ByteOffset } from "../../../pdf/types/byte-offset/index";
 import { GenerationNumber } from "../../../pdf/types/generation-number/index";
 import type { Token } from "../../../pdf/types/index";
-import { TokenType } from "../../../pdf/types/index";
+import { TokenType, tokenDisplayString } from "../../../pdf/types/index";
 import { ObjectNumber } from "../../../pdf/types/object-number/index";
 import type {
   PdfDictionary,
@@ -60,10 +60,10 @@ function readValue(
       return ok({ type: "null" });
 
     case TokenType.Boolean:
-      return ok({ type: "boolean", value: token.value as boolean });
+      return ok({ type: "boolean", value: token.value });
 
     case TokenType.Integer: {
-      const intVal = token.value as number;
+      const intVal = token.value;
       if (Number.isNaN(intVal)) {
         return err({
           code: "OBJECT_PARSE_UNEXPECTED_TOKEN",
@@ -79,7 +79,7 @@ function readValue(
     }
 
     case TokenType.Real: {
-      const realVal = token.value as number;
+      const realVal = token.value;
       if (Number.isNaN(realVal)) {
         return err({
           code: "OBJECT_PARSE_UNEXPECTED_TOKEN",
@@ -91,10 +91,10 @@ function readValue(
     }
 
     case TokenType.Name:
-      return ok({ type: "name", value: token.value as string });
+      return ok({ type: "name", value: token.value });
 
     case TokenType.LiteralString: {
-      const literalResult = decodeLiteralString(token.value as string);
+      const literalResult = decodeLiteralString(token.value);
       if (!literalResult.ok) {
         return err({
           code: "OBJECT_PARSE_UNEXPECTED_TOKEN",
@@ -110,7 +110,7 @@ function readValue(
     }
 
     case TokenType.HexString: {
-      const hexResult = decodeHexString(token.value as string);
+      const hexResult = decodeHexString(token.value);
       if (!hexResult.ok) {
         return err({
           code: "OBJECT_PARSE_UNEXPECTED_TOKEN",
@@ -141,7 +141,7 @@ function readValue(
     default:
       return err({
         code: "OBJECT_PARSE_UNEXPECTED_TOKEN",
-        message: `Unexpected token type ${token.type}: ${String(token.value)}`,
+        message: `Unexpected token type ${token.type}: ${tokenDisplayString(token)}`,
         offset: ByteOffset.add(baseOffset, token.offset),
       });
   }
@@ -167,7 +167,7 @@ function tryReadIndirectRef(
     return none;
   }
 
-  const secondVal = second.value as number;
+  const secondVal = second.value;
   if (Number.isNaN(secondVal)) {
     bt.pushBack(second);
     return none;
@@ -304,6 +304,6 @@ function readDictEntries(
     if (!valResult.ok) {
       return valResult;
     }
-    entries.set(keyToken.value as string, valResult.value);
+    entries.set(keyToken.value, valResult.value);
   }
 }

--- a/packages/core/src/objects/object-parser/indirect-object/index.ts
+++ b/packages/core/src/objects/object-parser/indirect-object/index.ts
@@ -2,7 +2,7 @@ import { Tokenizer } from "../../../lexer/tokenizer/index";
 import type { PdfParseError } from "../../../pdf/errors/index";
 import { ByteOffset } from "../../../pdf/types/byte-offset/index";
 import { GenerationNumber } from "../../../pdf/types/generation-number/index";
-import { TokenType } from "../../../pdf/types/index";
+import { TokenType, tokenDisplayString } from "../../../pdf/types/index";
 import { ObjectNumber } from "../../../pdf/types/object-number/index";
 import type { Option } from "../../../utils/option/index";
 import { none, some } from "../../../utils/option/index";
@@ -31,11 +31,11 @@ export const IndirectObject = {
     const objNumToken = bt.next();
     if (
       objNumToken.type !== TokenType.Integer ||
-      Number.isNaN(objNumToken.value as number)
+      Number.isNaN(objNumToken.value)
     ) {
       return err({
         code: "OBJECT_PARSE_UNEXPECTED_TOKEN",
-        message: `Expected object number (integer), got ${objNumToken.type}: ${String(objNumToken.value)}`,
+        message: `Expected object number (integer), got ${objNumToken.type}: ${tokenDisplayString(objNumToken)}`,
         offset: ByteOffset.add(baseOffset, objNumToken.offset),
       });
     }
@@ -43,11 +43,11 @@ export const IndirectObject = {
     const genNumToken = bt.next();
     if (
       genNumToken.type !== TokenType.Integer ||
-      Number.isNaN(genNumToken.value as number)
+      Number.isNaN(genNumToken.value)
     ) {
       return err({
         code: "OBJECT_PARSE_UNEXPECTED_TOKEN",
-        message: `Expected generation number (integer), got ${genNumToken.type}: ${String(genNumToken.value)}`,
+        message: `Expected generation number (integer), got ${genNumToken.type}: ${tokenDisplayString(genNumToken)}`,
         offset: ByteOffset.add(baseOffset, genNumToken.offset),
       });
     }
@@ -56,12 +56,12 @@ export const IndirectObject = {
     if (objKeyword.type !== TokenType.Keyword || objKeyword.value !== "obj") {
       return err({
         code: "OBJECT_PARSE_UNEXPECTED_TOKEN",
-        message: `Expected "obj" keyword, got ${objKeyword.type}: ${String(objKeyword.value)}`,
+        message: `Expected "obj" keyword, got ${objKeyword.type}: ${tokenDisplayString(objKeyword)}`,
         offset: ByteOffset.add(baseOffset, objKeyword.offset),
       });
     }
 
-    const objectNumberResult = ObjectNumber.create(objNumToken.value as number);
+    const objectNumberResult = ObjectNumber.create(objNumToken.value);
     if (!objectNumberResult.ok) {
       return err({
         code: "OBJECT_PARSE_UNEXPECTED_TOKEN",
@@ -70,9 +70,7 @@ export const IndirectObject = {
       });
     }
 
-    const generationNumberResult = GenerationNumber.create(
-      genNumToken.value as number,
-    );
+    const generationNumberResult = GenerationNumber.create(genNumToken.value);
     if (!generationNumberResult.ok) {
       return err({
         code: "OBJECT_PARSE_UNEXPECTED_TOKEN",
@@ -114,7 +112,7 @@ export const IndirectObject = {
     }
     return some({
       code: "OBJECT_PARSE_UNEXPECTED_TOKEN",
-      message: `Expected "endobj", got ${String(endobjToken.value)}`,
+      message: `Expected "endobj", got ${tokenDisplayString(endobjToken)}`,
       offset: ByteOffset.add(baseOffset, endobjToken.offset),
     });
   },
@@ -150,7 +148,7 @@ export const IndirectObject = {
     }
     return some({
       code: "OBJECT_PARSE_UNEXPECTED_TOKEN",
-      message: `Expected "endobj" after endstream, got ${String(endobjToken.value)}`,
+      message: `Expected "endobj" after endstream, got ${tokenDisplayString(endobjToken)}`,
       offset: ByteOffset.add(afterEndstreamAbsPos, endobjToken.offset),
     });
   },

--- a/packages/core/src/objects/object-stream-extractor/header/index.ts
+++ b/packages/core/src/objects/object-stream-extractor/header/index.ts
@@ -2,8 +2,8 @@ import { NumberEx } from "../../../ext/number/index";
 import { Tokenizer } from "../../../lexer/index";
 import type { PdfParseError } from "../../../pdf/errors/index";
 import { ByteOffset } from "../../../pdf/types/byte-offset/index";
+import { TokenType } from "../../../pdf/types/index";
 import { ObjectNumber } from "../../../pdf/types/object-number/index";
-import { TokenType } from "../../../pdf/types/pdf-types/index";
 import type { Result } from "../../../utils/result/index";
 import { err, ok } from "../../../utils/result/index";
 
@@ -62,7 +62,7 @@ export const ObjectStreamHeader = {
           message: `Expected integer objNum at pair ${i}, got ${objNumToken.type}`,
         });
       }
-      const objNumValue = objNumToken.value as number;
+      const objNumValue = objNumToken.value;
       if (!NumberEx.isSafeIntegerAtLeastZero(objNumValue)) {
         return err({
           code: "OBJECT_STREAM_HEADER_INVALID",
@@ -77,7 +77,7 @@ export const ObjectStreamHeader = {
           message: `Expected integer offset at pair ${i}, got ${offsetToken.type}`,
         });
       }
-      const offsetValue = offsetToken.value as number;
+      const offsetValue = offsetToken.value;
       if (!NumberEx.isSafeIntegerAtLeastZero(offsetValue)) {
         return err({
           code: "OBJECT_STREAM_HEADER_INVALID",

--- a/packages/core/src/pdf/types/index.ts
+++ b/packages/core/src/pdf/types/index.ts
@@ -3,3 +3,4 @@ export { GenerationNumber } from "./generation-number/index";
 export { IndirectRef } from "./indirect-ref/index";
 export { ObjectNumber } from "./object-number/index";
 export * from "./pdf-types/index";
+export * from "./token/index";

--- a/packages/core/src/pdf/types/pdf-types/index.ts
+++ b/packages/core/src/pdf/types/pdf-types/index.ts
@@ -1,55 +1,9 @@
-/**
- * PDFトークンの種別を表す列挙型。
- * PDF字句解析器が生成するトークンの分類に使用する。
- *
- * @example
- * ```ts
- * const token: Token = { type: TokenType.Integer, value: 42, offset: ByteOffset.of(0) };
- * if (token.type === TokenType.Name) {
- *   console.log(token.value); // "Type" など
- * }
- * ```
- */
-export enum TokenType {
-  Boolean = "Boolean",
-  Integer = "Integer",
-  Real = "Real",
-  LiteralString = "LiteralString",
-  HexString = "HexString",
-  Name = "Name",
-  ArrayBegin = "ArrayBegin",
-  ArrayEnd = "ArrayEnd",
-  DictBegin = "DictBegin",
-  DictEnd = "DictEnd",
-  Null = "Null",
-  Keyword = "Keyword",
-  EOF = "EOF",
-}
-
 import type { ByteOffset } from "../byte-offset/index";
 import type { GenerationNumber } from "../generation-number/index";
 import type { IndirectRef } from "../indirect-ref/index";
 import type { ObjectNumber } from "../object-number/index";
 
 export type { IndirectRef } from "../indirect-ref/index";
-
-/**
- * 字句解析器が生成する単一のトークン。
- * トークン種別、値、およびバイトストリーム内の出現位置を保持する。
- *
- * @example
- * ```ts
- * const token: Token = { type: TokenType.Name, value: "Type", offset: ByteOffset.of(15) };
- * ```
- */
-export interface Token {
-  /** トークン種別 */
-  type: TokenType;
-  /** トークンの値（型はトークン種別に依存する） */
-  value: string | number | boolean | null;
-  /** バイトストリーム内のオフセット位置 */
-  offset: ByteOffset;
-}
 
 /**
  * フリーオブジェクトの相互参照エントリ (type 0)。

--- a/packages/core/src/pdf/types/token/index.ts
+++ b/packages/core/src/pdf/types/token/index.ts
@@ -1,0 +1,206 @@
+import type { ByteOffset } from "../byte-offset/index";
+
+/**
+ * PDFトークンの種別を表す列挙型。
+ * PDF字句解析器および ContentStream 解釈器が生成するトークンの分類に使用する。
+ */
+export enum TokenType {
+  Boolean = "Boolean",
+  Integer = "Integer",
+  Real = "Real",
+  LiteralString = "LiteralString",
+  HexString = "HexString",
+  Name = "Name",
+  ArrayBegin = "ArrayBegin",
+  ArrayEnd = "ArrayEnd",
+  DictBegin = "DictBegin",
+  DictEnd = "DictEnd",
+  Null = "Null",
+  Keyword = "Keyword",
+  Operator = "Operator",
+  EOF = "EOF",
+}
+
+/**
+ * Boolean リテラル (`true` / `false`) トークン。
+ */
+export interface TokenBoolean {
+  type: TokenType.Boolean;
+  value: boolean;
+  offset: ByteOffset;
+}
+
+/**
+ * 整数リテラル (`123`, `-7`) トークン。
+ */
+export interface TokenInteger {
+  type: TokenType.Integer;
+  value: number;
+  offset: ByteOffset;
+}
+
+/**
+ * 実数リテラル (`3.14`, `.5`) トークン。
+ */
+export interface TokenReal {
+  type: TokenType.Real;
+  value: number;
+  offset: ByteOffset;
+}
+
+/**
+ * リテラル文字列 (`(...)`) トークン。
+ */
+export interface TokenLiteralString {
+  type: TokenType.LiteralString;
+  value: string;
+  offset: ByteOffset;
+}
+
+/**
+ * 16進文字列 (`<...>`) トークン。
+ */
+export interface TokenHexString {
+  type: TokenType.HexString;
+  value: string;
+  offset: ByteOffset;
+}
+
+/**
+ * 名前オブジェクト (`/Name`) トークン。
+ */
+export interface TokenName {
+  type: TokenType.Name;
+  value: string;
+  offset: ByteOffset;
+}
+
+/**
+ * 配列開始 (`[`) トークン。
+ */
+export interface TokenArrayBegin {
+  type: TokenType.ArrayBegin;
+  value: "[";
+  offset: ByteOffset;
+}
+
+/**
+ * 配列終了 (`]`) トークン。
+ */
+export interface TokenArrayEnd {
+  type: TokenType.ArrayEnd;
+  value: "]";
+  offset: ByteOffset;
+}
+
+/**
+ * 辞書開始 (`<<`) トークン。
+ */
+export interface TokenDictBegin {
+  type: TokenType.DictBegin;
+  value: "<<";
+  offset: ByteOffset;
+}
+
+/**
+ * 辞書終了 (`>>`) トークン。
+ */
+export interface TokenDictEnd {
+  type: TokenType.DictEnd;
+  value: ">>";
+  offset: ByteOffset;
+}
+
+/**
+ * `null` リテラルトークン。
+ * PDF 仕様の `null` オブジェクトを保持するため、value は `null` 固定。
+ */
+export interface TokenNull {
+  type: TokenType.Null;
+  value: null;
+  offset: ByteOffset;
+}
+
+/**
+ * キーワード (`obj`, `endobj`, `stream`, `R` 等) トークン。
+ */
+export interface TokenKeyword {
+  type: TokenType.Keyword;
+  value: string;
+  offset: ByteOffset;
+}
+
+/**
+ * EOFトークン。終端を示す非値トークンとして value は `null` 固定。
+ */
+export interface TokenEOF {
+  type: TokenType.EOF;
+  value: null;
+  offset: ByteOffset;
+}
+
+/**
+ * ContentStream の演算子 (例: `BT`, `m`, `l`, `S`) を表すトークン。
+ * Tokenizer は生成しない。`Operator.of()` から生成される。
+ */
+export interface Operator {
+  type: TokenType.Operator;
+  name: string;
+  offset: ByteOffset;
+}
+
+/**
+ * PDF字句解析器および ContentStream 解釈器が扱う全トークンの discriminated union。
+ * `type` フィールドで variant を識別する。
+ */
+export type Token =
+  | TokenBoolean
+  | TokenInteger
+  | TokenReal
+  | TokenLiteralString
+  | TokenHexString
+  | TokenName
+  | TokenArrayBegin
+  | TokenArrayEnd
+  | TokenDictBegin
+  | TokenDictEnd
+  | TokenNull
+  | TokenKeyword
+  | Operator
+  | TokenEOF;
+
+const OperatorCompanion = {
+  /**
+   * Operator バリアントを生成する。検証は行わず、生 string をそのまま受け取る。
+   *
+   * @param name - 演算子名 (例: `BT`, `m`)
+   * @param offset - バイトオフセット
+   * @returns Operator バリアント
+   */
+  of(name: string, offset: ByteOffset): Operator {
+    return { type: TokenType.Operator, name, offset };
+  },
+} as const;
+
+/**
+ * `Operator` の factory utility を束ねた companion object。
+ * 型と value を同一識別子で公開する declaration merging パターン。
+ */
+export const Operator = OperatorCompanion;
+
+/**
+ * Token をエラーメッセージなどに埋め込むための文字列表現。
+ * Operator は name、Null/EOF は "null"、それ以外は value を文字列化する。
+ *
+ * @param token - 表示対象のトークン
+ * @returns 表示用文字列
+ */
+export function tokenDisplayString(token: Token): string {
+  if (token.type === TokenType.Operator) {
+    return token.name;
+  }
+  if (token.value === null) {
+    return "null";
+  }
+  return String(token.value);
+}

--- a/packages/core/src/pdf/types/token/token.basic.test.ts
+++ b/packages/core/src/pdf/types/token/token.basic.test.ts
@@ -1,0 +1,69 @@
+import { expect, test } from "vitest";
+import { ByteOffset } from "../byte-offset/index";
+import { Operator, TokenType, tokenDisplayString } from "./index";
+
+test("Operator.of は TokenType.Operator variant を返す", () => {
+  const op = Operator.of("m", ByteOffset.of(0));
+  expect(op).toEqual({ type: TokenType.Operator, name: "m", offset: 0 });
+});
+
+test("Operator.of は与えた name/offset をそのまま保持する", () => {
+  const op = Operator.of("BT", ByteOffset.of(128));
+  expect(op.name).toBe("BT");
+  expect(op.offset).toBe(128);
+});
+
+test("Operator.of は空文字 name でも variant を返す", () => {
+  const op = Operator.of("", ByteOffset.of(0));
+  expect(op.name).toBe("");
+  expect(op.type).toBe(TokenType.Operator);
+});
+
+test("TokenType.Operator メンバが定義されている", () => {
+  expect(TokenType.Operator).toBe("Operator");
+});
+
+test("tokenDisplayString は Operator に対して name を返す", () => {
+  const op = Operator.of("BT", ByteOffset.of(0));
+  expect(tokenDisplayString(op)).toBe("BT");
+});
+
+test("tokenDisplayString は Integer に対して数値の文字列化を返す", () => {
+  expect(
+    tokenDisplayString({
+      type: TokenType.Integer,
+      value: 42,
+      offset: ByteOffset.of(0),
+    }),
+  ).toBe("42");
+});
+
+test("tokenDisplayString は Keyword に対して keyword 文字列を返す", () => {
+  expect(
+    tokenDisplayString({
+      type: TokenType.Keyword,
+      value: "obj",
+      offset: ByteOffset.of(0),
+    }),
+  ).toBe("obj");
+});
+
+test('tokenDisplayString は Null variant に対して "null" を返す', () => {
+  expect(
+    tokenDisplayString({
+      type: TokenType.Null,
+      value: null,
+      offset: ByteOffset.of(0),
+    }),
+  ).toBe("null");
+});
+
+test('tokenDisplayString は EOF variant に対して "null" を返す', () => {
+  expect(
+    tokenDisplayString({
+      type: TokenType.EOF,
+      value: null,
+      offset: ByteOffset.of(0),
+    }),
+  ).toBe("null");
+});

--- a/packages/core/src/xref/trailer/parser/index.ts
+++ b/packages/core/src/xref/trailer/parser/index.ts
@@ -307,8 +307,8 @@ function readValue(
           return ok({
             value: {
               type: "indirect-ref",
-              objectNumber: firstToken.value as number,
-              generationNumber: second.value as number,
+              objectNumber: firstToken.value,
+              generationNumber: second.value,
             },
             offset,
           });
@@ -317,22 +317,22 @@ function readValue(
       }
       tokens.pushBack(second);
       return ok({
-        value: { type: "integer", value: firstToken.value as number },
+        value: { type: "integer", value: firstToken.value },
         offset,
       });
     }
     case TokenType.Real:
       return ok({
-        value: { type: "real", value: firstToken.value as number },
+        value: { type: "real", value: firstToken.value },
         offset,
       });
     case TokenType.Name:
       return ok({
-        value: { type: "name", value: firstToken.value as string },
+        value: { type: "name", value: firstToken.value },
         offset,
       });
     case TokenType.HexString: {
-      const hexBytes = hexStringToBytes(firstToken.value as string);
+      const hexBytes = hexStringToBytes(firstToken.value);
       if (!hexBytes) {
         return err({
           code: "XREF_TABLE_INVALID",
@@ -350,7 +350,7 @@ function readValue(
       });
     }
     case TokenType.LiteralString: {
-      const litBytes = literalStringToBytes(firstToken.value as string);
+      const litBytes = literalStringToBytes(firstToken.value);
       if (!litBytes) {
         return err({
           code: "XREF_TABLE_INVALID",
@@ -370,7 +370,7 @@ function readValue(
     }
     case TokenType.Boolean:
       return ok({
-        value: { type: "boolean", value: firstToken.value as boolean },
+        value: { type: "boolean", value: firstToken.value },
         offset,
       });
     case TokenType.Null:
@@ -584,7 +584,7 @@ function parseDictTokens(
       });
     }
 
-    const key = token.value as string;
+    const key = token.value;
     const valueToken = tokens.next();
 
     if (valueToken.type === TokenType.EOF) {


### PR DESCRIPTION
## 概要

spec-022 (#129)。Phase 3 (Stream Interpreter, Epic #128) の最初の基盤タスクとして、既存 `Token` を **14 variant** の discriminated union に再設計し、`Operator` バリアント (`{ type: TokenType.Operator, name: string, offset: ByteOffset }`) を companion object 付きで追加する。後続 #132 / #135 / #136 が依存する型基盤の整備。

## 変更の種類

- ✨ New Feature — Token 判別 union + Operator companion 追加
- 🏷️ Types — `TokenType` enum を 13 → 14 メンバ化、各 variant interface 化
- ♻️ Refactoring — 24 箇所の `token.value as ...` キャストを narrowing に置換
- 🚨 Tests — `Operator.of` / `tokenDisplayString` の TDD 追加 + 既存 tokenizer/buffered-tokenizer テストの `.value` 直接参照を `toMatchObject` に統一

## 追加した内容

- `packages/core/src/pdf/types/token/index.ts`
  - `TokenType` enum (14 メンバ: 既存 13 + `Operator`)
  - 14 variant interface (`TokenBoolean` / `TokenInteger` / ... / `TokenEOF` / `Operator`)
  - `Token` discriminated union 型
  - `Operator` companion (`Operator.of(name, offset)`、検証なし factory)
  - `tokenDisplayString(token)` — エラーメッセージ用 helper（Operator は `name`、Null/EOF は `"null"`、それ以外は `String(value)`）
- `packages/core/src/pdf/types/token/token.basic.test.ts` — TDD 追加（`Operator.of` / `tokenDisplayString` の runtime probe 9 件）
- `namespace-export.runtime.test.ts` に `TokenType.Operator` / `Operator.of` の probe を追加

## 変更した内容

- `packages/core/src/pdf/types/pdf-types/index.ts` から `Token` interface / `TokenType` enum を撤去（`token/index` に移動）
- `packages/core/src/pdf/types/index.ts` で `token/index` を re-export
- `packages/core/src/index.ts` で `Operator` を value export
- `packages/core/src/objects/object-parser/direct-object/index.ts` — switch 内 7 箇所のキャスト撤去 + default error を `tokenDisplayString` に置換
- `packages/core/src/objects/object-parser/indirect-object/index.ts` — `objNumToken.value as number` 等を narrowing 化、エラーメッセージを `tokenDisplayString` に置換
- `packages/core/src/objects/object-stream-extractor/header/index.ts` — `pdf-types/index` 直接 import を `pdf/types/index` バレル経由に統一 + キャスト撤去
- `packages/core/src/xref/trailer/parser/index.ts` — 8+ 箇所のキャスト撤去
- `tokenizer.basic.test.ts` / `tokenizer.pdf-spec.test.ts` / `buffered-tokenizer.basic.test.ts` — `.value` 直接参照を `toMatchObject({ type, value })` 形式に統一

## システム図

```mermaid
flowchart TB
  subgraph S1["pdf/types/token/index.ts (NEW)"]
    direction TB
    TT["TokenType enum<br/>(14 メンバ)"]
    Variants["TokenBoolean / TokenInteger / TokenReal /<br/>TokenLiteralString / TokenHexString / TokenName /<br/>TokenArrayBegin / TokenArrayEnd / TokenDictBegin /<br/>TokenDictEnd / TokenNull / TokenKeyword /<br/>Operator [NEW] / TokenEOF"]
    UnionT["type Token = union of 14 variants"]
    OpC["Operator companion<br/>Operator.of(name, offset)"]
    Helper["tokenDisplayString(token)"]
  end

  subgraph S2["pdf/types/pdf-types/index.ts"]
    Removed["Token / TokenType<br/>(REMOVED → token/index へ移動)"]
  end

  Barrel["pdf/types/index.ts<br/>export * from token/index"]
  Root["src/index.ts<br/>+ Operator value export"]

  S1 --> Barrel
  S2 --> Barrel
  Barrel --> Root

  Root --> Tokenizer["lexer/tokenizer/index.ts<br/>(13 variant 生成 / Operator は #132 範囲)"]
  Root --> DirectObj["object-parser/direct-object<br/>(キャスト 7→0、tokenDisplayString 化)"]
  Root --> IndirectObj["object-parser/indirect-object<br/>(キャスト 4→0、tokenDisplayString 化)"]
  Root --> Header["object-stream-extractor/header<br/>(直接 import 解消、キャスト 2→0)"]
  Root --> Trailer["xref/trailer/parser<br/>(キャスト 8→0)"]

  style S1 fill:#e8f5e9,stroke:#2e7d32
  style OpC fill:#fff3e0,stroke:#e65100
  style Helper fill:#fff3e0,stroke:#e65100
  style Removed fill:#ffebee,stroke:#c62828
```

## 関連 spec / Issue

- spec: `.plugin-workspace/.specs/022-token-operator-type/`
- Refs #129
- 後続: #132 (ContentStreamTokenizer) / #135 (OperatorRegistry) / #136 (ContentStreamInterpreter) の前提となる型基盤

## テスト

```
pnpm --filter @pdfmod/core test       → 100 files / 1424 passed (新規 9 件含む)
pnpm --filter @pdfmod/core typecheck  → エラーゼロ
pnpm --filter @pdfmod/core build      → 成功 (dist/index.d.ts に Token / TokenType / Operator emit)
pnpm lint                              → 0 errors / 0 warnings
```

Codex レビュー（`code-review/review-001.md`）: **問題なし**

CI 用ゼロ件チェック:
- `rg "\.value as" {direct-object,indirect-object,header,trailer/parser}/index.ts` → 0 件
- `rg "String\([^)]*\.value\)" {direct-object,indirect-object}/index.ts` → 0 件

## レビューポイント

- **discriminated union 化の影響範囲**: 既存 Tokenizer 13 variant の return 文は型推論で通っているか（`as` を増やしていないこと）。Operator は本 PR では生成しない（#132 範囲）
- **`value: null` の扱い**: `TokenNull` / `TokenEOF` は PDF lexical の `null` 表現としての value を保持しており、`feedback_no_undefined_use_option.md` の「値の有無」用途ではない（plan の「`value: null` を残す例外について」参照）
- **エラーメッセージ helper**: `tokenDisplayString` を `pdf/types/token/index.ts` に共置（`feedback_no_callback_util.md` 準拠で util 化はしない）
- **Companion Object パターン**: `Operator` は型と value を同一識別子で公開（declaration merging）。consumer 側は `import { Operator }` 一括で取得する想定

## 破壊的変更（内部のみ）

`Token` が単一 interface から discriminated union に変わるため、`@pdfmod/core` 公開バレル経由で `Token` を import している外部コードがあれば、`token.value` 直接アクセスは型エラーになる。Phase 3 前の基盤整備として hearing で許容済み。

🤖 Generated with [Claude Code](https://claude.com/claude-code)