### PR TITLE
✨ [New Feature]: #216 暫定版 registerColorOperators (G/g) を追加

### DIFF
--- a/packages/core/src/content-stream/operators/color/color-operators/__tests__/color-operators.basic.test.ts
+++ b/packages/core/src/content-stream/operators/color/color-operators/__tests__/color-operators.basic.test.ts
@@ -1,0 +1,25 @@
+import { assert, expect, test } from "vitest";
+import {
+  type OperatorHandler,
+  OperatorRegistry,
+} from "../../../../operator-registry/index";
+import { GHandler, gHandler, registerColorOperators } from "../index";
+
+test.each<readonly [string, OperatorHandler]>([
+  ["G", GHandler],
+  ["g", gHandler],
+])("registerColorOperators は %s に対応する handler を登録する", (name, expectedHandler) => {
+  const result = registerColorOperators(OperatorRegistry.create());
+  assert(result.ok);
+
+  const looked = OperatorRegistry.lookup(result.value, name);
+  assert(looked.some);
+  expect(looked.value).toBe(expectedHandler);
+});
+
+test("registerColorOperators の戻り値は ok で OperatorRegistry を保持する", () => {
+  const result = registerColorOperators(OperatorRegistry.create());
+  assert(result.ok);
+  expect(OperatorRegistry.has(result.value, "G")).toBe(true);
+  expect(OperatorRegistry.has(result.value, "g")).toBe(true);
+});

--- a/packages/core/src/content-stream/operators/color/color-operators/__tests__/color-operators.error.test.ts
+++ b/packages/core/src/content-stream/operators/color/color-operators/__tests__/color-operators.error.test.ts
@@ -1,0 +1,45 @@
+import { afterEach, assert, expect, test, vi } from "vitest";
+import { OperatorRegistry } from "../../../../operator-registry/index";
+import { GHandler, gHandler, registerColorOperators } from "../index";
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+test("G 重複時、reduce は先頭で短絡し register は ['G'] でのみ呼ばれる", () => {
+  const seed = OperatorRegistry.register(
+    OperatorRegistry.create(),
+    "G",
+    GHandler,
+  );
+  assert(seed.ok);
+
+  const registerSpy = vi.spyOn(OperatorRegistry, "register");
+  const result = registerColorOperators(seed.value);
+
+  assert(!result.ok);
+  expect(result.error.code).toBe("OPERATOR_ALREADY_REGISTERED");
+  assert(result.error.code === "OPERATOR_ALREADY_REGISTERED");
+  expect(result.error.operatorName).toBe("G");
+  const calledNames = registerSpy.mock.calls.map((call) => call[1]);
+  expect(calledNames).toEqual(["G"]);
+});
+
+test("g 重複時、reduce は途中で短絡し register は ['G', 'g'] で止まる", () => {
+  const seed = OperatorRegistry.register(
+    OperatorRegistry.create(),
+    "g",
+    gHandler,
+  );
+  assert(seed.ok);
+
+  const registerSpy = vi.spyOn(OperatorRegistry, "register");
+  const result = registerColorOperators(seed.value);
+
+  assert(!result.ok);
+  expect(result.error.code).toBe("OPERATOR_ALREADY_REGISTERED");
+  assert(result.error.code === "OPERATOR_ALREADY_REGISTERED");
+  expect(result.error.operatorName).toBe("g");
+  const calledNames = registerSpy.mock.calls.map((call) => call[1]);
+  expect(calledNames).toEqual(["G", "g"]);
+});

--- a/packages/core/src/content-stream/operators/color/color-operators/__tests__/color-operators.integration.test.ts
+++ b/packages/core/src/content-stream/operators/color/color-operators/__tests__/color-operators.integration.test.ts
@@ -1,0 +1,47 @@
+import { assert, expect, test } from "vitest";
+import {
+  Color,
+  ColorSpace,
+  GraphicsStateStack,
+} from "../../../../graphics-state/index";
+import { ContentStreamInterpreter } from "../../../../interpreter/index";
+import { OperatorRegistry } from "../../../../operator-registry/index";
+import { registerColorOperators } from "../index";
+
+const encode = (s: string): Uint8Array => new TextEncoder().encode(s);
+
+test("0.5 G を実行すると strokeColor が Color.gray(0.5) に更新される", () => {
+  const registered = registerColorOperators(OperatorRegistry.create());
+  assert(registered.ok);
+
+  const result = ContentStreamInterpreter.execute({
+    data: encode("0.5 G"),
+    registry: registered.value,
+  });
+  assert(result.ok);
+  expect(result.value.warnings).toEqual([]);
+
+  const current = GraphicsStateStack.current(
+    result.value.context.graphicsStateStack,
+  );
+  expect(current.strokeColor).toEqual(Color.gray(0.5));
+  expect(current.strokeColorSpace).toEqual(ColorSpace.deviceGray());
+});
+
+test("0.5 g を実行すると fillColor が Color.gray(0.5) に更新される", () => {
+  const registered = registerColorOperators(OperatorRegistry.create());
+  assert(registered.ok);
+
+  const result = ContentStreamInterpreter.execute({
+    data: encode("0.5 g"),
+    registry: registered.value,
+  });
+  assert(result.ok);
+  expect(result.value.warnings).toEqual([]);
+
+  const current = GraphicsStateStack.current(
+    result.value.context.graphicsStateStack,
+  );
+  expect(current.fillColor).toEqual(Color.gray(0.5));
+  expect(current.fillColorSpace).toEqual(ColorSpace.deviceGray());
+});

--- a/packages/core/src/content-stream/operators/color/color-operators/index.ts
+++ b/packages/core/src/content-stream/operators/color/color-operators/index.ts
@@ -1,0 +1,33 @@
+import type { PdfError } from "../../../../pdf/errors/index";
+import type { Result } from "../../../../utils/result/index";
+import { flatMap, ok } from "../../../../utils/result/index";
+import type { OperatorHandler } from "../../../operator-registry/index";
+import { OperatorRegistry } from "../../../operator-registry/index";
+import { gHandler } from "../gray/fill";
+import { GHandler } from "../gray/stroke";
+
+export { gHandler } from "../gray/fill";
+export { GHandler } from "../gray/stroke";
+
+const COLOR_OPERATORS: ReadonlyArray<readonly [string, OperatorHandler]> = [
+  ["G", GHandler],
+  ["g", gHandler],
+];
+
+/**
+ * Color operator (G / g) を OperatorRegistry に一括登録するヘルパ (暫定 G/g 版)。
+ *
+ * fail-fast: いずれかの register が Err を返した時点で reduce 内 flatMap が
+ * 短絡し、後続 operator の register は呼ばれない。
+ *
+ * @param registry - 登録元 registry
+ * @returns 全 operator が登録された新しい registry、または重複登録時の PdfError
+ */
+export const registerColorOperators = (
+  registry: OperatorRegistry,
+): Result<OperatorRegistry, PdfError> =>
+  COLOR_OPERATORS.reduce<Result<OperatorRegistry, PdfError>>(
+    (acc, [name, handler]) =>
+      flatMap(acc, (r) => OperatorRegistry.register(r, name, handler)),
+    ok(registry),
+  );


### PR DESCRIPTION
## 概要

spec-061。Phase 4-C の `registerColorOperators` ヘルパを `OperatorRegistry` に追加する。Phase 4-A `registerGraphicsStateOperators` / Phase 4-B `registerPathOperators` と同型の reduce + flatMap パターン。

**暫定版**: 現時点で handler 実装済の `GHandler` (#210) と `gHandler` (#211) のみを対象とし、`RG/rg/K/k` (Issue #212-215, 全 OPEN) は別 PR で対応する。

## 変更の種類

- ✨ [New Feature]: 新機能

## 追加した内容

- `packages/core/src/content-stream/operators/color/color-operators/index.ts`
  - `registerColorOperators(registry)` 関数 (`Result<OperatorRegistry, PdfError>` 戻り値)
  - `GHandler` / `gHandler` の barrel re-export
- `__tests__/color-operators.basic.test.ts` (3 tests)
  - `test.each` で G/g の lookup 一致を検証
  - 戻り値が ok で `has("G")` / `has("g")` が true
- `__tests__/color-operators.error.test.ts` (2 tests)
  - G 重複時: `calledNames === ["G"]` で先頭短絡を確認
  - g 重複時: `calledNames === ["G", "g"]` で途中短絡を確認
- `__tests__/color-operators.integration.test.ts` (2 tests)
  - `0.5 G` → strokeColor / strokeColorSpace 更新
  - `0.5 g` → fillColor / fillColorSpace 更新

## 変更した内容

なし。`gray/stroke.ts` / `gray/fill.ts` / 既存 path / graphics-state 系には触れていない。

## 削除した内容

なし。

## システム図

```mermaid
flowchart TD
    A[registerColorOperators registry] --> B[acc = ok registry]
    B --> C{Step1: G GHandler}
    C -->|ok| D[acc = Ok r']
    C -->|err| E[Err 伝播 - 短絡]
    D --> F{Step2: g gHandler}
    F -->|ok| G[Ok r'']
    F -->|err| H[Err OPERATOR_ALREADY_REGISTERED]
    E --> I[Result OperatorRegistry, PdfError]
    G --> I
    H --> I

    style C fill:#e1f5ff
    style F fill:#e1f5ff
```

```mermaid
flowchart LR
    A[color-operators/index.ts<br/>COLOR_OPERATORS] -->|import GHandler| B[gray/stroke.ts]
    A -->|import gHandler| C[gray/fill.ts]
    A -->|register| D[OperatorRegistry]
    B --> E[OperatorHandler 型]
    C --> E
    E --> D
```

## 関連 spec / Issue

- spec: `.plugin-workspace/.specs/061-register-color-operators/`
- Refs #216 (本 PR では close しない — 暫定版のため)
- 後続 PR で対応: #212 (RG), #213 (rg), #214 (K), #215 (k) + 完成版 helper

## テスト

```
pnpm --filter @pdfmod/core test
→ Test Files  140 passed (140)
→      Tests  1976 passed (1976)

pnpm --filter @pdfmod/core build
→ ✓ built in 952ms (TypeScript エラーなし)

lint (oxlint / biome)
→ 0 warnings / 0 errors
```

新規 7 tests:
- basic: 3 (G/g の lookup + has)
- error: 2 (G/g 重複時の fail-fast)
- integration: 2 (interpreter 経由の状態更新)

### Codex レビュー

Codex CLI は bubblewrap が当該カーネルの unprivileged user namespace を作成できず実行不可だったため、`code-review/review-001.md` にセルフレビューを記録。DoD 全項目を照合済み。

## レビューポイント

1. **path-operators との同型性**: `index.ts` が `packages/core/src/content-stream/operators/path/path-operators/index.ts` と diff してほぼ同型 (配列要素・import 源のみ差分)
2. **暫定版方針**: `COLOR_OPERATORS` が `[["G", GHandler], ["g", gHandler]]` の 2 要素のみで、#216 を本 PR で close しないこと
3. **fail-fast 検証**: error test の `calledNames` 検証で reduce + flatMap の短絡動作を観測している点
4. **テスト規約準拠**: `__tests__/` 配置、describe 不使用、`test.each` パラメータ化、セクションコメントなし
5. **Result 型運用**: throw 不使用、`Result<OperatorRegistry, PdfError>` で重複登録エラーを返す