### PR TITLE
✨ [New Feature]: #152 line-join (j) operator handler を実装

### DIFF
--- a/packages/core/src/content-stream/graphics-state/line-join.basic.test.ts
+++ b/packages/core/src/content-stream/graphics-state/line-join.basic.test.ts
@@ -4,3 +4,21 @@ import { LineJoin } from "./line-join";
 test.each([0, 1, 2] as const)("create(%d)はnを保持する", (n) => {
   expect(LineJoin.create(n)).toBe(n);
 });
+
+test("LineJoin.allowed は [0, 1, 2] を保持する", () => {
+  expect(LineJoin.allowed).toEqual([0, 1, 2]);
+});
+
+test.each([0, 1, 2] as const)("LineJoin.isValid(%d) は true を返す", (n) => {
+  expect(LineJoin.isValid(n)).toBe(true);
+});
+
+test.each([
+  3,
+  -1,
+  1.5,
+  Number.NaN,
+  Number.MAX_SAFE_INTEGER,
+])("LineJoin.isValid(%s) は false を返す", (n) => {
+  expect(LineJoin.isValid(n)).toBe(false);
+});

--- a/packages/core/src/content-stream/graphics-state/line-join.ts
+++ b/packages/core/src/content-stream/graphics-state/line-join.ts
@@ -14,6 +14,25 @@ export type LineJoin = Brand<0 | 1 | 2, typeof LineJoinBrand>;
 
 export const LineJoin = {
   /**
+   * PDF §4.1 が定める line join の許容値 (0=Miter / 1=Round / 2=Bevel)。
+   * `readonly [0, 1, 2]` のリテラル tuple 型を保持しつつ
+   * `readonly number[]` への代入互換性を `satisfies` で静的検査する。
+   * categorical operand を扱う `PdfError` の `allowed: readonly number[]` に直接渡せる。
+   */
+  allowed: [0, 1, 2] as const satisfies readonly number[],
+
+  /**
+   * 任意の number が line join の許容値 (0|1|2) かを判定する型ガード。
+   * `true` を返した先で `n` は `0 | 1 | 2` に narrow される。
+   *
+   * @param n - 検査対象の数値
+   * @returns n が 0/1/2 のいずれかなら true
+   */
+  isValid(n: number): n is 0 | 1 | 2 {
+    return n === 0 || n === 1 || n === 2;
+  },
+
+  /**
    * 0 | 1 | 2 のいずれかを LineJoin として返す。
    *
    * @param n - line join style (0=Miter / 1=Round / 2=Bevel)

--- a/packages/core/src/content-stream/operators/graphics-state/line-join.basic.test.ts
+++ b/packages/core/src/content-stream/operators/graphics-state/line-join.basic.test.ts
@@ -1,0 +1,163 @@
+import { assert, expect, test } from "vitest";
+import type { PdfObject } from "../../../pdf/types/pdf-types/index";
+import { GraphicsStateStack, LineJoin } from "../../graphics-state/index";
+import { OperandStack } from "../../operand-stack/index";
+import type { OperatorHandlerContext } from "../../operator-registry/index";
+import { lineJoinHandler } from "./line-join";
+
+const buildContext = (operands: PdfObject[]): OperatorHandlerContext => {
+  const operandStack = OperandStack.create();
+  for (const operand of operands) {
+    OperandStack.push(operandStack, operand);
+  }
+  const graphicsStateStack = GraphicsStateStack.create();
+  return { operandStack, graphicsStateStack };
+};
+
+test.each([
+  { value: 0 },
+  { value: 1 },
+  { value: 2 },
+] as const)("integer operand $value で current lineJoin が LineJoin.create($value) に更新される", ({
+  value,
+}) => {
+  const ctx = buildContext([{ type: "integer", value }]);
+
+  const result = lineJoinHandler(ctx);
+
+  assert(result.ok);
+  const current = GraphicsStateStack.current(result.value.graphicsStateStack);
+  expect(current.lineJoin).toBe(LineJoin.create(value));
+});
+
+test.each([
+  { label: "3", value: 3 },
+  { label: "negative", value: -1 },
+  { label: "MAX_SAFE_INTEGER", value: Number.MAX_SAFE_INTEGER },
+])("値域外 integer $label で OPERATOR_OPERAND_VALUE_OUT_OF_RANGE を返す", ({
+  value,
+}) => {
+  const ctx = buildContext([{ type: "integer", value }]);
+
+  const result = lineJoinHandler(ctx);
+
+  assert(!result.ok);
+  assert(result.error.code === "OPERATOR_OPERAND_VALUE_OUT_OF_RANGE");
+  expect(result.error.operatorName).toBe("j");
+  expect(result.error.allowed).toBe(LineJoin.allowed);
+  expect(result.error.allowed).toEqual([0, 1, 2]);
+  expect(result.error.actual).toBe(value);
+  expect(result.error.message).toBe(
+    `Operator 'j' operand value ${value} is out of range, expected one of [0, 1, 2]`,
+  );
+});
+
+test.each([
+  {
+    type: "real" as const,
+    operand: { type: "real", value: 1.5 } as PdfObject,
+  },
+  {
+    type: "name" as const,
+    operand: { type: "name", value: "Foo" } as PdfObject,
+  },
+  {
+    type: "boolean" as const,
+    operand: { type: "boolean", value: true } as PdfObject,
+  },
+  {
+    type: "array" as const,
+    operand: { type: "array", elements: [] } as PdfObject,
+  },
+  {
+    type: "dictionary" as const,
+    operand: { type: "dictionary", entries: new Map() } as PdfObject,
+  },
+])("末尾が $type のとき OPERATOR_OPERAND_TYPE_MISMATCH を返す (expected='integer')", ({
+  type,
+  operand,
+}) => {
+  const ctx = buildContext([operand]);
+
+  const result = lineJoinHandler(ctx);
+
+  assert(!result.ok);
+  assert(result.error.code === "OPERATOR_OPERAND_TYPE_MISMATCH");
+  expect(result.error.operatorName).toBe("j");
+  expect(result.error.expected).toBe("integer");
+  expect(result.error.actual).toBe(type);
+  expect(result.error.message).toBe(
+    `Operator 'j' expected integer operand, got ${type}`,
+  );
+});
+
+test("空 operand stack で OPERATOR_OPERAND_MISSING を返す", () => {
+  const ctx = buildContext([]);
+
+  const result = lineJoinHandler(ctx);
+
+  assert(!result.ok);
+  assert(result.error.code === "OPERATOR_OPERAND_MISSING");
+  expect(result.error.operatorName).toBe("j");
+  expect(result.error.required).toBe(1);
+  expect(result.error.actual).toBe(0);
+  expect(result.error.message).toBe(
+    "Operator 'j' requires 1 operand(s), got 0",
+  );
+});
+
+test("operand stack に複数要素がある場合、末尾 1 つだけ pop し残りはそのまま", () => {
+  const head: PdfObject = { type: "integer", value: 99 };
+  const tail: PdfObject = { type: "integer", value: 1 };
+  const ctx = buildContext([head, tail]);
+
+  const result = lineJoinHandler(ctx);
+
+  assert(result.ok);
+  expect(OperandStack.depth(result.value.operandStack)).toBe(1);
+  const top = OperandStack.peek(result.value.operandStack);
+  assert(top.some);
+  expect(top.value).toEqual(head);
+});
+
+test("値域外 integer 3 のとき末尾 1 つだけ pop し、残り operand は保持される", () => {
+  const head: PdfObject = { type: "integer", value: 99 };
+  const tail: PdfObject = { type: "integer", value: 3 };
+  const ctx = buildContext([head, tail]);
+
+  const result = lineJoinHandler(ctx);
+
+  assert(!result.ok);
+  expect(OperandStack.depth(ctx.operandStack)).toBe(1);
+  const top = OperandStack.peek(ctx.operandStack);
+  assert(top.some);
+  expect(top.value).toEqual(head);
+});
+
+test("末尾が name のとき (TYPE_MISMATCH)、末尾 1 つだけ pop し残り operand は保持される", () => {
+  const head: PdfObject = { type: "integer", value: 99 };
+  const tail: PdfObject = { type: "name", value: "Foo" };
+  const ctx = buildContext([head, tail]);
+
+  const result = lineJoinHandler(ctx);
+
+  assert(!result.ok);
+  expect(OperandStack.depth(ctx.operandStack)).toBe(1);
+  const top = OperandStack.peek(ctx.operandStack);
+  assert(top.some);
+  expect(top.value).toEqual(head);
+});
+
+test("lineJoin 更新後も lineWidth/lineCap/miterLimit/ctm は不変", () => {
+  const ctx = buildContext([{ type: "integer", value: 1 }]);
+  const before = GraphicsStateStack.current(ctx.graphicsStateStack);
+
+  const result = lineJoinHandler(ctx);
+
+  assert(result.ok);
+  const after = GraphicsStateStack.current(result.value.graphicsStateStack);
+  expect(after.lineWidth).toBe(before.lineWidth);
+  expect(after.lineCap).toBe(before.lineCap);
+  expect(after.miterLimit).toBe(before.miterLimit);
+  expect(after.ctm).toEqual(before.ctm);
+});

--- a/packages/core/src/content-stream/operators/graphics-state/line-join.ts
+++ b/packages/core/src/content-stream/operators/graphics-state/line-join.ts
@@ -1,0 +1,83 @@
+import type { PdfError } from "../../../pdf/errors/index";
+import { err, ok } from "../../../utils/result/index";
+import {
+  GraphicsState,
+  GraphicsStateStack,
+  LineJoin,
+} from "../../graphics-state/index";
+import { OperandStack } from "../../operand-stack/index";
+import type {
+  OperatorHandler,
+  OperatorHandlerContext,
+} from "../../operator-registry/index";
+
+const OPERATOR_NAME = "j";
+
+/**
+ * PDF §8.4.4 `j` operator (line join style) のハンドラ。
+ * operand stack 末尾の整数 (0=Miter / 1=Round / 2=Bevel) で
+ * current GraphicsState の `lineJoin` を更新する。
+ *
+ * - operand stack が空なら `OPERATOR_OPERAND_MISSING` を返す
+ * - 末尾が integer 以外 (real / name / boolean / array / dictionary / ...) なら
+ *   `OPERATOR_OPERAND_TYPE_MISMATCH` を返す (PDF §8.4.4 は integer 指定のため real も弾く)
+ * - 末尾 integer の値が 0/1/2 以外 (3 / -1 / MAX_SAFE_INTEGER 等) なら
+ *   `OPERATOR_OPERAND_VALUE_OUT_OF_RANGE` を返す (`allowed = LineJoin.allowed`)
+ * - エラー時も operand は pop された状態のまま err を返す
+ *   (operand stack は in-place で 1 つ消費済み)
+ *
+ * @param context - 実行コンテキスト (operand stack / graphics state stack)
+ * @returns 成功なら更新後コンテキスト、失敗なら PdfError
+ */
+export const lineJoinHandler: OperatorHandler = (
+  context: OperatorHandlerContext,
+) => {
+  const popped = OperandStack.pop(context.operandStack);
+  if (!popped.some) {
+    const error: PdfError = {
+      code: "OPERATOR_OPERAND_MISSING",
+      message: `Operator '${OPERATOR_NAME}' requires 1 operand(s), got 0`,
+      operatorName: OPERATOR_NAME,
+      required: 1,
+      actual: 0,
+    };
+    return err(error);
+  }
+
+  const operand = popped.value;
+  if (operand.type !== "integer") {
+    const error: PdfError = {
+      code: "OPERATOR_OPERAND_TYPE_MISMATCH",
+      message: `Operator '${OPERATOR_NAME}' expected integer operand, got ${operand.type}`,
+      operatorName: OPERATOR_NAME,
+      expected: "integer",
+      actual: operand.type,
+    };
+    return err(error);
+  }
+
+  const value = operand.value;
+  if (!LineJoin.isValid(value)) {
+    const error: PdfError = {
+      code: "OPERATOR_OPERAND_VALUE_OUT_OF_RANGE",
+      message: `Operator '${OPERATOR_NAME}' operand value ${value} is out of range, expected one of [${LineJoin.allowed.join(", ")}]`,
+      operatorName: OPERATOR_NAME,
+      allowed: LineJoin.allowed,
+      actual: value,
+    };
+    return err(error);
+  }
+
+  const join = LineJoin.create(value);
+  const current = GraphicsStateStack.current(context.graphicsStateStack);
+  const next = GraphicsState.update(current, { lineJoin: join });
+  const graphicsStateStack = GraphicsStateStack.replaceCurrent(
+    context.graphicsStateStack,
+    next,
+  );
+
+  return ok({
+    operandStack: context.operandStack,
+    graphicsStateStack,
+  });
+};


### PR DESCRIPTION
## 概要

spec-034 (line-join operator) PR。PDF §8.4.4 で定義される `j` operator (line join style) のハンドラを新規追加し、operand 末尾の integer (0=Miter / 1=Round / 2=Bevel) で current `GraphicsState.lineJoin` を更新する。直前 merge された `J` (line-cap, #151) と完全対称な構成 (handler / companion / テスト)。

## 変更の種類

- ✨ 新機能 (New Feature)

## 追加した内容

- `LineJoin` companion に `allowed: readonly [0, 1, 2]` と型ガード `isValid(n: number): n is 0 | 1 | 2` を追加 (additive)
- `lineJoinHandler: OperatorHandler` を `packages/core/src/content-stream/operators/graphics-state/line-join.ts` に新規実装
  - `OPERATOR_NAME = "j"` (lowercase)
  - 3 段検証: pop → integer 型チェック → `LineJoin.isValid` 値域チェック
  - 全パス `Result<T, PdfError>` で返却 (`throw` なし)
  - エラー時も operand stack は in-place で 1 つ消費される
- `line-join.basic.test.ts` (companion) に `allowed` / `isValid` 用 `test.each` を追加
- `line-join.basic.test.ts` (handler) を新規追加 — 成功 / `OPERATOR_OPERAND_MISSING` / `OPERATOR_OPERAND_TYPE_MISMATCH` / `OPERATOR_OPERAND_VALUE_OUT_OF_RANGE` / pop 残存 / 他フィールド不変

## 変更した内容

- `LineJoin` companion: `create` シグネチャは変更なし (additive 拡張)

## システム図

```mermaid
flowchart TD
  Start[lineJoinHandler context] --> Pop[OperandStack.pop]
  Pop -->|none| ErrMissing[OPERATOR_OPERAND_MISSING]
  Pop -->|some| TypeCheck{operand.type === integer?}
  TypeCheck -->|no| ErrType[OPERATOR_OPERAND_TYPE_MISMATCH]
  TypeCheck -->|yes| RangeCheck{LineJoin.isValid value?}
  RangeCheck -->|no| ErrRange[OPERATOR_OPERAND_VALUE_OUT_OF_RANGE]
  RangeCheck -->|yes| Apply[LineJoin.create + GraphicsState.update lineJoin + replaceCurrent]
  Apply --> Success[ok operandStack graphicsStateStack]

  ErrMissing --> ReturnErr[return err PdfError]
  ErrType --> ReturnErr
  ErrRange --> ReturnErr

  style Apply fill:#cfc
  style Success fill:#cfc
```

## 関連 spec / Issue

- spec: `.plugin-workspace/.specs/034-line-join-operator/`
- Closes #152

## テスト

- `pnpm --filter @pdfmod/core test`: **1610 passed** (Test Files 114 passed)
- `pnpm lint` (= `biome check . && oxlint .`): **0 errors** (oxlint 0 warnings/errors, biome 0 fixes)
- `pnpm --filter @pdfmod/core typecheck` (= `tsc --noEmit`): **green**
- Codex レビュー (spec-implement-codex フロー): `review-001.md` で「問題なし」 (1 ラウンドで完了)

## レビューポイント

- `LineCap` (#151) と完全対称な構成にしているため、差分は 1:1 置換 (`J` → `j`、`LineCap` → `LineJoin`、`{ lineCap }` → `{ lineJoin }`、Butt/Round/Projecting Square → Miter/Round/Bevel) であることを確認してほしい
- `LineJoin` companion 拡張は **additive 変更**で、既存 `create` シグネチャ・実装に変更がないこと (`graphics-state.ts` の利用箇所に影響しない) を確認してほしい
- handler の `OperatorRegistry.register` / barrel export は本 PR スコープ外 (line-cap (#151) と同じく後続 issue で集約予定)
- テスト規約観点:
  - flat 構造 (describe 不使用)、colocated (`__tests__/` 不使用)、section コメントなし、companion 一括 import を遵守
  - `LineJoin.allowed.toEqual([0, 1, 2])` は型保証の runtime 再確認に近いが、`LineCap` (#151) のテスト形を 1:1 で踏襲する対称性・回帰検出を優先する方針 (hearing 論点 2 で確定済み)
  - 「他フィールド不変」検証は `lineWidth` / `lineCap` / `miterLimit` / `ctm` の 4 項目を verify (hearing 論点 3 で確定済み)