### PR TITLE
✨ [New Feature]: graphics-state operators の barrel と register helper を追加

### DIFF
--- a/packages/core/src/content-stream/operators/graphics-state/index.basic.test.ts
+++ b/packages/core/src/content-stream/operators/graphics-state/index.basic.test.ts
@@ -1,0 +1,15 @@
+import { assert, expect, test } from "vitest";
+import { OperatorRegistry } from "../../operator-registry/index";
+import { registerGraphicsStateOperators } from "./index";
+
+test.each([
+  ["cm"],
+  ["w"],
+  ["J"],
+  ["j"],
+  ["M"],
+])("registerGraphicsStateOperators は %s を登録する", (name) => {
+  const result = registerGraphicsStateOperators(OperatorRegistry.create());
+  assert(result.ok);
+  expect(OperatorRegistry.has(result.value, name)).toBe(true);
+});

--- a/packages/core/src/content-stream/operators/graphics-state/index.error.test.ts
+++ b/packages/core/src/content-stream/operators/graphics-state/index.error.test.ts
@@ -1,0 +1,44 @@
+import { assert, expect, test } from "vitest";
+import { OperatorRegistry } from "../../operator-registry/index";
+import {
+  cmHandler,
+  lineWidthHandler,
+  registerGraphicsStateOperators,
+} from "./index";
+
+test("cm が登録済みなら OPERATOR_ALREADY_REGISTERED の Err を返し operatorName が cm", () => {
+  const seed = OperatorRegistry.register(
+    OperatorRegistry.create(),
+    "cm",
+    cmHandler,
+  );
+  assert(seed.ok);
+
+  const result = registerGraphicsStateOperators(seed.value);
+
+  assert(!result.ok);
+  expect(result.error.code).toBe("OPERATOR_ALREADY_REGISTERED");
+  assert(result.error.code === "OPERATOR_ALREADY_REGISTERED");
+  expect(result.error.operatorName).toBe("cm");
+});
+
+test("cm と w が事前登録済みでも 最初の重複 cm の Err が返る (fail-fast 短絡)", () => {
+  const withCm = OperatorRegistry.register(
+    OperatorRegistry.create(),
+    "cm",
+    cmHandler,
+  );
+  assert(withCm.ok);
+  const withCmAndW = OperatorRegistry.register(
+    withCm.value,
+    "w",
+    lineWidthHandler,
+  );
+  assert(withCmAndW.ok);
+
+  const result = registerGraphicsStateOperators(withCmAndW.value);
+
+  assert(!result.ok);
+  assert(result.error.code === "OPERATOR_ALREADY_REGISTERED");
+  expect(result.error.operatorName).toBe("cm");
+});

--- a/packages/core/src/content-stream/operators/graphics-state/index.integration.test.ts
+++ b/packages/core/src/content-stream/operators/graphics-state/index.integration.test.ts
@@ -1,0 +1,66 @@
+import { assert, expect, test } from "vitest";
+import { ok } from "../../../utils/result/index";
+import {
+  GraphicsState,
+  GraphicsStateStack,
+  Matrix,
+} from "../../graphics-state/index";
+import { ContentStreamInterpreter } from "../../interpreter/index";
+import {
+  type OperatorHandler,
+  OperatorRegistry,
+} from "../../operator-registry/index";
+import { registerGraphicsStateOperators } from "./index";
+
+const encode = (s: string): Uint8Array => new TextEncoder().encode(s);
+
+const qHandler: OperatorHandler = (context) =>
+  ok({
+    ...context,
+    graphicsStateStack: GraphicsStateStack.save(context.graphicsStateStack),
+  });
+
+const QHandler: OperatorHandler = (context) =>
+  ok({
+    ...context,
+    graphicsStateStack: GraphicsStateStack.restore(context.graphicsStateStack),
+  });
+
+test("barrel 経由で `1 0 0 1 100 200 cm 2 w` を実行すると CTM と lineWidth が更新される", () => {
+  const registered = registerGraphicsStateOperators(OperatorRegistry.create());
+  assert(registered.ok);
+
+  const result = ContentStreamInterpreter.execute({
+    data: encode("1 0 0 1 100 200 cm 2 w"),
+    registry: registered.value,
+  });
+
+  assert(result.ok);
+  const current = GraphicsStateStack.current(
+    result.value.context.graphicsStateStack,
+  );
+  expect(current.ctm).toEqual(Matrix.create(1, 0, 0, 1, 100, 200));
+  expect(current.lineWidth).toBe(2);
+});
+
+test("`q 1 0 0 1 100 200 cm 2 w Q` を実行すると save/restore で初期 GraphicsState に戻る", () => {
+  const baseRegistered = registerGraphicsStateOperators(
+    OperatorRegistry.create(),
+  );
+  assert(baseRegistered.ok);
+  const withQ = OperatorRegistry.register(baseRegistered.value, "q", qHandler);
+  assert(withQ.ok);
+  const withQQ = OperatorRegistry.register(withQ.value, "Q", QHandler);
+  assert(withQQ.ok);
+
+  const result = ContentStreamInterpreter.execute({
+    data: encode("q 1 0 0 1 100 200 cm 2 w Q"),
+    registry: withQQ.value,
+  });
+
+  assert(result.ok);
+  const current = GraphicsStateStack.current(
+    result.value.context.graphicsStateStack,
+  );
+  expect(current).toEqual(GraphicsState.create());
+});

--- a/packages/core/src/content-stream/operators/graphics-state/index.integration.test.ts
+++ b/packages/core/src/content-stream/operators/graphics-state/index.integration.test.ts
@@ -20,7 +20,7 @@ const qHandler: OperatorHandler = (context) =>
     graphicsStateStack: GraphicsStateStack.save(context.graphicsStateStack),
   });
 
-const QHandler: OperatorHandler = (context) =>
+const qRestoreHandler: OperatorHandler = (context) =>
   ok({
     ...context,
     graphicsStateStack: GraphicsStateStack.restore(context.graphicsStateStack),
@@ -50,7 +50,7 @@ test("`q 1 0 0 1 100 200 cm 2 w Q` を実行すると save/restore で初期 Gra
   assert(baseRegistered.ok);
   const withQ = OperatorRegistry.register(baseRegistered.value, "q", qHandler);
   assert(withQ.ok);
-  const withQQ = OperatorRegistry.register(withQ.value, "Q", QHandler);
+  const withQQ = OperatorRegistry.register(withQ.value, "Q", qRestoreHandler);
   assert(withQQ.ok);
 
   const result = ContentStreamInterpreter.execute({

--- a/packages/core/src/content-stream/operators/graphics-state/index.ts
+++ b/packages/core/src/content-stream/operators/graphics-state/index.ts
@@ -1,0 +1,45 @@
+import type { PdfError } from "../../../pdf/errors/index";
+import type { Result } from "../../../utils/result/index";
+import { flatMap, ok } from "../../../utils/result/index";
+import type { OperatorHandler } from "../../operator-registry/index";
+import { OperatorRegistry } from "../../operator-registry/index";
+import { cmHandler } from "./cm";
+import { lineCapHandler } from "./line-cap";
+import { lineJoinHandler } from "./line-join";
+import { lineWidthHandler } from "./line-width";
+import { miterLimitHandler } from "./miter-limit";
+
+export { cmHandler } from "./cm";
+export { lineCapHandler } from "./line-cap";
+export { lineJoinHandler } from "./line-join";
+export { lineWidthHandler } from "./line-width";
+export { miterLimitHandler } from "./miter-limit";
+
+const GRAPHICS_STATE_OPERATORS: ReadonlyArray<
+  readonly [string, OperatorHandler]
+> = [
+  ["cm", cmHandler],
+  ["w", lineWidthHandler],
+  ["J", lineCapHandler],
+  ["j", lineJoinHandler],
+  ["M", miterLimitHandler],
+];
+
+/**
+ * Graphics State operator (cm / w / J / j / M) を OperatorRegistry に
+ * 一括登録するヘルパ。
+ *
+ * fail-fast: いずれかの register が Err を返した時点で reduce 内 flatMap が
+ * 短絡し、後続 operator の register は呼ばれない。
+ *
+ * @param registry - 登録元 registry
+ * @returns 全 operator が登録された新しい registry、または重複登録時の PdfError
+ */
+export const registerGraphicsStateOperators = (
+  registry: OperatorRegistry,
+): Result<OperatorRegistry, PdfError> =>
+  GRAPHICS_STATE_OPERATORS.reduce<Result<OperatorRegistry, PdfError>>(
+    (acc, [name, handler]) =>
+      flatMap(acc, (r) => OperatorRegistry.register(r, name, handler)),
+    ok(registry),
+  );


### PR DESCRIPTION
## 概要

spec-037 PR-1。Phase 4-A 締めとして `cm` / `w` / `J` / `j` / `M` の 5 Graphics State operator handler を 1 箇所から import できる barrel を作成し、`OperatorRegistry` に一括登録する `registerGraphicsStateOperators` ヘルパを提供する。後続フェーズ (text / path 等) の登録パターンの雛形となる。

## 変更の種類

✨ New Feature / 🧪 Tests

## 追加した内容

- `packages/core/src/content-stream/operators/graphics-state/index.ts`
  - 5 handler の re-export
  - `registerGraphicsStateOperators(registry) => Result<OperatorRegistry, PdfError>`
  - 実装スタイル: `[name, handler][]` のタプル配列を `reduce` で畳み込み、各周回で `Result.flatMap` を適用 (fail-fast は flatMap の短絡で達成)
- `index.basic.test.ts`: `test.each` で 5 operator の `has` 確認
- `index.error.test.ts`: cm 重複 / cm+w 事前登録時の fail-fast 短絡証明
- `index.integration.test.ts`: barrel + ContentStreamInterpreter 経由で `1 0 0 1 100 200 cm 2 w` / `q ... Q` save/restore を検証

## システム図

```mermaid
flowchart TB
    A["GRAPHICS_STATE_OPERATORS<br/>[cm, w, J, j, M]"] --> B["initial: ok(registry)"]
    B --> C["reduce: cm<br/>flatMap → register"]
    C -->|"Ok"| D["reduce: w"]
    C -->|"Err (重複)"| Z["以降 flatMap 短絡<br/>(fail-fast)"]
    D -->|"Ok"| E["reduce: J"]
    D -->|"Err"| Z
    E -->|"Ok"| F["reduce: j"]
    E -->|"Err"| Z
    F -->|"Ok"| G["reduce: M"]
    F -->|"Err"| Z
    G -->|"Ok"| H["Ok(reg_all)"]
    G -->|"Err"| Z
    Z --> I["最初の Err を返却"]

    style A fill:#e1f5ff
    style H fill:#d4f4dd
    style Z fill:#ffe1e1
```

## 関連 spec / Issue

- spec: `.plugin-workspace/.specs/037-graphics-state-operators-barrel/`
- Refs #155

## テスト

- `pnpm --filter @pdfmod/core test`: **120 files / 1668 tests passed**
- `pnpm --filter @pdfmod/core build`: **success**
- Codex レビュー (spec-implement-codex): **問題なし**

## レビューポイント

- `reduce` + `Result.flatMap` 連鎖による fail-fast 設計が後続の operator カテゴリ barrel の雛形として妥当か
- テストファイル分割: 計画書では `index.test.ts` 単一だったが、プロジェクト命名規則 `{対象名}.{カテゴリ}.test.ts` に合わせ `.basic` / `.error` / `.integration` の 3 ファイルに分割
- 上位 (`operators/index.ts` 等) からの集約 export は **out of scope** (hearing-notes / spec の合意)