### PR TITLE
✨ [New Feature]: #138 GraphicsState を public API として公開し namespace-export テストを拡充

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -5,7 +5,10 @@
  * @packageDocumentation
  */
 
-export { GraphicsStateStack } from "./content-stream/graphics-state/index";
+export {
+  GraphicsState,
+  GraphicsStateStack,
+} from "./content-stream/graphics-state/index";
 export type {
   ContentStreamInterpreterExecuteOptions,
   ContentStreamInterpreterResult,

--- a/packages/core/src/namespace-export.runtime.test.ts
+++ b/packages/core/src/namespace-export.runtime.test.ts
@@ -6,6 +6,7 @@ import {
   ContentStreamTokenizer,
   DocumentInfoParser,
   GenerationNumber,
+  GraphicsState,
   GraphicsStateStack,
   InheritanceResolver,
   LRUCache,
@@ -16,6 +17,7 @@ import {
   ObjectStreamHeader,
   OperandStack,
   Operator,
+  type OperatorHandler,
   OperatorRegistry,
   PageTreeWalker,
   PdfDocument,
@@ -24,6 +26,7 @@ import {
   PdfVersion,
   parseTrailer,
   parseXRefTable,
+  Result,
   scanStartXRef,
   Tokenizer,
   TokenType,
@@ -35,6 +38,8 @@ test.each([
     value: ContentStreamInterpreter.execute,
   },
   { name: "ContentStreamTokenizer", value: ContentStreamTokenizer },
+  { name: "GraphicsState.create", value: GraphicsState.create },
+  { name: "GraphicsState.update", value: GraphicsState.update },
   { name: "GraphicsStateStack.create", value: GraphicsStateStack.create },
   { name: "OperandStack.create", value: OperandStack.create },
   { name: "OperatorRegistry.create", value: OperatorRegistry.create },
@@ -94,4 +99,18 @@ test("Operatorコンパニオンがルートからexportされている", () => 
   expect(op.type).toBe(TokenType.Operator);
   expect(op.name).toBe("m");
   expect(op.offset).toBe(42);
+});
+
+test("OperatorRegistry.registerでルート公開済みのAPIだけからoperatorを拡張できる", () => {
+  const handler: OperatorHandler = (context) => Result.ok(context);
+  const registry = OperatorRegistry.create();
+  const result = OperatorRegistry.register(registry, "m", handler);
+  const updated = Result.unwrapOr(result, registry);
+
+  expect(result.ok).toBe(true);
+  expect(updated).not.toBe(registry);
+  expect(OperatorRegistry.lookup(updated, "m")).toEqual({
+    some: true,
+    value: handler,
+  });
 });

--- a/packages/core/src/namespace-export.type.test.ts
+++ b/packages/core/src/namespace-export.type.test.ts
@@ -15,6 +15,7 @@ import type {
 import {
   ContentStreamInterpreter,
   ContentStreamTokenizer,
+  GraphicsState,
   OperatorRegistry,
   Option,
   PdfVersion,
@@ -58,6 +59,11 @@ test("Result.Result型が参照できる", () => {
 test("Option.Option型が参照できる", () => {
   const o: Option.Option<number> = Option.some(42);
   expect(o.some).toBe(true);
+});
+
+test("GraphicsState型とコンパニオンがルートから参照できる", () => {
+  const state: GraphicsState = GraphicsState.create();
+  expect(typeof state.lineWidth).toBe("number");
 });
 
 test("ContentStreamTokenizerがルートから参照できる", () => {


### PR DESCRIPTION
## 概要

spec-030 PR。Phase 3 で追加した content-stream モジュールのうち未公開だった `GraphicsState` を `@pdfmod/core` ルートから re-export し、`namespace-export.runtime.test.ts` / `namespace-export.type.test.ts` に配線テストと `OperatorRegistry.register` の利用サンプル回帰テストを追加する。既存 export の文言・順序・挙動は変更しない（SemVer minor 相当）。

## 変更の種類

- ✨ 新機能（公開 API の追加）
- 🧪 テスト追加

## 追加した内容

- `packages/core/src/index.ts`: `export { GraphicsState }` を `GraphicsStateStack` と同 export 句にまとめて追加
- `packages/core/src/namespace-export.runtime.test.ts`:
  - `test.each` に `GraphicsState.create` / `GraphicsState.update` を追加
  - `OperatorRegistry.register` を **ルート (`./index`) からの import のみ**で動かす利用サンプルテストを追加（`type OperatorHandler` / `Result.ok` / `Result.unwrapOr` / `OperatorRegistry.lookup`）
- `packages/core/src/namespace-export.type.test.ts`: `GraphicsState` 型束縛 + コンパニオン参照テストを追加

## 変更した内容

なし（既存 export 文・既存テストには手を加えていない）

## システム図

```mermaid
flowchart LR
  user["ユーザーコード<br/>import { ... } from '@pdfmod/core'"]
  root["packages/core/src/index.ts"]
  gs_index["content-stream/graphics-state/index.ts"]
  gs["GraphicsState (Companion Object)"]
  reg["OperatorRegistry"]
  result["Result"]

  user --> root
  root -- "GraphicsStateStack (既存)" --> gs_index
  root -- "GraphicsState [NEW]" --> gs_index
  root -- "OperatorRegistry / OperatorHandler (既存)" --> reg
  root -- "Result namespace (既存)" --> result
  gs_index --> gs

  style gs fill:#bbf,stroke:#33f,stroke-width:2px
```

```mermaid
flowchart TD
  create["OperatorRegistry.create()"]
  reg0["registry: handlers Map(0)"]
  register["OperatorRegistry.register(registry, 'm', handler)"]
  ok["Result.ok(newRegistry)"]
  unwrap["Result.unwrapOr(result, registry)"]
  reg1["updated: handlers Map(1)"]
  lookup["OperatorRegistry.lookup(updated, 'm')"]
  some["Some(handler)"]

  create --> reg0
  reg0 --> register
  register --> ok
  ok --> unwrap
  unwrap --> reg1
  reg1 --> lookup
  lookup --> some

  style register fill:#bfb,stroke:#3a3,stroke-width:2px
```

## 関連 spec / Issue

- spec: `.plugin-workspace/.specs/030-public-api-content-stream/`
- Closes #138

## テスト

- `pnpm --filter @pdfmod/core test`: 110 files / 1536 tests pass
- `pnpm test` (リポジトリ全体): 114 files / 1556 tests pass（リグレッションなし）
- `pnpm --filter @pdfmod/core build`: 成功。生成された `dist/index.d.ts` に `export { GraphicsState, GraphicsStateStack, } from "./content-stream/graphics-state/index";` を確認
- Copilot レビュー (`code-review/review-001.md`): Medium 1 件（`unwrapOr` を `result.ok` 検証前に呼ぶ可読性）。ただし既存 `operator-registry.basic.test.ts:20-22` の確立済みパターンと同一であり、tasks.md の「既存テストの慣習に揃える」指示とも合致するためコードベース整合性を優先して不採用

## レビューポイント

- `index.ts`: `GraphicsState` 行追加が SemVer minor 相当であること（既存 export の文言・順序・挙動が不変）
- runtime テスト: 追加された `OperatorRegistry.register` サンプルの全 import が **ルート (`./index`) 経由のみ**であり、内部パス (`./utils/result/index` 等) への依存が新規追加されていないこと
- Issue #138 チェックリストの「`packages/core/src/content-stream/index.ts` を作成 / 更新」は **意図的に不採用**。content-stream 配下は flat 構造（バレルファイルなし、各 sub-index をルートが直接参照）であり、新規にバレルを作るとアーキテクチャに不整合をもたらすため、ルート `index.ts` への直接 export で代替（spec の DoD に明記済み）