### PR TITLE
✨ #136 ContentStreamInterpreter core loopを追加

### DIFF
--- a/docs/specs/05_content_streams.md
+++ b/docs/specs/05_content_streams.md
@@ -33,6 +33,110 @@ PDFページの視覚的な構成は、すべてコンテンツストリーム�
 
 この段階の `ContentStreamInterpreter` は、標準描画オペレータそのものを実装する層ではない。仕様上の `m` / `l` / `cm` / `BT` / `Tj` / `q` / `Q` などの意味解釈は、後続で `OperatorRegistry` に登録する handler 群が担う。
 
+### PDFファイル内での実際の位置
+
+`ContentStreamInterpreter` が扱うのは、PDFファイル全体のうち Page object の `/Contents` から参照される stream body である。
+
+```text
+PDF file
+  ├─ Header
+  ├─ Body objects
+  │   ├─ Catalog
+  │   ├─ Pages
+  │   ├─ Page
+  │   │   └─ /Contents -> Content stream  [今回の対象]
+  │   └─ Font / Image / Resource objects
+  ├─ XRef
+  └─ Trailer
+```
+
+実際のPDFオブジェクトでは、Page object が `/Contents` で stream object を参照する。
+
+```pdf
+3 0 obj
+<< /Type /Page
+   /Parent 2 0 R
+   /MediaBox [0 0 612 792]
+   /Resources << /Font << /F1 5 0 R >> >>
+   /Contents 4 0 R
+>>
+endobj
+
+4 0 obj
+<< /Length 45 >>
+stream
+q
+1 0 0 1 100 200 cm
+10 20 m
+200 20 l
+S
+Q
+endstream
+endobj
+```
+
+今回の interpreter が読むのは、上記のうち `stream` と `endstream` に挟まれた命令列である。
+
+```pdf
+q
+1 0 0 1 100 200 cm
+10 20 m
+200 20 l
+S
+Q
+```
+
+この命令列は、PDF の lexical token として次のように解釈される。
+
+```text
+q              operator
+1              operand
+0              operand
+0              operand
+1              operand
+100            operand
+200            operand
+cm             operator
+10             operand
+20             operand
+m              operator
+200            operand
+20             operand
+l              operator
+S              operator
+Q              operator
+EOF
+```
+
+`ContentStreamInterpreter` は operand token を `OperandStack` に積み、operator token が現れた時点で `OperatorRegistry` から handler を検索して実行する。
+
+```text
+content stream bytes
+  ↓
+ContentStreamTokenizer
+  ↓
+Token stream
+  ↓
+ContentStreamInterpreter
+  ├─ primitive token -> PdfObject -> OperandStack.push()
+  ├─ operator token  -> OperatorRegistry.lookup()
+  └─ EOF             -> final OperatorHandlerContext
+```
+
+例えば `1 0 0 1 100 200 cm` は、6つの numeric operand を stack に積んだ後、`cm` operator handler に dispatch される。
+
+```text
+1      -> push integer 1
+0      -> push integer 0
+0      -> push integer 0
+1      -> push integer 1
+100    -> push integer 100
+200    -> push integer 200
+cm     -> lookup("cm") -> handler(context)
+```
+
+この時点では `cm` の行列連結そのものは実装しない。`ContentStreamInterpreter` は「命令列を読む」「operand を積む」「operator handler に渡す」までを担当し、`cm` / `m` / `l` / `S` / `q` / `Q` などの意味処理は registry に登録される個別 handler の責務とする。
+
 ## 2. グラフィックスステートオペレータ
 
 ### 2.1 ステート管理

--- a/docs/specs/05_content_streams.md
+++ b/docs/specs/05_content_streams.md
@@ -16,6 +16,23 @@ PDFページの視覚的な構成は、すべてコンテンツストリーム�
 
 **重要**: ループ構文（for/while）、条件分岐（if）、変数宣言は一切存在しない。絶対的なグラフィック描画命令の羅列である。
 
+### 実装対応範囲: ContentStreamInterpreter core loop
+
+今回追加した `ContentStreamInterpreter` は、PDF の仕様上は「コンテンツストリームの構文を逐次解釈し、オペランドを蓄積してオペレータを実行する」部分に対応する。
+
+| 実装要素 | PDF仕様上の位置づけ | 対応内容 |
+|:---------|:--------------------|:---------|
+| `ContentStreamTokenizer` からの逐次 token 読み取り | ISO 32000-1:2008 7.8.2 Content streams、7.2 Lexical conventions | content stream bytes を PDF token 列として読み、keyword を content stream operator として扱う |
+| `OperandStack.push()` | ISO 32000-1:2008 7.8.2 Content streams | operator の直前に現れる direct object を operand として一時的に保持する |
+| primitive token から `PdfObject` への変換 | ISO 32000-1:2008 7.3 Objects | boolean / integer / real / string / name / null を content stream operand として扱う |
+| NaN 数値 token の拒否 | ISO 32000-1:2008 7.3.3 Numeric objects | `.` / `+` / `-` のような妥当な数値でない token は `OBJECT_PARSE_UNEXPECTED_TOKEN` として扱い、operator handler へ渡さない |
+| `OperatorRegistry.lookup()` による dispatch | ISO 32000-1:2008 7.8.2 Content streams、8 Graphics、9 Text | operator 名に対応する handler を呼び出す。標準 operator の意味解釈は registry 側の責務とする |
+| 未登録 operator で operand stack を clear | content stream interpreter の実装方針 | 未知 operator の operand が後続 operator handler に混入することを防ぐ |
+| `GraphicsStateStack` を context として渡す | ISO 32000-1:2008 8.4 Graphics state | `q` / `Q` などの graphics state operator を handler 経由で実装できるようにする |
+| array / dictionary / inline image を `Err` で中断 | ISO 32000-1:2008 7.3.6 Arrays、7.3.7 Dictionaries、8.9 Images | 複合 operand の構築と inline image 解釈は後続フェーズの範囲とし、primitive として flatten しない |
+
+この段階の `ContentStreamInterpreter` は、標準描画オペレータそのものを実装する層ではない。仕様上の `m` / `l` / `cm` / `BT` / `Tj` / `q` / `Q` などの意味解釈は、後続で `OperatorRegistry` に登録する handler 群が担う。
+
 ## 2. グラフィックスステートオペレータ
 
 ### 2.1 ステート管理

--- a/packages/core/src/content-stream/interpreter/index.test.ts
+++ b/packages/core/src/content-stream/interpreter/index.test.ts
@@ -130,6 +130,21 @@ test.each([
 });
 
 test.each([
+  { input: ". capture", message: "NaN real token" },
+  { input: "+ capture", message: "NaN integer token" },
+  { input: "- capture", message: "NaN integer token" },
+])("NaN数値tokenはPdfErrorを返す: $input", ({ input, message }) => {
+  const result = ContentStreamInterpreter.execute({
+    data: encode(input),
+    registry: OperatorRegistry.create(),
+  });
+
+  assert(!result.ok);
+  expect(result.error.code).toBe("OBJECT_PARSE_UNEXPECTED_TOKEN");
+  expect(result.error.message).toContain(message);
+});
+
+test.each([
   { input: "[ (A) 120 ] TJ", code: "NOT_IMPLEMENTED" },
   { input: "<< /K /V >> op", code: "NOT_IMPLEMENTED" },
   { input: "BI /W 1 /H 1 ID abc EI op", code: "NOT_IMPLEMENTED" },

--- a/packages/core/src/content-stream/interpreter/index.test.ts
+++ b/packages/core/src/content-stream/interpreter/index.test.ts
@@ -1,0 +1,285 @@
+import { assert, expect, test } from "vitest";
+import type { PdfError, PdfObject } from "../../pdf/index";
+import { ok } from "../../utils/result/index";
+import {
+  GraphicsState,
+  GraphicsStateStack,
+  LineCap,
+} from "../graphics-state/index";
+import { OperandStack } from "../operand-stack/index";
+import {
+  type OperatorHandler,
+  OperatorRegistry,
+} from "../operator-registry/index";
+import { ContentStreamInterpreter } from "./index";
+
+const encode = (value: string): Uint8Array => new TextEncoder().encode(value);
+
+function registerOperator(
+  registry: ReturnType<typeof OperatorRegistry.create>,
+  name: string,
+  handler: OperatorHandler,
+): ReturnType<typeof OperatorRegistry.create> {
+  const result = OperatorRegistry.register(registry, name, handler);
+  assert(result.ok);
+  return result.value;
+}
+
+function popAll(stack: ReturnType<typeof OperandStack.create>): PdfObject[] {
+  return Array.from({ length: OperandStack.depth(stack) }, () => {
+    const value = OperandStack.pop(stack);
+    assert(value.some);
+    return value.value;
+  });
+}
+
+test("空inputはEOFでOk終了しfinal contextを返す", () => {
+  const result = ContentStreamInterpreter.execute({
+    data: encode(""),
+    registry: OperatorRegistry.create(),
+  });
+
+  assert(result.ok);
+  expect(OperandStack.depth(result.value.context.operandStack)).toBe(0);
+  expect(
+    GraphicsStateStack.current(result.value.context.graphicsStateStack),
+  ).toEqual(GraphicsState.create());
+});
+
+test("primitive operandはPdfObjectとしてhandlerからpopできる", () => {
+  const observed: PdfObject[][] = [];
+  const registry = registerOperator(
+    OperatorRegistry.create(),
+    "capture",
+    (context) => {
+      observed.push(popAll(context.operandStack));
+      return ok(context);
+    },
+  );
+
+  const result = ContentStreamInterpreter.execute({
+    data: encode("true false 12 -3 4.5 /Name null capture"),
+    registry,
+  });
+
+  assert(result.ok);
+  expect(observed).toEqual([
+    [
+      { type: "null" },
+      { type: "name", value: "Name" },
+      { type: "real", value: 4.5 },
+      { type: "integer", value: -3 },
+      { type: "integer", value: 12 },
+      { type: "boolean", value: false },
+      { type: "boolean", value: true },
+    ],
+  ]);
+});
+
+test("literal stringとhex stringはbyte列を保持する", () => {
+  const observed: PdfObject[][] = [];
+  const registry = registerOperator(
+    OperatorRegistry.create(),
+    "capture",
+    (context) => {
+      observed.push(popAll(context.operandStack));
+      return ok(context);
+    },
+  );
+
+  const result = ContentStreamInterpreter.execute({
+    data: encode("(A\\nB) <4142F> capture"),
+    registry,
+  });
+
+  assert(result.ok);
+  expect(observed).toEqual([
+    [
+      {
+        type: "string",
+        value: new Uint8Array([0x41, 0x42, 0xf0]),
+        encoding: "hex",
+      },
+      {
+        type: "string",
+        value: new Uint8Array([0x41, 0x0a, 0x42]),
+        encoding: "literal",
+      },
+    ],
+  ]);
+});
+
+test.each([
+  {
+    input: "(\\400) capture",
+    message: "Invalid literal string byte value",
+  },
+  {
+    input: "<4Z> capture",
+    message: "Invalid hex digits in hex string",
+  },
+])("文字列変換失敗はPdfErrorを返す: $input", ({ input, message }) => {
+  const result = ContentStreamInterpreter.execute({
+    data: encode(input),
+    registry: OperatorRegistry.create(),
+  });
+
+  assert(!result.ok);
+  expect(result.error.code).toBe("OBJECT_PARSE_UNEXPECTED_TOKEN");
+  expect(result.error.message).toContain(message);
+});
+
+test.each([
+  { input: "[ (A) 120 ] TJ", code: "NOT_IMPLEMENTED" },
+  { input: "<< /K /V >> op", code: "NOT_IMPLEMENTED" },
+  { input: "BI /W 1 /H 1 ID abc EI op", code: "NOT_IMPLEMENTED" },
+  { input: "] op", code: "OBJECT_PARSE_UNEXPECTED_TOKEN" },
+  { input: ">> op", code: "OBJECT_PARSE_UNEXPECTED_TOKEN" },
+])("composite tokenはstackを汚染せずErrで中断する: $input", ({
+  input,
+  code,
+}) => {
+  let called = false;
+  const registry = registerOperator(
+    OperatorRegistry.create(),
+    "op",
+    (context) => {
+      called = true;
+      return ok(context);
+    },
+  );
+
+  const result = ContentStreamInterpreter.execute({
+    data: encode(input),
+    registry,
+  });
+
+  assert(!result.ok);
+  expect(result.error.code).toBe(code);
+  expect(called).toBe(false);
+});
+
+test("登録済みhandlerの更新contextは次operatorと最終resultへ引き継がれる", () => {
+  const observedDepths: number[] = [];
+  const firstRegistry = registerOperator(
+    OperatorRegistry.create(),
+    "first",
+    (context) => {
+      observedDepths.push(OperandStack.depth(context.operandStack));
+      return ok({
+        ...context,
+        operandStack: OperandStack.create(),
+      });
+    },
+  );
+  const registry = registerOperator(firstRegistry, "second", (context) => {
+    observedDepths.push(OperandStack.depth(context.operandStack));
+    OperandStack.push(context.operandStack, { type: "integer", value: 99 });
+    return ok(context);
+  });
+
+  const result = ContentStreamInterpreter.execute({
+    data: encode("1 2 first 3 second"),
+    registry,
+  });
+
+  assert(result.ok);
+  expect(observedDepths).toEqual([2, 1]);
+  expect(OperandStack.pop(result.value.context.operandStack)).toEqual({
+    some: true,
+    value: { type: "integer", value: 99 },
+  });
+});
+
+test("未登録operatorは直前operandsをclearして後続処理を継続する", () => {
+  const observed: PdfObject[][] = [];
+  const registry = registerOperator(
+    OperatorRegistry.create(),
+    "capture",
+    (context) => {
+      observed.push(popAll(context.operandStack));
+      return ok(context);
+    },
+  );
+
+  const result = ContentStreamInterpreter.execute({
+    data: encode("1 2 unknown 3 capture"),
+    registry,
+  });
+
+  assert(result.ok);
+  expect(observed).toEqual([[{ type: "integer", value: 3 }]]);
+});
+
+test("handlerのErrは同じerrorを返して後続operatorを実行しない", () => {
+  const expectedError = {
+    code: "NOT_IMPLEMENTED",
+    message: "test failure",
+  } satisfies PdfError;
+  let laterCalled = false;
+  const firstRegistry = registerOperator(
+    OperatorRegistry.create(),
+    "fail",
+    () => ({
+      ok: false,
+      error: expectedError,
+    }),
+  );
+  const registry = registerOperator(firstRegistry, "later", (context) => {
+    laterCalled = true;
+    return ok(context);
+  });
+
+  const result = ContentStreamInterpreter.execute({
+    data: encode("fail later"),
+    registry,
+  });
+
+  expect(result).toEqual({ ok: false, error: expectedError });
+  expect(laterCalled).toBe(false);
+});
+
+test("qとQはregistry handler経由でgraphics state stackを更新する", () => {
+  const qRegistry = registerOperator(
+    OperatorRegistry.create(),
+    "q",
+    (context) =>
+      ok({
+        ...context,
+        graphicsStateStack: GraphicsStateStack.save(context.graphicsStateStack),
+      }),
+  );
+  const changeRegistry = registerOperator(qRegistry, "change", (context) =>
+    ok({
+      ...context,
+      graphicsStateStack: GraphicsStateStack.replaceCurrent(
+        context.graphicsStateStack,
+        GraphicsState.update(
+          GraphicsStateStack.current(context.graphicsStateStack),
+          {
+            lineCap: LineCap.create(2),
+            lineWidth: 8,
+          },
+        ),
+      ),
+    }),
+  );
+  const registry = registerOperator(changeRegistry, "Q", (context) =>
+    ok({
+      ...context,
+      graphicsStateStack: GraphicsStateStack.restore(
+        context.graphicsStateStack,
+      ),
+    }),
+  );
+
+  const result = ContentStreamInterpreter.execute({
+    data: encode("q change Q"),
+    registry,
+  });
+
+  assert(result.ok);
+  expect(
+    GraphicsStateStack.current(result.value.context.graphicsStateStack),
+  ).toEqual(GraphicsState.create());
+});

--- a/packages/core/src/content-stream/interpreter/index.ts
+++ b/packages/core/src/content-stream/interpreter/index.ts
@@ -173,9 +173,9 @@ function tokenToPrimitivePdfObject(
     case TokenType.Boolean:
       return ok(some({ type: "boolean", value: token.value }));
     case TokenType.Integer:
-      return ok(some({ type: "integer", value: token.value }));
+      return integerToPdfObject(token);
     case TokenType.Real:
-      return ok(some({ type: "real", value: token.value }));
+      return realToPdfObject(token);
     case TokenType.LiteralString:
       return literalStringToPdfObject(token);
     case TokenType.HexString:
@@ -202,6 +202,46 @@ function tokenToPrimitivePdfObject(
     default:
       return ok(none);
   }
+}
+
+/**
+ * integer token をPdfIntegerへ変換する。
+ *
+ * @param token - integer token
+ * @returns 変換したPdfInteger、またはNaN tokenエラー
+ */
+function integerToPdfObject(
+  token: Extract<Token, { readonly type: TokenType.Integer }>,
+): Result<Option<PdfObject>, PdfError> {
+  if (Number.isNaN(token.value)) {
+    return err({
+      code: "OBJECT_PARSE_UNEXPECTED_TOKEN",
+      message: `NaN integer token at offset ${token.offset}`,
+      offset: token.offset,
+    });
+  }
+
+  return ok(some({ type: "integer", value: token.value }));
+}
+
+/**
+ * real token をPdfRealへ変換する。
+ *
+ * @param token - real token
+ * @returns 変換したPdfReal、またはNaN tokenエラー
+ */
+function realToPdfObject(
+  token: Extract<Token, { readonly type: TokenType.Real }>,
+): Result<Option<PdfObject>, PdfError> {
+  if (Number.isNaN(token.value)) {
+    return err({
+      code: "OBJECT_PARSE_UNEXPECTED_TOKEN",
+      message: `NaN real token at offset ${token.offset}`,
+      offset: token.offset,
+    });
+  }
+
+  return ok(some({ type: "real", value: token.value }));
 }
 
 /**

--- a/packages/core/src/content-stream/interpreter/index.ts
+++ b/packages/core/src/content-stream/interpreter/index.ts
@@ -1,0 +1,259 @@
+import {
+  decodeHexString,
+  decodeLiteralString,
+} from "../../objects/object-parser/string-decoder/index";
+import type { PdfError, PdfObject, Token } from "../../pdf/index";
+import { TokenType } from "../../pdf/index";
+import type { Option } from "../../utils/option/index";
+import { none, some } from "../../utils/option/index";
+import type { Result } from "../../utils/result/index";
+import { err, ok } from "../../utils/result/index";
+import { GraphicsStateStack } from "../graphics-state/index";
+import { OperandStack } from "../operand-stack/index";
+import {
+  type OperatorHandlerContext,
+  OperatorRegistry,
+} from "../operator-registry/index";
+import { ContentStreamTokenizer } from "../tokenizer/index";
+
+export type ContentStreamInterpreterExecuteOptions = {
+  readonly data: Uint8Array;
+  readonly registry: OperatorRegistry;
+  readonly initialContext?: OperatorHandlerContext;
+};
+
+export type ContentStreamInterpreterResult = {
+  readonly context: OperatorHandlerContext;
+};
+
+type InterpreterStep =
+  | { readonly type: "continue"; readonly context: OperatorHandlerContext }
+  | { readonly type: "done"; readonly result: ContentStreamInterpreterResult };
+
+export const ContentStreamInterpreter = {
+  /**
+   * Content stream の token 列をRPNとしてEOFまで逐次実行する。
+   *
+   * @param options - 入力データ、operator registry、任意の初期context
+   * @returns 最終context、またはtokenize / 変換 / handlerのエラー
+   */
+  execute(
+    options: ContentStreamInterpreterExecuteOptions,
+  ): Result<ContentStreamInterpreterResult, PdfError> {
+    const tokenizer = new ContentStreamTokenizer(options.data);
+    let context = createInitialContext(options.initialContext);
+
+    while (true) {
+      const tokenResult = tokenizer.nextToken();
+      if (!tokenResult.ok) {
+        return err(tokenResult.error);
+      }
+
+      const step = executeToken({
+        token: tokenResult.value,
+        registry: options.registry,
+        context,
+      });
+      if (!step.ok) {
+        return err(step.error);
+      }
+
+      if (step.value.type === "done") {
+        return ok(step.value.result);
+      }
+
+      context = step.value.context;
+    }
+  },
+} as const;
+
+/**
+ * 1 token を分類し、EOF / operator dispatch / operand push のいずれかを実行する。
+ *
+ * @param options - 実行対象tokenと現在context
+ * @returns 次step、または処理エラー
+ */
+function executeToken(options: {
+  readonly token: Token;
+  readonly registry: OperatorRegistry;
+  readonly context: OperatorHandlerContext;
+}): Result<InterpreterStep, PdfError> {
+  if (options.token.type === TokenType.EOF) {
+    return ok({ type: "done", result: { context: options.context } });
+  }
+
+  if (options.token.type === TokenType.Operator) {
+    return dispatchOperator({
+      token: options.token,
+      registry: options.registry,
+      context: options.context,
+    });
+  }
+
+  return pushPrimitiveOperand(options.token, options.context);
+}
+
+/**
+ * 登録済みoperator handlerを呼び出す。未登録operatorはoperand stackをclearして継続する。
+ *
+ * @param options - operator token、registry、現在context
+ * @returns 次step、またはhandlerエラー
+ */
+function dispatchOperator(options: {
+  readonly token: Extract<Token, { readonly type: TokenType.Operator }>;
+  readonly registry: OperatorRegistry;
+  readonly context: OperatorHandlerContext;
+}): Result<InterpreterStep, PdfError> {
+  const handler = OperatorRegistry.lookup(options.registry, options.token.name);
+  if (!handler.some) {
+    OperandStack.clear(options.context.operandStack);
+    return ok({ type: "continue", context: options.context });
+  }
+
+  const handled = handler.value(options.context);
+  if (!handled.ok) {
+    return err(handled.error);
+  }
+
+  return ok({ type: "continue", context: handled.value });
+}
+
+/**
+ * primitive token をPdfObjectへ変換してoperand stackへ積む。
+ *
+ * @param token - operand候補token
+ * @param context - 現在context
+ * @returns 次step、または変換エラー
+ */
+function pushPrimitiveOperand(
+  token: Token,
+  context: OperatorHandlerContext,
+): Result<InterpreterStep, PdfError> {
+  const objectResult = tokenToPrimitivePdfObject(token);
+  if (!objectResult.ok) {
+    return err(objectResult.error);
+  }
+
+  if (objectResult.value.some) {
+    OperandStack.push(context.operandStack, objectResult.value.value);
+  }
+
+  return ok({ type: "continue", context });
+}
+
+/**
+ * 初期contextを生成する。
+ *
+ * @param initialContext - 呼び出し側が渡した任意の初期context
+ * @returns 実行開始時のcontext
+ */
+function createInitialContext(
+  initialContext: OperatorHandlerContext | undefined,
+): OperatorHandlerContext {
+  if (initialContext !== undefined) {
+    return initialContext;
+  }
+
+  return {
+    operandStack: OperandStack.create(),
+    graphicsStateStack: GraphicsStateStack.create(),
+  };
+}
+
+/**
+ * content stream の primitive token をPdfObjectへ変換する。
+ *
+ * @param token - 変換対象token
+ * @returns 変換したPdfObject、変換対象外tokenのNone、または変換エラー
+ */
+function tokenToPrimitivePdfObject(
+  token: Token,
+): Result<Option<PdfObject>, PdfError> {
+  switch (token.type) {
+    case TokenType.Boolean:
+      return ok(some({ type: "boolean", value: token.value }));
+    case TokenType.Integer:
+      return ok(some({ type: "integer", value: token.value }));
+    case TokenType.Real:
+      return ok(some({ type: "real", value: token.value }));
+    case TokenType.LiteralString:
+      return literalStringToPdfObject(token);
+    case TokenType.HexString:
+      return hexStringToPdfObject(token);
+    case TokenType.Name:
+      return ok(some({ type: "name", value: token.value }));
+    case TokenType.Null:
+      return ok(some({ type: "null" }));
+    case TokenType.ArrayBegin:
+    case TokenType.DictBegin:
+    case TokenType.InlineImage:
+      return err({
+        code: "NOT_IMPLEMENTED",
+        message: `Composite content stream operand is not supported in Phase 3: ${token.type}`,
+        offset: token.offset,
+      });
+    case TokenType.ArrayEnd:
+    case TokenType.DictEnd:
+      return err({
+        code: "OBJECT_PARSE_UNEXPECTED_TOKEN",
+        message: `Unexpected composite delimiter in content stream: ${token.type}`,
+        offset: token.offset,
+      });
+    default:
+      return ok(none);
+  }
+}
+
+/**
+ * literal string token をPdfStringへ変換する。
+ *
+ * @param token - literal string token
+ * @returns 変換したPdfString、またはdecodeエラー
+ */
+function literalStringToPdfObject(
+  token: Extract<Token, { readonly type: TokenType.LiteralString }>,
+): Result<Option<PdfObject>, PdfError> {
+  const decoded = decodeLiteralString(token.value);
+  if (!decoded.ok) {
+    return err({
+      code: "OBJECT_PARSE_UNEXPECTED_TOKEN",
+      message: decoded.error,
+      offset: token.offset,
+    });
+  }
+
+  return ok(
+    some({
+      type: "string",
+      value: decoded.value,
+      encoding: "literal",
+    }),
+  );
+}
+
+/**
+ * hex string token をPdfStringへ変換する。
+ *
+ * @param token - hex string token
+ * @returns 変換したPdfString、またはdecodeエラー
+ */
+function hexStringToPdfObject(
+  token: Extract<Token, { readonly type: TokenType.HexString }>,
+): Result<Option<PdfObject>, PdfError> {
+  const decoded = decodeHexString(token.value);
+  if (!decoded.ok) {
+    return err({
+      code: "OBJECT_PARSE_UNEXPECTED_TOKEN",
+      message: decoded.error,
+      offset: token.offset,
+    });
+  }
+
+  return ok(
+    some({
+      type: "string",
+      value: decoded.value,
+      encoding: "hex",
+    }),
+  );
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -5,6 +5,18 @@
  * @packageDocumentation
  */
 
+export { GraphicsStateStack } from "./content-stream/graphics-state/index";
+export type {
+  ContentStreamInterpreterExecuteOptions,
+  ContentStreamInterpreterResult,
+} from "./content-stream/interpreter/index";
+export { ContentStreamInterpreter } from "./content-stream/interpreter/index";
+export { OperandStack } from "./content-stream/operand-stack/index";
+export type {
+  OperatorHandler,
+  OperatorHandlerContext,
+} from "./content-stream/operator-registry/index";
+export { OperatorRegistry } from "./content-stream/operator-registry/index";
 export { ContentStreamTokenizer } from "./content-stream/tokenizer/index";
 export type {
   DocumentMetadata,

--- a/packages/core/src/namespace-export.runtime.test.ts
+++ b/packages/core/src/namespace-export.runtime.test.ts
@@ -2,9 +2,11 @@ import { expect, test } from "vitest";
 import {
   ByteOffset,
   CatalogParser,
+  ContentStreamInterpreter,
   ContentStreamTokenizer,
   DocumentInfoParser,
   GenerationNumber,
+  GraphicsStateStack,
   InheritanceResolver,
   LRUCache,
   ObjectNumber,
@@ -12,7 +14,9 @@ import {
   ObjectStore,
   ObjectStreamBody,
   ObjectStreamHeader,
+  OperandStack,
   Operator,
+  OperatorRegistry,
   PageTreeWalker,
   PdfDocument,
   PdfPage,
@@ -26,7 +30,14 @@ import {
 } from "./index";
 
 test.each([
+  {
+    name: "ContentStreamInterpreter.execute",
+    value: ContentStreamInterpreter.execute,
+  },
   { name: "ContentStreamTokenizer", value: ContentStreamTokenizer },
+  { name: "GraphicsStateStack.create", value: GraphicsStateStack.create },
+  { name: "OperandStack.create", value: OperandStack.create },
+  { name: "OperatorRegistry.create", value: OperatorRegistry.create },
   { name: "Tokenizer", value: Tokenizer },
   { name: "LRUCache.create", value: LRUCache.create },
   { name: "scanStartXRef", value: scanStartXRef },

--- a/packages/core/src/namespace-export.type.test.ts
+++ b/packages/core/src/namespace-export.type.test.ts
@@ -1,7 +1,10 @@
 import { expect, test } from "vitest";
 import type {
+  ContentStreamInterpreterExecuteOptions,
+  ContentStreamInterpreterResult,
   InheritedAttrs,
   LoadOptions,
+  OperatorHandlerContext,
   ParsedCatalog,
   PdfDocumentLoadError,
   PdfPageRectangle,
@@ -9,7 +12,14 @@ import type {
   ResolveRef,
   WalkPageTreeResult,
 } from "./index";
-import { ContentStreamTokenizer, Option, PdfVersion, Result } from "./index";
+import {
+  ContentStreamInterpreter,
+  ContentStreamTokenizer,
+  OperatorRegistry,
+  Option,
+  PdfVersion,
+  Result,
+} from "./index";
 
 test("Result.okがランタイムで動作する", () => {
   const result = Result.ok(42);
@@ -53,6 +63,20 @@ test("Option.Option型が参照できる", () => {
 test("ContentStreamTokenizerがルートから参照できる", () => {
   const tokenizer = new ContentStreamTokenizer(new Uint8Array());
   expect(tokenizer.position).toBe(0);
+});
+
+test("ContentStreamInterpreter型とコンパニオンがルートから参照できる", () => {
+  const options: ContentStreamInterpreterExecuteOptions = {
+    data: new Uint8Array(),
+    registry: OperatorRegistry.create(),
+  };
+  const result = ContentStreamInterpreter.execute(options);
+  const value = {} as ContentStreamInterpreterResult;
+  const context = {} as OperatorHandlerContext;
+
+  expect(result.ok).toBe(true);
+  expect(value).toBeDefined();
+  expect(context).toBeDefined();
 });
 
 test("ParsedCatalog型とResolveRef型が参照できる", () => {


### PR DESCRIPTION
## 概要

`@pdfmod/core` に PDF content stream の token 列を RPN として逐次実行する `ContentStreamInterpreter` を追加しました。`ContentStreamTokenizer`、`OperandStack`、`GraphicsStateStack`、`OperatorRegistry` を接続し、operator dispatch の最小コアループを提供します。

## 変更内容

### 🎯 変更の種類

- [ ] 🐛 バグ修正 (Bug fix)
- [x] ✨ 新機能 (New feature)
- [ ] ♻️ リファクタリング (Refactoring)
- [ ] 🎨 UI/UX 改善 (UI/UX improvement)
- [ ] 🐎 パフォーマンス改善 (Performance improvement)
- [x] 🚨 テスト追加/修正 (Tests)
- [ ] 📖 ドキュメント更新 (Documentation)
- [ ] 🔧 設定変更 (Configuration)
- [ ] 🗑️ 削除 (Removal)

### 📝 詳細な変更内容

#### 追加された機能・修正

- `ContentStreamInterpreter.execute` を追加
- EOF までの逐次 token 読み取りと step 適用を実装
- primitive token を `PdfObject` に変換して `OperandStack` に push
- literal / hex string の decode に既存 `decodeLiteralString` / `decodeHexString` を再利用
- 登録済み operator を `OperatorRegistry.lookup()` 経由で handler dispatch
- 未登録 operator は operand stack を clear して継続
- handler `Err<PdfError>` は即中断して同じ error を返却
- array / dictionary / inline image は Phase 3 範囲外として stack 汚染前に `Err` で中断
- root export に interpreter / registry / stack 関連 API を追加

#### 変更されたファイル

- `packages/core/src/content-stream/interpreter/index.ts`
- `packages/core/src/content-stream/interpreter/index.test.ts`
- `packages/core/src/index.ts`
- `packages/core/src/namespace-export.runtime.test.ts`
- `packages/core/src/namespace-export.type.test.ts`

#### 削除されたファイル・機能

- なし

## 📊 システム図

```mermaid
flowchart TD
    Input[Uint8Array content stream] --> Tokenizer[ContentStreamTokenizer]
    Tokenizer --> ReadToken[READ_TOKEN]
    ReadToken --> Classify{Token type}
    Classify -->|EOF| Done[Ok final context]
    Classify -->|Primitive| Convert[Convert to PdfObject]
    Convert -->|Ok Some| Push[OperandStack.push]
    Convert -->|Err| Error[Err PdfError]
    Push --> ReadToken
    Classify -->|Operator| Lookup[OperatorRegistry.lookup]
    Lookup -->|None| Clear[OperandStack.clear]
    Clear --> ReadToken
    Lookup -->|Some handler| Handler[Call OperatorHandler]
    Handler -->|Ok next context| ReadToken
    Handler -->|Err| Error
    Classify -->|Composite token| CompositeErr[Err before stack pollution]
    CompositeErr --> Error

    classDef new fill:#e0f2fe,stroke:#0284c7,stroke-width:2px
    class Tokenizer,Convert,Lookup,Handler,CompositeErr new
```

## 📋 関連 Issue

- Closes #136

## 🧪 テスト

### テスト実行方法

```bash
pnpm --filter @pdfmod/core test -- content-stream/interpreter
pnpm --filter @pdfmod/core typecheck
pnpm test:run
pnpm exec biome check packages/core/src/content-stream/interpreter/index.ts packages/core/src/content-stream/interpreter/index.test.ts packages/core/src/index.ts packages/core/src/namespace-export.runtime.test.ts packages/core/src/namespace-export.type.test.ts
pnpm exec oxlint packages/core/src/content-stream/interpreter/index.ts packages/core/src/content-stream/interpreter/index.test.ts packages/core/src/index.ts packages/core/src/namespace-export.runtime.test.ts packages/core/src/namespace-export.type.test.ts
```

### テスト項目

- [x] 単体テスト (Unit tests)
- [x] 統合テスト (Integration tests)
- [ ] E2E テスト (End-to-end tests)
- [x] 手動テスト (Manual testing)

### テスト結果

- `pnpm --filter @pdfmod/core test -- content-stream/interpreter`: passed
- `pnpm --filter @pdfmod/core typecheck`: passed
- `pnpm test:run`: passed
- 変更ファイル単位の `biome check`: passed
- 変更ファイル単位の `oxlint`: passed

補足: `pnpm run lint` は `.pnpm-store` 配下の壊れた symlink で停止したため、変更ファイル単位で Biome / oxlint を確認しています。

## 🔍 レビューポイント

- unknown operator で `OperandStack.clear()` して後続 handler に stale operand を混入させない点
- composite token を primitive に flatten せず、stack 汚染前に `Err` で中断する点
- `q` / `Q` は interpreter built-in ではなく registry handler 経由でのみ検証している点
- root export の runtime / type tests が cast で隠さず public API を確認している点

## ⚠️ 破壊的変更

- [ ] この変更は既存の API に破壊的変更を含みます

## ✅ チェックリスト

- [x] コードレビューの準備ができている
- [x] テストが正常に実行される
- [x] ドキュメントが更新されている（必要に応じて）
- [x] コミットメッセージが適切な形式で書かれている
- [x] 関連する Issue が PR の「Development」に Linked されている
- [x] PR 本文に `Closes #` / `Fixes #` / `Refs #` などで Issue が記載されている
- [x] セルフレビューを実施した
- [x] 破壊的変更がある場合は明記されている