### PR TITLE
✨ [New Feature]: #212 RGHandler (DeviceRGB stroke color) を追加

### DIFF
--- a/packages/core/src/content-stream/operators/color/RG/__tests__/RG.basic.test.ts
+++ b/packages/core/src/content-stream/operators/color/RG/__tests__/RG.basic.test.ts
@@ -1,0 +1,194 @@
+import { assert, expect, test } from "vitest";
+import type { PdfObject } from "../../../../../pdf/types/pdf-types/index";
+import {
+  Color,
+  ColorSpace,
+  GraphicsState,
+  GraphicsStateStack,
+} from "../../../../graphics-state/index";
+import { OperandStack } from "../../../../operand-stack/index";
+import type { OperatorHandlerContext } from "../../../../operator-registry/index";
+import { RGHandler } from "../index";
+
+const buildContext = (operands: PdfObject[]): OperatorHandlerContext => {
+  const operandStack = OperandStack.create();
+  for (const operand of operands) {
+    OperandStack.push(operandStack, operand);
+  }
+  const graphicsStateStack = GraphicsStateStack.create();
+  return { operandStack, graphicsStateStack };
+};
+
+const real = (value: number): PdfObject => ({ type: "real", value });
+const int = (value: number): PdfObject => ({ type: "integer", value });
+
+test("`0 0 0 RG` で strokeColor が Color.rgb(0, 0, 0) に更新される", () => {
+  const ctx = buildContext([real(0), real(0), real(0)]);
+
+  const result = RGHandler(ctx);
+
+  assert(result.ok);
+  const current = GraphicsStateStack.current(result.value.graphicsStateStack);
+  expect(current.strokeColor).toEqual(Color.rgb(0, 0, 0));
+});
+
+test("`1 0 0 RG` で strokeColor=Color.rgb(1, 0, 0) / strokeColorSpace=deviceRGB() になる", () => {
+  const ctx = buildContext([real(1), real(0), real(0)]);
+
+  const result = RGHandler(ctx);
+
+  assert(result.ok);
+  const current = GraphicsStateStack.current(result.value.graphicsStateStack);
+  expect(current.strokeColor).toEqual(Color.rgb(1, 0, 0));
+  expect(current.strokeColorSpace).toEqual(ColorSpace.deviceRGB());
+});
+
+test("integer operand `1 0 0 RG` でも Color.rgb(1, 0, 0) になる", () => {
+  const ctx = buildContext([int(1), int(0), int(0)]);
+
+  const result = RGHandler(ctx);
+
+  assert(result.ok);
+  const current = GraphicsStateStack.current(result.value.graphicsStateStack);
+  expect(current.strokeColor).toEqual(Color.rgb(1, 0, 0));
+});
+
+test("成功時 fillColor / fillColorSpace は不変", () => {
+  const ctx = buildContext([real(0.1), real(0.2), real(0.3)]);
+  const before = GraphicsStateStack.current(ctx.graphicsStateStack);
+
+  const result = RGHandler(ctx);
+
+  assert(result.ok);
+  const after = GraphicsStateStack.current(result.value.graphicsStateStack);
+  expect(after.fillColor).toEqual(before.fillColor);
+  expect(after.fillColorSpace).toEqual(before.fillColorSpace);
+});
+
+test("初期 fillColor=rgb(0.5, 0.5, 0.5) の状態でも RG 実行後 fillColor は変わらない", () => {
+  const operandStack = OperandStack.create();
+  OperandStack.push(operandStack, real(1));
+  OperandStack.push(operandStack, real(0));
+  OperandStack.push(operandStack, real(0));
+  const baseStack = GraphicsStateStack.create();
+  const base = GraphicsStateStack.current(baseStack);
+  const seeded = GraphicsState.update(base, {
+    fillColor: Color.rgb(0.5, 0.5, 0.5),
+    fillColorSpace: ColorSpace.deviceRGB(),
+  });
+  const graphicsStateStack = GraphicsStateStack.replaceCurrent(
+    baseStack,
+    seeded,
+  );
+
+  const result = RGHandler({ operandStack, graphicsStateStack });
+
+  assert(result.ok);
+  const current = GraphicsStateStack.current(result.value.graphicsStateStack);
+  expect(current.fillColor).toEqual(Color.rgb(0.5, 0.5, 0.5));
+  expect(current.fillColorSpace).toEqual(ColorSpace.deviceRGB());
+  expect(current.strokeColor).toEqual(Color.rgb(1, 0, 0));
+});
+
+test("成功時 ctm / lineWidth / lineCap / lineJoin / miterLimit / currentPath は不変", () => {
+  const ctx = buildContext([real(0.1), real(0.2), real(0.3)]);
+  const before = GraphicsStateStack.current(ctx.graphicsStateStack);
+
+  const result = RGHandler(ctx);
+
+  assert(result.ok);
+  const after = GraphicsStateStack.current(result.value.graphicsStateStack);
+  expect(after.ctm).toEqual(before.ctm);
+  expect(after.lineWidth).toBe(before.lineWidth);
+  expect(after.lineCap).toBe(before.lineCap);
+  expect(after.lineJoin).toBe(before.lineJoin);
+  expect(after.miterLimit).toBe(before.miterLimit);
+  expect(after.currentPath).toEqual(before.currentPath);
+});
+
+test("成功時 pop で operand stack が空になる (depth 0)", () => {
+  const ctx = buildContext([real(0.1), real(0.2), real(0.3)]);
+
+  const result = RGHandler(ctx);
+
+  assert(result.ok);
+  expect(OperandStack.depth(result.value.operandStack)).toBe(0);
+});
+
+test("成功時 result.value.operandStack は context.operandStack と同一参照", () => {
+  const ctx = buildContext([real(0.1), real(0.2), real(0.3)]);
+
+  const result = RGHandler(ctx);
+
+  assert(result.ok);
+  expect(result.value.operandStack).toBe(ctx.operandStack);
+});
+
+test("operand stack に余剰要素 (5 個) がある場合、末尾 3 個だけ pop し残り 2 個は保持", () => {
+  const head1 = int(99);
+  const head2 = int(98);
+  const ctx = buildContext([head1, head2, real(0.1), real(0.2), real(0.3)]);
+
+  const result = RGHandler(ctx);
+
+  assert(result.ok);
+  const current = GraphicsStateStack.current(result.value.graphicsStateStack);
+  expect(current.strokeColor).toEqual(Color.rgb(0.1, 0.2, 0.3));
+  expect(OperandStack.depth(result.value.operandStack)).toBe(2);
+  const top = OperandStack.peek(result.value.operandStack);
+  assert(top.some);
+  expect(top.value).toEqual(head2);
+});
+
+test.each([
+  { label: "all zero", r: 0, g: 0, b: 0 },
+  { label: "all one", r: 1, g: 1, b: 1 },
+  { label: "negative r", r: -0.1, g: 0, b: 0 },
+  { label: "negative g", r: 0, g: -0.5, b: 0 },
+  { label: "negative b", r: 0, g: 0, b: -1 },
+  { label: "r > 1", r: 1.5, g: 0, b: 0 },
+  { label: "g > 1", r: 0, g: 2, b: 0 },
+  { label: "b > 1", r: 0, g: 0, b: 1.0001 },
+])("境界値 $label は検証せず Color.rgb にそのまま透過する", ({ r, g, b }) => {
+  const ctx = buildContext([real(r), real(g), real(b)]);
+
+  const result = RGHandler(ctx);
+
+  assert(result.ok);
+  const current = GraphicsStateStack.current(result.value.graphicsStateStack);
+  expect(current.strokeColor).toEqual(Color.rgb(r, g, b));
+});
+
+test("NaN operand を渡しても handler はエラーを返さず Color.rgb の各成分が NaN になる", () => {
+  const ctx = buildContext([
+    real(Number.NaN),
+    real(Number.NaN),
+    real(Number.NaN),
+  ]);
+
+  const result = RGHandler(ctx);
+
+  assert(result.ok);
+  const current = GraphicsStateStack.current(result.value.graphicsStateStack);
+  assert(current.strokeColor.kind === "rgb");
+  expect(Number.isNaN(current.strokeColor.r)).toBe(true);
+  expect(Number.isNaN(current.strokeColor.g)).toBe(true);
+  expect(Number.isNaN(current.strokeColor.b)).toBe(true);
+});
+
+test("+Infinity / -Infinity operand を渡しても handler はエラーを返さず Color.rgb にそのまま透過する", () => {
+  const ctx = buildContext([
+    real(Number.POSITIVE_INFINITY),
+    real(Number.NEGATIVE_INFINITY),
+    real(Number.POSITIVE_INFINITY),
+  ]);
+
+  const result = RGHandler(ctx);
+
+  assert(result.ok);
+  const current = GraphicsStateStack.current(result.value.graphicsStateStack);
+  assert(current.strokeColor.kind === "rgb");
+  expect(current.strokeColor.r).toBe(Number.POSITIVE_INFINITY);
+  expect(current.strokeColor.g).toBe(Number.NEGATIVE_INFINITY);
+  expect(current.strokeColor.b).toBe(Number.POSITIVE_INFINITY);
+});

--- a/packages/core/src/content-stream/operators/color/RG/__tests__/RG.error.test.ts
+++ b/packages/core/src/content-stream/operators/color/RG/__tests__/RG.error.test.ts
@@ -1,0 +1,130 @@
+import { assert, expect, test } from "vitest";
+import type { PdfObject } from "../../../../../pdf/types/pdf-types/index";
+import { GraphicsStateStack } from "../../../../graphics-state/index";
+import { OperandStack } from "../../../../operand-stack/index";
+import type { OperatorHandlerContext } from "../../../../operator-registry/index";
+import { RGHandler } from "../index";
+
+const buildContext = (operands: PdfObject[]): OperatorHandlerContext => {
+  const operandStack = OperandStack.create();
+  for (const operand of operands) {
+    OperandStack.push(operandStack, operand);
+  }
+  const graphicsStateStack = GraphicsStateStack.create();
+  return { operandStack, graphicsStateStack };
+};
+
+const real = (value: number): PdfObject => ({ type: "real", value });
+
+test.each([
+  { operands: [] as PdfObject[], actual: 0 },
+  { operands: [real(0.1)], actual: 1 },
+  { operands: [real(0.1), real(0.2)], actual: 2 },
+])("operand $actual 個のとき OPERATOR_OPERAND_MISSING を返し actual = $actual", ({
+  operands,
+  actual,
+}) => {
+  const ctx = buildContext(operands);
+
+  const result = RGHandler(ctx);
+
+  assert(!result.ok);
+  assert(result.error.code === "OPERATOR_OPERAND_MISSING");
+  expect(result.error.operatorName).toBe("RG");
+  expect(result.error.required).toBe(3);
+  expect(result.error.actual).toBe(actual);
+  expect(result.error.message).toBe(
+    `Operator 'RG' requires 3 operand(s), got ${actual}`,
+  );
+});
+
+const nonNumericOperands: Array<{ label: string; operand: PdfObject }> = [
+  { label: "name", operand: { type: "name", value: "Foo" } },
+  { label: "boolean", operand: { type: "boolean", value: true } },
+  {
+    label: "string",
+    operand: {
+      type: "string",
+      value: new Uint8Array([0x61]),
+      encoding: "literal",
+    },
+  },
+  { label: "null", operand: { type: "null" } },
+  { label: "array", operand: { type: "array", elements: [] } },
+  { label: "dictionary", operand: { type: "dictionary", entries: new Map() } },
+  {
+    label: "indirect-ref",
+    operand: { type: "indirect-ref", objectNumber: 1, generationNumber: 0 },
+  },
+  {
+    label: "stream",
+    operand: {
+      type: "stream",
+      dictionary: { type: "dictionary", entries: new Map() },
+      data: new Uint8Array(),
+    },
+  },
+];
+
+test.each(
+  nonNumericOperands,
+)("b 位置に $label が来たら OPERATOR_OPERAND_TYPE_MISMATCH を返す", ({
+  label,
+  operand,
+}) => {
+  const ctx = buildContext([real(0.1), real(0.2), operand]);
+
+  const result = RGHandler(ctx);
+
+  assert(!result.ok);
+  assert(result.error.code === "OPERATOR_OPERAND_TYPE_MISMATCH");
+  expect(result.error.operatorName).toBe("RG");
+  expect(result.error.expected).toBe("number");
+  expect(result.error.actual).toBe(label);
+  expect(result.error.message).toBe(
+    `Operator 'RG' expected number operand, got ${label}`,
+  );
+});
+
+test("g 位置 (push 順 2 番目) に name 型が来たら TYPE_MISMATCH を返し actual='name'", () => {
+  const ctx = buildContext([
+    real(0.1),
+    { type: "name", value: "Foo" },
+    real(0.3),
+  ]);
+
+  const result = RGHandler(ctx);
+
+  assert(!result.ok);
+  assert(result.error.code === "OPERATOR_OPERAND_TYPE_MISMATCH");
+  expect(result.error.actual).toBe("name");
+});
+
+test("r 位置 (push 順 1 番目) に name 型が来たら TYPE_MISMATCH を返し actual='name'", () => {
+  const ctx = buildContext([
+    { type: "name", value: "Foo" },
+    real(0.2),
+    real(0.3),
+  ]);
+
+  const result = RGHandler(ctx);
+
+  assert(!result.ok);
+  assert(result.error.code === "OPERATOR_OPERAND_TYPE_MISMATCH");
+  expect(result.error.actual).toBe("name");
+});
+
+test("TYPE_MISMATCH 時に pop 済みの operand は復元しない (depth が減ったまま)", () => {
+  const ctx = buildContext([
+    real(0.1),
+    real(0.2),
+    { type: "name", value: "Foo" },
+  ]);
+  const beforeDepth = OperandStack.depth(ctx.operandStack);
+
+  const result = RGHandler(ctx);
+
+  assert(!result.ok);
+  expect(beforeDepth).toBe(3);
+  expect(OperandStack.depth(ctx.operandStack)).toBe(2);
+});

--- a/packages/core/src/content-stream/operators/color/RG/__tests__/RG.integration.test.ts
+++ b/packages/core/src/content-stream/operators/color/RG/__tests__/RG.integration.test.ts
@@ -1,0 +1,55 @@
+import { assert, expect, test } from "vitest";
+import {
+  Color,
+  ColorSpace,
+  GraphicsStateStack,
+} from "../../../../graphics-state/index";
+import { ContentStreamInterpreter } from "../../../../interpreter/index";
+import { OperatorRegistry } from "../../../../operator-registry/index";
+import { RGHandler } from "../index";
+
+const encode = (s: string): Uint8Array => new TextEncoder().encode(s);
+
+test("`1 0 0 RG` を実行すると strokeColor が Color.rgb(1, 0, 0) に更新される", () => {
+  const registered = OperatorRegistry.register(
+    OperatorRegistry.create(),
+    "RG",
+    RGHandler,
+  );
+  assert(registered.ok);
+
+  const result = ContentStreamInterpreter.execute({
+    data: encode("1 0 0 RG"),
+    registry: registered.value,
+  });
+  assert(result.ok);
+  expect(result.value.warnings).toEqual([]);
+
+  const current = GraphicsStateStack.current(
+    result.value.context.graphicsStateStack,
+  );
+  expect(current.strokeColor).toEqual(Color.rgb(1, 0, 0));
+  expect(current.strokeColorSpace).toEqual(ColorSpace.deviceRGB());
+});
+
+test("`0.1 0.2 0.3 RG` を実行すると strokeColor が Color.rgb(0.1, 0.2, 0.3) になり warnings は空", () => {
+  const registered = OperatorRegistry.register(
+    OperatorRegistry.create(),
+    "RG",
+    RGHandler,
+  );
+  assert(registered.ok);
+
+  const result = ContentStreamInterpreter.execute({
+    data: encode("0.1 0.2 0.3 RG"),
+    registry: registered.value,
+  });
+  assert(result.ok);
+  expect(result.value.warnings).toEqual([]);
+
+  const current = GraphicsStateStack.current(
+    result.value.context.graphicsStateStack,
+  );
+  expect(current.strokeColor).toEqual(Color.rgb(0.1, 0.2, 0.3));
+  expect(current.strokeColorSpace).toEqual(ColorSpace.deviceRGB());
+});

--- a/packages/core/src/content-stream/operators/color/RG/index.ts
+++ b/packages/core/src/content-stream/operators/color/RG/index.ts
@@ -1,0 +1,84 @@
+import type { PdfError } from "../../../../pdf/errors/index";
+import { err, ok } from "../../../../utils/result/index";
+import {
+  Color,
+  ColorSpace,
+  GraphicsState,
+  GraphicsStateStack,
+} from "../../../graphics-state/index";
+import { OperandStack } from "../../../operand-stack/index";
+import type {
+  OperatorHandler,
+  OperatorHandlerContext,
+} from "../../../operator-registry/index";
+import { NumericPdfObject } from "../../graphics-state/numeric-pdf-object";
+
+const OPERATOR_NAME = "RG";
+const OPERAND_COUNT = 3;
+
+/**
+ * PDF §8.6.5.3 `RG r g b` operator (DeviceRGB stroke color) のハンドラ。
+ *
+ * operand stack から `r g b` 3 個を pop し、`Color.rgb(r, g, b)` と
+ * `ColorSpace.deviceRGB()` を生成して GraphicsState の strokeColor /
+ * strokeColorSpace を同時更新する。
+ *
+ * - operand 不足のとき `OPERATOR_OPERAND_MISSING` を返す
+ *   `actual` には pop に成功した個数 (= 0, 1, 2) を入れる
+ * - operand が integer / real 以外のとき `OPERATOR_OPERAND_TYPE_MISMATCH` を返す
+ * - 値域 (`NaN` / `Infinity` / 負値 / >1.0) は本 handler では検証しない
+ * - エラー時に operand stack の部分消費は復元しない (既存ハンドラ規約)
+ *
+ * @param context - 実行コンテキスト (operand stack / graphics state stack)
+ * @returns 成功なら更新後コンテキスト、失敗なら PdfError
+ */
+export const RGHandler: OperatorHandler = (context: OperatorHandlerContext) => {
+  const popped: NumericPdfObject[] = [];
+  for (let i = 0; i < OPERAND_COUNT; i++) {
+    const result = OperandStack.pop(context.operandStack);
+    if (!result.some) {
+      const error: PdfError = {
+        code: "OPERATOR_OPERAND_MISSING",
+        message: `Operator '${OPERATOR_NAME}' requires ${OPERAND_COUNT} operand(s), got ${i}`,
+        operatorName: OPERATOR_NAME,
+        required: OPERAND_COUNT,
+        actual: i,
+      };
+      return err(error);
+    }
+    const operand = result.value;
+    if (!NumericPdfObject.is(operand)) {
+      const error: PdfError = {
+        code: "OPERATOR_OPERAND_TYPE_MISMATCH",
+        message: `Operator '${OPERATOR_NAME}' expected number operand, got ${operand.type}`,
+        operatorName: OPERATOR_NAME,
+        expected: "number",
+        actual: operand.type,
+      };
+      return err(error);
+    }
+    popped.push(operand);
+  }
+
+  const [r, g, b] = popped
+    .slice()
+    .reverse()
+    .map((operand) => operand.value);
+
+  const strokeColor = Color.rgb(r, g, b);
+  const strokeColorSpace = ColorSpace.deviceRGB();
+  const current = GraphicsStateStack.current(context.graphicsStateStack);
+  const next = GraphicsState.update(current, {
+    strokeColor,
+    strokeColorSpace,
+  });
+  const graphicsStateStack = GraphicsStateStack.replaceCurrent(
+    context.graphicsStateStack,
+    next,
+  );
+
+  return ok({
+    operandStack: context.operandStack,
+    graphicsStateStack,
+  });
+};


### PR DESCRIPTION
## 概要

spec-062。PDF §8.6.5.3 `RG r g b` operator (DeviceRGB stroke color) のハンドラを新規実装する。
既存 `GHandler` (`color/gray/stroke.ts`) を雛形に、`OPERAND_COUNT=3` / `Color.rgb` / `ColorSpace.deviceRGB()` へ差し替えた。
`registerColorOperators` への登録は **#216 後続スコープ** のため、本 PR には含めない。

## 変更の種類

- ✨ [New Feature]: 新機能

## 追加した内容

- `packages/core/src/content-stream/operators/color/RG/index.ts`
  - `RGHandler: OperatorHandler` を export
  - operand stack から `r g b` 3 個を pop → `Color.rgb(r, g, b)` + `ColorSpace.deviceRGB()` を strokeColor / strokeColorSpace に同時反映
  - operand 不足 → `OPERATOR_OPERAND_MISSING` (`actual` = 0/1/2)
  - 非数値 operand → `OPERATOR_OPERAND_TYPE_MISMATCH` (`actual` = `operand.type`)
  - 値域 (`NaN` / `±Infinity` / 負値 / >1.0) は本 handler で検証しない（Color.rgb 側仕様 #208）
- `packages/core/src/content-stream/operators/color/RG/__tests__/RG.basic.test.ts` (19 ケース)
- `packages/core/src/content-stream/operators/color/RG/__tests__/RG.error.test.ts` (14 ケース)
- `packages/core/src/content-stream/operators/color/RG/__tests__/RG.integration.test.ts` (2 ケース)

## システム図

`RGHandler` の内部フロー:

```mermaid
flowchart TD
    Start([RGHandler context]) --> Init[popped=[]<br/>i=0]
    Init --> Loop{i &lt; 3?}
    Loop -->|yes| Pop[OperandStack.pop]
    Pop --> Some{some?}
    Some -->|no| Missing[OPERATOR_OPERAND_MISSING<br/>actual=i]
    Some -->|yes| TypeCheck{NumericPdfObject.is?}
    TypeCheck -->|no| Mismatch[OPERATOR_OPERAND_TYPE_MISMATCH<br/>actual=operand.type]
    TypeCheck -->|yes| Push[popped.push<br/>i++]
    Push --> Loop
    Loop -->|no| Reverse["popped.slice().reverse() → [r, g, b]"]
    Reverse --> Build["Color.rgb(r, g, b)<br/>ColorSpace.deviceRGB()<br/>GraphicsState.update strokeColor/strokeColorSpace"]
    Build --> Replace[GraphicsStateStack.replaceCurrent]
    Replace --> OkEnd([ok operandStack, graphicsStateStack])
    Missing --> ErrEnd([err PdfError])
    Mismatch --> ErrEnd

    style Build fill:#e8f5e9
    style OkEnd fill:#e8f5e9
    style ErrEnd fill:#ffebee
```

## 関連 spec / Issue

- spec: `.plugin-workspace/.specs/062-rg-operator-handler/`
- Refs #212
- 後続 (registerColorOperators への登録): #216

## テスト

```
$ pnpm --filter @pdfmod/core test
Test Files  143 passed (143)
     Tests  2011 passed (2011)
```

- RG 単独: 35 ケース (basic 19 / error 14 / integration 2) 全 GREEN
- `pnpm --filter @pdfmod/core build` 成功（型エラー無し）
- `git diff` で `color-operators/index.ts` (`registerColorOperators`) が未変更であることを確認 → スコープ #216 を侵食していない

## レビューポイント

- **差分対比表 (plan §4.5) の 10 項目** が `GHandler` との差分として正しく反映されているか
  - `OPERATOR_NAME` / `OPERAND_COUNT` / `Color.rgb` / `ColorSpace.deviceRGB()` / docstring (§8.6.5.3) / message 文字列
- **TYPE_MISMATCH 時の pop 済み operand 復元しない** 既存規約の踏襲
- **integration テストが `OperatorRegistry.register` で直接登録** している点（`registerColorOperators` を経由していない）— #216 スコープ温存のため
- **`describe` 不使用 / `__tests__/` 配置 / セクションコメント無し** の規約準拠
- **境界値テスト**で `Number.isNaN` の明示判定を併用している点 (toEqual 仕様に頼らない)

## チェックリスト

- [x] describe 不使用・フラット test 列挙
- [x] __tests__/ サブディレクトリ配置
- [x] throw 不使用 / Result/Option で表現
- [x] `T | undefined` ではなく Option<T>
- [x] pnpm test / build 通過
- [x] spec の implementation-plan.md / tasks.md と整合
- [x] セルフレビュー実施
- [x] 破壊的変更なし