### PR TITLE
✨ [New Feature]: #175 registerPathOperators ヘルパと path-operators barrel を実装

### DIFF
--- a/packages/core/src/content-stream/operators/path/path-operators/__tests__/path-operators.basic.test.ts
+++ b/packages/core/src/content-stream/operators/path/path-operators/__tests__/path-operators.basic.test.ts
@@ -1,0 +1,34 @@
+import { assert, expect, test } from "vitest";
+import {
+  type OperatorHandler,
+  OperatorRegistry,
+} from "../../../../operator-registry/index";
+import {
+  cHandler,
+  fillHandler,
+  fillStrokeHandler,
+  hHandler,
+  lHandler,
+  mHandler,
+  registerPathOperators,
+  reHandler,
+  strokeHandler,
+} from "../../path-operators";
+
+test.each<readonly [string, OperatorHandler]>([
+  ["m", mHandler],
+  ["l", lHandler],
+  ["c", cHandler],
+  ["h", hHandler],
+  ["re", reHandler],
+  ["S", strokeHandler],
+  ["f", fillHandler],
+  ["B", fillStrokeHandler],
+])("registerPathOperators は %s に対応する handler を登録する", (name, expectedHandler) => {
+  const result = registerPathOperators(OperatorRegistry.create());
+  assert(result.ok);
+
+  const looked = OperatorRegistry.lookup(result.value, name);
+  assert(looked.some);
+  expect(looked.value).toBe(expectedHandler);
+});

--- a/packages/core/src/content-stream/operators/path/path-operators/__tests__/path-operators.error.test.ts
+++ b/packages/core/src/content-stream/operators/path/path-operators/__tests__/path-operators.error.test.ts
@@ -1,0 +1,93 @@
+import { afterEach, assert, expect, test, vi } from "vitest";
+import { OperatorRegistry } from "../../../../operator-registry/index";
+import {
+  lHandler,
+  mHandler,
+  registerPathOperators,
+} from "../../path-operators";
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+test("m が登録済みなら OPERATOR_ALREADY_REGISTERED の Err を返し operatorName が m", () => {
+  const seed = OperatorRegistry.register(
+    OperatorRegistry.create(),
+    "m",
+    mHandler,
+  );
+  assert(seed.ok);
+
+  const result = registerPathOperators(seed.value);
+
+  assert(!result.ok);
+  expect(result.error.code).toBe("OPERATOR_ALREADY_REGISTERED");
+  assert(result.error.code === "OPERATOR_ALREADY_REGISTERED");
+  expect(result.error.operatorName).toBe("m");
+});
+
+test("m と l が事前登録済みでも最初の重複 m の Err が返る (fail-fast)", () => {
+  const seedM = OperatorRegistry.register(
+    OperatorRegistry.create(),
+    "m",
+    mHandler,
+  );
+  assert(seedM.ok);
+  const seedL = OperatorRegistry.register(seedM.value, "l", lHandler);
+  assert(seedL.ok);
+
+  const result = registerPathOperators(seedL.value);
+
+  assert(!result.ok);
+  assert(result.error.code === "OPERATOR_ALREADY_REGISTERED");
+  expect(result.error.operatorName).toBe("m");
+});
+
+test("l のみ事前登録済みなら配列順序で l に到達した時点で短絡する", () => {
+  const seed = OperatorRegistry.register(
+    OperatorRegistry.create(),
+    "l",
+    lHandler,
+  );
+  assert(seed.ok);
+
+  const result = registerPathOperators(seed.value);
+
+  assert(!result.ok);
+  assert(result.error.code === "OPERATOR_ALREADY_REGISTERED");
+  expect(result.error.operatorName).toBe("l");
+});
+
+test("m 重複時、後続 operator (l/c/h/re/S/f/B) への register は呼ばれない", () => {
+  const seed = OperatorRegistry.register(
+    OperatorRegistry.create(),
+    "m",
+    mHandler,
+  );
+  assert(seed.ok);
+
+  const registerSpy = vi.spyOn(OperatorRegistry, "register");
+
+  const result = registerPathOperators(seed.value);
+  assert(!result.ok);
+
+  const calledNames = registerSpy.mock.calls.map((call) => call[1]);
+  expect(calledNames).toEqual(["m"]);
+});
+
+test("l 重複時、配列順で m は成功 → l で短絡し c/h/re/S/f/B は呼ばれない", () => {
+  const seed = OperatorRegistry.register(
+    OperatorRegistry.create(),
+    "l",
+    lHandler,
+  );
+  assert(seed.ok);
+
+  const registerSpy = vi.spyOn(OperatorRegistry, "register");
+
+  const result = registerPathOperators(seed.value);
+  assert(!result.ok);
+
+  const calledNames = registerSpy.mock.calls.map((call) => call[1]);
+  expect(calledNames).toEqual(["m", "l"]);
+});

--- a/packages/core/src/content-stream/operators/path/path-operators/__tests__/path-operators.integration.test.ts
+++ b/packages/core/src/content-stream/operators/path/path-operators/__tests__/path-operators.integration.test.ts
@@ -1,0 +1,59 @@
+import { assert, expect, test } from "vitest";
+import { CurrentPath } from "../../../../graphics-state/current-path/index";
+import { GraphicsStateStack } from "../../../../graphics-state/stack/index";
+import { ContentStreamInterpreter } from "../../../../interpreter/index";
+import { OperatorRegistry } from "../../../../operator-registry/index";
+import { registerPathOperators } from "../../path-operators";
+
+const encode = (s: string): Uint8Array => new TextEncoder().encode(s);
+
+test("100 100 200 150 re B を実行すると path 構築 → reset で currentPath が空になる", () => {
+  const registered = registerPathOperators(OperatorRegistry.create());
+  assert(registered.ok);
+
+  const result = ContentStreamInterpreter.execute({
+    data: encode("100 100 200 150 re B"),
+    registry: registered.value,
+  });
+
+  assert(result.ok);
+  expect(result.value.warnings).toEqual([]);
+  const current = GraphicsStateStack.current(
+    result.value.context.graphicsStateStack,
+  );
+  expect(CurrentPath.isEmpty(current.currentPath)).toBe(true);
+});
+
+test("100 100 m 200 200 l S を実行すると path 構築 → stroke reset で currentPath が空になる", () => {
+  const registered = registerPathOperators(OperatorRegistry.create());
+  assert(registered.ok);
+
+  const result = ContentStreamInterpreter.execute({
+    data: encode("100 100 m 200 200 l S"),
+    registry: registered.value,
+  });
+
+  assert(result.ok);
+  expect(result.value.warnings).toEqual([]);
+  const current = GraphicsStateStack.current(
+    result.value.context.graphicsStateStack,
+  );
+  expect(CurrentPath.isEmpty(current.currentPath)).toBe(true);
+});
+
+test("100 100 m を実行すると currentPath に moveTo segment が積まれる (handler が dispatch された positive 観測)", () => {
+  const registered = registerPathOperators(OperatorRegistry.create());
+  assert(registered.ok);
+
+  const result = ContentStreamInterpreter.execute({
+    data: encode("100 100 m"),
+    registry: registered.value,
+  });
+
+  assert(result.ok);
+  expect(result.value.warnings).toEqual([]);
+  const current = GraphicsStateStack.current(
+    result.value.context.graphicsStateStack,
+  );
+  expect(CurrentPath.isEmpty(current.currentPath)).toBe(false);
+});

--- a/packages/core/src/content-stream/operators/path/path-operators/index.ts
+++ b/packages/core/src/content-stream/operators/path/path-operators/index.ts
@@ -1,0 +1,52 @@
+import type { PdfError } from "../../../../pdf/errors/index";
+import type { Result } from "../../../../utils/result/index";
+import { flatMap, ok } from "../../../../utils/result/index";
+import type { OperatorHandler } from "../../../operator-registry/index";
+import { OperatorRegistry } from "../../../operator-registry/index";
+import { cHandler } from "../c";
+import { fillHandler } from "../fill";
+import { fillStrokeHandler } from "../fill-stroke";
+import { hHandler } from "../h";
+import { lHandler } from "../l";
+import { mHandler } from "../m";
+import { reHandler } from "../re";
+import { strokeHandler } from "../stroke";
+
+export { cHandler } from "../c";
+export { fillHandler } from "../fill";
+export { fillStrokeHandler } from "../fill-stroke";
+export { hHandler } from "../h";
+export { lHandler } from "../l";
+export { mHandler } from "../m";
+export { reHandler } from "../re";
+export { strokeHandler } from "../stroke";
+
+const PATH_OPERATORS: ReadonlyArray<readonly [string, OperatorHandler]> = [
+  ["m", mHandler],
+  ["l", lHandler],
+  ["c", cHandler],
+  ["h", hHandler],
+  ["re", reHandler],
+  ["S", strokeHandler],
+  ["f", fillHandler],
+  ["B", fillStrokeHandler],
+];
+
+/**
+ * Path operator (m / l / c / h / re / S / f / B) を OperatorRegistry に
+ * 一括登録するヘルパ。
+ *
+ * fail-fast: いずれかの register が Err を返した時点で reduce 内 flatMap が
+ * 短絡し、後続 operator の register は呼ばれない。
+ *
+ * @param registry - 登録元 registry
+ * @returns 全 operator が登録された新しい registry、または重複登録時の PdfError
+ */
+export const registerPathOperators = (
+  registry: OperatorRegistry,
+): Result<OperatorRegistry, PdfError> =>
+  PATH_OPERATORS.reduce<Result<OperatorRegistry, PdfError>>(
+    (acc, [name, handler]) =>
+      flatMap(acc, (r) => OperatorRegistry.register(r, name, handler)),
+    ok(registry),
+  );


### PR DESCRIPTION
## 概要

spec-055 (archive)。PDF §8.5 / §8.5.3 で定義される 8 種類の path operator handler (`m` / `l` / `c` / `h` / `re` / `S` / `f` / `B`) を `OperatorRegistry` に一括登録するヘルパ `registerPathOperators` と、handler を named re-export する barrel `path-operators/index.ts` を Phase 4-A `registerGraphicsStateOperators` と構造同型で提供する。

## 変更の種類

- ✨ New Feature (本実装)
- 🧪 Tests (basic 8 / error 5 / integration 3 = 16 ケース)

## 追加した内容

- `packages/core/src/content-stream/operators/path/path-operators/index.ts`
  - 8 path handler を `../m`, `../l`, `../c`, `../h`, `../re`, `../stroke`, `../fill`, `../fill-stroke` から import + named re-export
  - `PATH_OPERATORS` 定数 (順序: `m → l → c → h → re → S → f → B`)
  - `registerPathOperators(registry)` — `reduce + flatMap + ok(registry)` で fail-fast 短絡を実装
- `__tests__/path-operators.basic.test.ts` — `test.each` で 8 operator が `OperatorRegistry.lookup` 経由で期待 handler と同一参照 (`toBe`) であることを検証 (T1〜T8)
- `__tests__/path-operators.error.test.ts` — E1〜E3 で重複登録時の `OPERATOR_ALREADY_REGISTERED` Err 内容を検証、E4/E5 で `vi.spyOn(OperatorRegistry, "register")` を使い fail-fast 短絡 (後続 register が呼ばれない) を直接観測
- `__tests__/path-operators.integration.test.ts` — `ContentStreamInterpreter.execute` 経由で end-to-end 動作を I1 (`100 100 200 150 re B`) / I2 (`100 100 m 200 200 l S`) / I3 (`100 100 m` の positive 観測) で確認。全ケースで `warnings.toEqual([])` を必須

## システム図

```mermaid
flowchart TD
    Start([registry: 任意の初期値])
    Acc0["acc = ok(registry₀)"]
    M{flatMap × m}
    L{flatMap × l}
    C{flatMap × c}
    H{flatMap × h}
    RE{flatMap × re}
    S{flatMap × S}
    F{flatMap × f}
    B{flatMap × B}
    Ok([Ok registry₈])
    Err([Err OPERATOR_ALREADY_REGISTERED])

    Start --> Acc0 --> M
    M -- ok --> L -- ok --> C -- ok --> H -- ok --> RE -- ok --> S -- ok --> F -- ok --> B -- ok --> Ok
    M -- err --> Err
    L -- err --> Err
    C -- err --> Err
    H -- err --> Err
    RE -- err --> Err
    S -- err --> Err
    F -- err --> Err
    B -- err --> Err

    style Start fill:#e8f5e9
    style Ok fill:#c8e6c9
    style Err fill:#ffcdd2
```

## 関連 spec / Issue

- spec: `.plugin-workspace/.specs/archive/055-register-path-operators/` (実装後 archive 済)
- Refs #175 (親 Epic: #163)
- Blocked by: #167–#174 (全て完了済)

## テスト

| コマンド | 結果 |
|---|---|
| `pnpm --filter @pdfmod/core test` | ✅ 1900 passed (新規 16 含む) |
| `pnpm --filter @pdfmod/core typecheck` | ✅ エラー 0 |
| `pnpm --filter @pdfmod/core build` | ✅ vite + tsc 成功 |
| `pnpm lint` | ✅ project ファイルでエラー 0 |

新規テスト内訳:
- basic: 8 ケース (`test.each` で T1〜T8)
- error: 5 ケース (E1〜E3: Err 内容、E4/E5: `vi.spyOn` で fail-fast 短絡観測)
- integration: 3 ケース (I1/I2: reset 後 isEmpty + warnings 0、I3: `m` 単独実行の positive 観測)

**Codex レビュー**: 2 回試行 (`code-review/review-001.md` / `review-002.md`)。途中ターンで「実装は計画とほぼ一致しています」「差分は計画どおり新規4ファイルのみで、`packages/core/src/index.ts` には露出していません」と評価。最終 verdict 行は codex の出力ストリーミング問題で取得できなかったが、他の自動検証 (test / typecheck / lint / build / Phase 4-A 同型 diff) で品質を担保。

## レビューポイント

- **Phase 4-A 同型**: `packages/core/src/content-stream/operators/graphics-state/graphics-state-operators/index.ts` との構造差分が「8 import 行 / 8 配列要素 / 関数名 (`registerPathOperators`) / 配列定数名 (`PATH_OPERATORS`)」のみであること
- **配列順序**: path construction (`m → l → c → h → re`) → path painting (`S → f → B`)
- **`warnings.toEqual([])` の必須化**: `ContentStreamInterpreter` は未登録 operator を `UNKNOWN_OPERATOR` warning にして継続するため、warning 0 件を担保しないと handler 未登録でも pass する false positive が出る
- **I3 (positive 観測)**: I1/I2 は `B`/`S` 後の reset で空になるため、`m` 単独実行で `currentPath` が非空になることを別途確認
- **公開 API 非露出**: `packages/core/src/index.ts` から re-export していない (Phase 4-A 同方針、内部用途のみ)

## チェックリスト

- [x] describe 不使用・フラット test 列挙
- [x] テストは `__tests__/` 配下に colocate (spec #041 で統一)
- [x] throw を使わず Result/Option で表現
- [x] `T | undefined` ではなく `Option<T>` を使用 (`OperatorRegistry.lookup` の戻り値)
- [x] `pnpm test` / `typecheck` / `lint` / `build` すべて通過
- [x] spec の implementation-plan.md / tasks.md と整合
- [x] Codex レビューを試行
- [x] セルフレビュー実施
- [x] 破壊的変更なし (純粋追加のみ)