### PR TITLE
✨ [New Feature]: OperandStack 型と companion object を追加 (spec-023)

### DIFF
--- a/packages/core/src/content-stream/operand-stack/index.ts
+++ b/packages/core/src/content-stream/operand-stack/index.ts
@@ -1,0 +1,95 @@
+import type { PdfObject } from "../../pdf/types/pdf-types/index";
+import type { Brand } from "../../utils/brand/index";
+import type { Option } from "../../utils/option/index";
+import { none, some } from "../../utils/option/index";
+
+/** OperandStack の内部表現を区別するためのブランドタグ。 */
+declare const OperandStackBrand: unique symbol;
+
+/**
+ * PDF コンテンツストリーム (RPN) のオペランドスタック型。
+ * 内部表現 `{ items: PdfObject[] }` を Brand 型で包むことで
+ * 素のオブジェクトリテラルが代入されることを防ぐ。
+ *
+ * 注: `items` フィールドは型システム上はモジュール外からも参照可能だが、
+ * 規約上 private 扱いとし、外部から `stack.items` に直接アクセス・変更してはならない。
+ * 公開 API は companion object（`create` / `push` / `pop` / `peek` / `depth` / `clear`）のみ。
+ */
+type OperandStack = Brand<{ items: PdfObject[] }, typeof OperandStackBrand>;
+
+/**
+ * `OperandStack` の factory / 操作群を束ねた companion object。
+ * 型と value を同一識別子で公開する declaration merging パターン。
+ */
+const OperandStack = {
+  /**
+   * 空のスタックを生成する。
+   *
+   * @returns 要素 0 件の `OperandStack`
+   */
+  create(): OperandStack {
+    return { items: [] as PdfObject[] } as unknown as OperandStack;
+  },
+
+  /**
+   * スタック先頭に値を積む（in-place、O(1) 償却）。
+   *
+   * @param stack - 対象スタック（mutate される）
+   * @param value - 積む値
+   */
+  push(stack: OperandStack, value: PdfObject): void {
+    stack.items.push(value);
+  },
+
+  /**
+   * スタック先頭から値を取り出す（in-place、O(1)）。
+   *
+   * @param stack - 対象スタック（mutate される）
+   * @returns 空なら `none`、それ以外は `some(value)`
+   */
+  pop(stack: OperandStack): Option<PdfObject> {
+    const length = stack.items.length;
+    if (length === 0) {
+      return none;
+    }
+    const lastIndex = length - 1;
+    const value = stack.items[lastIndex] as PdfObject;
+    stack.items.length = lastIndex;
+    return some(value);
+  },
+
+  /**
+   * スタック先頭の値を取り出さずに参照する。
+   *
+   * @param stack - 対象スタック
+   * @returns 空なら `none`、それ以外は `some(top)`
+   */
+  peek(stack: OperandStack): Option<PdfObject> {
+    const length = stack.items.length;
+    if (length === 0) {
+      return none;
+    }
+    return some(stack.items[length - 1] as PdfObject);
+  },
+
+  /**
+   * 現在の要素数を返す。
+   *
+   * @param stack - 対象スタック
+   * @returns 要素数（空なら 0）
+   */
+  depth(stack: OperandStack): number {
+    return stack.items.length;
+  },
+
+  /**
+   * スタックを空にする（in-place）。
+   *
+   * @param stack - 対象スタック（mutate される）
+   */
+  clear(stack: OperandStack): void {
+    stack.items.length = 0;
+  },
+} as const;
+
+export { OperandStack };

--- a/packages/core/src/content-stream/operand-stack/operand-stack.basic.test.ts
+++ b/packages/core/src/content-stream/operand-stack/operand-stack.basic.test.ts
@@ -1,0 +1,78 @@
+import { expect, test } from "vitest";
+import type { PdfObject } from "../../pdf/types/pdf-types/index";
+import { OperandStack } from "./index";
+
+const pdfInt = (n: number): PdfObject => ({ type: "integer", value: n });
+
+test("createしたスタックのdepthは0", () => {
+  const stack = OperandStack.create();
+
+  expect(OperandStack.depth(stack)).toBe(0);
+});
+
+test("pushするとdepthが1増える", () => {
+  const stack = OperandStack.create();
+
+  OperandStack.push(stack, pdfInt(42));
+
+  expect(OperandStack.depth(stack)).toBe(1);
+});
+
+test("空スタックのpopはnoneを返す", () => {
+  const stack = OperandStack.create();
+
+  expect(OperandStack.pop(stack)).toEqual({ some: false });
+});
+
+test("popはLIFO順で値を返す", () => {
+  const stack = OperandStack.create();
+  const a = pdfInt(1);
+  const b = pdfInt(2);
+  OperandStack.push(stack, a);
+  OperandStack.push(stack, b);
+
+  expect(OperandStack.pop(stack)).toEqual({ some: true, value: b });
+  expect(OperandStack.pop(stack)).toEqual({ some: true, value: a });
+});
+
+test("peekは要素を取り除かずsome(top)を返す", () => {
+  const stack = OperandStack.create();
+  const value = pdfInt(7);
+  OperandStack.push(stack, value);
+
+  expect(OperandStack.peek(stack)).toEqual({ some: true, value });
+  expect(OperandStack.depth(stack)).toBe(1);
+});
+
+test("空スタックのpeekはnoneを返す", () => {
+  const stack = OperandStack.create();
+
+  expect(OperandStack.peek(stack)).toEqual({ some: false });
+});
+
+test("clearでdepthが0に戻る", () => {
+  const stack = OperandStack.create();
+  OperandStack.push(stack, pdfInt(1));
+  OperandStack.push(stack, pdfInt(2));
+  OperandStack.push(stack, pdfInt(3));
+
+  OperandStack.clear(stack);
+
+  expect(OperandStack.depth(stack)).toBe(0);
+});
+
+test("空スタックに対するclearは安全（depth 0 維持）", () => {
+  const stack = OperandStack.create();
+
+  OperandStack.clear(stack);
+
+  expect(OperandStack.depth(stack)).toBe(0);
+});
+
+test("push 1回→pop 1回でdepthが0に戻る", () => {
+  const stack = OperandStack.create();
+  OperandStack.push(stack, pdfInt(99));
+  OperandStack.pop(stack);
+
+  expect(OperandStack.depth(stack)).toBe(0);
+});


### PR DESCRIPTION
## 概要

spec-023。PDF コンテンツストリーム (RPN 実行モデル) の心臓部となる OperandStack 型と最小 API を `packages/core/src/content-stream/operand-stack/` に新規追加する。Phase 3 のコンテンツストリーム処理が依存する基盤データ構造で、本 PR では型と単体動作のみを単一ファイルで完結させる（root export はスコープ外）。

## 変更の種類

- ✨ 新機能

## 追加した内容

- `packages/core/src/content-stream/operand-stack/index.ts` — `OperandStack` 型 + companion object（`create` / `push` / `pop` / `peek` / `depth` / `clear`）
- `packages/core/src/content-stream/operand-stack/operand-stack.basic.test.ts` — 9 シナリオ（create depth / push depth / 空 pop / LIFO pop / peek 非破壊 / 空 peek / clear / 空 clear / push-pop 往復）

## システム図

```mermaid
flowchart LR
    Caller[Caller<br/>future content-stream executor]
    subgraph CO[OperandStack companion object]
        create[create]
        push[push]
        pop[pop]
        peek[peek]
        depth[depth]
        clear[clear]
    end
    Internal["Brand&lt;{ items: PdfObject[] }, Symbol&gt;<br/>items は規約上 private、in-place mutate"]
    Caller --> create
    Caller --> push
    Caller --> pop
    Caller --> peek
    Caller --> depth
    Caller --> clear
    create --> Internal
    push -- "items.push(value)" --> Internal
    pop -- "length 先判定 + 短縮" --> Internal
    peek -- "length-1 を some / none" --> Internal
    depth -- "items.length" --> Internal
    clear -- "items.length = 0" --> Internal
    style Internal fill:#fef3c7,stroke:#d97706
```

## 関連 spec / Issue

- spec: `.plugin-workspace/.specs/023-operand-stack/`
- Refs #130

## テスト

- `pnpm --filter @pdfmod/core test` → 1433 tests passed
- `pnpm --filter @pdfmod/core typecheck` → pass
- `pnpm test` 全体 → 1453 tests passed（リグレッションなし）
- Codex レビュー (`code-review/review-001.md`) → **問題なし**

## レビューポイント

- 内部表現 `Brand<{ items: PdfObject[] }, typeof OperandStackBrand>` の採用と `as unknown as OperandStack` キャストの妥当性
- `pop` が `Array#pop()` の `undefined` 戻りに依存せず、`length` 先判定 + `items.length = lastIndex` で短縮している点（規約準拠）
- 計画書の `index.test.ts` ではなく、プロジェクト規約 `.test-rules.yml` の `file-naming` に合わせて `operand-stack.basic.test.ts` に命名している点（既存 colocated テストと一致）
- root export (`packages/core/src/index.ts`) は本 PR スコープ外で未変更