### PR TITLE
✨ [New Feature]: #209 GraphicsState に color / colorSpace フィールドを追加

### DIFF
--- a/packages/core/src/content-stream/graphics-state/graphics-state/__tests__/graphics-state.basic.test.ts
+++ b/packages/core/src/content-stream/graphics-state/graphics-state/__tests__/graphics-state.basic.test.ts
@@ -69,6 +69,10 @@ test.each([
       ),
     },
   ],
+  ["strokeColor", { strokeColor: Color.rgb(1, 0, 0) }],
+  ["fillColor", { fillColor: Color.cmyk(0, 1, 1, 0) }],
+  ["strokeColorSpace", { strokeColorSpace: ColorSpace.deviceRGB() }],
+  ["fillColorSpace", { fillColorSpace: ColorSpace.deviceCMYK() }],
 ] as const)("update(state, %s) は該当フィールドだけ書き換える", (_label, partial) => {
   const state = GraphicsState.create();
   const updated = GraphicsState.update(state, partial);
@@ -101,17 +105,33 @@ test("updateはundefinedの明示指定で既存フィールドを壊さない",
     CurrentPath.empty(),
     PathSegment.moveTo(1, 2),
   );
+  const strokeColor = Color.rgb(1, 0, 0);
+  const fillColor = Color.cmyk(0, 1, 1, 0);
+  const strokeColorSpace = ColorSpace.deviceRGB();
+  const fillColorSpace = ColorSpace.deviceCMYK();
   const state = GraphicsState.update(GraphicsState.create(), {
     lineWidth: 2.0,
     miterLimit: 5.0,
     currentPath: path,
+    strokeColor,
+    fillColor,
+    strokeColorSpace,
+    fillColorSpace,
   });
   const updated = GraphicsState.update(state, {
     lineWidth: undefined,
     miterLimit: undefined,
     currentPath: undefined,
+    strokeColor: undefined,
+    fillColor: undefined,
+    strokeColorSpace: undefined,
+    fillColorSpace: undefined,
   });
   expect(updated.lineWidth).toBe(2.0);
   expect(updated.miterLimit).toBe(5.0);
   expect(updated.currentPath).toBe(path);
+  expect(updated.strokeColor).toBe(strokeColor);
+  expect(updated.fillColor).toBe(fillColor);
+  expect(updated.strokeColorSpace).toBe(strokeColorSpace);
+  expect(updated.fillColorSpace).toBe(fillColorSpace);
 });

--- a/packages/core/src/content-stream/graphics-state/graphics-state/__tests__/graphics-state.basic.test.ts
+++ b/packages/core/src/content-stream/graphics-state/graphics-state/__tests__/graphics-state.basic.test.ts
@@ -1,5 +1,7 @@
 import { expect, test } from "vitest";
 import {
+  Color,
+  ColorSpace,
   CurrentPath,
   GraphicsState,
   LineCap,
@@ -17,6 +19,10 @@ test("createはPDF仕様準拠のデフォルト値を返す", () => {
     lineJoin: LineJoin.create(0),
     miterLimit: 10.0,
     currentPath: CurrentPath.empty(),
+    strokeColor: Color.defaultBlack(),
+    fillColor: Color.defaultBlack(),
+    strokeColorSpace: ColorSpace.deviceGray(),
+    fillColorSpace: ColorSpace.deviceGray(),
   });
 });
 

--- a/packages/core/src/content-stream/graphics-state/graphics-state/index.ts
+++ b/packages/core/src/content-stream/graphics-state/graphics-state/index.ts
@@ -1,4 +1,6 @@
 import type { Brand } from "../../../utils/brand/index";
+import { Color } from "../color";
+import { ColorSpace } from "../color-space";
 import { CurrentPath } from "../current-path";
 import { LineCap } from "../line-cap";
 import { LineJoin } from "../line-join";
@@ -13,6 +15,10 @@ type GraphicsStateFields = {
   readonly lineJoin: LineJoin;
   readonly miterLimit: number;
   readonly currentPath: CurrentPath;
+  readonly strokeColor: Color;
+  readonly fillColor: Color;
+  readonly strokeColorSpace: ColorSpace;
+  readonly fillColorSpace: ColorSpace;
 };
 
 /**
@@ -29,12 +35,16 @@ type GraphicsStatePartial = Partial<GraphicsStateFields>;
 export const GraphicsState = {
   /**
    * PDF 仕様 §4.1 デフォルト値で GraphicsState を生成する。
-   *   ctm         = identity
-   *   lineWidth   = 1.0
-   *   lineCap     = 0 (Butt)
-   *   lineJoin    = 0 (Miter)
-   *   miterLimit  = 10.0
-   *   currentPath = empty()
+   *   ctm              = identity
+   *   lineWidth        = 1.0
+   *   lineCap          = 0 (Butt)
+   *   lineJoin         = 0 (Miter)
+   *   miterLimit       = 10.0
+   *   currentPath      = empty()
+   *   strokeColor      = defaultBlack (DeviceGray gray=0)
+   *   fillColor        = defaultBlack (DeviceGray gray=0)
+   *   strokeColorSpace = DeviceGray
+   *   fillColorSpace   = DeviceGray
    *
    * @returns デフォルト値で初期化された GraphicsState
    */
@@ -46,6 +56,10 @@ export const GraphicsState = {
       lineJoin: LineJoin.create(0),
       miterLimit: 10.0,
       currentPath: CurrentPath.empty(),
+      strokeColor: Color.defaultBlack(),
+      fillColor: Color.defaultBlack(),
+      strokeColorSpace: ColorSpace.deviceGray(),
+      fillColorSpace: ColorSpace.deviceGray(),
     } as unknown as GraphicsState;
   },
 
@@ -73,6 +87,20 @@ export const GraphicsState = {
         partial.currentPath !== undefined
           ? partial.currentPath
           : state.currentPath,
+      strokeColor:
+        partial.strokeColor !== undefined
+          ? partial.strokeColor
+          : state.strokeColor,
+      fillColor:
+        partial.fillColor !== undefined ? partial.fillColor : state.fillColor,
+      strokeColorSpace:
+        partial.strokeColorSpace !== undefined
+          ? partial.strokeColorSpace
+          : state.strokeColorSpace,
+      fillColorSpace:
+        partial.fillColorSpace !== undefined
+          ? partial.fillColorSpace
+          : state.fillColorSpace,
     } as unknown as GraphicsState;
   },
 } as const;


### PR DESCRIPTION
## 概要

spec-058 (Issue #209)。`GraphicsState` に PDF ISO 32000-1:2008 §4.1 準拠の color / colorSpace フィールドを 4 つ追加する。後続の色 operator (CS/cs/SC/SCN/sc/scn/G/g/RG/rg/K/k, #210〜#215) の実装基盤となる。

## 変更の種類

- ✨ 新機能

## 追加した内容

- `GraphicsStateFields` に 4 つの readonly フィールド
  - `strokeColor: Color`
  - `fillColor: Color`
  - `strokeColorSpace: ColorSpace`
  - `fillColorSpace: ColorSpace`
- `GraphicsState.create()` の PDF §4.1 デフォルト値
  - `strokeColor` / `fillColor` = `Color.defaultBlack()` (DeviceGray gray=0)
  - `strokeColorSpace` / `fillColorSpace` = `ColorSpace.deviceGray()`
- `GraphicsState.update()` の partial 三項分岐 (既存 6 フィールドと同パターン)
- テスト
  - `create` テストの `toEqual` に 4 フィールド追加
  - `test.each` に 4 ケース追加 (`strokeColor` / `fillColor` / `strokeColorSpace` / `fillColorSpace`)
  - `undefined` 明示指定での既存値保持を 4 フィールドへ拡張 (regression 保護)

## 変更した内容

- `packages/core/src/content-stream/graphics-state/graphics-state/index.ts` (+34 行)
- `packages/core/src/content-stream/graphics-state/graphics-state/__tests__/graphics-state.basic.test.ts` (+26 行)

## システム図

```mermaid
flowchart TD
    Create[GraphicsState.create] --> Initial
    Initial["INITIAL STATE<br/>ctm = identity<br/>lineWidth = 1.0<br/>lineCap = 0 (butt)<br/>lineJoin = 0 (miter)<br/>miterLimit = 10.0<br/>currentPath = empty<br/>strokeColor = defaultBlack [NEW]<br/>fillColor = defaultBlack [NEW]<br/>strokeColorSpace = DeviceGray [NEW]<br/>fillColorSpace = DeviceGray [NEW]"]
    Initial -->|update partial| Dispatch{各キーを<br/>undefined 判定}
    Dispatch -->|partial.X !== undefined| Apply[partial.X を採用]
    Dispatch -->|partial.X === undefined| Keep[state.X を保持]
    Apply --> Next[NEXT STATE<br/>10 フィールド]
    Keep --> Next
    Next -.->|"将来 (#210〜#215)"| ColorOp[CS/cs/SC/SCN/sc/scn/<br/>G/g/RG/rg/K/k handler]

    style Initial fill:#e1f5ff
    style Next fill:#fff4e6
    style ColorOp stroke-dasharray: 5 5,fill:#f5f5f5
```

## 関連 spec / Issue

- spec: `.plugin-workspace/.specs/058-graphics-state-color-fields/`
- Refs #209
- 依存型: #207 (`ColorSpace`) / #208 (`Color`) — マージ済み

## テスト

```
pnpm --filter @pdfmod/core test
 Test Files  135 passed (135)
      Tests  1919 passed (1919)   ← 既存 1915 + 新規 4 (test.each)

pnpm --filter @pdfmod/core build
 vite build && tsc -p tsconfig.build.json --emitDeclarationOnly --outDir dist
 ✓ ESM + CJS + 型定義出力成功
```

Codex レビュー: **問題なし** (`.plugin-workspace/.specs/058-graphics-state-color-fields/code-review/review-001.md`)

## レビューポイント

- **PDF §4.1 デフォルト値**: `create()` の 4 デフォルト値 (黒 + DeviceGray) が PDF 仕様準拠であること
- **既存 6 フィールドとの三項一貫性**: `update()` の partial 分岐スタイルが既存と揃っていること (新規コードへの「三項より if」ルールはあえて適用せず、既存パターンに合わせた)
- **後方互換**: `Partial<GraphicsStateFields>` の widening により既存 28 ファイル (path operators / stack / interpreter 等) は型整合のまま無改修
- **スコープ外**: 色値と色空間の整合性検証 (例: `strokeColor = Color.rgb(...)` かつ `strokeColorSpace = DeviceGray` の組み合わせ) は本 PR では型レベルで禁止しない。後続 #210〜#215 の color operator handler 側で「色空間と色値を同時に update する」運用で担保する想定