### PR TITLE
✨ [New Feature]: #208 Color 型 (discriminated union) と factory を追加

### DIFF
--- a/packages/core/src/content-stream/graphics-state/color/__tests__/color.basic.test.ts
+++ b/packages/core/src/content-stream/graphics-state/color/__tests__/color.basic.test.ts
@@ -1,0 +1,42 @@
+import { expect, test } from "vitest";
+import { Color } from "../../color";
+import { ColorSpace } from "../../color-space";
+
+test.each([[0], [0.5], [1]])("Color.gray(%s) は gray color を返す", (g) => {
+  expect(Color.gray(g)).toEqual({ kind: "gray", g });
+});
+
+test.each([
+  [0, 0, 0],
+  [1, 0.5, 0.25],
+])("Color.rgb(%s, %s, %s) は rgb color を返す", (r, g, b) => {
+  expect(Color.rgb(r, g, b)).toEqual({ kind: "rgb", r, g, b });
+});
+
+test.each([
+  [0, 0, 0, 0],
+  [0.1, 0.2, 0.3, 0.4],
+])("Color.cmyk(%s, %s, %s, %s) は cmyk color を返す", (c, m, y, k) => {
+  expect(Color.cmyk(c, m, y, k)).toEqual({ kind: "cmyk", c, m, y, k });
+});
+
+test("Color.defaultBlack() は kind:gray, g:0 を返す", () => {
+  expect(Color.defaultBlack()).toEqual({ kind: "gray", g: 0 });
+});
+
+test.each([
+  [Color.gray(0.5), ColorSpace.deviceGray()],
+  [Color.rgb(1, 0, 0), ColorSpace.deviceRGB()],
+  [Color.cmyk(0, 1, 1, 0), ColorSpace.deviceCMYK()],
+] as const)("Color.colorSpaceOf(%j) は対応する ColorSpace を返す", (color, expected) => {
+  expect(Color.colorSpaceOf(color)).toBe(expected);
+});
+
+test("Color.rgb は範囲外の値もそのまま保持する (clamp / throw しない仕様の固定)", () => {
+  expect(Color.rgb(-0.1, 1.2, 2)).toEqual({
+    kind: "rgb",
+    r: -0.1,
+    g: 1.2,
+    b: 2,
+  });
+});

--- a/packages/core/src/content-stream/graphics-state/color/index.ts
+++ b/packages/core/src/content-stream/graphics-state/color/index.ts
@@ -1,0 +1,87 @@
+import { ColorSpace } from "../color-space";
+
+/**
+ * PDF spec §8.6 のデバイス色値。
+ * DeviceGray / DeviceRGB / DeviceCMYK を discriminated union で表現する。
+ * 値域 (0.0〜1.0) の検証はここでは行わない (Issue #208 仕様)。
+ */
+export type GrayColor = {
+  readonly kind: "gray";
+  readonly g: number;
+};
+
+export type RgbColor = {
+  readonly kind: "rgb";
+  readonly r: number;
+  readonly g: number;
+  readonly b: number;
+};
+
+export type CmykColor = {
+  readonly kind: "cmyk";
+  readonly c: number;
+  readonly m: number;
+  readonly y: number;
+  readonly k: number;
+};
+
+export type Color = GrayColor | RgbColor | CmykColor;
+
+export const Color = {
+  /**
+   * DeviceGray 値を生成する。
+   *
+   * @param g - グレースケール値 (PDF 仕様では 0.0〜1.0 だがここでは検証しない)
+   * @returns GrayColor
+   */
+  gray(g: number): GrayColor {
+    return { kind: "gray", g };
+  },
+  /**
+   * DeviceRGB 値を生成する。
+   *
+   * @param r - 赤チャンネル
+   * @param g - 緑チャンネル
+   * @param b - 青チャンネル
+   * @returns RgbColor
+   */
+  rgb(r: number, g: number, b: number): RgbColor {
+    return { kind: "rgb", r, g, b };
+  },
+  /**
+   * DeviceCMYK 値を生成する。
+   *
+   * @param c - シアンチャンネル
+   * @param m - マゼンタチャンネル
+   * @param y - イエローチャンネル
+   * @param k - キーチャンネル
+   * @returns CmykColor
+   */
+  cmyk(c: number, m: number, y: number, k: number): CmykColor {
+    return { kind: "cmyk", c, m, y, k };
+  },
+  /**
+   * PDF §4.1 のデフォルトカラー (黒)。
+   *
+   * @returns GrayColor { kind: "gray", g: 0 }
+   */
+  defaultBlack(): GrayColor {
+    return { kind: "gray", g: 0 };
+  },
+  /**
+   * Color 値に対応する ColorSpace を返す。
+   *
+   * @param color - Color 値
+   * @returns 対応する ColorSpace
+   */
+  colorSpaceOf(color: Color): ColorSpace {
+    switch (color.kind) {
+      case "gray":
+        return ColorSpace.deviceGray();
+      case "rgb":
+        return ColorSpace.deviceRGB();
+      case "cmyk":
+        return ColorSpace.deviceCMYK();
+    }
+  },
+} as const;

--- a/packages/core/src/content-stream/graphics-state/index.ts
+++ b/packages/core/src/content-stream/graphics-state/index.ts
@@ -1,3 +1,4 @@
+export { Color } from "./color";
 export { ColorSpace } from "./color-space";
 export { CurrentPath } from "./current-path";
 export { GraphicsState } from "./graphics-state";


### PR DESCRIPTION
## 概要

spec-057 (Issue #208)。PDF のストローク色 / フィル色を表す `Color` 型を `@pdfmod/core` に追加する。

3 種のデバイス色 (DeviceGray / DeviceRGB / DeviceCMYK) を discriminated union として表現し、companion object `Color` に純粋値 factory (`gray` / `rgb` / `cmyk` / `defaultBlack`) と `ColorSpace` への射 (`colorSpaceOf`) を集約する。値域 (0.0〜1.0) のバリデーションは Issue 仕様に従いここでは実施しない。

## 変更の種類

- ✨ 新機能 (New Feature)

## 追加した内容

- `packages/core/src/content-stream/graphics-state/color/index.ts` (新規)
  - 型: `GrayColor` / `RgbColor` / `CmykColor` / `Color` (union)
  - companion API: `Color.gray` / `Color.rgb` / `Color.cmyk` / `Color.defaultBlack` / `Color.colorSpaceOf`
- `packages/core/src/content-stream/graphics-state/color/__tests__/color.basic.test.ts` (新規, 8 テスト)
  - factory 正常系 (T1〜T4)
  - `colorSpaceOf` の 3 マッピング (T5)
  - 範囲外値の保持 = 「ここでは検証しない」仕様の回帰固定 (T6)

## 変更した内容

- `packages/core/src/content-stream/graphics-state/index.ts`
  - barrel に `export { Color } from "./color";` を alphabetical 順 (`ColorSpace` の直前) で追加 (+1 行)

## システム図

```mermaid
flowchart LR
    Caller["Caller (#209 等)"]
    subgraph CC["Color companion (NEW)"]
        Factory["Color.gray / rgb / cmyk / defaultBlack"]
        Of["Color.colorSpaceOf (switch kind)"]
    end
    subgraph Union["Color (discriminated union)"]
        Gray["GrayColor { kind: gray, g }"]
        Rgb["RgbColor { kind: rgb, r, g, b }"]
        Cmyk["CmykColor { kind: cmyk, c, m, y, k }"]
    end
    CS["ColorSpace companion (existing)"]

    Caller -->|"Color.gray(0.5) 等"| Factory
    Factory --> Gray
    Factory --> Rgb
    Factory --> Cmyk
    Gray -->|kind = gray| Of
    Rgb -->|kind = rgb| Of
    Cmyk -->|kind = cmyk| Of
    Of -->|deviceGray| CS
    Of -->|deviceRGB| CS
    Of -->|deviceCMYK| CS

    style CC fill:#ddffdd,stroke:#2a8f2a
    style Union fill:#eef
```

## 関連 spec / Issue

- spec: `.plugin-workspace/.specs/057-color-type/`
- Issue: Closes #208
- Blocked by: #207 (マージ済み)
- Blocks: #209 (`GraphicsState` への `strokeColor` / `fillColor` 統合)

## テスト

ローカル実行結果:

- `pnpm --filter @pdfmod/core test` — **1915 passed (135 files)** / 新規 8 テスト含む
- `pnpm --filter @pdfmod/core typecheck` — エラーなし
- `pnpm --filter @pdfmod/core build` — 成功 / `dist/.d.ts` に `Color` / `GrayColor` / `RgbColor` / `CmykColor` がエクスポートされていることを確認

Codex レビューは PR 作成後にまとめて実施する。

## レビューポイント

- `Color.colorSpaceOf` は `switch` で 3 分岐し、`default` 句なしで exhaustive narrowing に任せている (将来 variant を追加すると型エラーで検出される設計)
- Brand を使わず discriminated union を採用した判断 (兄弟 `path-segment` と同パターン。payload 持ちのため `LineCap` / `ColorSpace` のような Brand 単体型は不適)
- T6 は値域の "正しさ" ではなく「ここでは検証しない」仕様の回帰固定 (clamp / throw / Result 化が混入すれば検出される)
- 外部公開 (`packages/core/src/index.ts`) への追加は本 PR では行わない (兄弟 `ColorSpace` 等と同様、#209 で再評価)

🤖 Generated with [Claude Code](https://claude.com/claude-code)