### PR TITLE
✨ [New Feature]: #174 B operator handler (fill + stroke, nonzero) を実装

### DIFF
--- a/packages/core/src/content-stream/operators/path/fill-stroke/__tests__/fill-stroke.basic.test.ts
+++ b/packages/core/src/content-stream/operators/path/fill-stroke/__tests__/fill-stroke.basic.test.ts
@@ -1,0 +1,307 @@
+import { assert, expect, test } from "vitest";
+import type { PdfObject } from "../../../../../pdf/types/pdf-types/index";
+import {
+  CurrentPath,
+  GraphicsState,
+  GraphicsStateStack,
+  LineCap,
+  LineJoin,
+  Matrix,
+} from "../../../../graphics-state/index";
+import { PathSegment } from "../../../../graphics-state/path-segment";
+import { OperandStack } from "../../../../operand-stack/index";
+import type { OperatorHandlerContext } from "../../../../operator-registry/index";
+import { fillStrokeHandler } from "../index";
+
+const real = (value: number): PdfObject => ({ type: "real", value });
+
+const buildContext = (operands: PdfObject[]): OperatorHandlerContext => {
+  const operandStack = OperandStack.create();
+  for (const operand of operands) {
+    OperandStack.push(operandStack, operand);
+  }
+  const graphicsStateStack = GraphicsStateStack.create();
+  return { operandStack, graphicsStateStack };
+};
+
+const buildContextWithSegments = (
+  segments: PathSegment[],
+  operands: PdfObject[] = [],
+): OperatorHandlerContext => {
+  const operandStack = OperandStack.create();
+  for (const operand of operands) {
+    OperandStack.push(operandStack, operand);
+  }
+  const initialState = GraphicsState.create();
+  let path = initialState.currentPath;
+  for (const segment of segments) {
+    path = CurrentPath.append(path, segment);
+  }
+  const seededState = GraphicsState.update(initialState, { currentPath: path });
+  const graphicsStateStack = GraphicsStateStack.replaceCurrent(
+    GraphicsStateStack.create(),
+    seededState,
+  );
+  return { operandStack, graphicsStateStack };
+};
+
+const buildContextWithGraphicsState = (
+  state: GraphicsState,
+  operands: PdfObject[] = [],
+): OperatorHandlerContext => {
+  const operandStack = OperandStack.create();
+  for (const operand of operands) {
+    OperandStack.push(operandStack, operand);
+  }
+  const graphicsStateStack = GraphicsStateStack.replaceCurrent(
+    GraphicsStateStack.create(),
+    state,
+  );
+  return { operandStack, graphicsStateStack };
+};
+
+test("空 path に対して `B` は no-op で segments が空のまま保たれる", () => {
+  const ctx = buildContext([]);
+
+  const result = fillStrokeHandler(ctx);
+
+  assert(result.ok);
+  const current = GraphicsStateStack.current(result.value.graphicsStateStack);
+  expect(current.currentPath.segments).toEqual([]);
+});
+
+test("空 path に対する `B` の後、後続 `l` / `c` が依拠する CurrentPath.isEmpty 不変条件は保たれる", () => {
+  const ctx = buildContext([]);
+
+  const result = fillStrokeHandler(ctx);
+
+  assert(result.ok);
+  const current = GraphicsStateStack.current(result.value.graphicsStateStack);
+  expect(CurrentPath.isEmpty(current.currentPath)).toBe(true);
+});
+
+test("`m(0,0)` 済み path に `B` を実行すると segments が空になる", () => {
+  const ctx = buildContextWithSegments([PathSegment.moveTo(0, 0)]);
+
+  const result = fillStrokeHandler(ctx);
+
+  assert(result.ok);
+  const current = GraphicsStateStack.current(result.value.graphicsStateStack);
+  expect(current.currentPath.segments).toEqual([]);
+});
+
+test("`m(0,0) → l(100,200)` 済み path に `B` を実行すると segments が空になる", () => {
+  const ctx = buildContextWithSegments([
+    PathSegment.moveTo(0, 0),
+    PathSegment.lineTo(100, 200),
+  ]);
+
+  const result = fillStrokeHandler(ctx);
+
+  assert(result.ok);
+  const current = GraphicsStateStack.current(result.value.graphicsStateStack);
+  expect(current.currentPath.segments).toEqual([]);
+});
+
+test("`m → l → close` 済み path に `B` を実行すると segments が空になる", () => {
+  const ctx = buildContextWithSegments([
+    PathSegment.moveTo(0, 0),
+    PathSegment.lineTo(100, 200),
+    PathSegment.close(),
+  ]);
+
+  const result = fillStrokeHandler(ctx);
+
+  assert(result.ok);
+  const current = GraphicsStateStack.current(result.value.graphicsStateStack);
+  expect(current.currentPath.segments).toEqual([]);
+});
+
+test("operand stack が空でも `B` は成功する", () => {
+  const ctx = buildContext([]);
+
+  const result = fillStrokeHandler(ctx);
+
+  assert(result.ok);
+});
+
+test("operand stack に numeric 値があっても `B` は pop しない (depth / peek 維持)", () => {
+  const ctx = buildContext([real(1), real(2), real(3)]);
+  const depthBefore = OperandStack.depth(ctx.operandStack);
+  const peekBefore = OperandStack.peek(ctx.operandStack);
+
+  const result = fillStrokeHandler(ctx);
+
+  assert(result.ok);
+  expect(result.value.operandStack).toBe(ctx.operandStack);
+  expect(OperandStack.depth(result.value.operandStack)).toBe(depthBefore);
+  expect(OperandStack.depth(result.value.operandStack)).toBe(3);
+  const peekAfter = OperandStack.peek(result.value.operandStack);
+  assert(peekBefore.some);
+  assert(peekAfter.some);
+  expect(peekAfter.value).toEqual(real(3));
+  expect(peekAfter.value).toEqual(peekBefore.value);
+});
+
+test.each<{ label: string; operands: PdfObject[]; topExpected: PdfObject }>([
+  {
+    label: "name",
+    operands: [{ type: "name", value: "Foo" }],
+    topExpected: { type: "name", value: "Foo" },
+  },
+  {
+    label: "boolean",
+    operands: [{ type: "boolean", value: true }],
+    topExpected: { type: "boolean", value: true },
+  },
+  {
+    label: "dictionary",
+    operands: [{ type: "dictionary", entries: new Map() }],
+    topExpected: { type: "dictionary", entries: new Map() },
+  },
+])("operand stack に非 numeric 値 ($label) があっても `B` は成功し depth / peek を維持する", ({
+  operands,
+  topExpected,
+}) => {
+  const ctx = buildContext(operands);
+  const depthBefore = OperandStack.depth(ctx.operandStack);
+  const peekBefore = OperandStack.peek(ctx.operandStack);
+
+  const result = fillStrokeHandler(ctx);
+
+  assert(result.ok);
+  expect(result.value.operandStack).toBe(ctx.operandStack);
+  expect(OperandStack.depth(result.value.operandStack)).toBe(depthBefore);
+  const peekAfter = OperandStack.peek(result.value.operandStack);
+  assert(peekBefore.some);
+  assert(peekAfter.some);
+  expect(peekAfter.value).toEqual(topExpected);
+  expect(peekAfter.value).toEqual(peekBefore.value);
+});
+
+test("非空 path + 非デフォルト ctm / lineWidth / lineCap / lineJoin / miterLimit で `B` 実行しても currentPath 以外が保持される", () => {
+  const baseState = GraphicsState.create();
+  let path = baseState.currentPath;
+  path = CurrentPath.append(path, PathSegment.moveTo(0, 0));
+  path = CurrentPath.append(path, PathSegment.lineTo(100, 200));
+  const seededCtm = Matrix.create(2, 0, 0, 3, 10, 20);
+  const seededLineCap = LineCap.create(2);
+  const seededLineJoin = LineJoin.create(2);
+  const seededState = GraphicsState.update(baseState, {
+    currentPath: path,
+    ctm: seededCtm,
+    lineWidth: 5,
+    lineCap: seededLineCap,
+    lineJoin: seededLineJoin,
+    miterLimit: 20,
+  });
+  const ctx = buildContextWithGraphicsState(seededState);
+
+  const result = fillStrokeHandler(ctx);
+
+  assert(result.ok);
+  const after = GraphicsStateStack.current(result.value.graphicsStateStack);
+  expect(after.currentPath.segments).toEqual([]);
+  expect(after.ctm).toBe(seededCtm);
+  expect(after.lineWidth).toBe(5);
+  expect(after.lineCap).toBe(seededLineCap);
+  expect(after.lineJoin).toBe(seededLineJoin);
+  expect(after.miterLimit).toBe(20);
+});
+
+test("`m → l` 済み path に対する連続 `B → B` で 2 回目も成功し currentPath が空のまま保たれる", () => {
+  const ctx = buildContextWithSegments([
+    PathSegment.moveTo(0, 0),
+    PathSegment.lineTo(100, 200),
+  ]);
+
+  const firstResult = fillStrokeHandler(ctx);
+  assert(firstResult.ok);
+  const secondResult = fillStrokeHandler(firstResult.value);
+
+  assert(secondResult.ok);
+  const current = GraphicsStateStack.current(
+    secondResult.value.graphicsStateStack,
+  );
+  expect(current.currentPath.segments).toEqual([]);
+});
+
+test("reset 分岐: operandStack は同一参照、graphicsStateStack は別参照、入力 graphicsStateStack の currentPath は mutate されない", () => {
+  const ctx = buildContextWithSegments([PathSegment.moveTo(0, 0)], [real(1)]);
+
+  const result = fillStrokeHandler(ctx);
+
+  assert(result.ok);
+  expect(result.value.operandStack).toBe(ctx.operandStack);
+  expect(result.value.graphicsStateStack).not.toBe(ctx.graphicsStateStack);
+  expect(
+    GraphicsStateStack.current(ctx.graphicsStateStack).currentPath.segments,
+  ).toEqual([PathSegment.moveTo(0, 0)]);
+});
+
+test("空 path 早期 return 分岐で `result.value.operandStack` / `graphicsStateStack` は入力と同一参照", () => {
+  const ctx = buildContext([real(1)]);
+
+  const result = fillStrokeHandler(ctx);
+
+  assert(result.ok);
+  expect(result.value.operandStack).toBe(ctx.operandStack);
+  expect(result.value.graphicsStateStack).toBe(ctx.graphicsStateStack);
+});
+
+test("`q` 済み (saved state あり) 状態で `B` を実行しても saved stack が保持される", () => {
+  const baseState = GraphicsState.create();
+  const savedCtm = Matrix.create(2, 0, 0, 3, 10, 20);
+  const savedPath = CurrentPath.append(
+    baseState.currentPath,
+    PathSegment.moveTo(0, 0),
+  );
+  const savedState = GraphicsState.update(baseState, {
+    currentPath: savedPath,
+    ctm: savedCtm,
+    lineWidth: 5,
+  });
+  const stackWithSavedCurrent = GraphicsStateStack.replaceCurrent(
+    GraphicsStateStack.create(),
+    savedState,
+  );
+  const savedStack = GraphicsStateStack.save(stackWithSavedCurrent);
+
+  let currentPath = baseState.currentPath;
+  currentPath = CurrentPath.append(currentPath, PathSegment.moveTo(50, 60));
+  currentPath = CurrentPath.append(currentPath, PathSegment.lineTo(100, 200));
+  const currentState = GraphicsState.update(baseState, {
+    currentPath,
+    lineWidth: 1,
+  });
+  const seededStack = GraphicsStateStack.replaceCurrent(
+    savedStack,
+    currentState,
+  );
+  const ctx: OperatorHandlerContext = {
+    operandStack: OperandStack.create(),
+    graphicsStateStack: seededStack,
+  };
+
+  const result = fillStrokeHandler(ctx);
+
+  assert(result.ok);
+
+  const restoredAfter = GraphicsStateStack.restore(
+    result.value.graphicsStateStack,
+  );
+  const restoredAfterCurrent = GraphicsStateStack.current(restoredAfter);
+  expect(restoredAfterCurrent.lineWidth).toBe(5);
+  expect(restoredAfterCurrent.ctm).toBe(savedCtm);
+  expect(restoredAfterCurrent.currentPath.segments).toEqual([
+    PathSegment.moveTo(0, 0),
+  ]);
+
+  const restoredInput = GraphicsStateStack.restore(ctx.graphicsStateStack);
+  const restoredInputCurrent = GraphicsStateStack.current(restoredInput);
+  expect(restoredInputCurrent.lineWidth).toBe(5);
+  expect(restoredInputCurrent.ctm).toBe(savedCtm);
+  expect(restoredInputCurrent.currentPath.segments).toEqual([
+    PathSegment.moveTo(0, 0),
+  ]);
+});

--- a/packages/core/src/content-stream/operators/path/fill-stroke/index.ts
+++ b/packages/core/src/content-stream/operators/path/fill-stroke/index.ts
@@ -1,0 +1,62 @@
+import { ok } from "../../../../utils/result/index";
+import {
+  CurrentPath,
+  GraphicsState,
+  GraphicsStateStack,
+} from "../../../graphics-state/index";
+import type {
+  OperatorHandler,
+  OperatorHandlerContext,
+} from "../../../operator-registry/index";
+
+/**
+ * PDF §8.5.3 `B` operator (fill the path, then stroke it; nonzero winding number rule) のハンドラ。
+ *
+ * operand を pop せず、実行後 current path を `CurrentPath.empty()` に
+ * リセットした新しい GraphicsState を生成する (ISO 32000-1:2008 §8.5.3:
+ * painting operators consume the current path)。`B` は引数を取らないため
+ * operand stack に値が残っていても pop / 検証 / clear のいずれも行わず、
+ * 同一参照のまま返す。
+ *
+ * fill rule (nonzero winding / even-odd) と close 動作は operator 種別
+ * (`B` / `B*` / `b` / `b*`) で表現するため state には書き込まない。
+ * また fill と stroke の合成順序 (`B` では fill → stroke) も renderer 側の
+ * 責務であり、本 handler は path リセットのみを担当する。実際のラスタライズは
+ * ライブラリのスコープ外で、ピクセル描画は将来 renderer 側が operator 種別から
+ * fill rule / close 動作 / fill+stroke の合成順序を解釈する。
+ *
+ * 命名: PDF 仕様上の大文字 `B` (fill+stroke) と小文字 `b` (close-and-fill-stroke)
+ * は別 operator のため、letter ディレクトリではなく semantic 名 `fill-stroke` を使う。
+ *
+ * - operand 数: 0 (operand stack を一切参照しない)
+ * - current path が空の場合は no-op で同一 operandStack / graphicsStateStack
+ *   参照を含む新 context を返す
+ * - ctm / lineWidth / lineCap / lineJoin / miterLimit など
+ *   currentPath 以外の graphics state は変更しない
+ * - 本 handler では PdfError を返さない (常に ok)
+ *
+ * @param context - 実行コンテキスト (operand stack / graphics state stack)
+ * @returns 更新後コンテキスト (常に ok)
+ */
+export const fillStrokeHandler: OperatorHandler = (
+  context: OperatorHandlerContext,
+) => {
+  const current = GraphicsStateStack.current(context.graphicsStateStack);
+  if (CurrentPath.isEmpty(current.currentPath)) {
+    return ok({
+      operandStack: context.operandStack,
+      graphicsStateStack: context.graphicsStateStack,
+    });
+  }
+  const next = GraphicsState.update(current, {
+    currentPath: CurrentPath.empty(),
+  });
+  const graphicsStateStack = GraphicsStateStack.replaceCurrent(
+    context.graphicsStateStack,
+    next,
+  );
+  return ok({
+    operandStack: context.operandStack,
+    graphicsStateStack,
+  });
+};


### PR DESCRIPTION
## 概要

spec-054 / Issue #174。PDF §8.5.3 で定義される `B` operator (パスを fill → stroke の順で描画、fill rule は非ゼロワインディング規則) のハンドラを `@pdfmod/core` に追加する。本 handler の責務は **state 上の `currentPath` を空にリセットすること** のみで、ラスタライズ・fill+stroke の合成順序解釈は renderer 側責務 (ライブラリスコープ外) とする。

operator-registry への登録は Blocks: #175 で別 PR とする (本 PR では handler 単体のみ)。

## 変更の種類

- ✨ New Feature

## 追加した内容

- `packages/core/src/content-stream/operators/path/fill-stroke/index.ts` — `fillStrokeHandler: OperatorHandler` (62 行)
- `packages/core/src/content-stream/operators/path/fill-stroke/__tests__/fill-stroke.basic.test.ts` — basic test 13 ケース (`test.each` 含む計 15 test 関数 / 307 行)

`fill` / `stroke` handler と完全に対称な構造 (早期 return + reset の 2 分岐)。命名は letter ディレクトリ (`b`) ではなく、`B` / `B*` / `b` / `b*` を区別するため semantic 名 `fill-stroke` を採用。

## システム図

```mermaid
flowchart TD
    Start([fillStrokeHandler ctx]) --> ReadCurrent["GraphicsStateStack.current(graphicsStateStack)"]
    ReadCurrent --> CheckEmpty{"CurrentPath.isEmpty?"}
    CheckEmpty -- true --> EarlyReturn["ok({ operandStack, graphicsStateStack })<br/>同一参照のまま返す"]
    CheckEmpty -- false --> UpdateState["GraphicsState.update(current,<br/>{ currentPath: CurrentPath.empty() })"]
    UpdateState --> ReplaceStack["GraphicsStateStack.replaceCurrent(<br/>graphicsStateStack, next)"]
    ReplaceStack --> ResetReturn["ok({ operandStack, graphicsStateStack' })<br/>operandStack は同一参照 / stack は新参照"]
    EarlyReturn --> End([Result Ok])
    ResetReturn --> End

    style EarlyReturn fill:#e8f5e9
    style ResetReturn fill:#fff3e0
```

## 関連 spec / Issue

- spec: `.plugin-workspace/.specs/054-b-operator-handler/`
- Refs #174
- 親 Epic: #163
- Blocked by: #166 (完了済み)
- Blocks: #175 (operator-registry への登録は別 PR)

## テスト

- `pnpm --filter @pdfmod/core test` ✅ pass — 130 files / 1884 tests (内 `fill-stroke.basic.test.ts` 15 tests)
- `pnpm --filter @pdfmod/core build` ✅ pass (vite + tsc 双方)
- Codex レビュー (`code-review/review-001.md`) ✅ 1 回で「問題なし」通過

### テストケース内訳 (13 ケース)

- T1〜T2: 空 path → no-op で segments / `isEmpty` 不変条件
- T3〜T5: `m` / `m→l` / `m→l→close` 済み path → segments が空に
- T6〜T8: operand stack が空 / numeric / 非 numeric (name / boolean / dictionary) でも pop しない
- T9: 非デフォルト `ctm` / `lineWidth` / `lineCap` / `lineJoin` / `miterLimit` を保持
- T10: 連続 `B → B`
- T11: reset 分岐の参照契約 (`operandStack` 同一 / `graphicsStateStack` 別参照 / 入力非破壊)
- T12: 早期 return 分岐の両 stack 同一参照
- T13: `q` 済み saved state を `B` 後も保持 (restore で復元可能)

## レビューポイント

- `fill` / `stroke` handler と構造が完全同型であること (差分は型名と JSDoc のみ)
- `B` / `B*` / `b` / `b*` を 1 handler で共有する factory 化は本 PR では行わず、4 種が揃ったタイミングで別途検討する判断
- fill rule (nonzero) と fill+stroke の合成順序を **state に書き込まない** 判断 (renderer 側責務)
- 命名: letter ディレクトリ `b/` ではなく `fill-stroke/` (semantic 名) を採用した理由 (JSDoc に明記)

🤖 Generated with [Claude Code](https://claude.com/claude-code)