### PR TITLE
✨ [New Feature]: #171 re (rectangle) operator handler を実装

### DIFF
--- a/packages/core/src/content-stream/operators/path/re/__tests__/re.basic.test.ts
+++ b/packages/core/src/content-stream/operators/path/re/__tests__/re.basic.test.ts
@@ -1,0 +1,327 @@
+import { assert, expect, test } from "vitest";
+import type { PdfObject } from "../../../../../pdf/types/pdf-types/index";
+import {
+  CurrentPath,
+  GraphicsState,
+  GraphicsStateStack,
+} from "../../../../graphics-state/index";
+import { PathSegment } from "../../../../graphics-state/path-segment";
+import { OperandStack } from "../../../../operand-stack/index";
+import type { OperatorHandlerContext } from "../../../../operator-registry/index";
+import { reHandler } from "../index";
+
+const real = (value: number): PdfObject => ({ type: "real", value });
+const int = (value: number): PdfObject => ({ type: "integer", value });
+
+const buildContext = (operands: PdfObject[]): OperatorHandlerContext => {
+  const operandStack = OperandStack.create();
+  for (const operand of operands) {
+    OperandStack.push(operandStack, operand);
+  }
+  const graphicsStateStack = GraphicsStateStack.create();
+  return { operandStack, graphicsStateStack };
+};
+
+const buildContextWithSegments = (
+  segments: PathSegment[],
+  operands: PdfObject[] = [],
+): OperatorHandlerContext => {
+  const operandStack = OperandStack.create();
+  for (const operand of operands) {
+    OperandStack.push(operandStack, operand);
+  }
+  const initialState = GraphicsState.create();
+  let path = initialState.currentPath;
+  for (const segment of segments) {
+    path = CurrentPath.append(path, segment);
+  }
+  const seededState = GraphicsState.update(initialState, { currentPath: path });
+  const graphicsStateStack = GraphicsStateStack.replaceCurrent(
+    GraphicsStateStack.create(),
+    seededState,
+  );
+  return { operandStack, graphicsStateStack };
+};
+
+test("`100 100 200 150 re` で PathSegment.rect(100,100,200,150) が空 currentPath に append される", () => {
+  const ctx = buildContext([real(100), real(100), real(200), real(150)]);
+
+  const result = reHandler(ctx);
+
+  assert(result.ok);
+  const current = GraphicsStateStack.current(result.value.graphicsStateStack);
+  expect(current.currentPath.segments).toEqual([
+    PathSegment.rect(100, 100, 200, 150),
+  ]);
+});
+
+test("`10 20 30 40 re` で x=10 / y=20 / width=30 / height=40 が PDF 順で格納される", () => {
+  const ctx = buildContext([real(10), real(20), real(30), real(40)]);
+
+  const result = reHandler(ctx);
+
+  assert(result.ok);
+  const current = GraphicsStateStack.current(result.value.graphicsStateStack);
+  const [segment] = current.currentPath.segments;
+  assert(segment.kind === "rect");
+  expect(segment.x).toBe(10);
+  expect(segment.y).toBe(20);
+  expect(segment.width).toBe(30);
+  expect(segment.height).toBe(40);
+});
+
+test("成功時 operandStack の depth は 0 かつ result.value.operandStack は同一参照", () => {
+  const ctx = buildContext([real(1), real(2), real(3), real(4)]);
+
+  const result = reHandler(ctx);
+
+  assert(result.ok);
+  expect(OperandStack.depth(result.value.operandStack)).toBe(0);
+  expect(result.value.operandStack).toBe(ctx.operandStack);
+});
+
+test("integer / real 混在 operand (int(100) real(150.5) int(200) real(75.25)) が許容される", () => {
+  const ctx = buildContext([int(100), real(150.5), int(200), real(75.25)]);
+
+  const result = reHandler(ctx);
+
+  assert(result.ok);
+  const current = GraphicsStateStack.current(result.value.graphicsStateStack);
+  expect(current.currentPath.segments).toEqual([
+    PathSegment.rect(100, 150.5, 200, 75.25),
+  ]);
+});
+
+test("既存 currentPath ([moveTo, lineTo, curveTo]) の末尾に rect が追加され元 segments が保持される", () => {
+  const ctx = buildContextWithSegments(
+    [
+      PathSegment.moveTo(10, 20),
+      PathSegment.lineTo(30, 40),
+      PathSegment.curveTo(50, 60, 70, 80, 90, 100),
+    ],
+    [real(200), real(300), real(40), real(60)],
+  );
+
+  const result = reHandler(ctx);
+
+  assert(result.ok);
+  const current = GraphicsStateStack.current(result.value.graphicsStateStack);
+  expect(current.currentPath.segments).toEqual([
+    PathSegment.moveTo(10, 20),
+    PathSegment.lineTo(30, 40),
+    PathSegment.curveTo(50, 60, 70, 80, 90, 100),
+    PathSegment.rect(200, 300, 40, 60),
+  ]);
+});
+
+test("成功時 ctm / lineWidth / lineCap / lineJoin / miterLimit は不変", () => {
+  const ctx = buildContext([real(0), real(0), real(100), real(100)]);
+  const before = GraphicsStateStack.current(ctx.graphicsStateStack);
+
+  const result = reHandler(ctx);
+
+  assert(result.ok);
+  const after = GraphicsStateStack.current(result.value.graphicsStateStack);
+  expect(after.ctm).toEqual(before.ctm);
+  expect(after.lineWidth).toBe(before.lineWidth);
+  expect(after.lineCap).toEqual(before.lineCap);
+  expect(after.lineJoin).toEqual(before.lineJoin);
+  expect(after.miterLimit).toBe(before.miterLimit);
+});
+
+test("width / height が 0 でも rect(0,0,0,0) がそのまま append される (reject しない)", () => {
+  const ctx = buildContext([real(0), real(0), real(0), real(0)]);
+
+  const result = reHandler(ctx);
+
+  assert(result.ok);
+  const current = GraphicsStateStack.current(result.value.graphicsStateStack);
+  expect(current.currentPath.segments).toEqual([PathSegment.rect(0, 0, 0, 0)]);
+});
+
+test("width / height が負値 (-50 / -100) でも rect(100,100,-50,-100) がそのまま append される", () => {
+  const ctx = buildContext([real(100), real(100), real(-50), real(-100)]);
+
+  const result = reHandler(ctx);
+
+  assert(result.ok);
+  const current = GraphicsStateStack.current(result.value.graphicsStateStack);
+  expect(current.currentPath.segments).toEqual([
+    PathSegment.rect(100, 100, -50, -100),
+  ]);
+});
+
+test.each([
+  { label: "NaN at x", x: Number.NaN, y: 0, w: 0, h: 0 },
+  { label: "NaN at y", x: 0, y: Number.NaN, w: 0, h: 0 },
+  {
+    label: "+Infinity at width",
+    x: 0,
+    y: 0,
+    w: Number.POSITIVE_INFINITY,
+    h: 0,
+  },
+  {
+    label: "-Infinity at width",
+    x: 0,
+    y: 0,
+    w: Number.NEGATIVE_INFINITY,
+    h: 0,
+  },
+  {
+    label: "+Infinity at height",
+    x: 0,
+    y: 0,
+    w: 0,
+    h: Number.POSITIVE_INFINITY,
+  },
+  {
+    label: "-Infinity at height",
+    x: 0,
+    y: 0,
+    w: 0,
+    h: Number.NEGATIVE_INFINITY,
+  },
+])("$label が混入しても検証せずそのまま格納する", ({ x, y, w, h }) => {
+  const ctx = buildContext([real(x), real(y), real(w), real(h)]);
+
+  const result = reHandler(ctx);
+
+  assert(result.ok);
+  const current = GraphicsStateStack.current(result.value.graphicsStateStack);
+  expect(current.currentPath.segments).toEqual([PathSegment.rect(x, y, w, h)]);
+});
+
+test("空 currentPath (current point 未確立) でも `re` は正常に append される", () => {
+  const ctx = buildContext([real(10), real(20), real(30), real(40)]);
+  const before = GraphicsStateStack.current(ctx.graphicsStateStack);
+  expect(CurrentPath.isEmpty(before.currentPath)).toBe(true);
+
+  const result = reHandler(ctx);
+
+  assert(result.ok);
+  const current = GraphicsStateStack.current(result.value.graphicsStateStack);
+  expect(current.currentPath.segments).toEqual([
+    PathSegment.rect(10, 20, 30, 40),
+  ]);
+});
+
+test.each([
+  { label: "0 個", count: 0 },
+  { label: "1 個", count: 1 },
+  { label: "2 個", count: 2 },
+  { label: "3 個", count: 3 },
+])("operand $label のとき OPERAND_MISSING を返し actual = pop 成功数", ({
+  count,
+}) => {
+  const operands: PdfObject[] = Array.from({ length: count }, () => real(1));
+  const ctx = buildContext(operands);
+
+  const result = reHandler(ctx);
+
+  assert(!result.ok);
+  assert(result.error.code === "OPERATOR_OPERAND_MISSING");
+  expect(result.error.operatorName).toBe("re");
+  expect(result.error.required).toBe(4);
+  expect(result.error.actual).toBe(count);
+  expect(result.error.message).toBe(
+    `Operator 're' requires 4 operand(s), got ${count}`,
+  );
+});
+
+test.each([
+  { label: "null", operand: { type: "null" } satisfies PdfObject },
+  {
+    label: "name",
+    operand: { type: "name", value: "Foo" } satisfies PdfObject,
+  },
+  {
+    label: "boolean",
+    operand: { type: "boolean", value: true } satisfies PdfObject,
+  },
+  {
+    label: "string",
+    operand: {
+      type: "string",
+      value: new Uint8Array([0x61]),
+      encoding: "literal",
+    } satisfies PdfObject,
+  },
+  {
+    label: "array",
+    operand: { type: "array", elements: [] } satisfies PdfObject,
+  },
+  {
+    label: "dictionary",
+    operand: { type: "dictionary", entries: new Map() } satisfies PdfObject,
+  },
+  {
+    label: "indirect-ref",
+    operand: {
+      type: "indirect-ref",
+      objectNumber: 1,
+      generationNumber: 0,
+    } satisfies PdfObject,
+  },
+  {
+    label: "stream",
+    operand: {
+      type: "stream",
+      dictionary: { type: "dictionary", entries: new Map() },
+      data: new Uint8Array(),
+    } satisfies PdfObject,
+  },
+])("top (PDF 順 height) が $label のとき TYPE_MISMATCH を返し depth は 3 (top のみ pop 済み)", ({
+  label,
+  operand,
+}) => {
+  const ctx = buildContext([real(100), real(100), real(200), operand]);
+
+  const result = reHandler(ctx);
+
+  assert(!result.ok);
+  assert(result.error.code === "OPERATOR_OPERAND_TYPE_MISMATCH");
+  expect(result.error.operatorName).toBe("re");
+  expect(result.error.expected).toBe("number");
+  expect(result.error.actual).toBe(label);
+  expect(result.error.message).toBe(
+    `Operator 're' expected number operand, got ${label}`,
+  );
+  expect(OperandStack.depth(ctx.operandStack)).toBe(3);
+});
+
+test("LIFO 2 個目 (PDF 順 width) が boolean のとき TYPE_MISMATCH を返し depth は 2 (部分消費の復元なし)", () => {
+  const bad: PdfObject = { type: "boolean", value: true };
+  const ctx = buildContext([real(100), real(100), bad, real(150)]);
+
+  const result = reHandler(ctx);
+
+  assert(!result.ok);
+  assert(result.error.code === "OPERATOR_OPERAND_TYPE_MISMATCH");
+  expect(result.error.actual).toBe("boolean");
+  expect(OperandStack.depth(ctx.operandStack)).toBe(2);
+});
+
+test("LIFO 3 個目 (PDF 順 y) が boolean のとき TYPE_MISMATCH を返し depth は 1", () => {
+  const bad: PdfObject = { type: "boolean", value: true };
+  const ctx = buildContext([real(100), bad, real(200), real(150)]);
+
+  const result = reHandler(ctx);
+
+  assert(!result.ok);
+  assert(result.error.code === "OPERATOR_OPERAND_TYPE_MISMATCH");
+  expect(result.error.actual).toBe("boolean");
+  expect(OperandStack.depth(ctx.operandStack)).toBe(1);
+});
+
+test("LIFO 4 個目 (PDF 順 x = bottom) が boolean のとき TYPE_MISMATCH を返し depth は 0 (4 個 pop 済み)", () => {
+  const bad: PdfObject = { type: "boolean", value: true };
+  const ctx = buildContext([bad, real(100), real(200), real(150)]);
+
+  const result = reHandler(ctx);
+
+  assert(!result.ok);
+  assert(result.error.code === "OPERATOR_OPERAND_TYPE_MISMATCH");
+  expect(result.error.actual).toBe("boolean");
+  expect(OperandStack.depth(ctx.operandStack)).toBe(0);
+});

--- a/packages/core/src/content-stream/operators/path/re/index.ts
+++ b/packages/core/src/content-stream/operators/path/re/index.ts
@@ -1,0 +1,89 @@
+import type { PdfError } from "../../../../pdf/errors/index";
+import { err, ok } from "../../../../utils/result/index";
+import {
+  CurrentPath,
+  GraphicsState,
+  GraphicsStateStack,
+} from "../../../graphics-state/index";
+import { PathSegment } from "../../../graphics-state/path-segment";
+import { OperandStack } from "../../../operand-stack/index";
+import type {
+  OperatorHandler,
+  OperatorHandlerContext,
+} from "../../../operator-registry/index";
+import { NumericPdfObject } from "../../graphics-state/numeric-pdf-object";
+
+const OPERATOR_NAME = "re";
+const OPERAND_COUNT = 4;
+
+/**
+ * PDF §8.5.2 `re` operator (rectangle) のハンドラ。
+ *
+ * operand stack から `x y width height` の 4 個の数値を pop し、
+ * `PathSegment.rect(x, y, width, height)` を current path の末尾に append する
+ * (ISO 32000-1:2008 §8.5.2)。`re` は自身が新しい subpath を開始するため、
+ * 直前に `m` 等で current point を確立する必要は無い
+ * (`CurrentPath.isEmpty` ガードを設けず無条件に append する)。
+ *
+ * - operand 不足 (< 4) のとき `OPERATOR_OPERAND_MISSING` を返す
+ *   `actual` には pop に成功した個数 (0..3) を入れる
+ * - operand に integer / real 以外が混在したとき `OPERATOR_OPERAND_TYPE_MISMATCH` を返す
+ * - 値域 (`NaN` / `Infinity` / 負値 / 0) は本 handler では検証せずそのまま格納する
+ *   (negative width/height は PDF 仕様で許容され、renderer 側で解釈される)
+ * - エラー時に operand stack の部分消費は復元しない (既存 m/l/c handler 規約)
+ * - `OPERATOR_PATH_NO_CURRENT_POINT` は返さない (re は current point 不要)
+ *
+ * @param context - 実行コンテキスト (operand stack / graphics state stack)
+ * @returns 成功なら更新後コンテキスト、失敗なら PdfError
+ */
+export const reHandler: OperatorHandler = (context: OperatorHandlerContext) => {
+  const popped: NumericPdfObject[] = [];
+  for (let i = 0; i < OPERAND_COUNT; i++) {
+    const result = OperandStack.pop(context.operandStack);
+    if (!result.some) {
+      const error: PdfError = {
+        code: "OPERATOR_OPERAND_MISSING",
+        message: `Operator '${OPERATOR_NAME}' requires ${OPERAND_COUNT} operand(s), got ${i}`,
+        operatorName: OPERATOR_NAME,
+        required: OPERAND_COUNT,
+        actual: i,
+      };
+      return err(error);
+    }
+    const operand = result.value;
+    if (!NumericPdfObject.is(operand)) {
+      const error: PdfError = {
+        code: "OPERATOR_OPERAND_TYPE_MISMATCH",
+        message: `Operator '${OPERATOR_NAME}' expected number operand, got ${operand.type}`,
+        operatorName: OPERATOR_NAME,
+        expected: "number",
+        actual: operand.type,
+      };
+      return err(error);
+    }
+    popped.push(operand);
+  }
+
+  // popped は LIFO 順 [height, width, y, x]。reverse して PDF 順 [x, y, width, height] に戻す
+  const [x, y, width, height] = popped
+    .slice()
+    .reverse()
+    .map((operand) => operand.value);
+
+  const current = GraphicsStateStack.current(context.graphicsStateStack);
+  // re は自身が subpath を開始するため CurrentPath.isEmpty ガードは設けず無条件 append
+  const nextPath = CurrentPath.append(
+    current.currentPath,
+    PathSegment.rect(x, y, width, height),
+  );
+  const next = GraphicsState.update(current, { currentPath: nextPath });
+  const graphicsStateStack = GraphicsStateStack.replaceCurrent(
+    context.graphicsStateStack,
+    next,
+  );
+
+  return ok({
+    operandStack: context.operandStack,
+    graphicsStateStack,
+  });
+};


### PR DESCRIPTION
## 概要

spec-051。PDF §8.5.2 `re` (rectangle) operator のハンドラ `reHandler` を `@pdfmod/core` に追加する。operand stack から `x y width height` の 4 数値を pop し、`PathSegment.rect(x, y, w, h)` を current path に append する決定的 handler。既存 path operator (`m` / `l` / `c` / `h`) と同じパターンに揃えつつ、`re` 固有差分として `CurrentPath.isEmpty` ガードを設けない (re は自身が subpath を開始するため)。レジストリ登録は範囲外で #175 で実施する。

## 変更の種類

- ✨ [New Feature]: 新機能
- 🧪 [Tests]: テスト追加

## 追加した内容

- `packages/core/src/content-stream/operators/path/re/index.ts` — `reHandler: OperatorHandler` 実装
- `packages/core/src/content-stream/operators/path/re/__tests__/re.basic.test.ts` — 14 シナリオ (test.each 展開で 30 ケース)

## システム図

```mermaid
flowchart TD
  Start([reHandler context]) --> PopLoop{i = 0..3<br/>OperandStack.pop}
  PopLoop -- none --> Missing[err: OPERATOR_OPERAND_MISSING<br/>actual = i, required = 4]
  PopLoop -- some operand --> TypeCheck{NumericPdfObject.is}
  TypeCheck -- false --> Mismatch[err: OPERATOR_OPERAND_TYPE_MISMATCH<br/>expected = number]
  TypeCheck -- true --> Push[popped.push operand]
  Push -- i &lt; 3 --> PopLoop
  Push -- i = 3 --> Reverse[popped.slice.reverse<br/>LIFO h,w,y,x → PDF x,y,w,h]
  Reverse --> Append[CurrentPath.append<br/>PathSegment.rect x,y,w,h<br/>★ isEmpty ガードなし]
  Append --> Update[GraphicsState.update<br/>GraphicsStateStack.replaceCurrent]
  Update --> OK([ok operandStack, graphicsStateStack])

  style Append fill:#fff4b8,stroke:#d4a72c
```

★ 印は既存 `c` handler との差分: `re` は current point 不要のため `OPERATOR_PATH_NO_CURRENT_POINT` を返さず、空 currentPath でも無条件 append する (PDF §8.5.2)。

## 関連 spec / Issue

- spec: `.plugin-workspace/.specs/051-re-operator-handler/`
- Closes #171

## テスト

| コマンド | 結果 |
|:-|:-|
| `pnpm --filter @pdfmod/core test src/content-stream/operators/path/re` | 30 tests passed |
| `pnpm --filter @pdfmod/core test` | 1842 tests passed (127 files, リグレッションなし) |
| `pnpm --filter @pdfmod/core typecheck` | 通過 |
| `pnpm --filter @pdfmod/core build` | 通過 (vite build + tsc declaration) |

Codex レビュー (`.plugin-workspace/.specs/051-re-operator-handler/code-review/review-001.md`): **問題なし**。実装計画整合性 / コード品質 / エッジケース / セキュリティ / パフォーマンス すべて OK。

## レビューポイント

- **re 固有差分**: `reHandler` 内に `CurrentPath.isEmpty` ガードが無く、`OPERATOR_PATH_NO_CURRENT_POINT` も返さない点 (`m`/`l`/`c` との重要な差分、PDF §8.5.2 準拠)
- **値域非検証**: `NaN` / `±Infinity` / 負値 / 0 はハンドラでは検証せずそのまま `PathSegment.rect` に格納する (renderer 側スコープ)
- **エラー時 stack 非復元**: TYPE_MISMATCH 時に operand stack の部分消費を復元しない (既存 m/l/c handler 規約に統一)
- **レジストリ登録は範囲外**: `OperatorRegistry.register(..., "re", reHandler)` は本 PR では行わず #175 で path operator 全体をまとめて登録する
- **テスト規約**: フラット構造 (describe 不使用) / section コメントなし / 型保証を runtime expect で再確認しない / `buildContext` `buildContextWithSegments` は h.basic.test.ts と同じパターン