### PR TITLE
✨ [New Feature]: spec-056 ColorSpace 型を graphics-state 配下に追加 (#207)

### DIFF
--- a/packages/core/src/content-stream/graphics-state/color-space/__tests__/color-space.basic.test.ts
+++ b/packages/core/src/content-stream/graphics-state/color-space/__tests__/color-space.basic.test.ts
@@ -1,0 +1,10 @@
+import { expect, test } from "vitest";
+import { ColorSpace } from "../../color-space";
+
+test.each([
+  ["deviceGray", "DeviceGray", ColorSpace.deviceGray],
+  ["deviceRGB", "DeviceRGB", ColorSpace.deviceRGB],
+  ["deviceCMYK", "DeviceCMYK", ColorSpace.deviceCMYK],
+] as const)("ColorSpace.%s() は %s を返す", (_name, expected, factory) => {
+  expect(factory()).toBe(expected);
+});

--- a/packages/core/src/content-stream/graphics-state/color-space/index.ts
+++ b/packages/core/src/content-stream/graphics-state/color-space/index.ts
@@ -1,0 +1,43 @@
+import type { Brand } from "../../../utils/brand/index";
+
+declare const ColorSpaceBrand: unique symbol;
+
+/**
+ * PDF 仕様 §8.6 のデバイス色空間。
+ * - DeviceGray  : グレースケール (1 チャンネル)
+ * - DeviceRGB   : RGB (3 チャンネル)
+ * - DeviceCMYK  : CMYK (4 チャンネル)
+ *
+ * Brand の基底型を文字列リテラル union に絞り、categorical domain を型レベルで保持する。
+ * 基底 union は外部に export せず、Brand 越しの `ColorSpace` のみを公開する。
+ */
+export type ColorSpace = Brand<
+  "DeviceGray" | "DeviceRGB" | "DeviceCMYK",
+  typeof ColorSpaceBrand
+>;
+
+export const ColorSpace = {
+  /**
+   * DeviceGray 色空間を返す。
+   * @returns Brand 付き ColorSpace 値
+   */
+  deviceGray(): ColorSpace {
+    return "DeviceGray" as ColorSpace;
+  },
+
+  /**
+   * DeviceRGB 色空間を返す。
+   * @returns Brand 付き ColorSpace 値
+   */
+  deviceRGB(): ColorSpace {
+    return "DeviceRGB" as ColorSpace;
+  },
+
+  /**
+   * DeviceCMYK 色空間を返す。
+   * @returns Brand 付き ColorSpace 値
+   */
+  deviceCMYK(): ColorSpace {
+    return "DeviceCMYK" as ColorSpace;
+  },
+} as const;

--- a/packages/core/src/content-stream/graphics-state/index.ts
+++ b/packages/core/src/content-stream/graphics-state/index.ts
@@ -1,3 +1,4 @@
+export { ColorSpace } from "./color-space";
 export { CurrentPath } from "./current-path";
 export { GraphicsState } from "./graphics-state";
 export { LineCap } from "./line-cap";


### PR DESCRIPTION
## 概要

spec-056。PDF 仕様 §8.6 のデバイス色空間 (DeviceGray / DeviceRGB / DeviceCMYK) を表す `ColorSpace` 型を、既存の categorical Brand パターン (LineCap / LineJoin) と同型な構成で `packages/core/src/content-stream/graphics-state/color-space/` 配下に新規追加する。後続の `Color` 型 (#208) と将来 GraphicsState からの参照に使う共通プリミティブ。

## 変更の種類

- ✨ [New Feature]: 新機能
- 🧪 [Tests]: テスト追加
- 🏷️ [Types]: 型定義の追加

## 追加した内容

- `packages/core/src/content-stream/graphics-state/color-space/index.ts`
  - `ColorSpace` Brand 型 (基底: `"DeviceGray" | "DeviceRGB" | "DeviceCMYK"`)
  - companion object: `deviceGray()` / `deviceRGB()` / `deviceCMYK()` の 3 factory
  - `isValid` / `allowed` / `equals` などの追加 API は **持たない** (factory が引数を取らないため不要)
- `packages/core/src/content-stream/graphics-state/color-space/__tests__/color-space.basic.test.ts`
  - `test.each` で 3 ケースをパラメータ化したフラット構造テスト

## 変更した内容

- `packages/core/src/content-stream/graphics-state/index.ts`
  - `export { ColorSpace } from "./color-space";` を `CurrentPath` の直前 (アルファベット順最上行) に 1 行追記
  - root barrel (`packages/core/src/index.ts`) は **変更しない** (LineCap / LineJoin と同じ境界を維持)

## システム図

```mermaid
flowchart TB
    caller["caller (将来 #208 Color / GraphicsState 拡張)"]

    subgraph companion["color-space/index.ts (companion object)"]
        gray["deviceGray() → 'DeviceGray'"]
        rgb["deviceRGB() → 'DeviceRGB'"]
        cmyk["deviceCMYK() → 'DeviceCMYK'"]
    end

    barrel["graphics-state/index.ts (barrel)<br/>export { ColorSpace }"]
    root["packages/core/src/index.ts (root barrel)<br/>※ 追加しない"]

    caller --> companion
    companion -.->|"Brand&lt;..., ColorSpaceBrand&gt;"| caller
    companion --> barrel
    barrel -.x root

    style companion fill:#e8f4ff,stroke:#0366d6
    style barrel fill:#fff5b1,stroke:#b08800
    style root fill:#fee,stroke:#cb2431,stroke-dasharray:4 2
```

## 関連 spec / Issue

- spec: `.plugin-workspace/.specs/056-color-space-type/`
- Refs #207

## テスト

- `pnpm --filter @pdfmod/core test` → **134 files / 1903 tests passed** (新規 3 tests 含む)
- `pnpm --filter @pdfmod/core build` → 成功
- `pnpm --filter @pdfmod/core typecheck` → 成功
- Codex レビュー (`code-review/review-001.md`) → **問題なし**

## レビューポイント

- 基底 union (`ColorSpaceKind` 相当) を **export していない** こと (Brand 越しの `ColorSpace` のみ公開)
- `equals` / `isValid` / `allowed` 等の追加 API を **持たない** こと (#207 受け入れ基準)
- root barrel (`packages/core/src/index.ts`) に `ColorSpace` を **追加していない** こと (LineCap / LineJoin と同じ境界)
- companion object を **一括 import** で参照していること (type / value の二重 import なし)
- テストが describe 不使用・フラット `test.each` 構造で、型保証された制約を runtime expect で再確認していないこと