### PR TITLE
✨ [New Feature]: #172 S (stroke) operator handler を実装

### DIFF
--- a/packages/core/src/content-stream/operators/path/stroke/__tests__/stroke.basic.test.ts
+++ b/packages/core/src/content-stream/operators/path/stroke/__tests__/stroke.basic.test.ts
@@ -1,0 +1,219 @@
+import { assert, expect, test } from "vitest";
+import type { PdfObject } from "../../../../../pdf/types/pdf-types/index";
+import {
+  CurrentPath,
+  GraphicsState,
+  GraphicsStateStack,
+  LineCap,
+  LineJoin,
+  Matrix,
+} from "../../../../graphics-state/index";
+import { PathSegment } from "../../../../graphics-state/path-segment";
+import { OperandStack } from "../../../../operand-stack/index";
+import type { OperatorHandlerContext } from "../../../../operator-registry/index";
+import { strokeHandler } from "../index";
+
+const real = (value: number): PdfObject => ({ type: "real", value });
+
+const buildContext = (operands: PdfObject[]): OperatorHandlerContext => {
+  const operandStack = OperandStack.create();
+  for (const operand of operands) {
+    OperandStack.push(operandStack, operand);
+  }
+  const graphicsStateStack = GraphicsStateStack.create();
+  return { operandStack, graphicsStateStack };
+};
+
+const buildContextWithSegments = (
+  segments: PathSegment[],
+  operands: PdfObject[] = [],
+): OperatorHandlerContext => {
+  const operandStack = OperandStack.create();
+  for (const operand of operands) {
+    OperandStack.push(operandStack, operand);
+  }
+  const initialState = GraphicsState.create();
+  let path = initialState.currentPath;
+  for (const segment of segments) {
+    path = CurrentPath.append(path, segment);
+  }
+  const seededState = GraphicsState.update(initialState, { currentPath: path });
+  const graphicsStateStack = GraphicsStateStack.replaceCurrent(
+    GraphicsStateStack.create(),
+    seededState,
+  );
+  return { operandStack, graphicsStateStack };
+};
+
+const buildContextWithGraphicsState = (
+  state: GraphicsState,
+  operands: PdfObject[] = [],
+): OperatorHandlerContext => {
+  const operandStack = OperandStack.create();
+  for (const operand of operands) {
+    OperandStack.push(operandStack, operand);
+  }
+  const graphicsStateStack = GraphicsStateStack.replaceCurrent(
+    GraphicsStateStack.create(),
+    state,
+  );
+  return { operandStack, graphicsStateStack };
+};
+
+test("空 path に対して `S` は no-op で segments が空のまま保たれる", () => {
+  const ctx = buildContext([]);
+
+  const result = strokeHandler(ctx);
+
+  assert(result.ok);
+  const current = GraphicsStateStack.current(result.value.graphicsStateStack);
+  expect(current.currentPath.segments).toEqual([]);
+});
+
+test("空 path に対する `S` の後、後続 `l` / `c` が依拠する CurrentPath.isEmpty 不変条件は保たれる", () => {
+  const ctx = buildContext([]);
+
+  const result = strokeHandler(ctx);
+
+  assert(result.ok);
+  const current = GraphicsStateStack.current(result.value.graphicsStateStack);
+  expect(CurrentPath.isEmpty(current.currentPath)).toBe(true);
+});
+
+test("`m(0,0)` 済み path に `S` を実行すると segments が空になる", () => {
+  const ctx = buildContextWithSegments([PathSegment.moveTo(0, 0)]);
+
+  const result = strokeHandler(ctx);
+
+  assert(result.ok);
+  const current = GraphicsStateStack.current(result.value.graphicsStateStack);
+  expect(current.currentPath.segments).toEqual([]);
+});
+
+test("`m(0,0) → l(100,200)` 済み path に `S` を実行すると segments が空になる", () => {
+  const ctx = buildContextWithSegments([
+    PathSegment.moveTo(0, 0),
+    PathSegment.lineTo(100, 200),
+  ]);
+
+  const result = strokeHandler(ctx);
+
+  assert(result.ok);
+  const current = GraphicsStateStack.current(result.value.graphicsStateStack);
+  expect(current.currentPath.segments).toEqual([]);
+});
+
+test("`m → l → close` 済み path に `S` を実行すると segments が空になる", () => {
+  const ctx = buildContextWithSegments([
+    PathSegment.moveTo(0, 0),
+    PathSegment.lineTo(100, 200),
+    PathSegment.close(),
+  ]);
+
+  const result = strokeHandler(ctx);
+
+  assert(result.ok);
+  const current = GraphicsStateStack.current(result.value.graphicsStateStack);
+  expect(current.currentPath.segments).toEqual([]);
+});
+
+test("operand stack が空でも `S` は成功する", () => {
+  const ctx = buildContext([]);
+
+  const result = strokeHandler(ctx);
+
+  assert(result.ok);
+});
+
+test("operand stack に numeric 値があっても `S` は pop しない (depth / peek 維持)", () => {
+  const ctx = buildContext([real(1), real(2), real(3)]);
+  const depthBefore = OperandStack.depth(ctx.operandStack);
+  const peekBefore = OperandStack.peek(ctx.operandStack);
+
+  const result = strokeHandler(ctx);
+
+  assert(result.ok);
+  expect(OperandStack.depth(result.value.operandStack)).toBe(depthBefore);
+  expect(OperandStack.depth(result.value.operandStack)).toBe(3);
+  const peekAfter = OperandStack.peek(result.value.operandStack);
+  assert(peekBefore.some);
+  assert(peekAfter.some);
+  expect(peekAfter.value).toEqual(real(3));
+  expect(peekAfter.value).toEqual(peekBefore.value);
+});
+
+test("operand stack に非 numeric 値があっても `S` は成功し、depth / peek を維持する", () => {
+  const name: PdfObject = { type: "name", value: "Foo" };
+  const bool: PdfObject = { type: "boolean", value: true };
+  const dict: PdfObject = { type: "dictionary", entries: new Map() };
+  const ctx = buildContext([name, bool, dict]);
+  const depthBefore = OperandStack.depth(ctx.operandStack);
+  const peekBefore = OperandStack.peek(ctx.operandStack);
+
+  const result = strokeHandler(ctx);
+
+  assert(result.ok);
+  expect(OperandStack.depth(result.value.operandStack)).toBe(depthBefore);
+  expect(OperandStack.depth(result.value.operandStack)).toBe(3);
+  const peekAfter = OperandStack.peek(result.value.operandStack);
+  assert(peekBefore.some);
+  assert(peekAfter.some);
+  expect(peekAfter.value).toEqual(dict);
+  expect(peekAfter.value).toEqual(peekBefore.value);
+});
+
+test("非空 path + 非デフォルト ctm / lineWidth / lineCap / lineJoin / miterLimit で `S` 実行しても currentPath 以外が保持される", () => {
+  const baseState = GraphicsState.create();
+  let path = baseState.currentPath;
+  path = CurrentPath.append(path, PathSegment.moveTo(0, 0));
+  path = CurrentPath.append(path, PathSegment.lineTo(100, 200));
+  const seededCtm = Matrix.create(2, 0, 0, 3, 10, 20);
+  const seededLineCap = LineCap.create(2);
+  const seededLineJoin = LineJoin.create(2);
+  const seededState = GraphicsState.update(baseState, {
+    currentPath: path,
+    ctm: seededCtm,
+    lineWidth: 5,
+    lineCap: seededLineCap,
+    lineJoin: seededLineJoin,
+    miterLimit: 20,
+  });
+  const ctx = buildContextWithGraphicsState(seededState);
+
+  const result = strokeHandler(ctx);
+
+  assert(result.ok);
+  const after = GraphicsStateStack.current(result.value.graphicsStateStack);
+  expect(after.currentPath.segments).toEqual([]);
+  expect(after.ctm).toEqual(seededCtm);
+  expect(after.lineWidth).toBe(5);
+  expect(after.lineCap).toBe(seededLineCap);
+  expect(after.lineJoin).toBe(seededLineJoin);
+  expect(after.miterLimit).toBe(20);
+});
+
+test("`m → l` 済み path に対する連続 `S → S` で 2 回目も成功し currentPath が空のまま保たれる", () => {
+  const ctx = buildContextWithSegments([
+    PathSegment.moveTo(0, 0),
+    PathSegment.lineTo(100, 200),
+  ]);
+
+  const firstResult = strokeHandler(ctx);
+  assert(firstResult.ok);
+  const secondResult = strokeHandler(firstResult.value);
+
+  assert(secondResult.ok);
+  const current = GraphicsStateStack.current(
+    secondResult.value.graphicsStateStack,
+  );
+  expect(current.currentPath.segments).toEqual([]);
+});
+
+test("成功時 `result.value.operandStack` は入力 `ctx.operandStack` と同一参照 (reset 分岐)", () => {
+  const ctx = buildContextWithSegments([PathSegment.moveTo(0, 0)], [real(1)]);
+
+  const result = strokeHandler(ctx);
+
+  assert(result.ok);
+  expect(result.value.operandStack).toBe(ctx.operandStack);
+});

--- a/packages/core/src/content-stream/operators/path/stroke/__tests__/stroke.basic.test.ts
+++ b/packages/core/src/content-stream/operators/path/stroke/__tests__/stroke.basic.test.ts
@@ -185,7 +185,7 @@ test("非空 path + 非デフォルト ctm / lineWidth / lineCap / lineJoin / mi
   assert(result.ok);
   const after = GraphicsStateStack.current(result.value.graphicsStateStack);
   expect(after.currentPath.segments).toEqual([]);
-  expect(after.ctm).toEqual(seededCtm);
+  expect(after.ctm).toBe(seededCtm);
   expect(after.lineWidth).toBe(5);
   expect(after.lineCap).toBe(seededLineCap);
   expect(after.lineJoin).toBe(seededLineJoin);
@@ -216,4 +216,14 @@ test("成功時 `result.value.operandStack` は入力 `ctx.operandStack` と同�
 
   assert(result.ok);
   expect(result.value.operandStack).toBe(ctx.operandStack);
+});
+
+test("空 path 早期 return 分岐で `result.value.operandStack` / `graphicsStateStack` は入力と同一参照", () => {
+  const ctx = buildContext([real(1)]);
+
+  const result = strokeHandler(ctx);
+
+  assert(result.ok);
+  expect(result.value.operandStack).toBe(ctx.operandStack);
+  expect(result.value.graphicsStateStack).toBe(ctx.graphicsStateStack);
 });

--- a/packages/core/src/content-stream/operators/path/stroke/index.ts
+++ b/packages/core/src/content-stream/operators/path/stroke/index.ts
@@ -1,0 +1,56 @@
+import { ok } from "../../../../utils/result/index";
+import {
+  CurrentPath,
+  GraphicsState,
+  GraphicsStateStack,
+} from "../../../graphics-state/index";
+import type {
+  OperatorHandler,
+  OperatorHandlerContext,
+} from "../../../operator-registry/index";
+
+/**
+ * PDF §8.5.3 `S` operator (stroke the path) のハンドラ。
+ *
+ * operand を pop せず、実行後 current path を `CurrentPath.empty()` に
+ * リセットした新しい GraphicsState を生成する (ISO 32000-1:2008 §8.5.3:
+ * painting operators consume the current path)。`S` は引数を取らないため
+ * operand stack に値が残っていても pop / 検証 / clear のいずれも行わず、
+ * 同一参照のまま返す。
+ *
+ * 命名: PDF 仕様上の大文字 `S` (stroke) と小文字 `s` (close-and-stroke) は
+ * 別 operator のため、letter ディレクトリではなく semantic 名 `stroke` を使う。
+ *
+ * - operand 数: 0 (operand stack を一切参照しない)
+ * - current path が空の場合は no-op で同一 operandStack / graphicsStateStack
+ *   参照を含む新 context を返す
+ * - 実際のラスタライズは本ライブラリのスコープ外。state の path リセットのみ
+ * - ctm / lineWidth / lineCap / lineJoin / miterLimit など
+ *   currentPath 以外の graphics state は変更しない
+ * - 本 handler では PdfError を返さない (常に ok)
+ *
+ * @param context - 実行コンテキスト (operand stack / graphics state stack)
+ * @returns 更新後コンテキスト (常に ok)
+ */
+export const strokeHandler: OperatorHandler = (
+  context: OperatorHandlerContext,
+) => {
+  const current = GraphicsStateStack.current(context.graphicsStateStack);
+  if (CurrentPath.isEmpty(current.currentPath)) {
+    return ok({
+      operandStack: context.operandStack,
+      graphicsStateStack: context.graphicsStateStack,
+    });
+  }
+  const next = GraphicsState.update(current, {
+    currentPath: CurrentPath.empty(),
+  });
+  const graphicsStateStack = GraphicsStateStack.replaceCurrent(
+    context.graphicsStateStack,
+    next,
+  );
+  return ok({
+    operandStack: context.operandStack,
+    graphicsStateStack,
+  });
+};


### PR DESCRIPTION
## 概要

spec-052。PDF §8.5.3 `S` (stroke) operator のハンドラを実装する。operand を pop せず、実行後に current path を `CurrentPath.empty()` にリセットする path-painting operator。空 path の場合は no-op で同一 context を返す (実装パターンは PR #200 `h` operator を踏襲)。

## 変更の種類

- ✨ 新機能

## 追加した内容

- `packages/core/src/content-stream/operators/path/stroke/index.ts`: `strokeHandler: OperatorHandler` を named export。空 path 早期 return + reset 分岐の 2 経路で実装
- `packages/core/src/content-stream/operators/path/stroke/__tests__/stroke.basic.test.ts`: T1〜T11 の 11 ケース (空 path no-op, segments reset, operand 不変契約, ctm/lineWidth/lineCap/lineJoin/miterLimit 不変, 連続実行冪等性, operandStack 同一参照)

## システム図

```mermaid
flowchart TD
  ctx[OperatorHandlerContext]
  current[GraphicsStateStack.current]
  empty{CurrentPath.isEmpty?}
  noop[早期 return: 同一 operandStack / graphicsStateStack 参照]
  update[GraphicsState.update<br/>currentPath: CurrentPath.empty]
  replace[GraphicsStateStack.replaceCurrent]
  okResult[ok new context]

  ctx --> current
  current --> empty
  empty -- yes --> noop --> okResult
  empty -- no --> update --> replace --> okResult

  style update fill:#e1f5ff
  style replace fill:#e1f5ff
```

## 命名方針

- export 名: `strokeHandler`
- ディレクトリ: `packages/core/src/content-stream/operators/path/stroke/`
- 大文字 `S` (stroke) と小文字 `s` (close-and-stroke) は別 operator のため、letter ディレクトリではなく semantic 名を採用。将来の `s` は `path/close-stroke/` として実装される想定 (本 PR スコープ外)

## 関連 spec / Issue

- spec: `.plugin-workspace/.specs/052-s-operator-handler/`
- Refs #172
- 依存: #170 (h operator, 完了済), #163 (epic)

## テスト

- `pnpm --filter @pdfmod/core test`: **1853 / 1853 pass**
- `pnpm --filter @pdfmod/core build`: **成功**
- `pnpm lint`: **0 errors** (`.pnpm-store` の broken symlink warning 3 件は spec 外)
- Codex レビュー (`.config.yml` review-tool: codex): **「問題なし」**。Codex 側でも `pnpm test stroke.basic` / `build` / `lint` を再実行し全件 pass

## レビューポイント

- T9 が早期 return ではなく **reset 分岐** を通っているか (path を seed したうえで非デフォルト ctm/lineWidth/lineCap/lineJoin/miterLimit を assert)
- ctm を含む 5 フィールドが `GraphicsState.update` で保持されていることを assert し、誤って `GraphicsState.create()` で state を作り直す実装も検出できる
- handler が `h` operator (#170) と同じスタイル (early-return ガード、ok-only、operand 不変参照) になっているか
- 命名方針: 1 文字ディレクトリ `s` を避けて semantic 名 `stroke` を採用した判断 (将来の close-and-stroke との衝突回避)