### PR TITLE
✨ [New Feature]: #151 line-cap (J) operator handler を実装

### DIFF
--- a/packages/core/src/content-stream/graphics-state/line-cap.basic.test.ts
+++ b/packages/core/src/content-stream/graphics-state/line-cap.basic.test.ts
@@ -4,3 +4,21 @@ import { LineCap } from "./line-cap";
 test.each([0, 1, 2] as const)("create(%d)はnを保持する", (n) => {
   expect(LineCap.create(n)).toBe(n);
 });
+
+test("LineCap.allowed は [0, 1, 2] を保持する", () => {
+  expect(LineCap.allowed).toEqual([0, 1, 2]);
+});
+
+test.each([0, 1, 2] as const)("LineCap.isValid(%d) は true を返す", (n) => {
+  expect(LineCap.isValid(n)).toBe(true);
+});
+
+test.each([
+  3,
+  -1,
+  1.5,
+  Number.NaN,
+  Number.MAX_SAFE_INTEGER,
+])("LineCap.isValid(%s) は false を返す", (n) => {
+  expect(LineCap.isValid(n)).toBe(false);
+});

--- a/packages/core/src/content-stream/graphics-state/line-cap.ts
+++ b/packages/core/src/content-stream/graphics-state/line-cap.ts
@@ -14,6 +14,25 @@ export type LineCap = Brand<0 | 1 | 2, typeof LineCapBrand>;
 
 export const LineCap = {
   /**
+   * PDF §4.1 が定める line cap の許容値 (0=Butt / 1=Round / 2=Projecting Square)。
+   * `readonly [0, 1, 2]` のリテラル tuple 型を保持しつつ
+   * `readonly number[]` への代入互換性を `satisfies` で静的検査する。
+   * categorical operand を扱う `PdfError` の `allowed: readonly number[]` に直接渡せる。
+   */
+  allowed: [0, 1, 2] as const satisfies readonly number[],
+
+  /**
+   * 任意の number が line cap の許容値 (0|1|2) かを判定する型ガード。
+   * `true` を返した先で `n` は `0 | 1 | 2` に narrow される。
+   *
+   * @param n - 検査対象の数値
+   * @returns n が 0/1/2 のいずれかなら true
+   */
+  isValid(n: number): n is 0 | 1 | 2 {
+    return n === 0 || n === 1 || n === 2;
+  },
+
+  /**
    * 0 | 1 | 2 のいずれかを LineCap として返す。
    *
    * @param n - line cap style (0=Butt / 1=Round / 2=Projecting Square)

--- a/packages/core/src/content-stream/operators/graphics-state/line-cap.basic.test.ts
+++ b/packages/core/src/content-stream/operators/graphics-state/line-cap.basic.test.ts
@@ -1,0 +1,163 @@
+import { assert, expect, test } from "vitest";
+import type { PdfObject } from "../../../pdf/types/pdf-types/index";
+import { GraphicsStateStack, LineCap } from "../../graphics-state/index";
+import { OperandStack } from "../../operand-stack/index";
+import type { OperatorHandlerContext } from "../../operator-registry/index";
+import { lineCapHandler } from "./line-cap";
+
+const buildContext = (operands: PdfObject[]): OperatorHandlerContext => {
+  const operandStack = OperandStack.create();
+  for (const operand of operands) {
+    OperandStack.push(operandStack, operand);
+  }
+  const graphicsStateStack = GraphicsStateStack.create();
+  return { operandStack, graphicsStateStack };
+};
+
+test.each([
+  { value: 0 },
+  { value: 1 },
+  { value: 2 },
+] as const)("integer operand $value で current lineCap が LineCap.create($value) に更新される", ({
+  value,
+}) => {
+  const ctx = buildContext([{ type: "integer", value }]);
+
+  const result = lineCapHandler(ctx);
+
+  assert(result.ok);
+  const current = GraphicsStateStack.current(result.value.graphicsStateStack);
+  expect(current.lineCap).toBe(LineCap.create(value));
+});
+
+test.each([
+  { label: "3", value: 3 },
+  { label: "negative", value: -1 },
+  { label: "MAX_SAFE_INTEGER", value: Number.MAX_SAFE_INTEGER },
+])("値域外 integer $label で OPERATOR_OPERAND_VALUE_OUT_OF_RANGE を返す", ({
+  value,
+}) => {
+  const ctx = buildContext([{ type: "integer", value }]);
+
+  const result = lineCapHandler(ctx);
+
+  assert(!result.ok);
+  assert(result.error.code === "OPERATOR_OPERAND_VALUE_OUT_OF_RANGE");
+  expect(result.error.operatorName).toBe("J");
+  expect(result.error.allowed).toBe(LineCap.allowed);
+  expect(result.error.allowed).toEqual([0, 1, 2]);
+  expect(result.error.actual).toBe(value);
+  expect(result.error.message).toBe(
+    `Operator 'J' operand value ${value} is out of range, expected one of [0, 1, 2]`,
+  );
+});
+
+test.each([
+  {
+    type: "real" as const,
+    operand: { type: "real", value: 1.5 } as PdfObject,
+  },
+  {
+    type: "name" as const,
+    operand: { type: "name", value: "Foo" } as PdfObject,
+  },
+  {
+    type: "boolean" as const,
+    operand: { type: "boolean", value: true } as PdfObject,
+  },
+  {
+    type: "array" as const,
+    operand: { type: "array", elements: [] } as PdfObject,
+  },
+  {
+    type: "dictionary" as const,
+    operand: { type: "dictionary", entries: new Map() } as PdfObject,
+  },
+])("末尾が $type のとき OPERATOR_OPERAND_TYPE_MISMATCH を返す (expected='integer')", ({
+  type,
+  operand,
+}) => {
+  const ctx = buildContext([operand]);
+
+  const result = lineCapHandler(ctx);
+
+  assert(!result.ok);
+  assert(result.error.code === "OPERATOR_OPERAND_TYPE_MISMATCH");
+  expect(result.error.operatorName).toBe("J");
+  expect(result.error.expected).toBe("integer");
+  expect(result.error.actual).toBe(type);
+  expect(result.error.message).toBe(
+    `Operator 'J' expected integer operand, got ${type}`,
+  );
+});
+
+test("空 operand stack で OPERATOR_OPERAND_MISSING を返す", () => {
+  const ctx = buildContext([]);
+
+  const result = lineCapHandler(ctx);
+
+  assert(!result.ok);
+  assert(result.error.code === "OPERATOR_OPERAND_MISSING");
+  expect(result.error.operatorName).toBe("J");
+  expect(result.error.required).toBe(1);
+  expect(result.error.actual).toBe(0);
+  expect(result.error.message).toBe(
+    "Operator 'J' requires 1 operand(s), got 0",
+  );
+});
+
+test("operand stack に複数要素がある場合、末尾 1 つだけ pop し残りはそのまま", () => {
+  const head: PdfObject = { type: "integer", value: 99 };
+  const tail: PdfObject = { type: "integer", value: 1 };
+  const ctx = buildContext([head, tail]);
+
+  const result = lineCapHandler(ctx);
+
+  assert(result.ok);
+  expect(OperandStack.depth(result.value.operandStack)).toBe(1);
+  const top = OperandStack.peek(result.value.operandStack);
+  assert(top.some);
+  expect(top.value).toEqual(head);
+});
+
+test("値域外 integer 3 のとき末尾 1 つだけ pop し、残り operand は保持される", () => {
+  const head: PdfObject = { type: "integer", value: 99 };
+  const tail: PdfObject = { type: "integer", value: 3 };
+  const ctx = buildContext([head, tail]);
+
+  const result = lineCapHandler(ctx);
+
+  assert(!result.ok);
+  expect(OperandStack.depth(ctx.operandStack)).toBe(1);
+  const top = OperandStack.peek(ctx.operandStack);
+  assert(top.some);
+  expect(top.value).toEqual(head);
+});
+
+test("末尾が name のとき (TYPE_MISMATCH)、末尾 1 つだけ pop し残り operand は保持される", () => {
+  const head: PdfObject = { type: "integer", value: 99 };
+  const tail: PdfObject = { type: "name", value: "Foo" };
+  const ctx = buildContext([head, tail]);
+
+  const result = lineCapHandler(ctx);
+
+  assert(!result.ok);
+  expect(OperandStack.depth(ctx.operandStack)).toBe(1);
+  const top = OperandStack.peek(ctx.operandStack);
+  assert(top.some);
+  expect(top.value).toEqual(head);
+});
+
+test("lineCap 更新後も lineWidth/lineJoin/miterLimit/ctm は不変", () => {
+  const ctx = buildContext([{ type: "integer", value: 1 }]);
+  const before = GraphicsStateStack.current(ctx.graphicsStateStack);
+
+  const result = lineCapHandler(ctx);
+
+  assert(result.ok);
+  const after = GraphicsStateStack.current(result.value.graphicsStateStack);
+  expect(after.lineWidth).toBe(before.lineWidth);
+  expect(after.lineJoin).toBe(before.lineJoin);
+  expect(after.miterLimit).toBe(before.miterLimit);
+  expect(after.ctm).toEqual(before.ctm);
+});

--- a/packages/core/src/content-stream/operators/graphics-state/line-cap.ts
+++ b/packages/core/src/content-stream/operators/graphics-state/line-cap.ts
@@ -1,0 +1,83 @@
+import type { PdfError } from "../../../pdf/errors/index";
+import { err, ok } from "../../../utils/result/index";
+import {
+  GraphicsState,
+  GraphicsStateStack,
+  LineCap,
+} from "../../graphics-state/index";
+import { OperandStack } from "../../operand-stack/index";
+import type {
+  OperatorHandler,
+  OperatorHandlerContext,
+} from "../../operator-registry/index";
+
+const OPERATOR_NAME = "J";
+
+/**
+ * PDF §8.4.4 `J` operator (line cap style) のハンドラ。
+ * operand stack 末尾の整数 (0=Butt / 1=Round / 2=Projecting Square) で
+ * current GraphicsState の `lineCap` を更新する。
+ *
+ * - operand stack が空なら `OPERATOR_OPERAND_MISSING` を返す
+ * - 末尾が integer 以外 (real / name / boolean / array / dictionary / ...) なら
+ *   `OPERATOR_OPERAND_TYPE_MISMATCH` を返す (PDF §8.4.4 は integer 指定のため real も弾く)
+ * - 末尾 integer の値が 0/1/2 以外 (3 / -1 / MAX_SAFE_INTEGER 等) なら
+ *   `OPERATOR_OPERAND_VALUE_OUT_OF_RANGE` を返す (`allowed = LineCap.allowed`)
+ * - エラー時も operand は pop された状態のまま err を返す
+ *   (operand stack は in-place で 1 つ消費済み)
+ *
+ * @param context - 実行コンテキスト (operand stack / graphics state stack)
+ * @returns 成功なら更新後コンテキスト、失敗なら PdfError
+ */
+export const lineCapHandler: OperatorHandler = (
+  context: OperatorHandlerContext,
+) => {
+  const popped = OperandStack.pop(context.operandStack);
+  if (!popped.some) {
+    const error: PdfError = {
+      code: "OPERATOR_OPERAND_MISSING",
+      message: `Operator '${OPERATOR_NAME}' requires 1 operand(s), got 0`,
+      operatorName: OPERATOR_NAME,
+      required: 1,
+      actual: 0,
+    };
+    return err(error);
+  }
+
+  const operand = popped.value;
+  if (operand.type !== "integer") {
+    const error: PdfError = {
+      code: "OPERATOR_OPERAND_TYPE_MISMATCH",
+      message: `Operator '${OPERATOR_NAME}' expected integer operand, got ${operand.type}`,
+      operatorName: OPERATOR_NAME,
+      expected: "integer",
+      actual: operand.type,
+    };
+    return err(error);
+  }
+
+  const value = operand.value;
+  if (!LineCap.isValid(value)) {
+    const error: PdfError = {
+      code: "OPERATOR_OPERAND_VALUE_OUT_OF_RANGE",
+      message: `Operator '${OPERATOR_NAME}' operand value ${value} is out of range, expected one of [${LineCap.allowed.join(", ")}]`,
+      operatorName: OPERATOR_NAME,
+      allowed: LineCap.allowed,
+      actual: value,
+    };
+    return err(error);
+  }
+
+  const cap = LineCap.create(value);
+  const current = GraphicsStateStack.current(context.graphicsStateStack);
+  const next = GraphicsState.update(current, { lineCap: cap });
+  const graphicsStateStack = GraphicsStateStack.replaceCurrent(
+    context.graphicsStateStack,
+    next,
+  );
+
+  return ok({
+    operandStack: context.operandStack,
+    graphicsStateStack,
+  });
+};

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -77,6 +77,7 @@ export type {
   PdfObject,
   PdfOperatorOperandMissingError,
   PdfOperatorOperandTypeMismatchError,
+  PdfOperatorOperandValueOutOfRangeError,
   PdfOperatorRegistryError,
   PdfParseError,
   PdfParseErrorCode,

--- a/packages/core/src/pdf/errors/error/error.basic.test.ts
+++ b/packages/core/src/pdf/errors/error/error.basic.test.ts
@@ -94,6 +94,25 @@ test("PdfOperatorOperandTypeMismatchError は expected/actual を保持する", 
   expect(error.actual).toBe("name");
 });
 
+test("PdfOperatorOperandValueOutOfRangeError は operatorName/allowed/actual を保持する", () => {
+  const error: Extract<
+    PdfError,
+    { code: "OPERATOR_OPERAND_VALUE_OUT_OF_RANGE" }
+  > = {
+    code: "OPERATOR_OPERAND_VALUE_OUT_OF_RANGE",
+    message:
+      "Operator 'J' operand value 3 is out of range, expected one of [0, 1, 2]",
+    operatorName: "J",
+    allowed: [0, 1, 2],
+    actual: 3,
+  };
+
+  expect(error.code).toBe("OPERATOR_OPERAND_VALUE_OUT_OF_RANGE");
+  expect(error.operatorName).toBe("J");
+  expect(error.allowed).toEqual([0, 1, 2]);
+  expect(error.actual).toBe(3);
+});
+
 test("PdfParseErrorのoffsetは省略可能", () => {
   const withOffset: PdfParseError = {
     code: "INVALID_HEADER",

--- a/packages/core/src/pdf/errors/error/error.type-export.test.ts
+++ b/packages/core/src/pdf/errors/error/error.type-export.test.ts
@@ -6,6 +6,7 @@ import type {
   PdfErrorCode,
   PdfOperatorOperandMissingError,
   PdfOperatorOperandTypeMismatchError,
+  PdfOperatorOperandValueOutOfRangeError,
   PdfOperatorRegistryError,
   PdfParseError,
   PdfParseErrorCode,
@@ -142,4 +143,26 @@ test("PdfOperatorOperandTypeMismatchError は PdfError union から narrow で�
   expect(error.code).toBe("OPERATOR_OPERAND_TYPE_MISMATCH");
   expect(typeMismatchError.expected).toBe("number");
   expect(typeMismatchError.actual).toBe("name");
+});
+
+test("PdfOperatorOperandValueOutOfRangeError は PdfError union から narrow できる", () => {
+  const valueOutOfRangeError: PdfOperatorOperandValueOutOfRangeError = {
+    code: "OPERATOR_OPERAND_VALUE_OUT_OF_RANGE",
+    message:
+      "Operator 'J' operand value 3 is out of range, expected one of [0, 1, 2]",
+    operatorName: "J",
+    allowed: [0, 1, 2],
+    actual: 3,
+  };
+  const error: PdfError = valueOutOfRangeError;
+
+  const narrowed: Exact<
+    Extract<PdfError, { code: "OPERATOR_OPERAND_VALUE_OUT_OF_RANGE" }>,
+    PdfOperatorOperandValueOutOfRangeError
+  > = true;
+
+  expect(narrowed).toBe(true);
+  expect(error.code).toBe("OPERATOR_OPERAND_VALUE_OUT_OF_RANGE");
+  expect(valueOutOfRangeError.allowed).toEqual([0, 1, 2]);
+  expect(valueOutOfRangeError.actual).toBe(3);
 });

--- a/packages/core/src/pdf/errors/error/index.ts
+++ b/packages/core/src/pdf/errors/error/index.ts
@@ -53,7 +53,8 @@ export type PdfErrorCode =
   | "TYPE_MISMATCH"
   | "OPERATOR_ALREADY_REGISTERED"
   | "OPERATOR_OPERAND_MISSING"
-  | "OPERATOR_OPERAND_TYPE_MISMATCH";
+  | "OPERATOR_OPERAND_TYPE_MISMATCH"
+  | "OPERATOR_OPERAND_VALUE_OUT_OF_RANGE";
 
 /**
  * PDFパースエラーを表すインターフェース。
@@ -197,6 +198,38 @@ export interface PdfOperatorOperandTypeMismatchError {
 }
 
 /**
+ * Content stream operator のオペランド値域外エラー。
+ * categorical operand (line cap 0|1|2 / line join 0|1|2 / text rendering mode 0..7 等) の
+ * 値が許容集合に含まれない場合に発生する。
+ *
+ * - `allowed` は汎用 number 配列 (operator 側で `[0, 1, 2]` 等を渡す)。
+ * - `actual` は pop された生の数値 (例: 3, -1, MAX_SAFE_INTEGER)。
+ *
+ * @example
+ * ```ts
+ * const error: PdfOperatorOperandValueOutOfRangeError = {
+ *   code: "OPERATOR_OPERAND_VALUE_OUT_OF_RANGE",
+ *   message: "Operator 'J' operand value 3 is out of range, expected one of [0, 1, 2]",
+ *   operatorName: "J",
+ *   allowed: [0, 1, 2],
+ *   actual: 3,
+ * };
+ * ```
+ */
+export interface PdfOperatorOperandValueOutOfRangeError {
+  /** エラーコード（常に "OPERATOR_OPERAND_VALUE_OUT_OF_RANGE"） */
+  readonly code: "OPERATOR_OPERAND_VALUE_OUT_OF_RANGE";
+  /** 人間可読なエラーメッセージ */
+  readonly message: string;
+  /** 値域外を検出した operator 名 */
+  readonly operatorName: string;
+  /** operator が許容する categorical 値の集合 */
+  readonly allowed: readonly number[];
+  /** 実際に pop された数値 */
+  readonly actual: number;
+}
+
+/**
  * 全致命的PDFエラーの判別共用体型。
  * パースエラー、循環参照エラー、型不一致エラー、operator registry エラー、
  * operator オペランド不足／型不一致エラーを包含する。
@@ -219,4 +252,5 @@ export type PdfError =
   | PdfTypeMismatchError
   | PdfOperatorRegistryError
   | PdfOperatorOperandMissingError
-  | PdfOperatorOperandTypeMismatchError;
+  | PdfOperatorOperandTypeMismatchError
+  | PdfOperatorOperandValueOutOfRangeError;

--- a/packages/core/src/pdf/errors/index.ts
+++ b/packages/core/src/pdf/errors/index.ts
@@ -9,6 +9,7 @@ export type {
   PdfErrorCode,
   PdfOperatorOperandMissingError,
   PdfOperatorOperandTypeMismatchError,
+  PdfOperatorOperandValueOutOfRangeError,
   PdfOperatorRegistryError,
   PdfParseError,
   PdfParseErrorCode,


### PR DESCRIPTION
## 概要

spec-033 PR。PDF §8.4.4 の `J` operator (line cap style) を扱う `OperatorHandler` を新設する。
親 PR #157 (`w` line-width) で確立された雛形を踏襲しつつ、categorical operand 用の
新エラーバリアント `OPERATOR_OPERAND_VALUE_OUT_OF_RANGE` を `PdfError` union に追加する。

## 変更の種類

- ✨ **New Feature** — `J` operator handler 新規追加
- 🏷️ **Types** — `PdfError` 拡張 / `LineCap` companion 拡張

## 追加した内容

- `packages/core/src/content-stream/operators/graphics-state/line-cap.ts`
  - `lineCapHandler: OperatorHandler` (`J` operator)
- `packages/core/src/content-stream/operators/graphics-state/line-cap.basic.test.ts`
  - 単体テスト 16 ケース (正常系 / 値域外 / 型不一致 / 空 stack / 末尾 1 つだけ pop / 不変性)
- `PdfOperatorOperandValueOutOfRangeError` interface
  - `code` / `message` / `operatorName` / `allowed: readonly number[]` / `actual: number`
  - 将来の `j` (line-join 0|1|2) や `Tr` (text rendering mode 0..7) でも再利用可能な汎用設計
- `LineCap` companion に `allowed: readonly [0, 1, 2]` 定数と `isValid(n): n is 0 | 1 | 2` 型ガード

## 変更した内容

- `packages/core/src/pdf/errors/error/index.ts` — `PdfErrorCode` / `PdfError` union に追加
- `packages/core/src/pdf/errors/index.ts` / `packages/core/src/index.ts` — barrel に新 interface 追加 (アルファベット順)
- `packages/core/src/pdf/errors/error/error.basic.test.ts` / `error.type-export.test.ts` — 新バリアント検証テスト追加

## システム図

```mermaid
flowchart TD
    Start([lineCapHandler ctx 呼び出し]) --> Pop["OperandStack.pop ctx.operandStack"]
    Pop -->|None| Missing["err: OPERATOR_OPERAND_MISSING<br/>required=1, actual=0"]
    Pop -->|Some operand| TypeCheck{"operand.type === 'integer'?"}
    TypeCheck -->|No real / name / boolean / ...| TypeMismatch["err: OPERATOR_OPERAND_TYPE_MISMATCH<br/>expected='integer', actual=operand.type"]
    TypeCheck -->|Yes| RangeCheck{"LineCap.isValid value?"}
    RangeCheck -->|false 3 / -1 / MAX_SAFE_INTEGER| OutOfRange["err: OPERATOR_OPERAND_VALUE_OUT_OF_RANGE<br/>NEW allowed=LineCap.allowed, actual=value"]
    RangeCheck -->|true value: 0 / 1 / 2| Update["LineCap.create value<br/>GraphicsState.update lineCap<br/>GraphicsStateStack.replaceCurrent"]
    Update --> Ok([ok 更新後 context])

    style OutOfRange fill:#fff4ce,stroke:#d4a017
    style RangeCheck fill:#e8f4f8,stroke:#2b7a8a
```

## 関連 spec / Issue

- spec: `.plugin-workspace/.specs/033-line-cap-operator/`
- Closes #151
- 親 PR #157 (`w` line-width) のパターン踏襲
- 後続 issue: `OperatorRegistry.register` 配線 + barrel export (graphics-state operators 一括対応)

## テスト

- `pnpm --filter @pdfmod/core test` — **1585 / 1585 passed** (`line-cap.basic.test.ts` 16 件 + `line-cap` companion 12 件 + `error.basic.test.ts` / `error.type-export.test.ts` 拡張)
- `pnpm --filter @pdfmod/core typecheck` — エラーなし
- `pnpm lint` — 0 errors / 0 warnings
- **Codex レビュー**: review-001 で `test.each` の `$value` 展開不備を指摘 → 修正後 review-002 で **問題なし**

## レビューポイント

- **値域知識の集約**: handler 内に `value !== 0 && value !== 1 && value !== 2` を直書きせず、`LineCap.isValid` 型ガード経由で control-flow narrow → `LineCap.create(value)` を呼ぶ設計。`as 0 | 1 | 2` キャスト不採用。
- **`real` を許可しない**: PDF §8.4.4 は line cap を integer 指定のため `operand.type !== "integer"` で real も `TYPE_MISMATCH` に倒す（親 `w` の number 受容と異なる新パターン）。`expected: "integer"` 文字列で識別。
- **エラー時も pop 済み**: `OperandStack.pop` は in-place mutate のため、err 時も operand stack は 1 つ消費済み（`w` と同じ振る舞い）。複数要素 stack で「末尾だけ消費 / 残り保持」を `VALUE_OUT_OF_RANGE` / `TYPE_MISMATCH` 各々で確認。
- **公開 API への影響 (破壊的変更ではないが要注意)**: `PdfError` union に新バリアントを追加。本 repo 内では網羅 switch の消費側がないため安全だが、外部利用者の exhaustive switch には型レベル影響あり。CHANGELOG / `.changeset` が無いため本 PR 説明をリリースノート相当として扱う。
- **ファイル命名**: issue #151 記述の `line-cap-set.ts` ではなく `line-cap.ts` を採用（同階層 `line-width.ts` と一貫性を取るため動詞抜き）。
- **本 PR 範囲外**: `OperatorRegistry.register` への配線および operators barrel は別 issue で一括対応。