### PR TITLE
✨ [New Feature]: #166 GraphicsState に currentPath フィールドを追加

### DIFF
--- a/packages/core/src/content-stream/graphics-state/graphics-state/__tests__/graphics-state.basic.test.ts
+++ b/packages/core/src/content-stream/graphics-state/graphics-state/__tests__/graphics-state.basic.test.ts
@@ -1,5 +1,12 @@
 import { expect, test } from "vitest";
-import { GraphicsState, LineCap, LineJoin, Matrix } from "../../index";
+import {
+  CurrentPath,
+  GraphicsState,
+  LineCap,
+  LineJoin,
+  Matrix,
+} from "../../index";
+import { PathSegment } from "../../path-segment";
 
 test("createはPDF仕様準拠のデフォルト値を返す", () => {
   const state = GraphicsState.create();
@@ -9,6 +16,7 @@ test("createはPDF仕様準拠のデフォルト値を返す", () => {
     lineCap: LineCap.create(0),
     lineJoin: LineJoin.create(0),
     miterLimit: 10.0,
+    currentPath: CurrentPath.empty(),
   });
 });
 
@@ -25,6 +33,7 @@ test("updateは未指定フィールドを保持する", () => {
   expect(updated.lineCap).toBe(state.lineCap);
   expect(updated.lineJoin).toBe(state.lineJoin);
   expect(updated.miterLimit).toBe(state.miterLimit);
+  expect(updated.currentPath).toBe(state.currentPath);
 });
 
 test("updateは元のstateを変更しない", () => {
@@ -45,21 +54,58 @@ test.each([
   ["lineJoin", { lineJoin: LineJoin.create(2) }],
   ["miterLimit", { miterLimit: 5.0 }],
   ["ctm", { ctm: Matrix.create(2, 0, 0, 2, 0, 0) }],
+  [
+    "currentPath",
+    {
+      currentPath: CurrentPath.append(
+        CurrentPath.empty(),
+        PathSegment.moveTo(1, 2),
+      ),
+    },
+  ],
 ] as const)("update(state, %s) は該当フィールドだけ書き換える", (_label, partial) => {
   const state = GraphicsState.create();
   const updated = GraphicsState.update(state, partial);
   expect(updated).toEqual({ ...state, ...partial });
 });
 
+test("update({ currentPath }) は currentPath を書き換える", () => {
+  const state = GraphicsState.create();
+  const newPath = CurrentPath.append(
+    CurrentPath.empty(),
+    PathSegment.moveTo(10, 20),
+  );
+  const updated = GraphicsState.update(state, { currentPath: newPath });
+  expect(updated.currentPath).toBe(newPath);
+});
+
+test("update は currentPath 未指定で既存値を保持する", () => {
+  const initial = GraphicsState.update(GraphicsState.create(), {
+    currentPath: CurrentPath.append(
+      CurrentPath.empty(),
+      PathSegment.moveTo(1, 2),
+    ),
+  });
+  const updated = GraphicsState.update(initial, { lineWidth: 3.0 });
+  expect(updated.currentPath).toBe(initial.currentPath);
+});
+
 test("updateはundefinedの明示指定で既存フィールドを壊さない", () => {
+  const path = CurrentPath.append(
+    CurrentPath.empty(),
+    PathSegment.moveTo(1, 2),
+  );
   const state = GraphicsState.update(GraphicsState.create(), {
     lineWidth: 2.0,
     miterLimit: 5.0,
+    currentPath: path,
   });
   const updated = GraphicsState.update(state, {
     lineWidth: undefined,
     miterLimit: undefined,
+    currentPath: undefined,
   });
   expect(updated.lineWidth).toBe(2.0);
   expect(updated.miterLimit).toBe(5.0);
+  expect(updated.currentPath).toBe(path);
 });

--- a/packages/core/src/content-stream/graphics-state/graphics-state/index.ts
+++ b/packages/core/src/content-stream/graphics-state/graphics-state/index.ts
@@ -1,10 +1,8 @@
 import type { Brand } from "../../../utils/brand/index";
-import type { LineCap } from "../line-cap";
-import { LineCap as LineCapFactory } from "../line-cap";
-import type { LineJoin } from "../line-join";
-import { LineJoin as LineJoinFactory } from "../line-join";
-import type { Matrix } from "../matrix";
-import { Matrix as MatrixFactory } from "../matrix";
+import { CurrentPath } from "../current-path";
+import { LineCap } from "../line-cap";
+import { LineJoin } from "../line-join";
+import { Matrix } from "../matrix";
 
 declare const GraphicsStateBrand: unique symbol;
 
@@ -14,6 +12,7 @@ type GraphicsStateFields = {
   readonly lineCap: LineCap;
   readonly lineJoin: LineJoin;
   readonly miterLimit: number;
+  readonly currentPath: CurrentPath;
 };
 
 /**
@@ -30,21 +29,23 @@ type GraphicsStatePartial = Partial<GraphicsStateFields>;
 export const GraphicsState = {
   /**
    * PDF 仕様 §4.1 デフォルト値で GraphicsState を生成する。
-   *   ctm        = identity
-   *   lineWidth  = 1.0
-   *   lineCap    = 0 (Butt)
-   *   lineJoin   = 0 (Miter)
-   *   miterLimit = 10.0
+   *   ctm         = identity
+   *   lineWidth   = 1.0
+   *   lineCap     = 0 (Butt)
+   *   lineJoin    = 0 (Miter)
+   *   miterLimit  = 10.0
+   *   currentPath = empty()
    *
    * @returns デフォルト値で初期化された GraphicsState
    */
   create(): GraphicsState {
     return {
-      ctm: MatrixFactory.identity(),
+      ctm: Matrix.identity(),
       lineWidth: 1.0,
-      lineCap: LineCapFactory.create(0),
-      lineJoin: LineJoinFactory.create(0),
+      lineCap: LineCap.create(0),
+      lineJoin: LineJoin.create(0),
       miterLimit: 10.0,
+      currentPath: CurrentPath.empty(),
     } as unknown as GraphicsState;
   },
 
@@ -68,6 +69,10 @@ export const GraphicsState = {
         partial.miterLimit !== undefined
           ? partial.miterLimit
           : state.miterLimit,
+      currentPath:
+        partial.currentPath !== undefined
+          ? partial.currentPath
+          : state.currentPath,
     } as unknown as GraphicsState;
   },
 } as const;

--- a/packages/core/src/content-stream/graphics-state/index.ts
+++ b/packages/core/src/content-stream/graphics-state/index.ts
@@ -1,3 +1,4 @@
+export { CurrentPath } from "./current-path";
 export { GraphicsState } from "./graphics-state";
 export { LineCap } from "./line-cap";
 export { LineJoin } from "./line-join";


### PR DESCRIPTION
## 概要

spec-046 / Issue #166。`GraphicsState` Brand 型に `readonly currentPath: CurrentPath` を加え、後続の path construction operator handler (#167-#174) が `GraphicsState.update(state, { currentPath })` で path を更新できる土台を整える。

## 変更の種類

- ✨ 新機能（GraphicsState に currentPath フィールドを追加）
- 🧪 テスト（currentPath まわりの単体テストを追加）
- ♻️ リファクタリング（既存 `LineCap` / `LineJoin` / `Matrix` の import を Companion Object パターンの 1 行 import に統一）

## 追加した内容

- `GraphicsStateFields` に `readonly currentPath: CurrentPath` を追加
- `GraphicsState.create()` のデフォルトに `currentPath: CurrentPath.empty()` を設定
- `GraphicsState.update()` に `currentPath` の shallow merge を追加（`undefined` 明示時は既存値を保持）
- `graphics-state/index.ts` (barrel) に `CurrentPath` を export 追加
- テスト 3 件を新規追加 + 既存テスト 3 件に `currentPath` のアサーションを統合（合計 14 テスト）

## 変更した内容

- `LineCap` / `LineJoin` / `Matrix` の `import type X` + `import { X as XFactory }` の 2 行 import を `import { X }` の 1 行に統一し、`XxxFactory.create()` / `MatrixFactory.identity()` を `Xxx.create()` / `Matrix.identity()` に書き換え

## システム図

```mermaid
flowchart TD
    A[GraphicsState.create] --> B[ctm = identity<br/>lineWidth = 1.0<br/>lineCap = 0<br/>lineJoin = 0<br/>miterLimit = 10.0<br/>currentPath = empty NEW]
    B --> C[GraphicsState.update<br/>state, partial]
    C --> D{shallow merge<br/>5 既存 + 1 新規}
    D --> E[GraphicsState updated<br/>別インスタンス]

    style B fill:#e0f2fe,stroke:#0284c7
```

後続 Issue #167-#174 の handler 利用イメージ:

```mermaid
flowchart LR
    H[path operator<br/>m / l / c / re / h] --> S[GraphicsStateStack.current]
    S --> P[CurrentPath.append<br/>current.currentPath, segment]
    P --> U[GraphicsState.update<br/>current, { currentPath: newPath }] 
    U --> R[GraphicsStateStack.replaceCurrent]

    style U fill:#e0f2fe,stroke:#0284c7
```

## 関連 spec / Issue

- spec: `.plugin-workspace/.specs/046-graphics-state-current-path/`
- Closes #166
- 後続: #167-#174 (path construction operator handler)

## 既知の意味論ギャップ（スコープ外）

ISO 32000-1:2008 §8.5.1.1 では current path は GraphicsState parameter table に含まれず、`q`/`Q` で save/restore されない。本 Issue では Epic #163 の方針に従い `GraphicsState` のフィールドとして配置するため、現状の `GraphicsStateStack.save/restore` は currentPath まで含めて保存・復元する形になる。これは Epic 全体での設計判断であり、本 PR のスコープ外（`q`/`Q` handler 実装または Phase 4-C 以降でフォローアップ Issue 化）。

## テスト

- `pnpm --filter @pdfmod/core test`: ✅ 1713 tests passed (122 files)
- `pnpm --filter @pdfmod/core typecheck`: ✅ 成功
- `pnpm --filter @pdfmod/core build`: ✅ 成功
- Codex レビュー: 1 回目で「問題なし」（`.plugin-workspace/.specs/046-graphics-state-current-path/code-review/review-001.md`）
- 既存 operator handler (cm / w / J / j / M) のテストにリグレッションなし

## レビューポイント

- `update()` の shallow merge が既存パターン (`partial.X !== undefined ? partial.X : state.X`) を踏襲しており、`undefined` 明示時に既存値を保持する仕様になっていること
- `LineCap` / `LineJoin` / `Matrix` の import 統一が `feedback_companion_object_import.md` ルールに準拠していること
- barrel `graphics-state/index.ts` への `CurrentPath` export 追加が public API (`packages/core/src/index.ts`) には届かないこと（後続 Issue のスコープ）