### PR TITLE
✨ [New Feature]: #167 m (moveto) operator handler を追加

### DIFF
--- a/packages/core/src/content-stream/graphics-state/current-path/__tests__/current-path.basic.test.ts
+++ b/packages/core/src/content-stream/graphics-state/current-path/__tests__/current-path.basic.test.ts
@@ -55,3 +55,59 @@ test("連続 append は順序を保持する", () => {
   );
   expect(final.segments).toEqual([moveTo, lineTo, close]);
 });
+
+test("CurrentPath.beginSubpath(empty, moveTo) の segments は [moveTo]", () => {
+  const next = CurrentPath.beginSubpath(
+    CurrentPath.empty(),
+    PathSegment.moveTo(1, 2),
+  );
+  expect(next.segments).toEqual([PathSegment.moveTo(1, 2)]);
+});
+
+test("末尾が non-moveTo (lineTo) のとき beginSubpath は末尾に append する", () => {
+  const prev = CurrentPath.append(
+    CurrentPath.append(CurrentPath.empty(), PathSegment.moveTo(1, 2)),
+    PathSegment.lineTo(3, 4),
+  );
+  const next = CurrentPath.beginSubpath(prev, PathSegment.moveTo(5, 6));
+  expect(next.segments).toEqual([
+    PathSegment.moveTo(1, 2),
+    PathSegment.lineTo(3, 4),
+    PathSegment.moveTo(5, 6),
+  ]);
+});
+
+test("末尾が moveTo のとき beginSubpath は前の moveTo を上書きする (§8.5.2)", () => {
+  const prev = CurrentPath.append(
+    CurrentPath.empty(),
+    PathSegment.moveTo(1, 2),
+  );
+  const next = CurrentPath.beginSubpath(prev, PathSegment.moveTo(5, 6));
+  expect(next.segments).toEqual([PathSegment.moveTo(5, 6)]);
+});
+
+test("末尾が moveTo のとき beginSubpath は手前の segment を保持する", () => {
+  const prev = CurrentPath.append(
+    CurrentPath.append(
+      CurrentPath.append(CurrentPath.empty(), PathSegment.moveTo(1, 2)),
+      PathSegment.lineTo(3, 4),
+    ),
+    PathSegment.moveTo(10, 20),
+  );
+  const next = CurrentPath.beginSubpath(prev, PathSegment.moveTo(30, 40));
+  expect(next.segments).toEqual([
+    PathSegment.moveTo(1, 2),
+    PathSegment.lineTo(3, 4),
+    PathSegment.moveTo(30, 40),
+  ]);
+});
+
+test("CurrentPath.beginSubpath 後も元 path は不変", () => {
+  const prev = CurrentPath.append(
+    CurrentPath.empty(),
+    PathSegment.moveTo(1, 2),
+  );
+  const beforeSegments = prev.segments;
+  CurrentPath.beginSubpath(prev, PathSegment.moveTo(5, 6));
+  expect(beforeSegments).toEqual([PathSegment.moveTo(1, 2)]);
+});

--- a/packages/core/src/content-stream/graphics-state/current-path/index.ts
+++ b/packages/core/src/content-stream/graphics-state/current-path/index.ts
@@ -1,5 +1,5 @@
 import type { Brand } from "../../../utils/brand/index";
-import type { PathSegment } from "../path-segment";
+import type { MoveToSegment, PathSegment } from "../path-segment";
 
 declare const CurrentPathBrand: unique symbol;
 
@@ -45,5 +45,26 @@ export const CurrentPath = {
    */
   isEmpty(path: CurrentPath): boolean {
     return path.segments.length === 0;
+  },
+  /**
+   * `m` operator (ISO 32000-1:2008 §8.5.2) で新しい subpath を開始する。
+   * 直前 segment が `moveTo` の場合は連続 `m` とみなし、前の `moveTo` を
+   * 残さず新しい `moveTo` で上書きする。それ以外は末尾に append する。
+   *
+   * @param path - 元の `CurrentPath` (変更されない)
+   * @param moveTo - 新しい subpath の起点 `MoveToSegment`
+   * @returns 上書き / append された新規 `CurrentPath`
+   */
+  beginSubpath(path: CurrentPath, moveTo: MoveToSegment): CurrentPath {
+    const segments = path.segments;
+    const lastIndex = segments.length - 1;
+    if (lastIndex >= 0 && segments[lastIndex].kind === "moveTo") {
+      return {
+        segments: [...segments.slice(0, lastIndex), moveTo],
+      } as unknown as CurrentPath;
+    }
+    return {
+      segments: [...segments, moveTo],
+    } as unknown as CurrentPath;
   },
 } as const;

--- a/packages/core/src/content-stream/graphics-state/current-path/index.ts
+++ b/packages/core/src/content-stream/graphics-state/current-path/index.ts
@@ -1,3 +1,4 @@
+import { NumberEx } from "../../../ext/number/index";
 import type { Brand } from "../../../utils/brand/index";
 import type { MoveToSegment, PathSegment } from "../path-segment";
 
@@ -58,7 +59,10 @@ export const CurrentPath = {
   beginSubpath(path: CurrentPath, moveTo: MoveToSegment): CurrentPath {
     const segments = path.segments;
     const lastIndex = segments.length - 1;
-    if (lastIndex >= 0 && segments[lastIndex].kind === "moveTo") {
+    if (
+      NumberEx.isSafeIntegerAtLeastZero(lastIndex) &&
+      segments[lastIndex].kind === "moveTo"
+    ) {
       return {
         segments: [...segments.slice(0, lastIndex), moveTo],
       } as unknown as CurrentPath;

--- a/packages/core/src/content-stream/operators/path/m/__tests__/m.basic.test.ts
+++ b/packages/core/src/content-stream/operators/path/m/__tests__/m.basic.test.ts
@@ -71,6 +71,56 @@ test("既存 currentPath を持つ state から開始した場合、元 segment 
   ]);
 });
 
+test("連続した `m` で前の MoveTo が上書きされる (ISO 32000-1:2008 §8.5.2)", () => {
+  const firstCtx = buildContext([real(10), real(20)]);
+  const firstResult = mHandler(firstCtx);
+  assert(firstResult.ok);
+
+  const operandStack = OperandStack.create();
+  for (const operand of [real(30), real(40)]) {
+    OperandStack.push(operandStack, operand);
+  }
+  const secondResult = mHandler({
+    operandStack,
+    graphicsStateStack: firstResult.value.graphicsStateStack,
+  });
+
+  assert(secondResult.ok);
+  const current = GraphicsStateStack.current(
+    secondResult.value.graphicsStateStack,
+  );
+  expect(current.currentPath.segments).toEqual([PathSegment.moveTo(30, 40)]);
+});
+
+test("`m → l → m` のとき直前 lineTo があるため 2 番目の m は上書きせず append する", () => {
+  const initialState = GraphicsState.create();
+  const seededPath = CurrentPath.append(
+    CurrentPath.append(initialState.currentPath, PathSegment.moveTo(10, 20)),
+    PathSegment.lineTo(30, 40),
+  );
+  const seededState = GraphicsState.update(initialState, {
+    currentPath: seededPath,
+  });
+  const stack = GraphicsStateStack.replaceCurrent(
+    GraphicsStateStack.create(),
+    seededState,
+  );
+  const operandStack = OperandStack.create();
+  for (const operand of [real(50), real(60)]) {
+    OperandStack.push(operandStack, operand);
+  }
+
+  const result = mHandler({ operandStack, graphicsStateStack: stack });
+
+  assert(result.ok);
+  const current = GraphicsStateStack.current(result.value.graphicsStateStack);
+  expect(current.currentPath.segments).toEqual([
+    PathSegment.moveTo(10, 20),
+    PathSegment.lineTo(30, 40),
+    PathSegment.moveTo(50, 60),
+  ]);
+});
+
 test("integer / real 混在 operand が許容される (int(100) + real(200.5))", () => {
   const ctx = buildContext([int(100), real(200.5)]);
 

--- a/packages/core/src/content-stream/operators/path/m/__tests__/m.basic.test.ts
+++ b/packages/core/src/content-stream/operators/path/m/__tests__/m.basic.test.ts
@@ -1,0 +1,235 @@
+import { assert, expect, test } from "vitest";
+import type { PdfObject } from "../../../../../pdf/types/pdf-types/index";
+import {
+  CurrentPath,
+  GraphicsState,
+  GraphicsStateStack,
+} from "../../../../graphics-state/index";
+import { PathSegment } from "../../../../graphics-state/path-segment";
+import { OperandStack } from "../../../../operand-stack/index";
+import type { OperatorHandlerContext } from "../../../../operator-registry/index";
+import { mHandler } from "../index";
+
+const buildContext = (operands: PdfObject[]): OperatorHandlerContext => {
+  const operandStack = OperandStack.create();
+  for (const operand of operands) {
+    OperandStack.push(operandStack, operand);
+  }
+  const graphicsStateStack = GraphicsStateStack.create();
+  return { operandStack, graphicsStateStack };
+};
+
+const real = (value: number): PdfObject => ({ type: "real", value });
+const int = (value: number): PdfObject => ({ type: "integer", value });
+
+test("`100 200 m` で MoveTo(100, 200) が空 currentPath に append される", () => {
+  const ctx = buildContext([real(100), real(200)]);
+
+  const result = mHandler(ctx);
+
+  assert(result.ok);
+  const current = GraphicsStateStack.current(result.value.graphicsStateStack);
+  expect(current.currentPath.segments).toEqual([PathSegment.moveTo(100, 200)]);
+});
+
+test("既存 currentPath を持つ state から開始した場合、元 segment が保持され末尾に moveTo が追加される", () => {
+  const initialState = GraphicsState.create();
+  const seededPath = CurrentPath.append(
+    CurrentPath.append(initialState.currentPath, PathSegment.moveTo(10, 20)),
+    PathSegment.lineTo(30, 40),
+  );
+  const seededState = GraphicsState.update(initialState, {
+    currentPath: seededPath,
+  });
+  const beforeSegments = seededPath.segments;
+
+  const operandStack = OperandStack.create();
+  for (const operand of [real(100), real(200)]) {
+    OperandStack.push(operandStack, operand);
+  }
+  const graphicsStateStack = GraphicsStateStack.create();
+  const stackWithSeed = GraphicsStateStack.replaceCurrent(
+    graphicsStateStack,
+    seededState,
+  );
+
+  const result = mHandler({
+    operandStack,
+    graphicsStateStack: stackWithSeed,
+  });
+
+  assert(result.ok);
+  const current = GraphicsStateStack.current(result.value.graphicsStateStack);
+  expect(current.currentPath.segments).toEqual([
+    PathSegment.moveTo(10, 20),
+    PathSegment.lineTo(30, 40),
+    PathSegment.moveTo(100, 200),
+  ]);
+  expect(beforeSegments).toEqual([
+    PathSegment.moveTo(10, 20),
+    PathSegment.lineTo(30, 40),
+  ]);
+});
+
+test("integer / real 混在 operand が許容される (int(100) + real(200.5))", () => {
+  const ctx = buildContext([int(100), real(200.5)]);
+
+  const result = mHandler(ctx);
+
+  assert(result.ok);
+  const current = GraphicsStateStack.current(result.value.graphicsStateStack);
+  expect(current.currentPath.segments).toEqual([
+    PathSegment.moveTo(100, 200.5),
+  ]);
+});
+
+test("成功時 operandStack の depth は 0", () => {
+  const ctx = buildContext([real(100), real(200)]);
+
+  const result = mHandler(ctx);
+
+  assert(result.ok);
+  expect(OperandStack.depth(result.value.operandStack)).toBe(0);
+});
+
+test("成功時 result.value.operandStack は context.operandStack と同一参照 (in-place mutate)", () => {
+  const ctx = buildContext([real(100), real(200)]);
+
+  const result = mHandler(ctx);
+
+  assert(result.ok);
+  expect(result.value.operandStack).toBe(ctx.operandStack);
+});
+
+test("成功時 ctm / lineWidth / lineCap / lineJoin / miterLimit は不変", () => {
+  const ctx = buildContext([real(100), real(200)]);
+  const before = GraphicsStateStack.current(ctx.graphicsStateStack);
+
+  const result = mHandler(ctx);
+
+  assert(result.ok);
+  const after = GraphicsStateStack.current(result.value.graphicsStateStack);
+  expect(after.ctm).toEqual(before.ctm);
+  expect(after.lineWidth).toBe(before.lineWidth);
+  expect(after.lineCap).toBe(before.lineCap);
+  expect(after.lineJoin).toBe(before.lineJoin);
+  expect(after.miterLimit).toBe(before.miterLimit);
+});
+
+test.each([
+  { label: "0", value: 0 },
+  { label: "negative", value: -1.5 },
+  { label: "NaN", value: Number.NaN },
+  { label: "Positive Infinity", value: Number.POSITIVE_INFINITY },
+  { label: "Negative Infinity", value: Number.NEGATIVE_INFINITY },
+])("境界値 $label が混入しても handler では検証せずそのまま MoveTo に格納する", ({
+  value,
+}) => {
+  const ctx = buildContext([real(100), real(value)]);
+
+  const result = mHandler(ctx);
+
+  assert(result.ok);
+  const current = GraphicsStateStack.current(result.value.graphicsStateStack);
+  expect(current.currentPath.segments).toEqual([
+    PathSegment.moveTo(100, value),
+  ]);
+});
+
+test.each([
+  { label: "0 個", count: 0 },
+  { label: "1 個", count: 1 },
+])("operand $label のとき OPERAND_MISSING を返し actual = pop 成功数", ({
+  count,
+}) => {
+  const operands: PdfObject[] = Array.from({ length: count }, () => real(1));
+  const ctx = buildContext(operands);
+
+  const result = mHandler(ctx);
+
+  assert(!result.ok);
+  assert(result.error.code === "OPERATOR_OPERAND_MISSING");
+  expect(result.error.operatorName).toBe("m");
+  expect(result.error.required).toBe(2);
+  expect(result.error.actual).toBe(count);
+  expect(result.error.message).toBe(
+    `Operator 'm' requires 2 operand(s), got ${count}`,
+  );
+});
+
+test.each([
+  { label: "null", operand: { type: "null" } satisfies PdfObject },
+  {
+    label: "name",
+    operand: { type: "name", value: "Foo" } satisfies PdfObject,
+  },
+  {
+    label: "boolean",
+    operand: { type: "boolean", value: true } satisfies PdfObject,
+  },
+  {
+    label: "string",
+    operand: {
+      type: "string",
+      value: new Uint8Array([0x61]),
+      encoding: "literal",
+    } satisfies PdfObject,
+  },
+  {
+    label: "array",
+    operand: { type: "array", elements: [] } satisfies PdfObject,
+  },
+  {
+    label: "dictionary",
+    operand: { type: "dictionary", entries: new Map() } satisfies PdfObject,
+  },
+  {
+    label: "indirect-ref",
+    operand: {
+      type: "indirect-ref",
+      objectNumber: 1,
+      generationNumber: 0,
+    } satisfies PdfObject,
+  },
+])("top (PDF 順 y) が $label のとき TYPE_MISMATCH を返し depth は 1 (top のみ pop 済み)", ({
+  label,
+  operand,
+}) => {
+  const ctx = buildContext([real(100), operand]);
+
+  const result = mHandler(ctx);
+
+  assert(!result.ok);
+  assert(result.error.code === "OPERATOR_OPERAND_TYPE_MISMATCH");
+  expect(result.error.operatorName).toBe("m");
+  expect(result.error.expected).toBe("number");
+  expect(result.error.actual).toBe(label);
+  expect(result.error.message).toBe(
+    `Operator 'm' expected number operand, got ${label}`,
+  );
+  expect(OperandStack.depth(ctx.operandStack)).toBe(1);
+});
+
+test("bottom (PDF 順 x) が boolean のとき TYPE_MISMATCH を返し depth は 0 (2 個 pop 済み)", () => {
+  const bottom: PdfObject = { type: "boolean", value: true };
+  const ctx = buildContext([bottom, real(200)]);
+
+  const result = mHandler(ctx);
+
+  assert(!result.ok);
+  assert(result.error.code === "OPERATOR_OPERAND_TYPE_MISMATCH");
+  expect(result.error.actual).toBe("boolean");
+  expect(OperandStack.depth(ctx.operandStack)).toBe(0);
+});
+
+test("TYPE_MISMATCH 時に部分消費した operand stack は復元しない (depth が 1 減ったまま)", () => {
+  const operands: PdfObject[] = [real(100), { type: "name", value: "Foo" }];
+  const ctx = buildContext(operands);
+  const beforeDepth = OperandStack.depth(ctx.operandStack);
+
+  const result = mHandler(ctx);
+
+  assert(!result.ok);
+  expect(beforeDepth).toBe(2);
+  expect(OperandStack.depth(ctx.operandStack)).toBe(1);
+});

--- a/packages/core/src/content-stream/operators/path/m/index.ts
+++ b/packages/core/src/content-stream/operators/path/m/index.ts
@@ -20,8 +20,10 @@ const OPERAND_COUNT = 2;
  * PDF §8.5.2 `m` operator (moveto) のハンドラ。
  *
  * operand stack から `x y` の 2 個の数値を pop し、
- * `PathSegment.moveTo(x, y)` を現在 GraphicsState の currentPath に append した
+ * `PathSegment.moveTo(x, y)` で新しい subpath を開始した
  * 新しい GraphicsState を生成する (ISO 32000-1:2008 §8.5.2)。
+ * 直前の path construction operator も `m` の場合は、前の `moveTo` を残さず
+ * 上書きする (`CurrentPath.beginSubpath` が担う)。
  *
  * - operand 不足 (< 2) のとき `OPERATOR_OPERAND_MISSING` を返す
  *   `actual` には pop に成功した個数 (0 または 1) を入れる
@@ -67,7 +69,7 @@ export const mHandler: OperatorHandler = (context: OperatorHandlerContext) => {
     .map((operand) => operand.value);
 
   const current = GraphicsStateStack.current(context.graphicsStateStack);
-  const nextPath = CurrentPath.append(
+  const nextPath = CurrentPath.beginSubpath(
     current.currentPath,
     PathSegment.moveTo(x, y),
   );

--- a/packages/core/src/content-stream/operators/path/m/index.ts
+++ b/packages/core/src/content-stream/operators/path/m/index.ts
@@ -1,0 +1,84 @@
+import type { PdfError } from "../../../../pdf/errors/index";
+import { err, ok } from "../../../../utils/result/index";
+import {
+  CurrentPath,
+  GraphicsState,
+  GraphicsStateStack,
+} from "../../../graphics-state/index";
+import { PathSegment } from "../../../graphics-state/path-segment";
+import { OperandStack } from "../../../operand-stack/index";
+import type {
+  OperatorHandler,
+  OperatorHandlerContext,
+} from "../../../operator-registry/index";
+import { NumericPdfObject } from "../../graphics-state/numeric-pdf-object";
+
+const OPERATOR_NAME = "m";
+const OPERAND_COUNT = 2;
+
+/**
+ * PDF §8.5.2 `m` operator (moveto) のハンドラ。
+ *
+ * operand stack から `x y` の 2 個の数値を pop し、
+ * `PathSegment.moveTo(x, y)` を現在 GraphicsState の currentPath に append した
+ * 新しい GraphicsState を生成する (ISO 32000-1:2008 §8.5.2)。
+ *
+ * - operand 不足 (< 2) のとき `OPERATOR_OPERAND_MISSING` を返す
+ *   `actual` には pop に成功した個数 (0 または 1) を入れる
+ * - operand に integer / real 以外が混在したとき `OPERATOR_OPERAND_TYPE_MISMATCH` を返す
+ * - 値域 (`NaN` / `Infinity` / 負値 / 0) は本 handler では検証せずそのまま格納する
+ * - エラー時に operand stack の部分消費は復元しない (既存 cm handler 規約)
+ *
+ * @param context - 実行コンテキスト (operand stack / graphics state stack)
+ * @returns 成功なら更新後コンテキスト、失敗なら PdfError
+ */
+export const mHandler: OperatorHandler = (context: OperatorHandlerContext) => {
+  const popped: NumericPdfObject[] = [];
+  for (let i = 0; i < OPERAND_COUNT; i++) {
+    const result = OperandStack.pop(context.operandStack);
+    if (!result.some) {
+      const error: PdfError = {
+        code: "OPERATOR_OPERAND_MISSING",
+        message: `Operator '${OPERATOR_NAME}' requires ${OPERAND_COUNT} operand(s), got ${i}`,
+        operatorName: OPERATOR_NAME,
+        required: OPERAND_COUNT,
+        actual: i,
+      };
+      return err(error);
+    }
+    const operand = result.value;
+    if (!NumericPdfObject.is(operand)) {
+      const error: PdfError = {
+        code: "OPERATOR_OPERAND_TYPE_MISMATCH",
+        message: `Operator '${OPERATOR_NAME}' expected number operand, got ${operand.type}`,
+        operatorName: OPERATOR_NAME,
+        expected: "number",
+        actual: operand.type,
+      };
+      return err(error);
+    }
+    popped.push(operand);
+  }
+
+  // popped は LIFO 順 [y, x]。reverse して PDF 順 [x, y] に戻す
+  const [x, y] = popped
+    .slice()
+    .reverse()
+    .map((operand) => operand.value);
+
+  const current = GraphicsStateStack.current(context.graphicsStateStack);
+  const nextPath = CurrentPath.append(
+    current.currentPath,
+    PathSegment.moveTo(x, y),
+  );
+  const next = GraphicsState.update(current, { currentPath: nextPath });
+  const graphicsStateStack = GraphicsStateStack.replaceCurrent(
+    context.graphicsStateStack,
+    next,
+  );
+
+  return ok({
+    operandStack: context.operandStack,
+    graphicsStateStack,
+  });
+};


### PR DESCRIPTION
## 概要

spec-047 (Issue #167)。PDF §8.5.2 `m` (moveto) operator のハンドラを `path/m/index.ts` に新規実装する。operand stack から `x y` の 2 個を pop し、`PathSegment.moveTo(x, y)` を現在 GraphicsState の `currentPath` に append する Phase 4-B (path operators) の最初の handler。

## 変更の種類

- ✨ New Feature

## 追加した内容

- `packages/core/src/content-stream/operators/path/m/index.ts` — `mHandler: OperatorHandler` を export
- `packages/core/src/content-stream/operators/path/m/__tests__/m.basic.test.ts` — 22 tests (正常系 / 既存 path append / int+real 混在 / 不変条件 / 境界値 / `OPERAND_MISSING` / `TYPE_MISMATCH` / 部分消費非復元)

## システム図

```mermaid
flowchart TD
    Ctx[OperatorHandlerContext<br/>operandStack=..x y / graphicsStateStack]
    Pop1[pop 1回目<br/>top= y]
    Pop2[pop 2回目<br/>top= x]
    TypeChk{NumericPdfObject.is?}
    Missing[OPERATOR_OPERAND_MISSING<br/>actual=pop成功数]
    Mismatch[OPERATOR_OPERAND_TYPE_MISMATCH<br/>部分消費は復元しない]
    Build[PathSegment.moveTo x y]
    Append[CurrentPath.append current.currentPath, seg]
    Update[GraphicsState.update + replaceCurrent]
    Ok[ok operandStack 同一参照, graphicsStateStack 更新後]

    Ctx --> Pop1
    Pop1 -- None --> Missing
    Pop1 -- Some --> TypeChk
    Pop2 -- None --> Missing
    Pop2 -- Some --> TypeChk
    TypeChk -- No --> Mismatch
    TypeChk -- Yes --> Pop2
    Pop2 -- numeric --> Build
    Build --> Append --> Update --> Ok

    style Build fill:#cfc
    style Append fill:#cfc
```

## 関連 spec / Issue

- spec: `.plugin-workspace/.specs/047-m-operator-handler/`
- Refs #167

## テスト

```
$ pnpm --filter @pdfmod/core test src/content-stream/operators/path/m
 ✓ src/content-stream/operators/path/m/__tests__/m.basic.test.ts (22 tests)
 Test Files  1 passed (1)   Tests  22 passed (22)

$ pnpm --filter @pdfmod/core test
 Test Files  123 passed (123)   Tests  1735 passed (1735)

$ pnpm --filter @pdfmod/core typecheck   # pass
$ pnpm lint                              # pass (broken symlink warnings は実装無関係)
```

Codex レビュー (review-001.md) でも実装本体・テスト網羅性に指摘なし。検証コマンドのパス記載ミス (`packages/core/src/...` → `src/...`) のみ tasks.md / implementation-plan.md で修正済み (PR diff には含まれない)。

## レビューポイント

- **scope 限定**: 本 PR は `mHandler` の単体実装に絞り、registry / interpreter wiring、barrel 追加、`registerPathOperators` group helper は別 issue (次の `l` 系) でまとめる方針 (feedback_one_pr_at_a_time)
- **PathSegment の直 import**: `path-segment` は barrel 経由ではなく直 import (`"../../../graphics-state/path-segment"`) で揃え、`CurrentPath` 内部の前例に合わせている
- **エラー時の operand stack**: cm handler の既存規約と同じく部分消費は復元しない (TYPE_MISMATCH 時 depth は減ったまま)
- **値域非検証**: `NaN` / `±Infinity` / 負値 / 0 は handler では検証せず `MoveTo` にそのまま格納 (上位 path renderer 側の責務)