### PR TITLE
✨ [New Feature]: #168 l (lineto) operator handler を追加

### DIFF
--- a/packages/core/src/content-stream/operators/path/l/__tests__/l.basic.test.ts
+++ b/packages/core/src/content-stream/operators/path/l/__tests__/l.basic.test.ts
@@ -8,6 +8,7 @@ import {
 import { PathSegment } from "../../../../graphics-state/path-segment";
 import { OperandStack } from "../../../../operand-stack/index";
 import type { OperatorHandlerContext } from "../../../../operator-registry/index";
+import { mHandler } from "../../m/index";
 import { lHandler } from "../index";
 
 const buildContext = (operands: PdfObject[]): OperatorHandlerContext => {
@@ -96,25 +97,19 @@ test("既存 currentPath を持つ state から開始した場合、元 segment 
   ]);
 });
 
-test("`m(10,20)` 実行後 `l(30,40)` を実行すると [MoveTo, LineTo] になる", () => {
-  const initialState = GraphicsState.create();
-  const seededPath = CurrentPath.append(
-    initialState.currentPath,
-    PathSegment.moveTo(10, 20),
-  );
-  const seededState = GraphicsState.update(initialState, {
-    currentPath: seededPath,
-  });
-  const stack = GraphicsStateStack.replaceCurrent(
-    GraphicsStateStack.create(),
-    seededState,
-  );
+test("`mHandler(10,20)` 実行後 `lHandler(30,40)` を実行すると [MoveTo, LineTo] になる", () => {
+  const mCtx = buildContext([real(10), real(20)]);
+  const mResult = mHandler(mCtx);
+  assert(mResult.ok);
+
   const operandStack = OperandStack.create();
   for (const operand of [real(30), real(40)]) {
     OperandStack.push(operandStack, operand);
   }
-
-  const result = lHandler({ operandStack, graphicsStateStack: stack });
+  const result = lHandler({
+    operandStack,
+    graphicsStateStack: mResult.value.graphicsStateStack,
+  });
 
   assert(result.ok);
   const current = GraphicsStateStack.current(result.value.graphicsStateStack);

--- a/packages/core/src/content-stream/operators/path/l/__tests__/l.basic.test.ts
+++ b/packages/core/src/content-stream/operators/path/l/__tests__/l.basic.test.ts
@@ -19,17 +19,42 @@ const buildContext = (operands: PdfObject[]): OperatorHandlerContext => {
   return { operandStack, graphicsStateStack };
 };
 
+const buildContextWithCurrentPoint = (
+  operands: PdfObject[],
+): OperatorHandlerContext => {
+  const operandStack = OperandStack.create();
+  for (const operand of operands) {
+    OperandStack.push(operandStack, operand);
+  }
+  const initialState = GraphicsState.create();
+  const seededPath = CurrentPath.append(
+    initialState.currentPath,
+    PathSegment.moveTo(0, 0),
+  );
+  const seededState = GraphicsState.update(initialState, {
+    currentPath: seededPath,
+  });
+  const graphicsStateStack = GraphicsStateStack.replaceCurrent(
+    GraphicsStateStack.create(),
+    seededState,
+  );
+  return { operandStack, graphicsStateStack };
+};
+
 const real = (value: number): PdfObject => ({ type: "real", value });
 const int = (value: number): PdfObject => ({ type: "integer", value });
 
-test("`100 200 l` で LineTo(100, 200) が空 currentPath に append される", () => {
-  const ctx = buildContext([real(100), real(200)]);
+test("`100 200 l` で LineTo(100, 200) が current point 確立済み path に append される", () => {
+  const ctx = buildContextWithCurrentPoint([real(100), real(200)]);
 
   const result = lHandler(ctx);
 
   assert(result.ok);
   const current = GraphicsStateStack.current(result.value.graphicsStateStack);
-  expect(current.currentPath.segments).toEqual([PathSegment.lineTo(100, 200)]);
+  expect(current.currentPath.segments).toEqual([
+    PathSegment.moveTo(0, 0),
+    PathSegment.lineTo(100, 200),
+  ]);
 });
 
 test("既存 currentPath を持つ state から開始した場合、元 segment が保持され末尾に lineTo が追加される", () => {
@@ -100,7 +125,7 @@ test("`m(10,20)` 実行後 `l(30,40)` を実行すると [MoveTo, LineTo] にな
 });
 
 test("連続 `l → l` で 2 つの LineTo が append され、前 LineTo は上書きされない", () => {
-  const firstCtx = buildContext([real(10), real(20)]);
+  const firstCtx = buildContextWithCurrentPoint([real(10), real(20)]);
   const firstResult = lHandler(firstCtx);
   assert(firstResult.ok);
 
@@ -118,23 +143,27 @@ test("連続 `l → l` で 2 つの LineTo が append され、前 LineTo は上
     secondResult.value.graphicsStateStack,
   );
   expect(current.currentPath.segments).toEqual([
+    PathSegment.moveTo(0, 0),
     PathSegment.lineTo(10, 20),
     PathSegment.lineTo(30, 40),
   ]);
 });
 
 test("integer / real 混在 operand が許容される (int(10) + real(20.5))", () => {
-  const ctx = buildContext([int(10), real(20.5)]);
+  const ctx = buildContextWithCurrentPoint([int(10), real(20.5)]);
 
   const result = lHandler(ctx);
 
   assert(result.ok);
   const current = GraphicsStateStack.current(result.value.graphicsStateStack);
-  expect(current.currentPath.segments).toEqual([PathSegment.lineTo(10, 20.5)]);
+  expect(current.currentPath.segments).toEqual([
+    PathSegment.moveTo(0, 0),
+    PathSegment.lineTo(10, 20.5),
+  ]);
 });
 
 test("成功時 operandStack の depth は 0", () => {
-  const ctx = buildContext([real(100), real(200)]);
+  const ctx = buildContextWithCurrentPoint([real(100), real(200)]);
 
   const result = lHandler(ctx);
 
@@ -143,7 +172,7 @@ test("成功時 operandStack の depth は 0", () => {
 });
 
 test("成功時 result.value.operandStack は context.operandStack と同一参照 (in-place mutate)", () => {
-  const ctx = buildContext([real(100), real(200)]);
+  const ctx = buildContextWithCurrentPoint([real(100), real(200)]);
 
   const result = lHandler(ctx);
 
@@ -152,7 +181,7 @@ test("成功時 result.value.operandStack は context.operandStack と同一参�
 });
 
 test("成功時 ctm / lineWidth / lineCap / lineJoin / miterLimit は不変", () => {
-  const ctx = buildContext([real(100), real(200)]);
+  const ctx = buildContextWithCurrentPoint([real(100), real(200)]);
   const before = GraphicsStateStack.current(ctx.graphicsStateStack);
 
   const result = lHandler(ctx);
@@ -175,13 +204,14 @@ test.each([
 ])("境界値 $label が混入しても handler では検証せずそのまま LineTo に格納する", ({
   value,
 }) => {
-  const ctx = buildContext([real(100), real(value)]);
+  const ctx = buildContextWithCurrentPoint([real(100), real(value)]);
 
   const result = lHandler(ctx);
 
   assert(result.ok);
   const current = GraphicsStateStack.current(result.value.graphicsStateStack);
   expect(current.currentPath.segments).toEqual([
+    PathSegment.moveTo(0, 0),
     PathSegment.lineTo(100, value),
   ]);
 });
@@ -290,4 +320,29 @@ test("TYPE_MISMATCH 時に部分消費した operand stack は復元しない (d
   assert(!result.ok);
   expect(beforeDepth).toBe(2);
   expect(OperandStack.depth(ctx.operandStack)).toBe(1);
+});
+
+test("current point 未確立 (currentPath が空) のとき NO_CURRENT_POINT を返し path に append しない", () => {
+  const ctx = buildContext([real(100), real(200)]);
+
+  const result = lHandler(ctx);
+
+  assert(!result.ok);
+  assert(result.error.code === "OPERATOR_PATH_NO_CURRENT_POINT");
+  expect(result.error.operatorName).toBe("l");
+  expect(result.error.message).toBe(
+    "Operator 'l' requires a current point established by a prior 'm' or 're'",
+  );
+  const current = GraphicsStateStack.current(ctx.graphicsStateStack);
+  expect(current.currentPath.segments).toEqual([]);
+});
+
+test("NO_CURRENT_POINT 時に operand stack は (TYPE_MISMATCH と同様) 復元しない", () => {
+  const ctx = buildContext([real(100), real(200)]);
+
+  const result = lHandler(ctx);
+
+  assert(!result.ok);
+  assert(result.error.code === "OPERATOR_PATH_NO_CURRENT_POINT");
+  expect(OperandStack.depth(ctx.operandStack)).toBe(0);
 });

--- a/packages/core/src/content-stream/operators/path/l/__tests__/l.basic.test.ts
+++ b/packages/core/src/content-stream/operators/path/l/__tests__/l.basic.test.ts
@@ -1,0 +1,293 @@
+import { assert, expect, test } from "vitest";
+import type { PdfObject } from "../../../../../pdf/types/pdf-types/index";
+import {
+  CurrentPath,
+  GraphicsState,
+  GraphicsStateStack,
+} from "../../../../graphics-state/index";
+import { PathSegment } from "../../../../graphics-state/path-segment";
+import { OperandStack } from "../../../../operand-stack/index";
+import type { OperatorHandlerContext } from "../../../../operator-registry/index";
+import { lHandler } from "../index";
+
+const buildContext = (operands: PdfObject[]): OperatorHandlerContext => {
+  const operandStack = OperandStack.create();
+  for (const operand of operands) {
+    OperandStack.push(operandStack, operand);
+  }
+  const graphicsStateStack = GraphicsStateStack.create();
+  return { operandStack, graphicsStateStack };
+};
+
+const real = (value: number): PdfObject => ({ type: "real", value });
+const int = (value: number): PdfObject => ({ type: "integer", value });
+
+test("`100 200 l` で LineTo(100, 200) が空 currentPath に append される", () => {
+  const ctx = buildContext([real(100), real(200)]);
+
+  const result = lHandler(ctx);
+
+  assert(result.ok);
+  const current = GraphicsStateStack.current(result.value.graphicsStateStack);
+  expect(current.currentPath.segments).toEqual([PathSegment.lineTo(100, 200)]);
+});
+
+test("既存 currentPath を持つ state から開始した場合、元 segment が保持され末尾に lineTo が追加される", () => {
+  const initialState = GraphicsState.create();
+  const seededPath = CurrentPath.append(
+    CurrentPath.append(initialState.currentPath, PathSegment.moveTo(10, 20)),
+    PathSegment.lineTo(30, 40),
+  );
+  const seededState = GraphicsState.update(initialState, {
+    currentPath: seededPath,
+  });
+  const beforeSegments = seededPath.segments;
+
+  const operandStack = OperandStack.create();
+  for (const operand of [real(100), real(200)]) {
+    OperandStack.push(operandStack, operand);
+  }
+  const graphicsStateStack = GraphicsStateStack.create();
+  const stackWithSeed = GraphicsStateStack.replaceCurrent(
+    graphicsStateStack,
+    seededState,
+  );
+
+  const result = lHandler({
+    operandStack,
+    graphicsStateStack: stackWithSeed,
+  });
+
+  assert(result.ok);
+  const current = GraphicsStateStack.current(result.value.graphicsStateStack);
+  expect(current.currentPath.segments).toEqual([
+    PathSegment.moveTo(10, 20),
+    PathSegment.lineTo(30, 40),
+    PathSegment.lineTo(100, 200),
+  ]);
+  expect(beforeSegments).toEqual([
+    PathSegment.moveTo(10, 20),
+    PathSegment.lineTo(30, 40),
+  ]);
+});
+
+test("`m(10,20)` 実行後 `l(30,40)` を実行すると [MoveTo, LineTo] になる", () => {
+  const initialState = GraphicsState.create();
+  const seededPath = CurrentPath.append(
+    initialState.currentPath,
+    PathSegment.moveTo(10, 20),
+  );
+  const seededState = GraphicsState.update(initialState, {
+    currentPath: seededPath,
+  });
+  const stack = GraphicsStateStack.replaceCurrent(
+    GraphicsStateStack.create(),
+    seededState,
+  );
+  const operandStack = OperandStack.create();
+  for (const operand of [real(30), real(40)]) {
+    OperandStack.push(operandStack, operand);
+  }
+
+  const result = lHandler({ operandStack, graphicsStateStack: stack });
+
+  assert(result.ok);
+  const current = GraphicsStateStack.current(result.value.graphicsStateStack);
+  expect(current.currentPath.segments).toEqual([
+    PathSegment.moveTo(10, 20),
+    PathSegment.lineTo(30, 40),
+  ]);
+});
+
+test("連続 `l → l` で 2 つの LineTo が append され、前 LineTo は上書きされない", () => {
+  const firstCtx = buildContext([real(10), real(20)]);
+  const firstResult = lHandler(firstCtx);
+  assert(firstResult.ok);
+
+  const operandStack = OperandStack.create();
+  for (const operand of [real(30), real(40)]) {
+    OperandStack.push(operandStack, operand);
+  }
+  const secondResult = lHandler({
+    operandStack,
+    graphicsStateStack: firstResult.value.graphicsStateStack,
+  });
+
+  assert(secondResult.ok);
+  const current = GraphicsStateStack.current(
+    secondResult.value.graphicsStateStack,
+  );
+  expect(current.currentPath.segments).toEqual([
+    PathSegment.lineTo(10, 20),
+    PathSegment.lineTo(30, 40),
+  ]);
+});
+
+test("integer / real 混在 operand が許容される (int(10) + real(20.5))", () => {
+  const ctx = buildContext([int(10), real(20.5)]);
+
+  const result = lHandler(ctx);
+
+  assert(result.ok);
+  const current = GraphicsStateStack.current(result.value.graphicsStateStack);
+  expect(current.currentPath.segments).toEqual([PathSegment.lineTo(10, 20.5)]);
+});
+
+test("成功時 operandStack の depth は 0", () => {
+  const ctx = buildContext([real(100), real(200)]);
+
+  const result = lHandler(ctx);
+
+  assert(result.ok);
+  expect(OperandStack.depth(result.value.operandStack)).toBe(0);
+});
+
+test("成功時 result.value.operandStack は context.operandStack と同一参照 (in-place mutate)", () => {
+  const ctx = buildContext([real(100), real(200)]);
+
+  const result = lHandler(ctx);
+
+  assert(result.ok);
+  expect(result.value.operandStack).toBe(ctx.operandStack);
+});
+
+test("成功時 ctm / lineWidth / lineCap / lineJoin / miterLimit は不変", () => {
+  const ctx = buildContext([real(100), real(200)]);
+  const before = GraphicsStateStack.current(ctx.graphicsStateStack);
+
+  const result = lHandler(ctx);
+
+  assert(result.ok);
+  const after = GraphicsStateStack.current(result.value.graphicsStateStack);
+  expect(after.ctm).toEqual(before.ctm);
+  expect(after.lineWidth).toBe(before.lineWidth);
+  expect(after.lineCap).toBe(before.lineCap);
+  expect(after.lineJoin).toBe(before.lineJoin);
+  expect(after.miterLimit).toBe(before.miterLimit);
+});
+
+test.each([
+  { label: "0", value: 0 },
+  { label: "negative", value: -1.5 },
+  { label: "NaN", value: Number.NaN },
+  { label: "Positive Infinity", value: Number.POSITIVE_INFINITY },
+  { label: "Negative Infinity", value: Number.NEGATIVE_INFINITY },
+])("境界値 $label が混入しても handler では検証せずそのまま LineTo に格納する", ({
+  value,
+}) => {
+  const ctx = buildContext([real(100), real(value)]);
+
+  const result = lHandler(ctx);
+
+  assert(result.ok);
+  const current = GraphicsStateStack.current(result.value.graphicsStateStack);
+  expect(current.currentPath.segments).toEqual([
+    PathSegment.lineTo(100, value),
+  ]);
+});
+
+test.each([
+  { label: "0 個", count: 0 },
+  { label: "1 個", count: 1 },
+])("operand $label のとき OPERAND_MISSING を返し actual = pop 成功数", ({
+  count,
+}) => {
+  const operands: PdfObject[] = Array.from({ length: count }, () => real(1));
+  const ctx = buildContext(operands);
+
+  const result = lHandler(ctx);
+
+  assert(!result.ok);
+  assert(result.error.code === "OPERATOR_OPERAND_MISSING");
+  expect(result.error.operatorName).toBe("l");
+  expect(result.error.required).toBe(2);
+  expect(result.error.actual).toBe(count);
+  expect(result.error.message).toBe(
+    `Operator 'l' requires 2 operand(s), got ${count}`,
+  );
+});
+
+test.each([
+  { label: "null", operand: { type: "null" } satisfies PdfObject },
+  {
+    label: "name",
+    operand: { type: "name", value: "Foo" } satisfies PdfObject,
+  },
+  {
+    label: "boolean",
+    operand: { type: "boolean", value: true } satisfies PdfObject,
+  },
+  {
+    label: "string",
+    operand: {
+      type: "string",
+      value: new Uint8Array([0x61]),
+      encoding: "literal",
+    } satisfies PdfObject,
+  },
+  {
+    label: "array",
+    operand: { type: "array", elements: [] } satisfies PdfObject,
+  },
+  {
+    label: "dictionary",
+    operand: { type: "dictionary", entries: new Map() } satisfies PdfObject,
+  },
+  {
+    label: "indirect-ref",
+    operand: {
+      type: "indirect-ref",
+      objectNumber: 1,
+      generationNumber: 0,
+    } satisfies PdfObject,
+  },
+  {
+    label: "stream",
+    operand: {
+      type: "stream",
+      dictionary: { type: "dictionary", entries: new Map() },
+      data: new Uint8Array(),
+    } satisfies PdfObject,
+  },
+])("top (PDF 順 y) が $label のとき TYPE_MISMATCH を返し depth は 1 (top のみ pop 済み)", ({
+  label,
+  operand,
+}) => {
+  const ctx = buildContext([real(100), operand]);
+
+  const result = lHandler(ctx);
+
+  assert(!result.ok);
+  assert(result.error.code === "OPERATOR_OPERAND_TYPE_MISMATCH");
+  expect(result.error.operatorName).toBe("l");
+  expect(result.error.expected).toBe("number");
+  expect(result.error.actual).toBe(label);
+  expect(result.error.message).toBe(
+    `Operator 'l' expected number operand, got ${label}`,
+  );
+  expect(OperandStack.depth(ctx.operandStack)).toBe(1);
+});
+
+test("bottom (PDF 順 x) が boolean のとき TYPE_MISMATCH を返し depth は 0 (2 個 pop 済み)", () => {
+  const bottom: PdfObject = { type: "boolean", value: true };
+  const ctx = buildContext([bottom, real(200)]);
+
+  const result = lHandler(ctx);
+
+  assert(!result.ok);
+  assert(result.error.code === "OPERATOR_OPERAND_TYPE_MISMATCH");
+  expect(result.error.actual).toBe("boolean");
+  expect(OperandStack.depth(ctx.operandStack)).toBe(0);
+});
+
+test("TYPE_MISMATCH 時に部分消費した operand stack は復元しない (depth が 1 減ったまま)", () => {
+  const operands: PdfObject[] = [real(100), { type: "name", value: "Foo" }];
+  const ctx = buildContext(operands);
+  const beforeDepth = OperandStack.depth(ctx.operandStack);
+
+  const result = lHandler(ctx);
+
+  assert(!result.ok);
+  expect(beforeDepth).toBe(2);
+  expect(OperandStack.depth(ctx.operandStack)).toBe(1);
+});

--- a/packages/core/src/content-stream/operators/path/l/index.ts
+++ b/packages/core/src/content-stream/operators/path/l/index.ts
@@ -27,6 +27,8 @@ const OPERAND_COUNT = 2;
  * - operand 不足 (< 2) のとき `OPERATOR_OPERAND_MISSING` を返す
  *   `actual` には pop に成功した個数 (0 または 1) を入れる
  * - operand に integer / real 以外が混在したとき `OPERATOR_OPERAND_TYPE_MISMATCH` を返す
+ * - current point が未確立 (先行する `m` / `re` がない / `currentPath` が空) の場合
+ *   `OPERATOR_PATH_NO_CURRENT_POINT` を返す (§8.5.2: `l` は current point から線分を引く)
  * - 値域 (`NaN` / `Infinity` / 負値 / 0) は本 handler では検証せずそのまま格納する
  * - エラー時に operand stack の部分消費は復元しない (既存 cm / m handler 規約)
  *
@@ -68,6 +70,14 @@ export const lHandler: OperatorHandler = (context: OperatorHandlerContext) => {
     .map((operand) => operand.value);
 
   const current = GraphicsStateStack.current(context.graphicsStateStack);
+  if (CurrentPath.isEmpty(current.currentPath)) {
+    const error: PdfError = {
+      code: "OPERATOR_PATH_NO_CURRENT_POINT",
+      message: `Operator '${OPERATOR_NAME}' requires a current point established by a prior 'm' or 're'`,
+      operatorName: OPERATOR_NAME,
+    };
+    return err(error);
+  }
   const nextPath = CurrentPath.append(
     current.currentPath,
     PathSegment.lineTo(x, y),

--- a/packages/core/src/content-stream/operators/path/l/index.ts
+++ b/packages/core/src/content-stream/operators/path/l/index.ts
@@ -1,0 +1,85 @@
+import type { PdfError } from "../../../../pdf/errors/index";
+import { err, ok } from "../../../../utils/result/index";
+import {
+  CurrentPath,
+  GraphicsState,
+  GraphicsStateStack,
+} from "../../../graphics-state/index";
+import { PathSegment } from "../../../graphics-state/path-segment";
+import { OperandStack } from "../../../operand-stack/index";
+import type {
+  OperatorHandler,
+  OperatorHandlerContext,
+} from "../../../operator-registry/index";
+import { NumericPdfObject } from "../../graphics-state/numeric-pdf-object";
+
+const OPERATOR_NAME = "l";
+const OPERAND_COUNT = 2;
+
+/**
+ * PDF §8.5.2 `l` operator (lineto) のハンドラ。
+ *
+ * operand stack から `x y` の 2 個の数値を pop し、
+ * `PathSegment.lineTo(x, y)` を current path の末尾に append した
+ * 新しい GraphicsState を生成する (ISO 32000-1:2008 §8.5.2)。
+ * `m` と異なり、直前 segment の種類によらず常に append する。
+ *
+ * - operand 不足 (< 2) のとき `OPERATOR_OPERAND_MISSING` を返す
+ *   `actual` には pop に成功した個数 (0 または 1) を入れる
+ * - operand に integer / real 以外が混在したとき `OPERATOR_OPERAND_TYPE_MISMATCH` を返す
+ * - 値域 (`NaN` / `Infinity` / 負値 / 0) は本 handler では検証せずそのまま格納する
+ * - エラー時に operand stack の部分消費は復元しない (既存 cm / m handler 規約)
+ *
+ * @param context - 実行コンテキスト (operand stack / graphics state stack)
+ * @returns 成功なら更新後コンテキスト、失敗なら PdfError
+ */
+export const lHandler: OperatorHandler = (context: OperatorHandlerContext) => {
+  const popped: NumericPdfObject[] = [];
+  for (let i = 0; i < OPERAND_COUNT; i++) {
+    const result = OperandStack.pop(context.operandStack);
+    if (!result.some) {
+      const error: PdfError = {
+        code: "OPERATOR_OPERAND_MISSING",
+        message: `Operator '${OPERATOR_NAME}' requires ${OPERAND_COUNT} operand(s), got ${i}`,
+        operatorName: OPERATOR_NAME,
+        required: OPERAND_COUNT,
+        actual: i,
+      };
+      return err(error);
+    }
+    const operand = result.value;
+    if (!NumericPdfObject.is(operand)) {
+      const error: PdfError = {
+        code: "OPERATOR_OPERAND_TYPE_MISMATCH",
+        message: `Operator '${OPERATOR_NAME}' expected number operand, got ${operand.type}`,
+        operatorName: OPERATOR_NAME,
+        expected: "number",
+        actual: operand.type,
+      };
+      return err(error);
+    }
+    popped.push(operand);
+  }
+
+  // popped は LIFO 順 [y, x]。reverse して PDF 順 [x, y] に戻す
+  const [x, y] = popped
+    .slice()
+    .reverse()
+    .map((operand) => operand.value);
+
+  const current = GraphicsStateStack.current(context.graphicsStateStack);
+  const nextPath = CurrentPath.append(
+    current.currentPath,
+    PathSegment.lineTo(x, y),
+  );
+  const next = GraphicsState.update(current, { currentPath: nextPath });
+  const graphicsStateStack = GraphicsStateStack.replaceCurrent(
+    context.graphicsStateStack,
+    next,
+  );
+
+  return ok({
+    operandStack: context.operandStack,
+    graphicsStateStack,
+  });
+};

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -78,6 +78,7 @@ export type {
   PdfOperatorOperandMissingError,
   PdfOperatorOperandTypeMismatchError,
   PdfOperatorOperandValueOutOfRangeError,
+  PdfOperatorPathNoCurrentPointError,
   PdfOperatorRegistryError,
   PdfParseError,
   PdfParseErrorCode,

--- a/packages/core/src/pdf/errors/error/__tests__/error.basic.test.ts
+++ b/packages/core/src/pdf/errors/error/__tests__/error.basic.test.ts
@@ -113,6 +113,21 @@ test("PdfOperatorOperandValueOutOfRangeError は operatorName/allowed/actual を
   expect(error.actual).toBe(3);
 });
 
+test("PdfOperatorPathNoCurrentPointError は operatorName を保持する", () => {
+  const error: Extract<PdfError, { code: "OPERATOR_PATH_NO_CURRENT_POINT" }> = {
+    code: "OPERATOR_PATH_NO_CURRENT_POINT",
+    message:
+      "Operator 'l' requires a current point established by a prior 'm' or 're'",
+    operatorName: "l",
+  };
+
+  expect(error.code).toBe("OPERATOR_PATH_NO_CURRENT_POINT");
+  expect(error.operatorName).toBe("l");
+  expect(error.message).toBe(
+    "Operator 'l' requires a current point established by a prior 'm' or 're'",
+  );
+});
+
 test("PdfParseErrorのoffsetは省略可能", () => {
   const withOffset: PdfParseError = {
     code: "INVALID_HEADER",

--- a/packages/core/src/pdf/errors/error/__tests__/error.type-export.test.ts
+++ b/packages/core/src/pdf/errors/error/__tests__/error.type-export.test.ts
@@ -7,6 +7,7 @@ import type {
   PdfOperatorOperandMissingError,
   PdfOperatorOperandTypeMismatchError,
   PdfOperatorOperandValueOutOfRangeError,
+  PdfOperatorPathNoCurrentPointError,
   PdfOperatorRegistryError,
   PdfParseError,
   PdfParseErrorCode,
@@ -165,4 +166,23 @@ test("PdfOperatorOperandValueOutOfRangeError は PdfError union から narrow �
   expect(error.code).toBe("OPERATOR_OPERAND_VALUE_OUT_OF_RANGE");
   expect(valueOutOfRangeError.allowed).toEqual([0, 1, 2]);
   expect(valueOutOfRangeError.actual).toBe(3);
+});
+
+test("PdfOperatorPathNoCurrentPointError は PdfError union から narrow できる", () => {
+  const noCurrentPointError: PdfOperatorPathNoCurrentPointError = {
+    code: "OPERATOR_PATH_NO_CURRENT_POINT",
+    message:
+      "Operator 'l' requires a current point established by a prior 'm' or 're'",
+    operatorName: "l",
+  };
+  const error: PdfError = noCurrentPointError;
+
+  const narrowed: Exact<
+    Extract<PdfError, { code: "OPERATOR_PATH_NO_CURRENT_POINT" }>,
+    PdfOperatorPathNoCurrentPointError
+  > = true;
+
+  expect(narrowed).toBe(true);
+  expect(error.code).toBe("OPERATOR_PATH_NO_CURRENT_POINT");
+  expect(noCurrentPointError.operatorName).toBe("l");
 });

--- a/packages/core/src/pdf/errors/error/index.ts
+++ b/packages/core/src/pdf/errors/error/index.ts
@@ -240,7 +240,7 @@ export interface PdfOperatorOperandValueOutOfRangeError {
  * ```ts
  * const error: PdfOperatorPathNoCurrentPointError = {
  *   code: "OPERATOR_PATH_NO_CURRENT_POINT",
- *   message: "Operator 'l' requires a current point established by a prior 'm'",
+ *   message: "Operator 'l' requires a current point established by a prior 'm' or 're'",
  *   operatorName: "l",
  * };
  * ```

--- a/packages/core/src/pdf/errors/error/index.ts
+++ b/packages/core/src/pdf/errors/error/index.ts
@@ -40,7 +40,9 @@ export type PdfParseErrorCode =
 
 /**
  * 全致命的PDFエラーコードの共用体型。
- * パースエラーコードに加え、循環参照・型不一致・operator registry エラーを含む。
+ * パースエラーコードに加え、循環参照・型不一致・operator registry エラー、
+ * operator オペランド不足／型不一致／値域外エラー、
+ * path operator の current point 未確立エラーのコードを含む。
  *
  * @example
  * ```ts

--- a/packages/core/src/pdf/errors/error/index.ts
+++ b/packages/core/src/pdf/errors/error/index.ts
@@ -257,7 +257,8 @@ export interface PdfOperatorPathNoCurrentPointError {
 /**
  * 全致命的PDFエラーの判別共用体型。
  * パースエラー、循環参照エラー、型不一致エラー、operator registry エラー、
- * operator オペランド不足／型不一致エラーを包含する。
+ * operator オペランド不足／型不一致／値域外エラー、
+ * path operator の current point 未確立エラーを包含する。
  *
  * @example
  * ```ts

--- a/packages/core/src/pdf/errors/error/index.ts
+++ b/packages/core/src/pdf/errors/error/index.ts
@@ -54,7 +54,8 @@ export type PdfErrorCode =
   | "OPERATOR_ALREADY_REGISTERED"
   | "OPERATOR_OPERAND_MISSING"
   | "OPERATOR_OPERAND_TYPE_MISMATCH"
-  | "OPERATOR_OPERAND_VALUE_OUT_OF_RANGE";
+  | "OPERATOR_OPERAND_VALUE_OUT_OF_RANGE"
+  | "OPERATOR_PATH_NO_CURRENT_POINT";
 
 /**
  * PDFパースエラーを表すインターフェース。
@@ -230,6 +231,30 @@ export interface PdfOperatorOperandValueOutOfRangeError {
 }
 
 /**
+ * Content stream path operator の current point 未定義エラー。
+ * `l` / `c` / `v` / `y` / `h` のように current point から segment を構築する
+ * operator が呼び出された時点で current point が確立されていない (`m` / `re`
+ * が先行していない) 場合に発生する (ISO 32000-1:2008 §8.5.2)。
+ *
+ * @example
+ * ```ts
+ * const error: PdfOperatorPathNoCurrentPointError = {
+ *   code: "OPERATOR_PATH_NO_CURRENT_POINT",
+ *   message: "Operator 'l' requires a current point established by a prior 'm'",
+ *   operatorName: "l",
+ * };
+ * ```
+ */
+export interface PdfOperatorPathNoCurrentPointError {
+  /** エラーコード（常に "OPERATOR_PATH_NO_CURRENT_POINT"） */
+  readonly code: "OPERATOR_PATH_NO_CURRENT_POINT";
+  /** 人間可読なエラーメッセージ */
+  readonly message: string;
+  /** current point 未定義を検出した operator 名 */
+  readonly operatorName: string;
+}
+
+/**
  * 全致命的PDFエラーの判別共用体型。
  * パースエラー、循環参照エラー、型不一致エラー、operator registry エラー、
  * operator オペランド不足／型不一致エラーを包含する。
@@ -253,4 +278,5 @@ export type PdfError =
   | PdfOperatorRegistryError
   | PdfOperatorOperandMissingError
   | PdfOperatorOperandTypeMismatchError
-  | PdfOperatorOperandValueOutOfRangeError;
+  | PdfOperatorOperandValueOutOfRangeError
+  | PdfOperatorPathNoCurrentPointError;

--- a/packages/core/src/pdf/errors/index.ts
+++ b/packages/core/src/pdf/errors/index.ts
@@ -10,6 +10,7 @@ export type {
   PdfOperatorOperandMissingError,
   PdfOperatorOperandTypeMismatchError,
   PdfOperatorOperandValueOutOfRangeError,
+  PdfOperatorPathNoCurrentPointError,
   PdfOperatorRegistryError,
   PdfParseError,
   PdfParseErrorCode,


### PR DESCRIPTION
## 概要

spec-048。PDF §8.5.2 `l` (lineto) operator のハンドラを `packages/core/src/content-stream/operators/path/l/` に新規追加する。operand stack から `x y` を pop し、`PathSegment.lineTo(x, y)` を current path の末尾に `CurrentPath.append` で追加する。`m` (#197) を雛形とした 4 箇所の差分を基本実装とし、**Copilot / Codex レビュー指摘により公開 API として新エラーコード `OPERATOR_PATH_NO_CURRENT_POINT` を追加して current point precondition を検証**するように拡張済み。registry 登録は別 Issue にスコープ外。

> **スコープ補足（レビュー結果反映）**: 当初計画 (spec-048 implementation-plan) は「m から 4 箇所の差分のみ」だったが、ISO 32000-1:2008 §8.5.2 が要求する current point 必須要件を Copilot / Codex が指摘したため、公開 API (`PdfErrorCode` union / `PdfOperatorPathNoCurrentPointError` interface / namespace 再エクスポート) を新規追加して対応した。これは behavior change を含む public API 拡張であり、後続の current-point 依存 operator (`c` / `v` / `y` / `h`) 実装時に同じパターンを再利用する。

## 変更の種類

- ✨ New Feature (l operator handler 追加)
- 🏷️ Types (`OPERATOR_PATH_NO_CURRENT_POINT` 公開 API 追加)
- 🦺 Validation (current point precondition 検証)

## 追加した内容

### 公開 API
- `PdfErrorCode` union に `"OPERATOR_PATH_NO_CURRENT_POINT"` を追加
- `PdfOperatorPathNoCurrentPointError` interface（`code` / `message` / `operatorName`）を新設
- namespace から再エクスポート（`packages/core/src/pdf/errors/index.ts` / `packages/core/src/index.ts`）

### 実装
- `packages/core/src/content-stream/operators/path/l/index.ts` — `lHandler: OperatorHandler`（85 → 94 行）
  - operand pop 後・append 前に `CurrentPath.isEmpty` で current point の有無を検証
  - 未確立時は `OPERATOR_PATH_NO_CURRENT_POINT` を返し append しない
  - 既存 `TYPE_MISMATCH` 規約と一貫: エラー時に operand stack の部分消費は復元しない

### テスト
- `packages/core/src/content-stream/operators/path/l/__tests__/l.basic.test.ts` — 27 件
  - T1 最小正常系 / T2 既存 path 末尾への append / T3 m→l 連携（`mHandler` 実呼び出し）
  - **T4 連続 `l → l` で 2 segment 残る差別化テスト**（`m` との核心的差別化）
  - T5 integer/real 混在 / T6-T8 不変条件 / T9 境界値（0/負/NaN/±Inf）
  - T10 OPERAND_MISSING (0/1個) / T11 TYPE_MISMATCH (top 8 種) / T12-T13 部分消費非復元
  - **T14-T15 NO_CURRENT_POINT 発火 + operand stack 状態検証**（公開 API 追加分）
- `packages/core/src/pdf/errors/error/__tests__/error.type-export.test.ts` — narrow 検証 +1
- `packages/core/src/pdf/errors/error/__tests__/error.basic.test.ts` — shape 検証 +1

## システム図

```mermaid
flowchart TD
  Start([lHandler context]) --> Pop["OperandStack.pop × 2 (LIFO)"]
  Pop -->|none| Missing["err: OPERAND_MISSING<br/>actual = i"]
  Pop -->|some, !NumericPdfObject| Mismatch["err: TYPE_MISMATCH<br/>(stack 復元しない)"]
  Pop -->|2 個成功| Reverse["reverse → [x, y]"]
  Reverse --> CheckPath{"CurrentPath.isEmpty?<br/>(current point 確立?)"}
  CheckPath -->|yes empty| NoPoint["err: NO_CURRENT_POINT<br/>(§8.5.2 precondition)"]
  CheckPath -->|no, has segments| Append["<b>CurrentPath.append</b><br/>PathSegment.lineTo(x, y)"]
  Append --> Update["GraphicsState.update { currentPath }"]
  Update --> Replace["GraphicsStateStack.replaceCurrent"]
  Replace --> Ok([ok: 更新後 context])

  style Append fill:#fff3b0,stroke:#d97706,stroke-width:2px
  style CheckPath fill:#cfe9ff,stroke:#0369a1,stroke-width:2px
  style NoPoint fill:#fecaca,stroke:#b91c1c,stroke-width:2px
```

★ `CheckPath` / `NoPoint` がレビュー反映で追加された precondition 検証パス。

## 関連 spec / Issue

- spec: `.plugin-workspace/.specs/048-l-operator-handler/`
- Refs #168 (親 Epic #163, depends on #166, blocks #175)
- 雛形 PR: #197 (`m` operator handler)

## テスト

- `pnpm --filter @pdfmod/core test` → ✅ **1771 passed** (124 files、l.basic 27 件 + 新規 error 2 件含む)
- `pnpm --filter @pdfmod/core build` → ✅ vite + tsc 成功
- 手動ガード確認: `CurrentPath.append` → `beginSubpath` に一時差し替えると T4 含む 10 件が即失敗
- Codex 初回レビュー: 問題なし（`.plugin-workspace/.specs/048-l-operator-handler/code-review/review-001.md`）
- Copilot / Codex 追加レビュー: §8.5.2 precondition / docstring 整合性 / mHandler 実呼び出し / shape test 網羅 → すべて対応済み

## レビューポイント

- **新エラーコード `OPERATOR_PATH_NO_CURRENT_POINT` を公開 API として追加する是非**（後続 `c` / `v` / `y` / `h` operator でも同じ precondition が必要となるため、共通エラーコードとして設計）
- 検査タイミング: operand pop 後・append 前（既存 `TYPE_MISMATCH` と一貫した「部分消費は復元しない」規約）
- `CurrentPath.isEmpty` を直接使用（path-painting operator 未実装のため `isEmpty === !hasCurrentPoint` が成立。実装時に概念分離予定）
- ディレクトリ構成: Issue #168 では `l.ts` フラット記載だが、既存 `m/` サブディレクトリ構成に揃えて `l/index.ts` + `l/__tests__/l.basic.test.ts` を採用
- registry 登録は本 Issue スコープ外