### PR TITLE
✨ [New Feature]: line-width (w) operator handler と PdfError operand エラー基盤

### DIFF
--- a/packages/core/src/content-stream/operators/graphics-state/line-width.basic.test.ts
+++ b/packages/core/src/content-stream/operators/graphics-state/line-width.basic.test.ts
@@ -1,0 +1,139 @@
+import { assert, expect, test } from "vitest";
+import type { PdfObject } from "../../../pdf/types/pdf-types/index";
+import { GraphicsStateStack } from "../../graphics-state/index";
+import { OperandStack } from "../../operand-stack/index";
+import type { OperatorHandlerContext } from "../../operator-registry/index";
+import { lineWidthHandler } from "./line-width";
+
+const buildContext = (operands: PdfObject[]): OperatorHandlerContext => {
+  const operandStack = OperandStack.create();
+  for (const operand of operands) {
+    OperandStack.push(operandStack, operand);
+  }
+  const graphicsStateStack = GraphicsStateStack.create();
+  return { operandStack, graphicsStateStack };
+};
+
+test("integer operand 5 で current lineWidth が 5 に更新される", () => {
+  const ctx = buildContext([{ type: "integer", value: 5 }]);
+
+  const result = lineWidthHandler(ctx);
+
+  assert(result.ok);
+  const current = GraphicsStateStack.current(result.value.graphicsStateStack);
+  expect(current.lineWidth).toBe(5);
+});
+
+test("real operand 2.5 で current lineWidth が 2.5 に更新される", () => {
+  const ctx = buildContext([{ type: "real", value: 2.5 }]);
+
+  const result = lineWidthHandler(ctx);
+
+  assert(result.ok);
+  const current = GraphicsStateStack.current(result.value.graphicsStateStack);
+  expect(current.lineWidth).toBe(2.5);
+});
+
+test.each([
+  {
+    label: "0",
+    operand: { type: "integer", value: 0 } as PdfObject,
+    expected: 0,
+  },
+  {
+    label: "negative",
+    operand: { type: "real", value: -1.5 } as PdfObject,
+    expected: -1.5,
+  },
+  {
+    label: "NaN",
+    operand: { type: "real", value: Number.NaN } as PdfObject,
+    expected: Number.NaN,
+  },
+  {
+    label: "Infinity",
+    operand: { type: "real", value: Number.POSITIVE_INFINITY } as PdfObject,
+    expected: Number.POSITIVE_INFINITY,
+  },
+])("境界値 $label の operand も handler では検証せずそのまま GraphicsState に格納する", ({
+  operand,
+  expected,
+}) => {
+  const ctx = buildContext([operand]);
+
+  const result = lineWidthHandler(ctx);
+
+  assert(result.ok);
+  const current = GraphicsStateStack.current(result.value.graphicsStateStack);
+  expect(current.lineWidth).toBe(expected);
+});
+
+test("空 operand stack では OPERATOR_OPERAND_MISSING を返す", () => {
+  const ctx = buildContext([]);
+
+  const result = lineWidthHandler(ctx);
+
+  assert(!result.ok);
+  assert(result.error.code === "OPERATOR_OPERAND_MISSING");
+  expect(result.error.operatorName).toBe("w");
+  expect(result.error.required).toBe(1);
+  expect(result.error.actual).toBe(0);
+  expect(result.error.message).toBe(
+    "Operator 'w' requires 1 operand(s), got 0",
+  );
+});
+
+test.each([
+  {
+    type: "name" as const,
+    operand: { type: "name", value: "Foo" } as PdfObject,
+  },
+  {
+    type: "boolean" as const,
+    operand: { type: "boolean", value: true } as PdfObject,
+  },
+])("末尾が $type のとき OPERATOR_OPERAND_TYPE_MISMATCH を返す", ({
+  type,
+  operand,
+}) => {
+  const ctx = buildContext([operand]);
+
+  const result = lineWidthHandler(ctx);
+
+  assert(!result.ok);
+  assert(result.error.code === "OPERATOR_OPERAND_TYPE_MISMATCH");
+  expect(result.error.operatorName).toBe("w");
+  expect(result.error.expected).toBe("number");
+  expect(result.error.actual).toBe(type);
+  expect(result.error.message).toBe(
+    `Operator 'w' expected number operand, got ${type}`,
+  );
+});
+
+test("operand stack に複数要素がある場合、末尾 1 つだけ pop し残りはそのまま", () => {
+  const head: PdfObject = { type: "integer", value: 99 };
+  const tail: PdfObject = { type: "integer", value: 7 };
+  const ctx = buildContext([head, tail]);
+
+  const result = lineWidthHandler(ctx);
+
+  assert(result.ok);
+  expect(OperandStack.depth(result.value.operandStack)).toBe(1);
+  const top = OperandStack.peek(result.value.operandStack);
+  assert(top.some);
+  expect(top.value).toEqual(head);
+});
+
+test("lineWidth 更新後も lineCap/lineJoin/ctm/miterLimit は不変", () => {
+  const ctx = buildContext([{ type: "integer", value: 3 }]);
+  const before = GraphicsStateStack.current(ctx.graphicsStateStack);
+
+  const result = lineWidthHandler(ctx);
+
+  assert(result.ok);
+  const after = GraphicsStateStack.current(result.value.graphicsStateStack);
+  expect(after.lineCap).toBe(before.lineCap);
+  expect(after.lineJoin).toBe(before.lineJoin);
+  expect(after.miterLimit).toBe(before.miterLimit);
+  expect(after.ctm).toEqual(before.ctm);
+});

--- a/packages/core/src/content-stream/operators/graphics-state/line-width.ts
+++ b/packages/core/src/content-stream/operators/graphics-state/line-width.ts
@@ -1,0 +1,62 @@
+import type { PdfError } from "../../../pdf/errors/index";
+import { err, ok } from "../../../utils/result/index";
+import { GraphicsState, GraphicsStateStack } from "../../graphics-state/index";
+import { OperandStack } from "../../operand-stack/index";
+import type {
+  OperatorHandler,
+  OperatorHandlerContext,
+} from "../../operator-registry/index";
+
+const OPERATOR_NAME = "w";
+
+/**
+ * PDF §8.4.4 `w` operator (line width) のハンドラ。
+ * operand stack 末尾の数値で current GraphicsState の `lineWidth` を更新する。
+ *
+ * - operand stack が空なら `OPERATOR_OPERAND_MISSING` を返す
+ * - 末尾が integer / real 以外なら `OPERATOR_OPERAND_TYPE_MISMATCH` を返す
+ * - 数値の境界値 (`0` / 負値 / `NaN` / `Infinity`) はそのまま `lineWidth` に格納する
+ *   (PDF §8.4.3.2 の非負制約は本 handler のスコープ外、別 issue で validator 化)
+ *
+ * @param context - 実行コンテキスト (operand stack / graphics state stack)
+ * @returns 成功なら更新後コンテキスト、失敗なら PdfError
+ */
+export const lineWidthHandler: OperatorHandler = (
+  context: OperatorHandlerContext,
+) => {
+  const popped = OperandStack.pop(context.operandStack);
+  if (!popped.some) {
+    const error: PdfError = {
+      code: "OPERATOR_OPERAND_MISSING",
+      message: `Operator '${OPERATOR_NAME}' requires 1 operand(s), got 0`,
+      operatorName: OPERATOR_NAME,
+      required: 1,
+      actual: 0,
+    };
+    return err(error);
+  }
+
+  const operand = popped.value;
+  if (operand.type !== "integer" && operand.type !== "real") {
+    const error: PdfError = {
+      code: "OPERATOR_OPERAND_TYPE_MISMATCH",
+      message: `Operator '${OPERATOR_NAME}' expected number operand, got ${operand.type}`,
+      operatorName: OPERATOR_NAME,
+      expected: "number",
+      actual: operand.type,
+    };
+    return err(error);
+  }
+
+  const current = GraphicsStateStack.current(context.graphicsStateStack);
+  const next = GraphicsState.update(current, { lineWidth: operand.value });
+  const graphicsStateStack = GraphicsStateStack.replaceCurrent(
+    context.graphicsStateStack,
+    next,
+  );
+
+  return ok({
+    operandStack: context.operandStack,
+    graphicsStateStack,
+  });
+};

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -75,6 +75,8 @@ export type {
   PdfName,
   PdfNull,
   PdfObject,
+  PdfOperatorOperandMissingError,
+  PdfOperatorOperandTypeMismatchError,
   PdfOperatorRegistryError,
   PdfParseError,
   PdfParseErrorCode,

--- a/packages/core/src/pdf/errors/error/error.basic.test.ts
+++ b/packages/core/src/pdf/errors/error/error.basic.test.ts
@@ -64,6 +64,36 @@ test("PdfOperatorRegistryErrorはoperatorNameを持つ", () => {
   ).toBe("rg");
 });
 
+test("PdfOperatorOperandMissingError は code/operatorName/required/actual を保持する", () => {
+  const error: Extract<PdfError, { code: "OPERATOR_OPERAND_MISSING" }> = {
+    code: "OPERATOR_OPERAND_MISSING",
+    message: "Operator 'w' requires 1 operand(s), got 0",
+    operatorName: "w",
+    required: 1,
+    actual: 0,
+  };
+
+  expect(error.code).toBe("OPERATOR_OPERAND_MISSING");
+  expect(error.operatorName).toBe("w");
+  expect(error.required).toBe(1);
+  expect(error.actual).toBe(0);
+});
+
+test("PdfOperatorOperandTypeMismatchError は expected/actual を保持する", () => {
+  const error: Extract<PdfError, { code: "OPERATOR_OPERAND_TYPE_MISMATCH" }> = {
+    code: "OPERATOR_OPERAND_TYPE_MISMATCH",
+    message: "Operator 'w' expected number operand, got name",
+    operatorName: "w",
+    expected: "number",
+    actual: "name",
+  };
+
+  expect(error.code).toBe("OPERATOR_OPERAND_TYPE_MISMATCH");
+  expect(error.operatorName).toBe("w");
+  expect(error.expected).toBe("number");
+  expect(error.actual).toBe("name");
+});
+
 test("PdfParseErrorのoffsetは省略可能", () => {
   const withOffset: PdfParseError = {
     code: "INVALID_HEADER",

--- a/packages/core/src/pdf/errors/error/error.type-export.test.ts
+++ b/packages/core/src/pdf/errors/error/error.type-export.test.ts
@@ -2,7 +2,10 @@ import { expect, test } from "vitest";
 import type {
   ObjectId,
   PdfCircularReferenceError,
+  PdfError,
   PdfErrorCode,
+  PdfOperatorOperandMissingError,
+  PdfOperatorOperandTypeMismatchError,
   PdfOperatorRegistryError,
   PdfParseError,
   PdfParseErrorCode,
@@ -97,4 +100,46 @@ test("型エクスポートが利用可能", () => {
   expect(typeError.code).toBe("TYPE_MISMATCH");
   expect(operatorRegistryError.operatorName).toBe("rg");
   expect(operatorRegistryErrorCode).toBe("OPERATOR_ALREADY_REGISTERED");
+});
+
+test("PdfOperatorOperandMissingError は PdfError union から narrow できる", () => {
+  const operandMissingError: PdfOperatorOperandMissingError = {
+    code: "OPERATOR_OPERAND_MISSING",
+    message: "Operator 'w' requires 1 operand(s), got 0",
+    operatorName: "w",
+    required: 1,
+    actual: 0,
+  };
+  const error: PdfError = operandMissingError;
+
+  const narrowed: Exact<
+    Extract<PdfError, { code: "OPERATOR_OPERAND_MISSING" }>,
+    PdfOperatorOperandMissingError
+  > = true;
+
+  expect(narrowed).toBe(true);
+  expect(error.code).toBe("OPERATOR_OPERAND_MISSING");
+  expect(operandMissingError.required).toBe(1);
+  expect(operandMissingError.actual).toBe(0);
+});
+
+test("PdfOperatorOperandTypeMismatchError は PdfError union から narrow できる", () => {
+  const typeMismatchError: PdfOperatorOperandTypeMismatchError = {
+    code: "OPERATOR_OPERAND_TYPE_MISMATCH",
+    message: "Operator 'w' expected number operand, got name",
+    operatorName: "w",
+    expected: "number",
+    actual: "name",
+  };
+  const error: PdfError = typeMismatchError;
+
+  const narrowed: Exact<
+    Extract<PdfError, { code: "OPERATOR_OPERAND_TYPE_MISMATCH" }>,
+    PdfOperatorOperandTypeMismatchError
+  > = true;
+
+  expect(narrowed).toBe(true);
+  expect(error.code).toBe("OPERATOR_OPERAND_TYPE_MISMATCH");
+  expect(typeMismatchError.expected).toBe("number");
+  expect(typeMismatchError.actual).toBe("name");
 });

--- a/packages/core/src/pdf/errors/error/index.ts
+++ b/packages/core/src/pdf/errors/error/index.ts
@@ -51,7 +51,9 @@ export type PdfErrorCode =
   | PdfParseErrorCode
   | "CIRCULAR_REFERENCE"
   | "TYPE_MISMATCH"
-  | "OPERATOR_ALREADY_REGISTERED";
+  | "OPERATOR_ALREADY_REGISTERED"
+  | "OPERATOR_OPERAND_MISSING"
+  | "OPERATOR_OPERAND_TYPE_MISMATCH";
 
 /**
  * PDFパースエラーを表すインターフェース。
@@ -136,6 +138,62 @@ export interface PdfOperatorRegistryError {
 }
 
 /**
+ * Content stream operator のオペランド不足エラー。
+ * handler が必要とする数のオペランドが operand stack に積まれていない場合に発生する。
+ *
+ * @example
+ * ```ts
+ * const error: PdfOperatorOperandMissingError = {
+ *   code: "OPERATOR_OPERAND_MISSING",
+ *   message: "Operator 'w' requires 1 operand(s), got 0",
+ *   operatorName: "w",
+ *   required: 1,
+ *   actual: 0,
+ * };
+ * ```
+ */
+export interface PdfOperatorOperandMissingError {
+  /** エラーコード（常に "OPERATOR_OPERAND_MISSING"） */
+  readonly code: "OPERATOR_OPERAND_MISSING";
+  /** 人間可読なエラーメッセージ */
+  readonly message: string;
+  /** 不足を検出した operator 名 */
+  readonly operatorName: string;
+  /** handler が必要とするオペランド数 */
+  readonly required: number;
+  /** 実際に存在したオペランド数 */
+  readonly actual: number;
+}
+
+/**
+ * Content stream operator のオペランド型不一致エラー。
+ * pop した PdfObject の `type` が handler の期待する型と一致しない場合に発生する。
+ *
+ * @example
+ * ```ts
+ * const error: PdfOperatorOperandTypeMismatchError = {
+ *   code: "OPERATOR_OPERAND_TYPE_MISMATCH",
+ *   message: "Operator 'w' expected number operand, got name",
+ *   operatorName: "w",
+ *   expected: "number",
+ *   actual: "name",
+ * };
+ * ```
+ */
+export interface PdfOperatorOperandTypeMismatchError {
+  /** エラーコード（常に "OPERATOR_OPERAND_TYPE_MISMATCH"） */
+  readonly code: "OPERATOR_OPERAND_TYPE_MISMATCH";
+  /** 人間可読なエラーメッセージ */
+  readonly message: string;
+  /** 不一致を検出した operator 名 */
+  readonly operatorName: string;
+  /** 期待されるオペランド型（例: "number"） */
+  readonly expected: string;
+  /** 実際の `PdfObject['type']` 値（例: "name" / "boolean"） */
+  readonly actual: string;
+}
+
+/**
  * 全致命的PDFエラーの判別共用体型。
  * パースエラー、循環参照エラー、型不一致エラー、operator registry エラーを包含する。
  *
@@ -155,4 +213,6 @@ export type PdfError =
   | PdfParseError
   | PdfCircularReferenceError
   | PdfTypeMismatchError
-  | PdfOperatorRegistryError;
+  | PdfOperatorRegistryError
+  | PdfOperatorOperandMissingError
+  | PdfOperatorOperandTypeMismatchError;

--- a/packages/core/src/pdf/errors/error/index.ts
+++ b/packages/core/src/pdf/errors/error/index.ts
@@ -187,9 +187,12 @@ export interface PdfOperatorOperandTypeMismatchError {
   readonly message: string;
   /** 不一致を検出した operator 名 */
   readonly operatorName: string;
-  /** 期待されるオペランド型（例: "number"） */
+  /** 期待されるオペランド型を表す文字列（例: "number"） */
   readonly expected: string;
-  /** 実際の `PdfObject['type']` 値（例: "name" / "boolean"） */
+  /**
+   * 実際に pop された PdfObject の `type` を表す文字列（例: "name" / "boolean"）。
+   * 型レベルでは `PdfObject['type']` 制約は持たず、後続 operator が独自型名を渡せる汎用 string とする。
+   */
   readonly actual: string;
 }
 

--- a/packages/core/src/pdf/errors/error/index.ts
+++ b/packages/core/src/pdf/errors/error/index.ts
@@ -198,7 +198,8 @@ export interface PdfOperatorOperandTypeMismatchError {
 
 /**
  * 全致命的PDFエラーの判別共用体型。
- * パースエラー、循環参照エラー、型不一致エラー、operator registry エラーを包含する。
+ * パースエラー、循環参照エラー、型不一致エラー、operator registry エラー、
+ * operator オペランド不足／型不一致エラーを包含する。
  *
  * @example
  * ```ts

--- a/packages/core/src/pdf/errors/index.ts
+++ b/packages/core/src/pdf/errors/index.ts
@@ -7,6 +7,8 @@ export type {
   PdfCircularReferenceError,
   PdfError,
   PdfErrorCode,
+  PdfOperatorOperandMissingError,
+  PdfOperatorOperandTypeMismatchError,
   PdfOperatorRegistryError,
   PdfParseError,
   PdfParseErrorCode,


### PR DESCRIPTION
## 概要

spec-032 / Issue #150。PDF コンテンツストリーム §8.4.4 `w` operator (line width) のハンドラを新設し、後続 #151–#154 (`J` / `j` / `M` / `cm`) でも踏襲する handler 雛形と `PdfError` operand エラー基盤を確立する。本 PR は handler 単体実装＋単体テストに限定し、`OperatorRegistry.register` への配線は #155 で対応する。

## 変更の種類

- ✨ New Feature

## 追加した内容

- `packages/core/src/content-stream/operators/graphics-state/line-width.ts`
  - `lineWidthHandler: OperatorHandler` を named const export
  - operand pop → 数値型判別 → `GraphicsState.update` → `GraphicsStateStack.replaceCurrent` のフロー、全分岐 `Result` 返却 (throw なし)
- `packages/core/src/content-stream/operators/graphics-state/line-width.basic.test.ts`
  - 正常系 (integer / real)、境界値 (`0` / `-1.5` / `NaN` / `Infinity`)、異常系 (空 stack / `name` / `boolean`)、複数 operand、不変性の 7 ケース
- `PdfError` 拡張: `OPERATOR_OPERAND_MISSING` / `OPERATOR_OPERAND_TYPE_MISMATCH` の 2 コードと対応 interface (`PdfOperatorOperandMissingError` / `PdfOperatorOperandTypeMismatchError`)
- `error.basic.test.ts` / `error.type-export.test.ts` に discriminated narrowing テスト 4 件追加

## 変更した内容

- `packages/core/src/pdf/errors/error/index.ts` — `PdfErrorCode` union と `PdfError` union に新 2 コードを追加
- `packages/core/src/pdf/errors/index.ts` — barrel に新 interface 2 つを追加
- `packages/core/src/index.ts` — ルート type re-export に新 interface 2 つを追加

## システム図

```mermaid
flowchart TD
    Caller[caller] -->|ctx: OperatorHandlerContext| Handler["lineWidthHandler<br/>(operators/graphics-state/line-width.ts) [NEW]"]
    Handler --> Pop["OperandStack.pop(ctx.operandStack)"]
    Pop -->|None| Missing["err: OPERATOR_OPERAND_MISSING<br/>required=1 / actual=0 [NEW]"]
    Pop -->|Some obj| TypeCheck{"obj.type ∈ {integer, real}?"}
    TypeCheck -->|No| Mismatch["err: OPERATOR_OPERAND_TYPE_MISMATCH<br/>expected='number' / actual=obj.type [NEW]"]
    TypeCheck -->|Yes| Update["GraphicsState.update(current, { lineWidth: obj.value })"]
    Update --> Replace["GraphicsStateStack.replaceCurrent(stack, next)"]
    Replace --> Ok["ok({ operandStack, graphicsStateStack })"]

    style Handler fill:#e0f7fa
    style Missing fill:#ffe0e0
    style Mismatch fill:#ffe0e0
```

## 関連 spec / Issue

- spec: `.plugin-workspace/.specs/032-line-width-operator/`
- Issue: Refs #150
- 後続: #151 (`J`) / #152 (`j`) / #153 (`M`) / #154 (`cm`) / #155 (registry 配線)

## テスト

| 項目 | 結果 |
|:-|:-|
| `pnpm --filter @pdfmod/core test` | **1558 tests passed (112 files)** |
| `pnpm --filter @pdfmod/core typecheck` | OK |
| `pnpm -w run lint` | 0 errors (`.pnpm-store` の broken symlink warning は無関係) |
| Codex レビュー (`spec-implement-codex`) | **問題なし** (1 回目で完了) |

## レビューポイント

本 PR で導入するパターンは後続 #151–#154 でそのまま踏襲する雛形のため、命名・配置・エラー設計を慎重にレビューしてほしい。

- **handler の export 形式**: `export const lineWidthHandler: OperatorHandler = (ctx) => ...` の named const export 1 関数 = 1 ファイル。state を持たない純関数のため Companion Object は採用せず、後続 handler は `<operatorName>Handler` 命名で統一する想定。
- **配置**: `operators/graphics-state/<kebab-name>.ts`。後続 `J` / `j` / `M` / `cm` も同フォルダに並ぶ前提。
- **PdfError 拡張の汎用性**: 新 2 コードは `operatorName` で個別 operator を識別する**汎用エラー**として設計。`required` / `actual` フィールドは後続 `cm` (6 operand) でも再利用可能。`operandIndex` は単一 operand では不要のため**含めない** (`cm` 着手時に必要なら別途検討)。
- **エラーメッセージ規約**: `Operator '{name}' requires {N} operand(s), got {n}` / `Operator '{name}' expected {expected} operand, got {actual}` の英語テンプレートで統一。
- **境界値の検証ポリシー**: handler では数値型 (`integer` / `real`) のみ検証し、`0` / 負値 / `NaN` / `Infinity` も pop した値をそのまま `GraphicsState.lineWidth` に格納する。PDF §8.4.3.2 (lineWidth は非負実数) 準拠の semantic validator は別 issue で spec validation 層に分離する方針。
- **破壊的変更**: なし (`PdfError` union への追加のみ。本 repo 内に網羅的 switch 消費側はなし)。
- **本 PR スコープ外**: `OperatorRegistry.register` 配線は #155 で一括対応。ルート `index.ts` の差分は新 PdfError interface 2 つの type 追加のみで、`lineWidthHandler` 本体の re-export は含まない。