### PR TITLE
✨ [New Feature]: #169 c operator (cubic Bezier) handler を実装

### DIFF
--- a/packages/core/src/content-stream/operators/path/c/__tests__/c.basic.test.ts
+++ b/packages/core/src/content-stream/operators/path/c/__tests__/c.basic.test.ts
@@ -1,0 +1,457 @@
+import { assert, expect, test } from "vitest";
+import type { PdfObject } from "../../../../../pdf/types/pdf-types/index";
+import {
+  CurrentPath,
+  GraphicsState,
+  GraphicsStateStack,
+} from "../../../../graphics-state/index";
+import { PathSegment } from "../../../../graphics-state/path-segment";
+import { OperandStack } from "../../../../operand-stack/index";
+import type { OperatorHandlerContext } from "../../../../operator-registry/index";
+import { mHandler } from "../../m/index";
+import { cHandler } from "../index";
+
+const buildContext = (operands: PdfObject[]): OperatorHandlerContext => {
+  const operandStack = OperandStack.create();
+  for (const operand of operands) {
+    OperandStack.push(operandStack, operand);
+  }
+  const graphicsStateStack = GraphicsStateStack.create();
+  return { operandStack, graphicsStateStack };
+};
+
+const buildContextWithCurrentPoint = (
+  operands: PdfObject[],
+): OperatorHandlerContext => {
+  const operandStack = OperandStack.create();
+  for (const operand of operands) {
+    OperandStack.push(operandStack, operand);
+  }
+  const initialState = GraphicsState.create();
+  const seededPath = CurrentPath.append(
+    initialState.currentPath,
+    PathSegment.moveTo(0, 0),
+  );
+  const seededState = GraphicsState.update(initialState, {
+    currentPath: seededPath,
+  });
+  const graphicsStateStack = GraphicsStateStack.replaceCurrent(
+    GraphicsStateStack.create(),
+    seededState,
+  );
+  return { operandStack, graphicsStateStack };
+};
+
+const real = (value: number): PdfObject => ({ type: "real", value });
+const int = (value: number): PdfObject => ({ type: "integer", value });
+
+test("`100 200 110 210 120 220 c` で CurveTo が current point 確立済み path に append される", () => {
+  const ctx = buildContextWithCurrentPoint([
+    real(100),
+    real(200),
+    real(110),
+    real(210),
+    real(120),
+    real(220),
+  ]);
+
+  const result = cHandler(ctx);
+
+  assert(result.ok);
+  const current = GraphicsStateStack.current(result.value.graphicsStateStack);
+  expect(current.currentPath.segments).toEqual([
+    PathSegment.moveTo(0, 0),
+    PathSegment.curveTo(100, 200, 110, 210, 120, 220),
+  ]);
+});
+
+test("既存 currentPath を持つ state から開始した場合、元 segment が保持され末尾に curveTo が追加される", () => {
+  const initialState = GraphicsState.create();
+  const seededPath = CurrentPath.append(
+    CurrentPath.append(initialState.currentPath, PathSegment.moveTo(10, 20)),
+    PathSegment.lineTo(30, 40),
+  );
+  const seededState = GraphicsState.update(initialState, {
+    currentPath: seededPath,
+  });
+  const beforeSegments = seededPath.segments;
+
+  const operandStack = OperandStack.create();
+  for (const operand of [
+    real(100),
+    real(200),
+    real(110),
+    real(210),
+    real(120),
+    real(220),
+  ]) {
+    OperandStack.push(operandStack, operand);
+  }
+  const graphicsStateStack = GraphicsStateStack.create();
+  const stackWithSeed = GraphicsStateStack.replaceCurrent(
+    graphicsStateStack,
+    seededState,
+  );
+
+  const result = cHandler({
+    operandStack,
+    graphicsStateStack: stackWithSeed,
+  });
+
+  assert(result.ok);
+  const current = GraphicsStateStack.current(result.value.graphicsStateStack);
+  expect(current.currentPath.segments).toEqual([
+    PathSegment.moveTo(10, 20),
+    PathSegment.lineTo(30, 40),
+    PathSegment.curveTo(100, 200, 110, 210, 120, 220),
+  ]);
+  expect(beforeSegments).toEqual([
+    PathSegment.moveTo(10, 20),
+    PathSegment.lineTo(30, 40),
+  ]);
+});
+
+test("`mHandler(10,20)` 実行後 `cHandler(30,40,50,60,70,80)` を実行すると [MoveTo, CurveTo] になる", () => {
+  const mCtx = buildContext([real(10), real(20)]);
+  const mResult = mHandler(mCtx);
+  assert(mResult.ok);
+
+  const operandStack = OperandStack.create();
+  for (const operand of [
+    real(30),
+    real(40),
+    real(50),
+    real(60),
+    real(70),
+    real(80),
+  ]) {
+    OperandStack.push(operandStack, operand);
+  }
+  const result = cHandler({
+    operandStack,
+    graphicsStateStack: mResult.value.graphicsStateStack,
+  });
+
+  assert(result.ok);
+  const current = GraphicsStateStack.current(result.value.graphicsStateStack);
+  expect(current.currentPath.segments).toEqual([
+    PathSegment.moveTo(10, 20),
+    PathSegment.curveTo(30, 40, 50, 60, 70, 80),
+  ]);
+});
+
+test("連続 `c → c` で 2 つの CurveTo が append され、前 CurveTo は上書きされない", () => {
+  const firstCtx = buildContextWithCurrentPoint([
+    real(10),
+    real(20),
+    real(30),
+    real(40),
+    real(50),
+    real(60),
+  ]);
+  const firstResult = cHandler(firstCtx);
+  assert(firstResult.ok);
+
+  const operandStack = OperandStack.create();
+  for (const operand of [
+    real(70),
+    real(80),
+    real(90),
+    real(100),
+    real(110),
+    real(120),
+  ]) {
+    OperandStack.push(operandStack, operand);
+  }
+  const secondResult = cHandler({
+    operandStack,
+    graphicsStateStack: firstResult.value.graphicsStateStack,
+  });
+
+  assert(secondResult.ok);
+  const current = GraphicsStateStack.current(
+    secondResult.value.graphicsStateStack,
+  );
+  expect(current.currentPath.segments).toEqual([
+    PathSegment.moveTo(0, 0),
+    PathSegment.curveTo(10, 20, 30, 40, 50, 60),
+    PathSegment.curveTo(70, 80, 90, 100, 110, 120),
+  ]);
+});
+
+test("integer / real 混在 operand が許容される (int/real 6 個ミックス)", () => {
+  const ctx = buildContextWithCurrentPoint([
+    int(10),
+    real(20.5),
+    int(30),
+    real(40.5),
+    int(50),
+    real(60.5),
+  ]);
+
+  const result = cHandler(ctx);
+
+  assert(result.ok);
+  const current = GraphicsStateStack.current(result.value.graphicsStateStack);
+  expect(current.currentPath.segments).toEqual([
+    PathSegment.moveTo(0, 0),
+    PathSegment.curveTo(10, 20.5, 30, 40.5, 50, 60.5),
+  ]);
+});
+
+test("成功時 operandStack の depth は 0", () => {
+  const ctx = buildContextWithCurrentPoint([
+    real(100),
+    real(200),
+    real(110),
+    real(210),
+    real(120),
+    real(220),
+  ]);
+
+  const result = cHandler(ctx);
+
+  assert(result.ok);
+  expect(OperandStack.depth(result.value.operandStack)).toBe(0);
+});
+
+test("成功時 result.value.operandStack は context.operandStack と同一参照 (in-place mutate)", () => {
+  const ctx = buildContextWithCurrentPoint([
+    real(100),
+    real(200),
+    real(110),
+    real(210),
+    real(120),
+    real(220),
+  ]);
+
+  const result = cHandler(ctx);
+
+  assert(result.ok);
+  expect(result.value.operandStack).toBe(ctx.operandStack);
+});
+
+test("成功時 ctm / lineWidth / lineCap / lineJoin / miterLimit は不変", () => {
+  const ctx = buildContextWithCurrentPoint([
+    real(100),
+    real(200),
+    real(110),
+    real(210),
+    real(120),
+    real(220),
+  ]);
+  const before = GraphicsStateStack.current(ctx.graphicsStateStack);
+
+  const result = cHandler(ctx);
+
+  assert(result.ok);
+  const after = GraphicsStateStack.current(result.value.graphicsStateStack);
+  expect(after.ctm).toEqual(before.ctm);
+  expect(after.lineWidth).toBe(before.lineWidth);
+  expect(after.lineCap).toBe(before.lineCap);
+  expect(after.lineJoin).toBe(before.lineJoin);
+  expect(after.miterLimit).toBe(before.miterLimit);
+});
+
+test.each([
+  { label: "0", value: 0 },
+  { label: "negative", value: -1.5 },
+  { label: "NaN", value: Number.NaN },
+  { label: "Positive Infinity", value: Number.POSITIVE_INFINITY },
+  { label: "Negative Infinity", value: Number.NEGATIVE_INFINITY },
+])("境界値 $label が y3 に混入しても handler では検証せずそのまま CurveTo に格納する", ({
+  value,
+}) => {
+  const ctx = buildContextWithCurrentPoint([
+    real(100),
+    real(200),
+    real(110),
+    real(210),
+    real(120),
+    real(value),
+  ]);
+
+  const result = cHandler(ctx);
+
+  assert(result.ok);
+  const current = GraphicsStateStack.current(result.value.graphicsStateStack);
+  expect(current.currentPath.segments).toEqual([
+    PathSegment.moveTo(0, 0),
+    PathSegment.curveTo(100, 200, 110, 210, 120, value),
+  ]);
+});
+
+test.each([
+  { label: "0 個", count: 0 },
+  { label: "1 個", count: 1 },
+  { label: "2 個", count: 2 },
+  { label: "3 個", count: 3 },
+  { label: "4 個", count: 4 },
+  { label: "5 個", count: 5 },
+])("operand $label のとき OPERAND_MISSING を返し actual = pop 成功数", ({
+  count,
+}) => {
+  const operands: PdfObject[] = Array.from({ length: count }, () => real(1));
+  const ctx = buildContext(operands);
+
+  const result = cHandler(ctx);
+
+  assert(!result.ok);
+  assert(result.error.code === "OPERATOR_OPERAND_MISSING");
+  expect(result.error.operatorName).toBe("c");
+  expect(result.error.required).toBe(6);
+  expect(result.error.actual).toBe(count);
+  expect(result.error.message).toBe(
+    `Operator 'c' requires 6 operand(s), got ${count}`,
+  );
+});
+
+test.each([
+  { label: "null", operand: { type: "null" } satisfies PdfObject },
+  {
+    label: "name",
+    operand: { type: "name", value: "Foo" } satisfies PdfObject,
+  },
+  {
+    label: "boolean",
+    operand: { type: "boolean", value: true } satisfies PdfObject,
+  },
+  {
+    label: "string",
+    operand: {
+      type: "string",
+      value: new Uint8Array([0x61]),
+      encoding: "literal",
+    } satisfies PdfObject,
+  },
+  {
+    label: "array",
+    operand: { type: "array", elements: [] } satisfies PdfObject,
+  },
+  {
+    label: "dictionary",
+    operand: { type: "dictionary", entries: new Map() } satisfies PdfObject,
+  },
+  {
+    label: "indirect-ref",
+    operand: {
+      type: "indirect-ref",
+      objectNumber: 1,
+      generationNumber: 0,
+    } satisfies PdfObject,
+  },
+  {
+    label: "stream",
+    operand: {
+      type: "stream",
+      dictionary: { type: "dictionary", entries: new Map() },
+      data: new Uint8Array(),
+    } satisfies PdfObject,
+  },
+])("top (PDF 順 y3) が $label のとき TYPE_MISMATCH を返し depth は 5 (top のみ pop 済み)", ({
+  label,
+  operand,
+}) => {
+  const ctx = buildContext([
+    real(100),
+    real(200),
+    real(110),
+    real(210),
+    real(120),
+    operand,
+  ]);
+
+  const result = cHandler(ctx);
+
+  assert(!result.ok);
+  assert(result.error.code === "OPERATOR_OPERAND_TYPE_MISMATCH");
+  expect(result.error.operatorName).toBe("c");
+  expect(result.error.expected).toBe("number");
+  expect(result.error.actual).toBe(label);
+  expect(result.error.message).toBe(
+    `Operator 'c' expected number operand, got ${label}`,
+  );
+  expect(OperandStack.depth(ctx.operandStack)).toBe(5);
+});
+
+test("bottom (PDF 順 x1) が boolean のとき TYPE_MISMATCH を返し depth は 0 (6 個 pop 済み)", () => {
+  const bottom: PdfObject = { type: "boolean", value: true };
+  const ctx = buildContext([
+    bottom,
+    real(200),
+    real(110),
+    real(210),
+    real(120),
+    real(220),
+  ]);
+
+  const result = cHandler(ctx);
+
+  assert(!result.ok);
+  assert(result.error.code === "OPERATOR_OPERAND_TYPE_MISMATCH");
+  expect(result.error.actual).toBe("boolean");
+  expect(OperandStack.depth(ctx.operandStack)).toBe(0);
+});
+
+test("中間 operand (PDF 順 x2 = LIFO 4 個目) が boolean のとき TYPE_MISMATCH を返し depth は 2 (部分消費の復元なし)", () => {
+  const middle: PdfObject = { type: "boolean", value: true };
+  const ctx = buildContext([
+    real(100),
+    real(200),
+    middle,
+    real(210),
+    real(120),
+    real(220),
+  ]);
+
+  const result = cHandler(ctx);
+
+  assert(!result.ok);
+  assert(result.error.code === "OPERATOR_OPERAND_TYPE_MISMATCH");
+  expect(result.error.operatorName).toBe("c");
+  expect(result.error.expected).toBe("number");
+  expect(result.error.actual).toBe("boolean");
+  expect(result.error.message).toBe(
+    "Operator 'c' expected number operand, got boolean",
+  );
+  expect(OperandStack.depth(ctx.operandStack)).toBe(2);
+});
+
+test("current point 未確立 (currentPath が空) のとき NO_CURRENT_POINT を返し path に append しない", () => {
+  const ctx = buildContext([
+    real(100),
+    real(200),
+    real(110),
+    real(210),
+    real(120),
+    real(220),
+  ]);
+
+  const result = cHandler(ctx);
+
+  assert(!result.ok);
+  assert(result.error.code === "OPERATOR_PATH_NO_CURRENT_POINT");
+  expect(result.error.operatorName).toBe("c");
+  expect(result.error.message).toBe(
+    "Operator 'c' requires a current point established by a prior 'm' or 're'",
+  );
+  const current = GraphicsStateStack.current(ctx.graphicsStateStack);
+  expect(current.currentPath.segments).toEqual([]);
+});
+
+test("NO_CURRENT_POINT 時に operand stack は (TYPE_MISMATCH と同様) 復元しない", () => {
+  const ctx = buildContext([
+    real(100),
+    real(200),
+    real(110),
+    real(210),
+    real(120),
+    real(220),
+  ]);
+
+  const result = cHandler(ctx);
+
+  assert(!result.ok);
+  assert(result.error.code === "OPERATOR_PATH_NO_CURRENT_POINT");
+  expect(OperandStack.depth(ctx.operandStack)).toBe(0);
+});

--- a/packages/core/src/content-stream/operators/path/c/index.ts
+++ b/packages/core/src/content-stream/operators/path/c/index.ts
@@ -1,0 +1,96 @@
+import type { PdfError } from "../../../../pdf/errors/index";
+import { err, ok } from "../../../../utils/result/index";
+import {
+  CurrentPath,
+  GraphicsState,
+  GraphicsStateStack,
+} from "../../../graphics-state/index";
+import { PathSegment } from "../../../graphics-state/path-segment";
+import { OperandStack } from "../../../operand-stack/index";
+import type {
+  OperatorHandler,
+  OperatorHandlerContext,
+} from "../../../operator-registry/index";
+import { NumericPdfObject } from "../../graphics-state/numeric-pdf-object";
+
+const OPERATOR_NAME = "c";
+const OPERAND_COUNT = 6;
+
+/**
+ * PDF §8.5.2 `c` operator (cubic Bezier curve) のハンドラ。
+ *
+ * operand stack から `x1 y1 x2 y2 x3 y3` の 6 個の数値を pop し、
+ * `PathSegment.curveTo(x1, y1, x2, y2, x3, y3)` を current path の末尾に append した
+ * 新しい GraphicsState を生成する (ISO 32000-1:2008 §8.5.2)。
+ * append 後の current point は追加された curveTo segment の終点 `(x3, y3)` として
+ * 後続処理で解釈される (現行データモデルでは明示的 current point フィールドは持たない)。
+ *
+ * - operand 不足 (< 6) のとき `OPERATOR_OPERAND_MISSING` を返す
+ *   `actual` には pop に成功した個数 (0..5) を入れる
+ * - operand に integer / real 以外が混在したとき `OPERATOR_OPERAND_TYPE_MISMATCH` を返す
+ * - current point が未確立 (先行する `m` / `re` がない / `currentPath` が空) の場合
+ *   `OPERATOR_PATH_NO_CURRENT_POINT` を返す (§8.5.2: `c` は current point から伸ばす)
+ * - 値域 (`NaN` / `Infinity` / 負値 / 0) は本 handler では検証せずそのまま格納する
+ * - エラー時に operand stack の部分消費は復元しない (既存 cm / m / l handler 規約)
+ *
+ * @param context - 実行コンテキスト (operand stack / graphics state stack)
+ * @returns 成功なら更新後コンテキスト、失敗なら PdfError
+ */
+export const cHandler: OperatorHandler = (context: OperatorHandlerContext) => {
+  const popped: NumericPdfObject[] = [];
+  for (let i = 0; i < OPERAND_COUNT; i++) {
+    const result = OperandStack.pop(context.operandStack);
+    if (!result.some) {
+      const error: PdfError = {
+        code: "OPERATOR_OPERAND_MISSING",
+        message: `Operator '${OPERATOR_NAME}' requires ${OPERAND_COUNT} operand(s), got ${i}`,
+        operatorName: OPERATOR_NAME,
+        required: OPERAND_COUNT,
+        actual: i,
+      };
+      return err(error);
+    }
+    const operand = result.value;
+    if (!NumericPdfObject.is(operand)) {
+      const error: PdfError = {
+        code: "OPERATOR_OPERAND_TYPE_MISMATCH",
+        message: `Operator '${OPERATOR_NAME}' expected number operand, got ${operand.type}`,
+        operatorName: OPERATOR_NAME,
+        expected: "number",
+        actual: operand.type,
+      };
+      return err(error);
+    }
+    popped.push(operand);
+  }
+
+  // popped は LIFO 順 [y3, x3, y2, x2, y1, x1]。reverse して PDF 順 [x1, y1, x2, y2, x3, y3] に戻す
+  const [x1, y1, x2, y2, x3, y3] = popped
+    .slice()
+    .reverse()
+    .map((operand) => operand.value);
+
+  const current = GraphicsStateStack.current(context.graphicsStateStack);
+  if (CurrentPath.isEmpty(current.currentPath)) {
+    const error: PdfError = {
+      code: "OPERATOR_PATH_NO_CURRENT_POINT",
+      message: `Operator '${OPERATOR_NAME}' requires a current point established by a prior 'm' or 're'`,
+      operatorName: OPERATOR_NAME,
+    };
+    return err(error);
+  }
+  const nextPath = CurrentPath.append(
+    current.currentPath,
+    PathSegment.curveTo(x1, y1, x2, y2, x3, y3),
+  );
+  const next = GraphicsState.update(current, { currentPath: nextPath });
+  const graphicsStateStack = GraphicsStateStack.replaceCurrent(
+    context.graphicsStateStack,
+    next,
+  );
+
+  return ok({
+    operandStack: context.operandStack,
+    graphicsStateStack,
+  });
+};


### PR DESCRIPTION
## 概要

spec-049 / Issue #169。PDF §8.5.2 の `c` operator (cubic Bezier curve) のハンドラを新規追加する。`l` operator (#168) を雛形とし、`OPERATOR_NAME` / `OPERAND_COUNT` / `PathSegment.curveTo` の 3 箇所のみ差分。operator registry への登録は別 Issue (スコープ外)。

## 変更の種類

- ✨ [New Feature]: 新機能
- 🧪 [Tests]: テスト追加

## 追加した内容

- `packages/core/src/content-stream/operators/path/c/index.ts` — `cHandler: OperatorHandler` を export
  - operand stack から `x1 y1 x2 y2 x3 y3` の 6 個の数値を pop
  - `PathSegment.curveTo(x1, y1, x2, y2, x3, y3)` を current path 末尾に append
  - current-point ガード (`CurrentPath.isEmpty` → `OPERATOR_PATH_NO_CURRENT_POINT`)
  - エラー時に部分消費した operand stack は復元しない (既存 cm / m / l handler 規約)
- `packages/core/src/content-stream/operators/path/c/__tests__/c.basic.test.ts` — T1〜T15 相当のテスト
  - 正常系: 単発 c / 既存 path 末尾 append / m→c 連携 / **連続 c→c (本実装の核)** / int+real 混在
  - 不変条件: operandStack depth=0 / 参照同一性 / ctm 他不変
  - 境界値 (0 / 負値 / NaN / ±Infinity) を `test.each` で網羅
  - 異常系: `OPERAND_MISSING` (0..5 個 × 6 ケース) / `TYPE_MISMATCH` (top 8 PdfObject 種 + bottom + 中間スロット) / `NO_CURRENT_POINT`

## システム図

```mermaid
flowchart TD
    Start([cHandler context])
    Pop["OperandStack.pop × 6 (LIFO)"]
    Reverse["reverse → x1, y1, x2, y2, x3, y3"]
    Guard{"CurrentPath.isEmpty?"}
    Build["PathSegment.curveTo(x1,y1,x2,y2,x3,y3)"]
    Append["CurrentPath.append(currentPath, curveTo)"]
    Update["GraphicsState.update / GraphicsStateStack.replaceCurrent"]
    OK([ok])
    ErrMissing([err: OPERATOR_OPERAND_MISSING])
    ErrType([err: OPERATOR_OPERAND_TYPE_MISMATCH])
    ErrNCP([err: OPERATOR_PATH_NO_CURRENT_POINT])

    Start --> Pop
    Pop -- Option.none --> ErrMissing
    Pop -- "!NumericPdfObject.is" --> ErrType
    Pop -- "6 個成功" --> Reverse
    Reverse --> Guard
    Guard -- "true (空 path)" --> ErrNCP
    Guard -- "false" --> Build
    Build --> Append --> Update --> OK

    style Build fill:#e7ffe7
    style Append fill:#e7ffe7
```

## 関連 spec / Issue

- spec: `.plugin-workspace/.specs/049-c-operator-handler/`
- Refs #169
- 親 Epic: #163
- 雛形: PR #198 (`l` operator handler, Issue #168)

## テスト

- `pnpm --filter @pdfmod/core test` → **1802 / 1802 passed** (新規 22 ケース含む)
- `pnpm --filter @pdfmod/core build` → **成功** (vite build + tsc emit)
- Codex CLI レビュー (`.plugin-workspace/.specs/049-c-operator-handler/code-review/review-001.md`) → **問題なし**

## レビューポイント

- **連続 `c → c` テスト**: `CurrentPath.append` を誤って `beginSubpath` に置き換えると必ず失敗する回帰防止ガード
- **中間スロット型不整合テスト**: spec の表記揺れ (T13 の "PDF 順 y2 = LIFO 4 個目") を、`depth=2`（4 個 pop 済み）の検証意図に合わせて "PDF 順 x2 = LIFO 4 個目" に補正している。中間スロットでの partial consumption non-restoration を検証する目的は維持
- **`l` との差分は 3 箇所のみ**: `OPERATOR_NAME = "c"` / `OPERAND_COUNT = 6` / `PathSegment.curveTo` (+ destructure)。doc コメントは `c` 用に書き直し、`l` 由来の `lineto` / `< 2` / `(0 または 1)` 表現は残していない
- operator registry への登録は本 Issue スコープ外 (別 PR で対応予定)