### PR TITLE
✨ #173 f (fill, nonzero) operator handler を実装

### DIFF
--- a/packages/core/src/content-stream/operators/path/fill/__tests__/fill.basic.test.ts
+++ b/packages/core/src/content-stream/operators/path/fill/__tests__/fill.basic.test.ts
@@ -1,0 +1,307 @@
+import { assert, expect, test } from "vitest";
+import type { PdfObject } from "../../../../../pdf/types/pdf-types/index";
+import {
+  CurrentPath,
+  GraphicsState,
+  GraphicsStateStack,
+  LineCap,
+  LineJoin,
+  Matrix,
+} from "../../../../graphics-state/index";
+import { PathSegment } from "../../../../graphics-state/path-segment";
+import { OperandStack } from "../../../../operand-stack/index";
+import type { OperatorHandlerContext } from "../../../../operator-registry/index";
+import { fillHandler } from "../index";
+
+const real = (value: number): PdfObject => ({ type: "real", value });
+
+const buildContext = (operands: PdfObject[]): OperatorHandlerContext => {
+  const operandStack = OperandStack.create();
+  for (const operand of operands) {
+    OperandStack.push(operandStack, operand);
+  }
+  const graphicsStateStack = GraphicsStateStack.create();
+  return { operandStack, graphicsStateStack };
+};
+
+const buildContextWithSegments = (
+  segments: PathSegment[],
+  operands: PdfObject[] = [],
+): OperatorHandlerContext => {
+  const operandStack = OperandStack.create();
+  for (const operand of operands) {
+    OperandStack.push(operandStack, operand);
+  }
+  const initialState = GraphicsState.create();
+  let path = initialState.currentPath;
+  for (const segment of segments) {
+    path = CurrentPath.append(path, segment);
+  }
+  const seededState = GraphicsState.update(initialState, { currentPath: path });
+  const graphicsStateStack = GraphicsStateStack.replaceCurrent(
+    GraphicsStateStack.create(),
+    seededState,
+  );
+  return { operandStack, graphicsStateStack };
+};
+
+const buildContextWithGraphicsState = (
+  state: GraphicsState,
+  operands: PdfObject[] = [],
+): OperatorHandlerContext => {
+  const operandStack = OperandStack.create();
+  for (const operand of operands) {
+    OperandStack.push(operandStack, operand);
+  }
+  const graphicsStateStack = GraphicsStateStack.replaceCurrent(
+    GraphicsStateStack.create(),
+    state,
+  );
+  return { operandStack, graphicsStateStack };
+};
+
+test("空 path に対して `f` は no-op で segments が空のまま保たれる", () => {
+  const ctx = buildContext([]);
+
+  const result = fillHandler(ctx);
+
+  assert(result.ok);
+  const current = GraphicsStateStack.current(result.value.graphicsStateStack);
+  expect(current.currentPath.segments).toEqual([]);
+});
+
+test("空 path に対する `f` の後、後続 `l` / `c` が依拠する CurrentPath.isEmpty 不変条件は保たれる", () => {
+  const ctx = buildContext([]);
+
+  const result = fillHandler(ctx);
+
+  assert(result.ok);
+  const current = GraphicsStateStack.current(result.value.graphicsStateStack);
+  expect(CurrentPath.isEmpty(current.currentPath)).toBe(true);
+});
+
+test("`m(0,0)` 済み path に `f` を実行すると segments が空になる", () => {
+  const ctx = buildContextWithSegments([PathSegment.moveTo(0, 0)]);
+
+  const result = fillHandler(ctx);
+
+  assert(result.ok);
+  const current = GraphicsStateStack.current(result.value.graphicsStateStack);
+  expect(current.currentPath.segments).toEqual([]);
+});
+
+test("`m(0,0) → l(100,200)` 済み path に `f` を実行すると segments が空になる", () => {
+  const ctx = buildContextWithSegments([
+    PathSegment.moveTo(0, 0),
+    PathSegment.lineTo(100, 200),
+  ]);
+
+  const result = fillHandler(ctx);
+
+  assert(result.ok);
+  const current = GraphicsStateStack.current(result.value.graphicsStateStack);
+  expect(current.currentPath.segments).toEqual([]);
+});
+
+test("`m → l → close` 済み path に `f` を実行すると segments が空になる", () => {
+  const ctx = buildContextWithSegments([
+    PathSegment.moveTo(0, 0),
+    PathSegment.lineTo(100, 200),
+    PathSegment.close(),
+  ]);
+
+  const result = fillHandler(ctx);
+
+  assert(result.ok);
+  const current = GraphicsStateStack.current(result.value.graphicsStateStack);
+  expect(current.currentPath.segments).toEqual([]);
+});
+
+test("operand stack が空でも `f` は成功する", () => {
+  const ctx = buildContext([]);
+
+  const result = fillHandler(ctx);
+
+  assert(result.ok);
+});
+
+test("operand stack に numeric 値があっても `f` は pop しない (depth / peek 維持)", () => {
+  const ctx = buildContext([real(1), real(2), real(3)]);
+  const depthBefore = OperandStack.depth(ctx.operandStack);
+  const peekBefore = OperandStack.peek(ctx.operandStack);
+
+  const result = fillHandler(ctx);
+
+  assert(result.ok);
+  expect(result.value.operandStack).toBe(ctx.operandStack);
+  expect(OperandStack.depth(result.value.operandStack)).toBe(depthBefore);
+  expect(OperandStack.depth(result.value.operandStack)).toBe(3);
+  const peekAfter = OperandStack.peek(result.value.operandStack);
+  assert(peekBefore.some);
+  assert(peekAfter.some);
+  expect(peekAfter.value).toEqual(real(3));
+  expect(peekAfter.value).toEqual(peekBefore.value);
+});
+
+test.each<{ label: string; operands: PdfObject[]; topExpected: PdfObject }>([
+  {
+    label: "name",
+    operands: [{ type: "name", value: "Foo" }],
+    topExpected: { type: "name", value: "Foo" },
+  },
+  {
+    label: "boolean",
+    operands: [{ type: "boolean", value: true }],
+    topExpected: { type: "boolean", value: true },
+  },
+  {
+    label: "dictionary",
+    operands: [{ type: "dictionary", entries: new Map() }],
+    topExpected: { type: "dictionary", entries: new Map() },
+  },
+])("operand stack に非 numeric 値 ($label) があっても `f` は成功し depth / peek を維持する", ({
+  operands,
+  topExpected,
+}) => {
+  const ctx = buildContext(operands);
+  const depthBefore = OperandStack.depth(ctx.operandStack);
+  const peekBefore = OperandStack.peek(ctx.operandStack);
+
+  const result = fillHandler(ctx);
+
+  assert(result.ok);
+  expect(result.value.operandStack).toBe(ctx.operandStack);
+  expect(OperandStack.depth(result.value.operandStack)).toBe(depthBefore);
+  const peekAfter = OperandStack.peek(result.value.operandStack);
+  assert(peekBefore.some);
+  assert(peekAfter.some);
+  expect(peekAfter.value).toEqual(topExpected);
+  expect(peekAfter.value).toEqual(peekBefore.value);
+});
+
+test("非空 path + 非デフォルト ctm / lineWidth / lineCap / lineJoin / miterLimit で `f` 実行しても currentPath 以外が保持される", () => {
+  const baseState = GraphicsState.create();
+  let path = baseState.currentPath;
+  path = CurrentPath.append(path, PathSegment.moveTo(0, 0));
+  path = CurrentPath.append(path, PathSegment.lineTo(100, 200));
+  const seededCtm = Matrix.create(2, 0, 0, 3, 10, 20);
+  const seededLineCap = LineCap.create(2);
+  const seededLineJoin = LineJoin.create(2);
+  const seededState = GraphicsState.update(baseState, {
+    currentPath: path,
+    ctm: seededCtm,
+    lineWidth: 5,
+    lineCap: seededLineCap,
+    lineJoin: seededLineJoin,
+    miterLimit: 20,
+  });
+  const ctx = buildContextWithGraphicsState(seededState);
+
+  const result = fillHandler(ctx);
+
+  assert(result.ok);
+  const after = GraphicsStateStack.current(result.value.graphicsStateStack);
+  expect(after.currentPath.segments).toEqual([]);
+  expect(after.ctm).toBe(seededCtm);
+  expect(after.lineWidth).toBe(5);
+  expect(after.lineCap).toBe(seededLineCap);
+  expect(after.lineJoin).toBe(seededLineJoin);
+  expect(after.miterLimit).toBe(20);
+});
+
+test("`m → l` 済み path に対する連続 `f → f` で 2 回目も成功し currentPath が空のまま保たれる", () => {
+  const ctx = buildContextWithSegments([
+    PathSegment.moveTo(0, 0),
+    PathSegment.lineTo(100, 200),
+  ]);
+
+  const firstResult = fillHandler(ctx);
+  assert(firstResult.ok);
+  const secondResult = fillHandler(firstResult.value);
+
+  assert(secondResult.ok);
+  const current = GraphicsStateStack.current(
+    secondResult.value.graphicsStateStack,
+  );
+  expect(current.currentPath.segments).toEqual([]);
+});
+
+test("reset 分岐: operandStack は同一参照、graphicsStateStack は別参照、入力 graphicsStateStack の currentPath は mutate されない", () => {
+  const ctx = buildContextWithSegments([PathSegment.moveTo(0, 0)], [real(1)]);
+
+  const result = fillHandler(ctx);
+
+  assert(result.ok);
+  expect(result.value.operandStack).toBe(ctx.operandStack);
+  expect(result.value.graphicsStateStack).not.toBe(ctx.graphicsStateStack);
+  expect(
+    GraphicsStateStack.current(ctx.graphicsStateStack).currentPath.segments,
+  ).toEqual([PathSegment.moveTo(0, 0)]);
+});
+
+test("空 path 早期 return 分岐で `result.value.operandStack` / `graphicsStateStack` は入力と同一参照", () => {
+  const ctx = buildContext([real(1)]);
+
+  const result = fillHandler(ctx);
+
+  assert(result.ok);
+  expect(result.value.operandStack).toBe(ctx.operandStack);
+  expect(result.value.graphicsStateStack).toBe(ctx.graphicsStateStack);
+});
+
+test("`q` 済み (saved state あり) 状態で `f` を実行しても saved stack が保持される", () => {
+  const baseState = GraphicsState.create();
+  const savedCtm = Matrix.create(2, 0, 0, 3, 10, 20);
+  const savedPath = CurrentPath.append(
+    baseState.currentPath,
+    PathSegment.moveTo(0, 0),
+  );
+  const savedState = GraphicsState.update(baseState, {
+    currentPath: savedPath,
+    ctm: savedCtm,
+    lineWidth: 5,
+  });
+  const stackWithSavedCurrent = GraphicsStateStack.replaceCurrent(
+    GraphicsStateStack.create(),
+    savedState,
+  );
+  const savedStack = GraphicsStateStack.save(stackWithSavedCurrent);
+
+  let currentPath = baseState.currentPath;
+  currentPath = CurrentPath.append(currentPath, PathSegment.moveTo(50, 60));
+  currentPath = CurrentPath.append(currentPath, PathSegment.lineTo(100, 200));
+  const currentState = GraphicsState.update(baseState, {
+    currentPath,
+    lineWidth: 1,
+  });
+  const seededStack = GraphicsStateStack.replaceCurrent(
+    savedStack,
+    currentState,
+  );
+  const ctx: OperatorHandlerContext = {
+    operandStack: OperandStack.create(),
+    graphicsStateStack: seededStack,
+  };
+
+  const result = fillHandler(ctx);
+
+  assert(result.ok);
+
+  const restoredAfter = GraphicsStateStack.restore(
+    result.value.graphicsStateStack,
+  );
+  const restoredAfterCurrent = GraphicsStateStack.current(restoredAfter);
+  expect(restoredAfterCurrent.lineWidth).toBe(5);
+  expect(restoredAfterCurrent.ctm).toBe(savedCtm);
+  expect(restoredAfterCurrent.currentPath.segments).toEqual([
+    PathSegment.moveTo(0, 0),
+  ]);
+
+  const restoredInput = GraphicsStateStack.restore(ctx.graphicsStateStack);
+  const restoredInputCurrent = GraphicsStateStack.current(restoredInput);
+  expect(restoredInputCurrent.lineWidth).toBe(5);
+  expect(restoredInputCurrent.ctm).toBe(savedCtm);
+  expect(restoredInputCurrent.currentPath.segments).toEqual([
+    PathSegment.moveTo(0, 0),
+  ]);
+});

--- a/packages/core/src/content-stream/operators/path/fill/index.ts
+++ b/packages/core/src/content-stream/operators/path/fill/index.ts
@@ -1,0 +1,57 @@
+import { ok } from "../../../../utils/result/index";
+import {
+  CurrentPath,
+  GraphicsState,
+  GraphicsStateStack,
+} from "../../../graphics-state/index";
+import type {
+  OperatorHandler,
+  OperatorHandlerContext,
+} from "../../../operator-registry/index";
+
+/**
+ * PDF §8.5.3 `f` operator (fill the path, nonzero winding number rule) のハンドラ。
+ *
+ * operand を pop せず、実行後 current path を `CurrentPath.empty()` に
+ * リセットした新しい GraphicsState を生成する (ISO 32000-1:2008 §8.5.3:
+ * painting operators consume the current path)。`f` は引数を取らないため
+ * operand stack に値が残っていても pop / 検証 / clear のいずれも行わず、
+ * 同一参照のまま返す。
+ *
+ * fill rule (nonzero winding / even-odd) は operator 種別 (`f` / `f*`) で
+ * 表現するため state には書き込まない。実際のラスタライズはライブラリの
+ * スコープ外で、ピクセル描画は将来 renderer 側が operator 種別から fill rule
+ * を解釈する。
+ *
+ * - operand 数: 0 (operand stack を一切参照しない)
+ * - current path が空の場合は no-op で同一 operandStack / graphicsStateStack
+ *   参照を含む新 context を返す
+ * - ctm / lineWidth / lineCap / lineJoin / miterLimit など
+ *   currentPath 以外の graphics state は変更しない
+ * - 本 handler では PdfError を返さない (常に ok)
+ *
+ * @param context - 実行コンテキスト (operand stack / graphics state stack)
+ * @returns 更新後コンテキスト (常に ok)
+ */
+export const fillHandler: OperatorHandler = (
+  context: OperatorHandlerContext,
+) => {
+  const current = GraphicsStateStack.current(context.graphicsStateStack);
+  if (CurrentPath.isEmpty(current.currentPath)) {
+    return ok({
+      operandStack: context.operandStack,
+      graphicsStateStack: context.graphicsStateStack,
+    });
+  }
+  const next = GraphicsState.update(current, {
+    currentPath: CurrentPath.empty(),
+  });
+  const graphicsStateStack = GraphicsStateStack.replaceCurrent(
+    context.graphicsStateStack,
+    next,
+  );
+  return ok({
+    operandStack: context.operandStack,
+    graphicsStateStack,
+  });
+};


### PR DESCRIPTION
## Summary

PDF §8.5.3 `f` operator (fill, nonzero winding rule) のハンドラを `@pdfmod/core` に追加。

- `fillHandler: OperatorHandler` を `packages/core/src/content-stream/operators/path/fill/index.ts` に実装
- 構造は `stroke` handler と対称: 空 path は早期 return (no-op)、非空 path は `currentPath` のみ `CurrentPath.empty()` にリセット
- operand stack は pop / peek / depth いずれも呼ばず、同一参照で返却
- fill rule (nonzero / even-odd) は operator 種別で表現するため state には書き込まない (ラスタライズはライブラリのスコープ外)
- 戻り値は常に `ok(...)`、`PdfError` を返す分岐はない

## 変更ファイル

- `packages/core/src/content-stream/operators/path/fill/index.ts` (NEW)
- `packages/core/src/content-stream/operators/path/fill/__tests__/fill.basic.test.ts` (NEW)

## テスト

`fill.basic.test.ts` に 13 ケース (T1〜T13) を flat 構造で実装:

- T1〜T5: 空 path / `m` / `m → l` / `m → l → close` で reset 動作確認
- T6〜T8: operand stack 非破壊 (空 / numeric / 非 numeric)
- T9: 非デフォルト ctm / lineWidth / lineCap / lineJoin / miterLimit が保持される
- T10: 連続 `f → f`
- T11: reset 分岐の参照契約 (operandStack 同一、graphicsStateStack 別、入力 mutate なし)
- T12: 早期 return 分岐の両 stack 同一参照
- T13: `q` 済み saved stack が保持される

## 受け入れ基準 (Issue #173)

- [x] `fillHandler: OperatorHandler` が export されている
- [x] 実行後 `currentPath` が空
- [x] 空 path 入力で no-op (early return / 同一参照)
- [x] operand stack を一切触らない
- [x] `currentPath` 以外の graphics state は保持される
- [x] `PdfError` を返す分岐がない
- [x] `fill.basic.test.ts` の 13 ケース pass
- [x] `pnpm --filter @pdfmod/core test` pass (1869 tests)
- [x] `pnpm --filter @pdfmod/core build` pass

## スコープ外 (本 PR では対応しない)

- operator-registry への `f` キー登録 → #175 で別途
- `F` / `f*` / `B` / `B*` operator → 別 Issue
- `packages/core/src/index.ts` への public re-export → stroke と同じ慣習 (export しない)

Closes #173