### PR TITLE
✨ [New Feature]: #131 GraphicsState 型定義 (CTM + 線系 4 フィールド) を追加

### DIFF
--- a/packages/core/src/content-stream/graphics-state/graphics-state.basic.test.ts
+++ b/packages/core/src/content-stream/graphics-state/graphics-state.basic.test.ts
@@ -21,7 +21,7 @@ test("updateは指定したフィールドだけを書き換える", () => {
 test("updateは未指定フィールドを保持する", () => {
   const state = GraphicsState.create();
   const updated = GraphicsState.update(state, { lineWidth: 2.0 });
-  expect(updated.ctm).toEqual(state.ctm);
+  expect(updated.ctm).toBe(state.ctm);
   expect(updated.lineCap).toBe(state.lineCap);
   expect(updated.lineJoin).toBe(state.lineJoin);
   expect(updated.miterLimit).toBe(state.miterLimit);

--- a/packages/core/src/content-stream/graphics-state/graphics-state.basic.test.ts
+++ b/packages/core/src/content-stream/graphics-state/graphics-state.basic.test.ts
@@ -1,0 +1,52 @@
+import { expect, test } from "vitest";
+import { GraphicsState, LineCap, LineJoin, Matrix } from "./index";
+
+test("createはPDF仕様準拠のデフォルト値を返す", () => {
+  const state = GraphicsState.create();
+  expect(state).toEqual({
+    ctm: Matrix.identity(),
+    lineWidth: 1.0,
+    lineCap: LineCap.create(0),
+    lineJoin: LineJoin.create(0),
+    miterLimit: 10.0,
+  });
+});
+
+test("updateは指定したフィールドだけを書き換える", () => {
+  const state = GraphicsState.create();
+  const updated = GraphicsState.update(state, { lineWidth: 2.0 });
+  expect(updated.lineWidth).toBe(2.0);
+});
+
+test("updateは未指定フィールドを保持する", () => {
+  const state = GraphicsState.create();
+  const updated = GraphicsState.update(state, { lineWidth: 2.0 });
+  expect(updated.ctm).toEqual(state.ctm);
+  expect(updated.lineCap).toBe(state.lineCap);
+  expect(updated.lineJoin).toBe(state.lineJoin);
+  expect(updated.miterLimit).toBe(state.miterLimit);
+});
+
+test("updateは元のstateを変更しない", () => {
+  const state = GraphicsState.create();
+  GraphicsState.update(state, { lineWidth: 2.0 });
+  expect(state.lineWidth).toBe(1.0);
+});
+
+test("updateは新しいインスタンスを返す", () => {
+  const state = GraphicsState.create();
+  const updated = GraphicsState.update(state, { lineWidth: 2.0 });
+  expect(updated).not.toBe(state);
+});
+
+test.each([
+  ["lineWidth", { lineWidth: 3.5 }],
+  ["lineCap", { lineCap: LineCap.create(1) }],
+  ["lineJoin", { lineJoin: LineJoin.create(2) }],
+  ["miterLimit", { miterLimit: 5.0 }],
+  ["ctm", { ctm: Matrix.create(2, 0, 0, 2, 0, 0) }],
+] as const)("update(state, %s) は該当フィールドだけ書き換える", (_label, partial) => {
+  const state = GraphicsState.create();
+  const updated = GraphicsState.update(state, partial);
+  expect(updated).toEqual({ ...state, ...partial });
+});

--- a/packages/core/src/content-stream/graphics-state/graphics-state.basic.test.ts
+++ b/packages/core/src/content-stream/graphics-state/graphics-state.basic.test.ts
@@ -50,3 +50,16 @@ test.each([
   const updated = GraphicsState.update(state, partial);
   expect(updated).toEqual({ ...state, ...partial });
 });
+
+test("updateはundefinedの明示指定で既存フィールドを壊さない", () => {
+  const state = GraphicsState.update(GraphicsState.create(), {
+    lineWidth: 2.0,
+    miterLimit: 5.0,
+  });
+  const updated = GraphicsState.update(state, {
+    lineWidth: undefined,
+    miterLimit: undefined,
+  });
+  expect(updated.lineWidth).toBe(2.0);
+  expect(updated.miterLimit).toBe(5.0);
+});

--- a/packages/core/src/content-stream/graphics-state/index.ts
+++ b/packages/core/src/content-stream/graphics-state/index.ts
@@ -1,0 +1,66 @@
+import type { Brand } from "../../utils/brand/index";
+import { LineCap } from "./line-cap";
+import { LineJoin } from "./line-join";
+import { Matrix } from "./matrix";
+
+export { LineCap } from "./line-cap";
+export { LineJoin } from "./line-join";
+export { Matrix } from "./matrix";
+
+declare const GraphicsStateBrand: unique symbol;
+
+/**
+ * PDF コンテンツストリーム実行時の現在のグラフィックスステート (最小サブセット)。
+ * 全フィールドは readonly。更新は GraphicsState.update で新インスタンスを生成する。
+ */
+export type GraphicsState = Brand<
+  {
+    readonly ctm: Matrix;
+    readonly lineWidth: number;
+    readonly lineCap: LineCap;
+    readonly lineJoin: LineJoin;
+    readonly miterLimit: number;
+  },
+  typeof GraphicsStateBrand
+>;
+
+type GraphicsStatePartial = Partial<{
+  ctm: Matrix;
+  lineWidth: number;
+  lineCap: LineCap;
+  lineJoin: LineJoin;
+  miterLimit: number;
+}>;
+
+export const GraphicsState = {
+  /**
+   * PDF 仕様 §4.1 デフォルト値で GraphicsState を生成する。
+   *   ctm        = identity
+   *   lineWidth  = 1.0
+   *   lineCap    = 0 (Butt)
+   *   lineJoin   = 0 (Miter)
+   *   miterLimit = 10.0
+   *
+   * @returns デフォルト値で初期化された GraphicsState
+   */
+  create(): GraphicsState {
+    return {
+      ctm: Matrix.identity(),
+      lineWidth: 1.0,
+      lineCap: LineCap.create(0),
+      lineJoin: LineJoin.create(0),
+      miterLimit: 10.0,
+    } as unknown as GraphicsState;
+  },
+  /**
+   * partial で指定したフィールドだけを書き換えた新しい GraphicsState を返す。
+   * 元の state は変更されない。同一参照は返さない。
+   *
+   * @param state - 元の GraphicsState
+   * @param partial - 書き換えたいフィールドの部分集合
+   * @returns 浅いマージで生成された新しい GraphicsState
+   */
+  update(state: GraphicsState, partial: GraphicsStatePartial): GraphicsState {
+    return { ...state, ...partial } as unknown as GraphicsState;
+  },
+} as const;

--- a/packages/core/src/content-stream/graphics-state/index.ts
+++ b/packages/core/src/content-stream/graphics-state/index.ts
@@ -57,6 +57,17 @@ export const GraphicsState = {
    * @returns 浅いマージで生成された新しい GraphicsState
    */
   update(state: GraphicsState, partial: GraphicsStatePartial): GraphicsState {
-    return { ...state, ...partial } as unknown as GraphicsState;
+    return {
+      ctm: partial.ctm !== undefined ? partial.ctm : state.ctm,
+      lineWidth:
+        partial.lineWidth !== undefined ? partial.lineWidth : state.lineWidth,
+      lineCap: partial.lineCap !== undefined ? partial.lineCap : state.lineCap,
+      lineJoin:
+        partial.lineJoin !== undefined ? partial.lineJoin : state.lineJoin,
+      miterLimit:
+        partial.miterLimit !== undefined
+          ? partial.miterLimit
+          : state.miterLimit,
+    } as unknown as GraphicsState;
   },
 } as const;

--- a/packages/core/src/content-stream/graphics-state/index.ts
+++ b/packages/core/src/content-stream/graphics-state/index.ts
@@ -9,28 +9,24 @@ export { Matrix } from "./matrix";
 
 declare const GraphicsStateBrand: unique symbol;
 
+type GraphicsStateFields = {
+  readonly ctm: Matrix;
+  readonly lineWidth: number;
+  readonly lineCap: LineCap;
+  readonly lineJoin: LineJoin;
+  readonly miterLimit: number;
+};
+
 /**
  * PDF コンテンツストリーム実行時の現在のグラフィックスステート (最小サブセット)。
  * 全フィールドは readonly。更新は GraphicsState.update で新インスタンスを生成する。
  */
 export type GraphicsState = Brand<
-  {
-    readonly ctm: Matrix;
-    readonly lineWidth: number;
-    readonly lineCap: LineCap;
-    readonly lineJoin: LineJoin;
-    readonly miterLimit: number;
-  },
+  GraphicsStateFields,
   typeof GraphicsStateBrand
 >;
 
-type GraphicsStatePartial = Partial<{
-  ctm: Matrix;
-  lineWidth: number;
-  lineCap: LineCap;
-  lineJoin: LineJoin;
-  miterLimit: number;
-}>;
+type GraphicsStatePartial = Partial<GraphicsStateFields>;
 
 export const GraphicsState = {
   /**

--- a/packages/core/src/content-stream/graphics-state/line-cap.basic.test.ts
+++ b/packages/core/src/content-stream/graphics-state/line-cap.basic.test.ts
@@ -1,0 +1,6 @@
+import { expect, test } from "vitest";
+import { LineCap } from "./line-cap";
+
+test.each([0, 1, 2] as const)("create(%d)はnを保持する", (n) => {
+  expect(LineCap.create(n)).toBe(n);
+});

--- a/packages/core/src/content-stream/graphics-state/line-cap.ts
+++ b/packages/core/src/content-stream/graphics-state/line-cap.ts
@@ -1,0 +1,25 @@
+import type { Brand } from "../../utils/brand/index";
+
+declare const LineCapBrand: unique symbol;
+
+/**
+ * PDF 仕様 §4.1 の line cap style。
+ * 0 = Butt (端をパスの終点で切る)
+ * 1 = Round (端を半円形にする)
+ * 2 = Projecting Square (端を半線幅分突き出す)
+ *
+ * Brand の基底型を 0|1|2 リテラル union に絞り categorical domain を型レベルで保持する。
+ */
+export type LineCap = Brand<0 | 1 | 2, typeof LineCapBrand>;
+
+export const LineCap = {
+  /**
+   * 0 | 1 | 2 のいずれかを LineCap として返す。
+   *
+   * @param n - line cap style (0=Butt / 1=Round / 2=Projecting Square)
+   * @returns Brand 付き LineCap
+   */
+  create(n: 0 | 1 | 2): LineCap {
+    return n as LineCap;
+  },
+} as const;

--- a/packages/core/src/content-stream/graphics-state/line-join.basic.test.ts
+++ b/packages/core/src/content-stream/graphics-state/line-join.basic.test.ts
@@ -1,0 +1,6 @@
+import { expect, test } from "vitest";
+import { LineJoin } from "./line-join";
+
+test.each([0, 1, 2] as const)("create(%d)はnを保持する", (n) => {
+  expect(LineJoin.create(n)).toBe(n);
+});

--- a/packages/core/src/content-stream/graphics-state/line-join.ts
+++ b/packages/core/src/content-stream/graphics-state/line-join.ts
@@ -1,0 +1,25 @@
+import type { Brand } from "../../utils/brand/index";
+
+declare const LineJoinBrand: unique symbol;
+
+/**
+ * PDF 仕様 §4.1 の line join style。
+ * 0 = Miter (尖った接合)
+ * 1 = Round (丸い接合)
+ * 2 = Bevel (面取り接合)
+ *
+ * Brand の基底型を 0|1|2 リテラル union に絞り categorical domain を型レベルで保持する。
+ */
+export type LineJoin = Brand<0 | 1 | 2, typeof LineJoinBrand>;
+
+export const LineJoin = {
+  /**
+   * 0 | 1 | 2 のいずれかを LineJoin として返す。
+   *
+   * @param n - line join style (0=Miter / 1=Round / 2=Bevel)
+   * @returns Brand 付き LineJoin
+   */
+  create(n: 0 | 1 | 2): LineJoin {
+    return n as LineJoin;
+  },
+} as const;

--- a/packages/core/src/content-stream/graphics-state/matrix.basic.test.ts
+++ b/packages/core/src/content-stream/graphics-state/matrix.basic.test.ts
@@ -1,0 +1,22 @@
+import { expect, test } from "vitest";
+import { Matrix } from "./matrix";
+
+test("identityは単位行列[1,0,0,1,0,0]を返す", () => {
+  expect(Matrix.identity()).toEqual([1, 0, 0, 1, 0, 0]);
+});
+
+test("createは指定された6要素を保持する", () => {
+  expect(Matrix.create(2, 0, 0, 3, 10, 20)).toEqual([2, 0, 0, 3, 10, 20]);
+});
+
+test.each([
+  [1, 2, 3, 4, 5, 6],
+  [-1, 0.5, 0, 1, 100, -50],
+  [0, 0, 0, 0, 0, 0],
+])("create(%d,%d,%d,%d,%d,%d)は値を維持する", (a, b, c, d, e, f) => {
+  expect(Matrix.create(a, b, c, d, e, f)).toEqual([a, b, c, d, e, f]);
+});
+
+test("identityは呼び出し毎に新しい tuple を返す (singleton ではない)", () => {
+  expect(Matrix.identity()).not.toBe(Matrix.identity());
+});

--- a/packages/core/src/content-stream/graphics-state/matrix.ts
+++ b/packages/core/src/content-stream/graphics-state/matrix.ts
@@ -1,0 +1,48 @@
+import type { Brand } from "../../utils/brand/index";
+
+declare const MatrixBrand: unique symbol;
+
+/**
+ * PDF の 6 要素変換行列 [a, b, c, d, e, f]。
+ * 完全な 3x3 行列では以下を表し、固定の第3列 [0, 0, 1] が省略される。
+ *   | a b 0 |
+ *   | c d 0 |
+ *   | e f 1 |
+ */
+export type Matrix = Brand<
+  readonly [number, number, number, number, number, number],
+  typeof MatrixBrand
+>;
+
+export const Matrix = {
+  /**
+   * 6 要素を保持する Matrix を生成する。
+   *
+   * @param a - 行列要素 a
+   * @param b - 行列要素 b
+   * @param c - 行列要素 c
+   * @param d - 行列要素 d
+   * @param e - 行列要素 e (平行移動 x)
+   * @param f - 行列要素 f (平行移動 y)
+   * @returns 6 要素を保持する Matrix
+   */
+  create(
+    a: number,
+    b: number,
+    c: number,
+    d: number,
+    e: number,
+    f: number,
+  ): Matrix {
+    return [a, b, c, d, e, f] as const as unknown as Matrix;
+  },
+  /**
+   * 単位行列 [1, 0, 0, 1, 0, 0] を返す。
+   * 呼び出し毎に新規 tuple を生成する (singleton 化しない)。
+   *
+   * @returns 単位行列を表す Matrix
+   */
+  identity(): Matrix {
+    return [1, 0, 0, 1, 0, 0] as const as unknown as Matrix;
+  },
+} as const;


### PR DESCRIPTION
## 概要

spec-024 (#131)。PDF コンテンツストリーム実行時の最小 GraphicsState (CTM + lineWidth / lineCap / lineJoin / miterLimit) を Brand + companion object で導入する。後続の `cm` / `w` / `J` / `j` / `M` / `gs` オペレータが「state を受け取り state を返す」関数として実装できる土台を作る。本 PR は型定義 + factory + 浅いマージ更新のみで、`q`/`Q` save/restore (#133) と個別オペレータは別 Issue。

## 変更の種類

- ✨ New Feature
- ✨ Types
- 🧪 Tests

## 追加した内容

`packages/core/src/content-stream/graphics-state/` 配下に新規モジュールを追加。

- `matrix.ts` — `Matrix` (Brand 付き 6 要素 readonly tuple) と `Matrix.identity()` / `Matrix.create()`
- `line-cap.ts` — `LineCap` (`Brand<0|1|2>`) と `LineCap.create()`
- `line-join.ts` — `LineJoin` (`Brand<0|1|2>`) と `LineJoin.create()`
- `index.ts` — `GraphicsState` (Brand) と `GraphicsState.create()` / `GraphicsState.update(state, partial)`、Matrix / LineCap / LineJoin の集約 re-export
- 4 つの basic テストファイル (合計 22 ケース)

## システム図

```mermaid
flowchart LR
    Factory["GraphicsState.create()"] -->|"defaults: ctm=identity, lineWidth=1.0,<br/>lineCap=0, lineJoin=0, miterLimit=10.0"| Initial["INITIAL STATE<br/>(immutable)"]
    Initial -->|"update(state, partial)"| Updated["UPDATED STATE<br/>(new immutable)"]
    Updated -->|"さらに update"| Updated

    subgraph "Modules (NEW)"
        Brand["utils/brand"]
        Matrix["matrix.ts<br/>Matrix.create/identity"]
        LineCap["line-cap.ts<br/>LineCap.create"]
        LineJoin["line-join.ts<br/>LineJoin.create"]
        Index["index.ts<br/>GraphicsState"]
        Brand --> Matrix
        Brand --> LineCap
        Brand --> LineJoin
        Matrix --> Index
        LineCap --> Index
        LineJoin --> Index
    end

    subgraph "out of scope (#133 / 後続オペレータ)"
        direction LR
        Stack["q/Q stack (#133)"]
        Ops["cm / w / J / j / M / gs"]
    end
    Updated -.-> Stack
    Updated -.-> Ops

    style Initial fill:#e6ffe6
    style Updated fill:#e6ffe6
    style Index fill:#e6ffe6
    style Matrix fill:#e6ffe6
    style LineCap fill:#e6ffe6
    style LineJoin fill:#e6ffe6
```

## 関連 spec / Issue

- spec: `.plugin-workspace/.specs/024-graphics-state/`
- Refs #131

## テスト

- `pnpm --filter @pdfmod/core test`: ✅ **1455 passed (105 files)** — 新規 22 ケース green、既存リグレッションなし
- `pnpm --filter @pdfmod/core build`: ✅ es + cjs ビルド成功
- `pnpm --filter @pdfmod/core typecheck`: ✅ 型エラー 0
- `pnpm lint` (ルート、biome + oxlint): ✅ 成功 (`.pnpm-store/` の symlink 警告 3 件は実装差分とは無関係の pre-existing インフラ警告)
- Codex レビュー (1 回目): **問題なし** — 計画整合・コード品質・エッジケース・セキュリティ・パフォーマンスすべて懸念なし

## レビューポイント

- **公開 API 非追加**: `packages/core/src/index.ts` には追加していません。後続 #133 が `content-stream/graphics-state/index.ts` から直接 import する想定です。
- **categorical types は Brand**: `LineCap` / `LineJoin` は `Brand<0|1|2, ...>` でリテラル union を型レベルで保持し、`create()` の引数型で runtime バリデーションを排除しています (memory `feedback_brand_categorical_types` に整合)。**外部 PDF 由来の任意 `number` を `0|1|2` に narrow する責務は本 PR ではなく後続 `J` / `j` オペレータ実装側です**。
- **`lineWidth` / `miterLimit` の domain 検証**: 非負・`>= 1.0`・有限値 (`Number.isFinite`) チェックは本 PR スコープ外で、後続 `w` / `M` オペレータ実装側の責務とします。`update.partial` も `Partial<{...}>` のため `{ lineWidth: undefined }` が型上通過しうる点は計画上の規約として明記しています (CLAUDE.md 「null/undefined 不使用」と整合)。
- **immutability の保証**: TypeScript の `readonly` 型と `update` API の契約 (新インスタンス返却 + 元 state 不変) で保証し、`Object.freeze` による runtime freeze は行いません。`Matrix.identity()` も singleton 化せず呼び出し毎に新規 tuple を生成 (`not.toBe` テストで担保)。
- **テスト規約準拠**: `*.basic.test.ts` 命名・`describe` 不使用フラット `test()`・test colocation・セクションコメント禁止 (`feedback_no_section_comments`) に準拠。