### PR TITLE
📝 [Docs]: #185 objects/ 3 兄弟 index.ts に @module を追加

### DIFF
--- a/packages/core/src/objects/index.ts
+++ b/packages/core/src/objects/index.ts
@@ -1,7 +1,18 @@
 /**
- * PDFオブジェクト管理モジュール。
- * LRUキャッシュによるオブジェクトキャッシング機能と、
- * オブジェクトストリーム（ObjStm）からのオブジェクト抽出機能を提供する。
+ * PDF オブジェクト (`PdfObject`) を扱う低レベル変換層。
+ * xref テーブル直下に位置し、上層の `document/pdf-document` から利用される。
+ *
+ * 配下には責務の異なる 3 兄弟モジュールがある:
+ *
+ * | モジュール | 責務 (2 行) |
+ * |---|---|
+ * | `object-parser` | `Uint8Array` + `ByteOffset` から `PdfObject` / `PdfIndirectObject` を 1 個構文解析する低レベルパーサ。xref を参照せず、stream の `/Length` が間接参照の場合だけ `ObjectResolver` コールバックで解決する。 |
+ * | `object-store` | `IndirectRef` を実体 `PdfObject` に解決する高レベル窓口。`XRefTable` のエントリ type を見て inline (type=1) は `object-parser`、ObjStm (type=2) は `object-stream-extractor` に dispatch し、LRU キャッシュと循環参照検出を提供する。 |
+ * | `object-stream-extractor` | オブジェクトストリーム (`/Type /ObjStm`, ISO 32000-1 §7.5.7) の中身から指定 `ObjectNumber` のオブジェクトを切り出すモジュール。辞書検証 (`/First` / `/N` / `/Filter`) → 必要に応じて FlateDecode 展開 → オフセットテーブル (`ObjectStreamHeader`) パース → 単位データの再パース (`ObjectParser.parse`) を担う。 |
+ *
+ * 補助モジュールとして `lru-cache/` を併設し、`object-store` のメモ化に使う。
+ *
+ * @module
  */
 export { LRUCache } from "./lru-cache/index";
 export type { ObjectResolver } from "./object-parser/index";

--- a/packages/core/src/objects/object-parser/index.ts
+++ b/packages/core/src/objects/object-parser/index.ts
@@ -1,3 +1,10 @@
+/**
+ * `Uint8Array` と `ByteOffset` を入力に、`PdfObject` / `PdfIndirectObject` を 1 個構文解析する低レベルパーサ。
+ * xref を参照せず、stream の `/Length` が間接参照の場合だけ `ObjectResolver` コールバックで解決する (それ以外の間接参照は `PdfIndirectRef` のまま呼び出し側へ返す)。
+ *
+ * @module
+ */
+
 import { NumberEx } from "../../ext/number/index";
 import { Tokenizer } from "../../lexer/tokenizer/index";
 import type { PdfError, PdfParseError } from "../../pdf/errors/index";

--- a/packages/core/src/objects/object-store/index.ts
+++ b/packages/core/src/objects/object-store/index.ts
@@ -1,3 +1,10 @@
+/**
+ * `IndirectRef` を実体 `PdfObject` に解決する高レベル窓口。
+ * `XRefTable` のエントリ type を見て inline (type=1) は `object-parser`、ObjStm (type=2) は `object-stream-extractor` に dispatch し、LRU キャッシュと循環参照検出を提供する。
+ *
+ * @module
+ */
+
 import type { PdfError } from "../../pdf/errors/index";
 import { GenerationNumber } from "../../pdf/types/generation-number/index";
 import type { ObjectNumber } from "../../pdf/types/object-number/index";

--- a/packages/core/src/objects/object-stream-extractor/index.ts
+++ b/packages/core/src/objects/object-stream-extractor/index.ts
@@ -1,3 +1,10 @@
+/**
+ * オブジェクトストリーム (`/Type /ObjStm`, ISO 32000-1 §7.5.7) の中身から指定 `ObjectNumber` のオブジェクトを切り出すモジュール。
+ * 辞書検証 (`/First` / `/N` / `/Filter`) → 必要に応じて FlateDecode 展開 → オフセットテーブル (`ObjectStreamHeader`) パース → 単位データの再パース (`ObjectParser.parse`) を担う。
+ *
+ * @module
+ */
+
 export { ObjectStreamBody } from "./body/index";
 export type { ObjectStreamHeaderEntry } from "./header/index";
 export { ObjectStreamHeader } from "./header/index";


### PR DESCRIPTION
## 概要

spec-043（Issue #185）。`packages/core/src/objects/` 配下 4 つの `index.ts` に TSDoc `@module` 付き docstring を追加し、名前が似ていて初見では責務が判別しづらい 3 兄弟 (`object-parser` / `object-store` / `object-stream-extractor`) の責務分担と dispatch 関係を明文化する。runtime 挙動・型シグネチャ・export 構成は不変（docs only）。

## 変更の種類

- 📝 [Doc]

## 変更した内容

- `packages/core/src/objects/index.ts`: 既存 5 行の docstring を `@module` 化し、3 兄弟の責務マップ（2 行）を表形式で追記
- `packages/core/src/objects/object-parser/index.ts`: 冒頭に `@module` 付き 2 行 docstring を追加（pure parser、stream `/Length` の indirect ref 解決時のみ `ObjectResolver` を呼ぶ旨）
- `packages/core/src/objects/object-store/index.ts`: 冒頭に `@module` 付き 2 行 docstring を追加（`ObjectStore` クラスの既存 docstring は維持）
- `packages/core/src/objects/object-stream-extractor/index.ts`: 冒頭に `@module` 付き 2 行 docstring を追加（ISO 32000-1 §7.5.7 に基づく `/ObjStm` 抽出責務）

## システム図

3 兄弟の責務分担と dispatch 関係（本 PR で docstring 化した内容）:

```mermaid
flowchart TD
    Doc["document/pdf-document<br/>(PdfDocument.load 等)"]
    Store["objects/object-store<br/>IndirectRef → PdfObject 解決窓口<br/>LRU + 循環参照検出 + in-flight 排他"]
    Parser["objects/object-parser<br/>Uint8Array+ByteOffset → PdfObject<br/>(pure parser, xref 非依存)"]
    Extractor["objects/object-stream-extractor<br/>/Type /ObjStm の中身を抽出<br/>(辞書検証 → FlateDecode → header parse)"]

    Doc -- "IndirectRef" --> Store
    Store -- "type=1 inline<br/>readInlineEntry" --> Parser
    Store -- "type=2 compressed<br/>readObjectStreamEntry" --> Extractor
    Extractor -- "抽出した単位データを<br/>ObjectParser.parse に再投入" --> Parser

    style Doc fill:#eef
    style Store fill:#fef
    style Parser fill:#efe
    style Extractor fill:#ffe
```

ポイント（docstring に明記した内容）:

- `object-store` だけが 2 兄弟（parser / stream-extractor）を統合する**窓口**
- `object-stream-extractor` は内部で `object-parser` を再帰的に呼ぶが、`object-store` を介さない
- `object-parser` は xref を一切知らない **pure parser**

## 関連 spec / Issue

- spec: `.plugin-workspace/.specs/043-objects-trio-docstring/`
- Closes #185

## テスト

docs only のため新規テストなし。既存テスト・ビルド・lint がすべて green であることを確認:

- `pnpm --filter @pdfmod/core build`: ✅ green
  - `dist/objects/index.d.ts` / `object-parser/index.d.ts` / `object-store/index.d.ts` / `object-stream-extractor/index.d.ts` の 4 ファイル全てに `@module` が転写済み
- `pnpm --filter @pdfmod/core test`: ✅ green（120 files / 1668 tests pass）
- `pnpm lint` (biome + oxlint): ✅ green（0 errors）
- TSDoc 配置確認:
  - 4 ファイルそれぞれで `@module` の出現がちょうど 1 回（`grep -c '@module'` で確認）
  - `@packageDocumentation` は `packages/core/src/index.ts` のみ（タグ意味の二重宣言なし）

### Codex レビュー結果

`spec-implement` 経由で Codex CLI レビューを 1 回実施し「**問題なし**」（`.plugin-workspace/.specs/043-objects-trio-docstring/code-review/review-001.md`）。

## レビューポイント

- TSDoc タグ選定: サブモジュールには `@packageDocumentation` ではなく TypeDoc の `@module` を採用している（理由は implementation-plan §4 のとおり、`packages/core/src/index.ts` 既存の `@packageDocumentation` との二重宣言回避）
- `object-store/index.ts` の **モジュール docstring** と **`ObjectStore` クラス docstring** は別ブロックとして両立させており、既存クラス docstring は変更していない
- 4 ファイルでトーン・粒度を統一（2 行責務記述）

## チェックリスト

- [x] テスト変更なし（docs only）
- [x] テスト配置ルール影響なし
- [x] throw を使わず Result/Option で表現（コード変更なし、適用外）
- [x] `T | undefined` ではなく `Option<T>`（コード変更なし、適用外）
- [x] `pnpm --filter @pdfmod/core test` / build / `pnpm lint` がすべて green
- [x] spec の implementation-plan.md / tasks.md と整合
- [x] テスト保留 spec ではない
- [x] fixture / skeleton PR ではない
- [x] Codex レビュー完了（問題なし）
- [x] セルフレビュー実施
- [x] 破壊的変更なし