### PR TITLE
✨ [New Feature]: miter-limit (M) operator handler を実装

### DIFF
--- a/packages/core/src/content-stream/operators/graphics-state/miter-limit.basic.test.ts
+++ b/packages/core/src/content-stream/operators/graphics-state/miter-limit.basic.test.ts
@@ -1,0 +1,163 @@
+import { assert, expect, test } from "vitest";
+import type { PdfObject } from "../../../pdf/types/pdf-types/index";
+import { GraphicsStateStack } from "../../graphics-state/index";
+import { OperandStack } from "../../operand-stack/index";
+import type { OperatorHandlerContext } from "../../operator-registry/index";
+import { miterLimitHandler } from "./miter-limit";
+
+const buildContext = (operands: PdfObject[]): OperatorHandlerContext => {
+  const operandStack = OperandStack.create();
+  for (const operand of operands) {
+    OperandStack.push(operandStack, operand);
+  }
+  const graphicsStateStack = GraphicsStateStack.create();
+  return { operandStack, graphicsStateStack };
+};
+
+test("integer operand 5 で current miterLimit が 5 に更新される", () => {
+  const ctx = buildContext([{ type: "integer", value: 5 }]);
+
+  const result = miterLimitHandler(ctx);
+
+  assert(result.ok);
+  const current = GraphicsStateStack.current(result.value.graphicsStateStack);
+  expect(current.miterLimit).toBe(5);
+});
+
+test("real operand 2.5 で current miterLimit が 2.5 に更新される", () => {
+  const ctx = buildContext([{ type: "real", value: 2.5 }]);
+
+  const result = miterLimitHandler(ctx);
+
+  assert(result.ok);
+  const current = GraphicsStateStack.current(result.value.graphicsStateStack);
+  expect(current.miterLimit).toBe(2.5);
+});
+
+test("real operand 10.0 (PDF default) で current miterLimit が 10.0 に更新される", () => {
+  const ctx = buildContext([{ type: "real", value: 10.0 }]);
+
+  const result = miterLimitHandler(ctx);
+
+  assert(result.ok);
+  const current = GraphicsStateStack.current(result.value.graphicsStateStack);
+  expect(current.miterLimit).toBe(10.0);
+});
+
+test.each([
+  {
+    label: "0",
+    operand: { type: "integer", value: 0 } as PdfObject,
+    expected: 0,
+  },
+  {
+    label: "negative",
+    operand: { type: "real", value: -1.5 } as PdfObject,
+    expected: -1.5,
+  },
+  {
+    label: "NaN",
+    operand: { type: "real", value: Number.NaN } as PdfObject,
+    expected: Number.NaN,
+  },
+  {
+    label: "Infinity",
+    operand: { type: "real", value: Number.POSITIVE_INFINITY } as PdfObject,
+    expected: Number.POSITIVE_INFINITY,
+  },
+])("境界値 $label の operand も handler では検証せずそのまま GraphicsState に格納する", ({
+  operand,
+  expected,
+}) => {
+  const ctx = buildContext([operand]);
+
+  const result = miterLimitHandler(ctx);
+
+  assert(result.ok);
+  const current = GraphicsStateStack.current(result.value.graphicsStateStack);
+  expect(current.miterLimit).toBe(expected);
+});
+
+test("空 operand stack では OPERATOR_OPERAND_MISSING を返す", () => {
+  const ctx = buildContext([]);
+
+  const result = miterLimitHandler(ctx);
+
+  assert(!result.ok);
+  assert(result.error.code === "OPERATOR_OPERAND_MISSING");
+  expect(result.error.operatorName).toBe("M");
+  expect(result.error.required).toBe(1);
+  expect(result.error.actual).toBe(0);
+  expect(result.error.message).toBe(
+    "Operator 'M' requires 1 operand(s), got 0",
+  );
+});
+
+test.each([
+  {
+    type: "name" as const,
+    operand: { type: "name", value: "Foo" } as PdfObject,
+  },
+  {
+    type: "boolean" as const,
+    operand: { type: "boolean", value: true } as PdfObject,
+  },
+])("末尾が $type のとき OPERATOR_OPERAND_TYPE_MISMATCH を返す", ({
+  type,
+  operand,
+}) => {
+  const ctx = buildContext([operand]);
+
+  const result = miterLimitHandler(ctx);
+
+  assert(!result.ok);
+  assert(result.error.code === "OPERATOR_OPERAND_TYPE_MISMATCH");
+  expect(result.error.operatorName).toBe("M");
+  expect(result.error.expected).toBe("number");
+  expect(result.error.actual).toBe(type);
+  expect(result.error.message).toBe(
+    `Operator 'M' expected number operand, got ${type}`,
+  );
+});
+
+test("operand stack に複数要素がある場合、成功時は末尾 1 つだけ pop し残りはそのまま", () => {
+  const head: PdfObject = { type: "integer", value: 99 };
+  const tail: PdfObject = { type: "integer", value: 7 };
+  const ctx = buildContext([head, tail]);
+
+  const result = miterLimitHandler(ctx);
+
+  assert(result.ok);
+  expect(OperandStack.depth(result.value.operandStack)).toBe(1);
+  const top = OperandStack.peek(result.value.operandStack);
+  assert(top.some);
+  expect(top.value).toEqual(head);
+});
+
+test("末尾が name のとき (TYPE_MISMATCH)、末尾 1 つだけ pop し残り operand は保持される", () => {
+  const head: PdfObject = { type: "integer", value: 99 };
+  const tail: PdfObject = { type: "name", value: "Foo" };
+  const ctx = buildContext([head, tail]);
+
+  const result = miterLimitHandler(ctx);
+
+  assert(!result.ok);
+  expect(OperandStack.depth(ctx.operandStack)).toBe(1);
+  const top = OperandStack.peek(ctx.operandStack);
+  assert(top.some);
+  expect(top.value).toEqual(head);
+});
+
+test("miterLimit 更新後も lineWidth/lineCap/lineJoin/ctm は不変", () => {
+  const ctx = buildContext([{ type: "integer", value: 3 }]);
+  const before = GraphicsStateStack.current(ctx.graphicsStateStack);
+
+  const result = miterLimitHandler(ctx);
+
+  assert(result.ok);
+  const after = GraphicsStateStack.current(result.value.graphicsStateStack);
+  expect(after.lineWidth).toBe(before.lineWidth);
+  expect(after.lineCap).toBe(before.lineCap);
+  expect(after.lineJoin).toBe(before.lineJoin);
+  expect(after.ctm).toEqual(before.ctm);
+});

--- a/packages/core/src/content-stream/operators/graphics-state/miter-limit.ts
+++ b/packages/core/src/content-stream/operators/graphics-state/miter-limit.ts
@@ -1,0 +1,62 @@
+import type { PdfError } from "../../../pdf/errors/index";
+import { err, ok } from "../../../utils/result/index";
+import { GraphicsState, GraphicsStateStack } from "../../graphics-state/index";
+import { OperandStack } from "../../operand-stack/index";
+import type {
+  OperatorHandler,
+  OperatorHandlerContext,
+} from "../../operator-registry/index";
+
+const OPERATOR_NAME = "M";
+
+/**
+ * PDF §8.4.4 `M` operator (miter limit) のハンドラ。
+ * operand stack 末尾の数値で current GraphicsState の `miterLimit` を更新する。
+ *
+ * - operand stack が空なら `OPERATOR_OPERAND_MISSING` を返す
+ * - 末尾が integer / real 以外なら `OPERATOR_OPERAND_TYPE_MISMATCH` を返す
+ * - 数値の境界値 (`0` / 負値 / `NaN` / `Infinity`) はそのまま `miterLimit` に格納する
+ *   (PDF §8.4.3.5 の `>0` 制約は本 handler のスコープ外、別 issue で validator 化)
+ *
+ * @param context - 実行コンテキスト (operand stack / graphics state stack)
+ * @returns 成功なら更新後コンテキスト、失敗なら PdfError
+ */
+export const miterLimitHandler: OperatorHandler = (
+  context: OperatorHandlerContext,
+) => {
+  const popped = OperandStack.pop(context.operandStack);
+  if (!popped.some) {
+    const error: PdfError = {
+      code: "OPERATOR_OPERAND_MISSING",
+      message: `Operator '${OPERATOR_NAME}' requires 1 operand(s), got 0`,
+      operatorName: OPERATOR_NAME,
+      required: 1,
+      actual: 0,
+    };
+    return err(error);
+  }
+
+  const operand = popped.value;
+  if (operand.type !== "integer" && operand.type !== "real") {
+    const error: PdfError = {
+      code: "OPERATOR_OPERAND_TYPE_MISMATCH",
+      message: `Operator '${OPERATOR_NAME}' expected number operand, got ${operand.type}`,
+      operatorName: OPERATOR_NAME,
+      expected: "number",
+      actual: operand.type,
+    };
+    return err(error);
+  }
+
+  const current = GraphicsStateStack.current(context.graphicsStateStack);
+  const next = GraphicsState.update(current, { miterLimit: operand.value });
+  const graphicsStateStack = GraphicsStateStack.replaceCurrent(
+    context.graphicsStateStack,
+    next,
+  );
+
+  return ok({
+    operandStack: context.operandStack,
+    graphicsStateStack,
+  });
+};


### PR DESCRIPTION
## 概要

PDF §8.4.4 の `M` operator (miter limit) ハンドラを新規追加する。`line-width.ts` と完全に同形（連続値 1 個 pop パターン）で構築。値域検証 (`>0`) は本 PR のスコープ外（line-width 同方針、別 issue で validator 化）、OperatorRegistry への配線も別 issue。

## 変更の種類

- ✨ 新機能

## 追加した内容

- `packages/core/src/content-stream/operators/graphics-state/miter-limit.ts`
  - `miterLimitHandler: OperatorHandler` を named export
  - `OPERATOR_NAME = "M"`
  - operand stack 末尾の integer / real を pop し `GraphicsState.update(current, { miterLimit })` で更新
  - 返すエラーは `OPERATOR_OPERAND_MISSING` / `OPERATOR_OPERAND_TYPE_MISMATCH` の 2 種のみ
  - `throw` 不使用、すべて `Result<T, PdfError>`
- `packages/core/src/content-stream/operators/graphics-state/miter-limit.basic.test.ts`
  - フラット構造（describe 不使用）、colocated 配置
  - `test.each` でパラメータ化（境界値 4 種 / TYPE_MISMATCH 2 種）
  - 全 9 観点 × 13 ケース pass

## 変更した内容

なし（既存ファイルへの変更なし）

## 削除した内容

なし

## システム図

```mermaid
flowchart TD
    A[miterLimitHandler context] --> B[OperandStack.pop]
    B --> C{popped.some?}
    C -- false --> D["err OPERATOR_OPERAND_MISSING<br/>required=1, actual=0"]
    C -- true --> E{operand.type ∈<br/>integer / real ?}
    E -- false --> F["err OPERATOR_OPERAND_TYPE_MISMATCH<br/>expected=number"]
    E -- true --> G["GraphicsState.update<br/>{ miterLimit: operand.value }"]
    G --> H[GraphicsStateStack.replaceCurrent]
    H --> I["ok { operandStack, graphicsStateStack }"]

    style A fill:#e1f5ff
    style I fill:#d4edda
    style D fill:#f8d7da
    style F fill:#f8d7da
```

> 注: 値域 (`>0` 制約) のチェックは行わない。`0` / 負数 / `NaN` / `Infinity` でも UPDATE 経路を通過し、そのまま `miterLimit` に格納される。

## 関連 spec / Issue

- spec: `.plugin-workspace/.specs/035-miter-limit-operator/`
- Closes #153

## テスト

- `pnpm --filter @pdfmod/core test miter-limit` → 13 tests passed
- `pnpm --filter @pdfmod/core test` → **115 files / 1623 tests passed**（既存テストのリグレッションなし）
- `pnpm --filter @pdfmod/core typecheck` → 型エラーなし
- `pnpm lint` → biome / oxlint 違反なし（pre-existing pnpm-store の symlink warning のみ）
- Codex レビュー (`spec-implement-codex` 経由) → **問題なし** (1 round)

## レビューポイント

- `line-width.ts` との差分が `OPERATOR_NAME` (`"w"` → `"M"`) / 更新フィールド名 (`lineWidth` → `miterLimit`) / JSDoc の §8.4.3.2 → §8.4.3.5 / export 名の 4 点に限定されていること
- 値域検証 (`>0`) を handler に入れていないこと（PDF §8.4.3.5 の制約は別 issue で validator 化する設計判断）
- `MiterLimit` companion object（Brand + create）を新設していないこと（連続値域は categorical 型でないため `feedback_brand_categorical_types` の対象外）
- barrel export / operator dispatcher / register helper への登録がないこと（スコープ厳守）
- テスト副作用観点に「TYPE_MISMATCH 時も末尾 1 つだけ pop」を `line-cap.basic.test.ts` 同形で含めていること