### PR TITLE
✨ [New Feature]: #210 G operator handler (DeviceGray stroke) を追加

### DIFF
--- a/packages/core/src/content-stream/operators/color/G/__tests__/G.basic.test.ts
+++ b/packages/core/src/content-stream/operators/color/G/__tests__/G.basic.test.ts
@@ -1,0 +1,221 @@
+import { assert, expect, test } from "vitest";
+import type { PdfObject } from "../../../../../pdf/types/pdf-types/index";
+import {
+  Color,
+  ColorSpace,
+  GraphicsState,
+  GraphicsStateStack,
+} from "../../../../graphics-state/index";
+import { OperandStack } from "../../../../operand-stack/index";
+import type { OperatorHandlerContext } from "../../../../operator-registry/index";
+import { GHandler } from "../index";
+
+const buildContext = (operands: PdfObject[]): OperatorHandlerContext => {
+  const operandStack = OperandStack.create();
+  for (const operand of operands) {
+    OperandStack.push(operandStack, operand);
+  }
+  const graphicsStateStack = GraphicsStateStack.create();
+  return { operandStack, graphicsStateStack };
+};
+
+const real = (value: number): PdfObject => ({ type: "real", value });
+const int = (value: number): PdfObject => ({ type: "integer", value });
+
+test("`0.5 G` で strokeColor が Color.gray(0.5) に更新される", () => {
+  const ctx = buildContext([real(0.5)]);
+
+  const result = GHandler(ctx);
+
+  assert(result.ok);
+  const current = GraphicsStateStack.current(result.value.graphicsStateStack);
+  expect(current.strokeColor).toEqual(Color.gray(0.5));
+});
+
+test("初期 strokeColorSpace=deviceRGB/strokeColor=rgb の状態から `0.5 G` で deviceGray + gray(0.5) に切り替わる", () => {
+  const operandStack = OperandStack.create();
+  OperandStack.push(operandStack, real(0.5));
+  const baseStack = GraphicsStateStack.create();
+  const base = GraphicsStateStack.current(baseStack);
+  const rgbState = GraphicsState.update(base, {
+    strokeColor: Color.rgb(1, 0, 0),
+    strokeColorSpace: ColorSpace.deviceRGB(),
+  });
+  const graphicsStateStack = GraphicsStateStack.replaceCurrent(
+    baseStack,
+    rgbState,
+  );
+
+  const result = GHandler({ operandStack, graphicsStateStack });
+
+  assert(result.ok);
+  const current = GraphicsStateStack.current(result.value.graphicsStateStack);
+  expect(current.strokeColor).toEqual(Color.gray(0.5));
+  expect(current.strokeColorSpace).toEqual(ColorSpace.deviceGray());
+});
+
+test("integer operand `1 G` でも Color.gray(1) になる", () => {
+  const ctx = buildContext([int(1)]);
+
+  const result = GHandler(ctx);
+
+  assert(result.ok);
+  const current = GraphicsStateStack.current(result.value.graphicsStateStack);
+  expect(current.strokeColor).toEqual(Color.gray(1));
+});
+
+test("成功時 fillColor / fillColorSpace は不変", () => {
+  const ctx = buildContext([real(0.5)]);
+  const before = GraphicsStateStack.current(ctx.graphicsStateStack);
+
+  const result = GHandler(ctx);
+
+  assert(result.ok);
+  const after = GraphicsStateStack.current(result.value.graphicsStateStack);
+  expect(after.fillColor).toEqual(before.fillColor);
+  expect(after.fillColorSpace).toEqual(before.fillColorSpace);
+});
+
+test("成功時 ctm / lineWidth / lineCap / lineJoin / miterLimit / currentPath は不変", () => {
+  const ctx = buildContext([real(0.5)]);
+  const before = GraphicsStateStack.current(ctx.graphicsStateStack);
+
+  const result = GHandler(ctx);
+
+  assert(result.ok);
+  const after = GraphicsStateStack.current(result.value.graphicsStateStack);
+  expect(after.ctm).toEqual(before.ctm);
+  expect(after.lineWidth).toBe(before.lineWidth);
+  expect(after.lineCap).toBe(before.lineCap);
+  expect(after.lineJoin).toBe(before.lineJoin);
+  expect(after.miterLimit).toBe(before.miterLimit);
+  expect(after.currentPath).toEqual(before.currentPath);
+});
+
+test("成功時 pop で operand stack が空になる (depth 0)", () => {
+  const ctx = buildContext([real(0.5)]);
+
+  const result = GHandler(ctx);
+
+  assert(result.ok);
+  expect(OperandStack.depth(result.value.operandStack)).toBe(0);
+});
+
+test("成功時 result.value.operandStack は context.operandStack と同一参照", () => {
+  const ctx = buildContext([real(0.5)]);
+
+  const result = GHandler(ctx);
+
+  assert(result.ok);
+  expect(result.value.operandStack).toBe(ctx.operandStack);
+});
+
+test("operand stack に余剰要素がある場合、末尾 1 個だけ pop し残りはそのまま", () => {
+  const head = int(99);
+  const ctx = buildContext([head, real(0.5)]);
+
+  const result = GHandler(ctx);
+
+  assert(result.ok);
+  const current = GraphicsStateStack.current(result.value.graphicsStateStack);
+  expect(current.strokeColor).toEqual(Color.gray(0.5));
+  expect(OperandStack.depth(result.value.operandStack)).toBe(1);
+  const top = OperandStack.peek(result.value.operandStack);
+  assert(top.some);
+  expect(top.value).toEqual(head);
+});
+
+test("operand 0 個のとき OPERATOR_OPERAND_MISSING を返し actual = 0", () => {
+  const ctx = buildContext([]);
+
+  const result = GHandler(ctx);
+
+  assert(!result.ok);
+  assert(result.error.code === "OPERATOR_OPERAND_MISSING");
+  expect(result.error.operatorName).toBe("G");
+  expect(result.error.required).toBe(1);
+  expect(result.error.actual).toBe(0);
+  expect(result.error.message).toBe(
+    "Operator 'G' requires 1 operand(s), got 0",
+  );
+});
+
+test.each([
+  { label: "name", operand: { type: "name", value: "Foo" } as PdfObject },
+  { label: "boolean", operand: { type: "boolean", value: true } as PdfObject },
+  {
+    label: "string",
+    operand: {
+      type: "string",
+      value: new Uint8Array([0x61]),
+      encoding: "literal",
+    } as PdfObject,
+  },
+  { label: "null", operand: { type: "null" } as PdfObject },
+  { label: "array", operand: { type: "array", elements: [] } as PdfObject },
+  {
+    label: "dictionary",
+    operand: { type: "dictionary", entries: new Map() } as PdfObject,
+  },
+  {
+    label: "indirect-ref",
+    operand: {
+      type: "indirect-ref",
+      objectNumber: 1,
+      generationNumber: 0,
+    } as PdfObject,
+  },
+  {
+    label: "stream",
+    operand: {
+      type: "stream",
+      dictionary: { type: "dictionary", entries: new Map() },
+      data: new Uint8Array(),
+    } as PdfObject,
+  },
+])("operand が $label のとき OPERATOR_OPERAND_TYPE_MISMATCH を返す", ({
+  label,
+  operand,
+}) => {
+  const ctx = buildContext([operand]);
+
+  const result = GHandler(ctx);
+
+  assert(!result.ok);
+  assert(result.error.code === "OPERATOR_OPERAND_TYPE_MISMATCH");
+  expect(result.error.operatorName).toBe("G");
+  expect(result.error.expected).toBe("number");
+  expect(result.error.actual).toBe(label);
+  expect(result.error.message).toBe(
+    `Operator 'G' expected number operand, got ${label}`,
+  );
+});
+
+test("TYPE_MISMATCH 時に pop 済みの operand は復元しない (depth が減ったまま)", () => {
+  const ctx = buildContext([{ type: "name", value: "Foo" }]);
+  const beforeDepth = OperandStack.depth(ctx.operandStack);
+
+  const result = GHandler(ctx);
+
+  assert(!result.ok);
+  expect(beforeDepth).toBe(1);
+  expect(OperandStack.depth(ctx.operandStack)).toBe(0);
+});
+
+test.each([
+  { label: "0", value: 0 },
+  { label: "1", value: 1 },
+  { label: "negative", value: -0.1 },
+  { label: ">1", value: 1.5 },
+  { label: "NaN", value: Number.NaN },
+  { label: "Positive Infinity", value: Number.POSITIVE_INFINITY },
+  { label: "Negative Infinity", value: Number.NEGATIVE_INFINITY },
+])("境界値 $label は検証せず Color.gray にそのまま透過する", ({ value }) => {
+  const ctx = buildContext([real(value)]);
+
+  const result = GHandler(ctx);
+
+  assert(result.ok);
+  const current = GraphicsStateStack.current(result.value.graphicsStateStack);
+  expect(current.strokeColor).toEqual(Color.gray(value));
+});

--- a/packages/core/src/content-stream/operators/color/G/index.ts
+++ b/packages/core/src/content-stream/operators/color/G/index.ts
@@ -1,0 +1,86 @@
+import type { PdfError } from "../../../../pdf/errors/index";
+import { err, ok } from "../../../../utils/result/index";
+import {
+  Color,
+  ColorSpace,
+  GraphicsState,
+  GraphicsStateStack,
+} from "../../../graphics-state/index";
+import { OperandStack } from "../../../operand-stack/index";
+import type {
+  OperatorHandler,
+  OperatorHandlerContext,
+} from "../../../operator-registry/index";
+import { NumericPdfObject } from "../../graphics-state/numeric-pdf-object";
+
+const OPERATOR_NAME = "G";
+const OPERAND_COUNT = 1;
+
+/**
+ * PDF §8.6.5.2 `G gray` operator (DeviceGray stroke color) のハンドラ。
+ *
+ * operand stack から `gray` 1 個を pop し、`Color.gray(g)` と
+ * `ColorSpace.deviceGray()` を生成して GraphicsState の strokeColor /
+ * strokeColorSpace を同時更新する。
+ *
+ * - operand 不足のとき `OPERATOR_OPERAND_MISSING` を返す
+ *   `actual` には pop に成功した個数 (= 0) を入れる
+ * - operand が integer / real 以外のとき `OPERATOR_OPERAND_TYPE_MISMATCH` を返す
+ * - 値域 (`NaN` / `Infinity` / 負値 / >1.0) は本 handler では検証しない
+ * - エラー時に operand stack の部分消費は復元しない (既存ハンドラ規約)
+ *
+ * 実装は cmHandler とテンプレ統一のため `OPERAND_COUNT = 1` でもループ構造を維持する。
+ *
+ * @param context - 実行コンテキスト (operand stack / graphics state stack)
+ * @returns 成功なら更新後コンテキスト、失敗なら PdfError
+ */
+export const GHandler: OperatorHandler = (context: OperatorHandlerContext) => {
+  const popped: NumericPdfObject[] = [];
+  for (let i = 0; i < OPERAND_COUNT; i++) {
+    const result = OperandStack.pop(context.operandStack);
+    if (!result.some) {
+      const error: PdfError = {
+        code: "OPERATOR_OPERAND_MISSING",
+        message: `Operator '${OPERATOR_NAME}' requires ${OPERAND_COUNT} operand(s), got ${i}`,
+        operatorName: OPERATOR_NAME,
+        required: OPERAND_COUNT,
+        actual: i,
+      };
+      return err(error);
+    }
+    const operand = result.value;
+    if (!NumericPdfObject.is(operand)) {
+      const error: PdfError = {
+        code: "OPERATOR_OPERAND_TYPE_MISMATCH",
+        message: `Operator '${OPERATOR_NAME}' expected number operand, got ${operand.type}`,
+        operatorName: OPERATOR_NAME,
+        expected: "number",
+        actual: operand.type,
+      };
+      return err(error);
+    }
+    popped.push(operand);
+  }
+
+  const [g] = popped
+    .slice()
+    .reverse()
+    .map((operand) => operand.value);
+
+  const strokeColor = Color.gray(g);
+  const strokeColorSpace = ColorSpace.deviceGray();
+  const current = GraphicsStateStack.current(context.graphicsStateStack);
+  const next = GraphicsState.update(current, {
+    strokeColor,
+    strokeColorSpace,
+  });
+  const graphicsStateStack = GraphicsStateStack.replaceCurrent(
+    context.graphicsStateStack,
+    next,
+  );
+
+  return ok({
+    operandStack: context.operandStack,
+    graphicsStateStack,
+  });
+};


### PR DESCRIPTION
## 概要

spec-059 PR-1。PDF §8.6.5.2 `G gray` operator のハンドラ `GHandler` を新規追加する。operand stack から 1 個の数値を pop し、`Color.gray(g)` と `ColorSpace.deviceGray()` で GraphicsState の strokeColor / strokeColorSpace を同時更新する。本 PR では handler 単体実装と単体テストのみで完結させ、`operator-registry` への登録および `operators/color/` barrel は Issue #216 で別 PR に分割する。

## 変更の種類

- ✨ New Feature (handler 本体)
- 🧪 Tests (basic test 12 ケース)

## 追加した内容

- `packages/core/src/content-stream/operators/color/G/index.ts` — `GHandler` 本体 (cmHandler テンプレ踏襲)
- `packages/core/src/content-stream/operators/color/G/__tests__/G.basic.test.ts` — basic test 12 ケース (test.each 展開後 25 ケース)

## 変更した内容

なし (既存ファイル変更 0 件)。

## システム図

```mermaid
flowchart TD
  CTX["OperatorHandlerContext<br/>{ operandStack, graphicsStateStack }"] --> POP[OperandStack.pop]
  POP -->|Option some=true| GUARD[NumericPdfObject.is]
  POP -->|some=false| EMISS["err: OPERAND_MISSING<br/>actual=0, required=1"]
  GUARD -->|true| FACT["Color.gray g<br/>ColorSpace.deviceGray"]
  GUARD -->|false| ETM["err: OPERAND_TYPE_MISMATCH<br/>expected=number"]
  FACT --> CUR[GraphicsStateStack.current]
  CUR --> UPD["GraphicsState.update<br/>{strokeColor, strokeColorSpace}"]
  UPD --> REP[GraphicsStateStack.replaceCurrent]
  REP --> OK["ok({ operandStack, graphicsStateStack })"]
  style FACT fill:#e1f5fe
  style UPD fill:#e1f5fe
```

## 関連 spec / Issue

- spec: `.plugin-workspace/.specs/059-g-operator-handler/`
- Refs #210
- 親 Epic: #206 (Phase 4-C / Color operators)
- Blocked by: #209 (merged) / Blocks: #216 (registry 登録)

## テスト

- `pnpm --filter @pdfmod/core test` → 1944 / 1944 passed
- `pnpm --filter @pdfmod/core build` → 成功
- `pnpm --filter @pdfmod/core typecheck` → green
- `pnpm lint` (biome + oxlint) → green
- `pnpm format:check` → green
- Codex CLI レビュー (`.plugin-workspace/.specs/059-g-operator-handler/code-review/review-001.md`) → **問題なし**

### テスト網羅 (12 ケース)

1. `0.5 G` で strokeColor が `Color.gray(0.5)` に更新される
2. 初期 strokeColorSpace=deviceRGB / strokeColor=rgb から `0.5 G` で deviceGray + gray(0.5) に切り替わる
3. integer operand `1 G` でも `Color.gray(1)` になる
4. 成功時 fillColor / fillColorSpace は不変
5. 成功時 ctm / lineWidth / lineCap / lineJoin / miterLimit / currentPath は不変
6. 成功時 pop で operand stack が空になる (depth 0)
7. 成功時 `result.value.operandStack === ctx.operandStack` (同一参照)
8. 余剰 operand があるとき末尾 1 個だけ pop し残りはそのまま
9. operand 0 個のとき `OPERATOR_OPERAND_MISSING`, actual=0
10. type mismatch 8 種 (`name` / `boolean` / `string` / `null` / `array` / `dictionary` / `indirect-ref` / `stream`) → `OPERATOR_OPERAND_TYPE_MISMATCH`
11. TYPE_MISMATCH 時に部分消費 operand stack は復元しない (depth が減ったまま)
12. 境界値 7 種 (`0` / `1` / `-0.1` / `1.5` / `NaN` / `±Infinity`) は検証せず `Color.gray` に透過

## レビューポイント

- **ループ構造を `OPERAND_COUNT = 1` で維持した理由**: 後続 `RG` (3 operand) / `K` (4 operand) handler とテンプレートを完全統一する目的。`popped.slice().reverse()` も同じ理由で残している (リスク表 #1 への対応)。
- **`GHandler` PascalCase 採用根拠**: 小文字 `g` operator (fill 用 DeviceGray) との曖昧性回避のため (リスク表 #2 / hearing-notes Batch 2)。既存の `cmHandler` / `mHandler` (lowerCamelCase) とは命名規則がずれて見えるが、PDF spec の operator 大文字小文字を保持するための意図的な選択。
- **scope 外**: `operator-registry` 登録 / `operators/color/index.ts` barrel / 小文字 `g` operator / RG / K / rg / k は本 PR に含まない (Issue #216 以降)。
- **値域検証なし**: 0.0〜1.0 範囲外 / NaN / Infinity は本 handler では検証せず `Color.gray(value)` にそのまま透過する。これは hearing-notes Batch 1 で確定した方針。

## チェックリスト

- [x] describe 不使用・フラット test 列挙の規約に準拠している
- [x] テストは `__tests__/` に対象と同階層で配置している
- [x] throw を使わず Result/Option で表現している
- [x] value の有無を表す型は Option<T> を使っている (NumericPdfObject.is で type guard)
- [x] `pnpm test` / `pnpm --filter @pdfmod/core typecheck` / `pnpm lint` がすべて通る
- [x] spec の implementation-plan.md / tasks.md と整合している
- [x] Codex レビュー (spec-implement-codex) を完了している
- [x] セルフレビュー実施
- [x] 破壊的変更なし