### PR TITLE
✨ [New Feature]: #214 K operator handler (DeviceCMYK stroke)

### DIFF
--- a/packages/core/src/content-stream/operators/color/cmyk/__tests__/stroke.basic.test.ts
+++ b/packages/core/src/content-stream/operators/color/cmyk/__tests__/stroke.basic.test.ts
@@ -1,0 +1,206 @@
+import { assert, expect, test } from "vitest";
+import type { PdfObject } from "../../../../../pdf/types/pdf-types/index";
+import {
+  Color,
+  ColorSpace,
+  GraphicsState,
+  GraphicsStateStack,
+} from "../../../../graphics-state/index";
+import { OperandStack } from "../../../../operand-stack/index";
+import type { OperatorHandlerContext } from "../../../../operator-registry/index";
+import { KHandler } from "../stroke";
+
+// 入力配列は push 順 = content stream 出現順 (c, m, y, k)。
+// pop は LIFO なので handler 内では k, y, m, c の順で取り出される。
+const buildContext = (operands: PdfObject[]): OperatorHandlerContext => {
+  const operandStack = OperandStack.create();
+  for (const operand of operands) {
+    OperandStack.push(operandStack, operand);
+  }
+  const graphicsStateStack = GraphicsStateStack.create();
+  return { operandStack, graphicsStateStack };
+};
+
+const real = (value: number): PdfObject => ({ type: "real", value });
+const int = (value: number): PdfObject => ({ type: "integer", value });
+
+test("`1 0 0 0 K` で strokeColor=Color.cmyk(1, 0, 0, 0) / strokeColorSpace=deviceCMYK() になる", () => {
+  const ctx = buildContext([real(1), real(0), real(0), real(0)]);
+
+  const result = KHandler(ctx);
+
+  assert(result.ok);
+  const current = GraphicsStateStack.current(result.value.graphicsStateStack);
+  expect(current.strokeColor).toEqual(Color.cmyk(1, 0, 0, 0));
+  expect(current.strokeColorSpace).toEqual(ColorSpace.deviceCMYK());
+});
+
+test.each([
+  { label: "0.2 0.4 0.6 0.8", c: 0.2, m: 0.4, y: 0.6, k: 0.8 },
+  { label: "all zero", c: 0, m: 0, y: 0, k: 0 },
+  { label: "all one", c: 1, m: 1, y: 1, k: 1 },
+])("値 $label が Color.cmyk にそのまま反映される", ({ c, m, y, k }) => {
+  const ctx = buildContext([real(c), real(m), real(y), real(k)]);
+
+  const result = KHandler(ctx);
+
+  assert(result.ok);
+  const current = GraphicsStateStack.current(result.value.graphicsStateStack);
+  expect(current.strokeColor).toEqual(Color.cmyk(c, m, y, k));
+  expect(current.strokeColorSpace).toEqual(ColorSpace.deviceCMYK());
+});
+
+test("integer/real 混在 operand でも Color.cmyk が正しく組み立てられる", () => {
+  const ctx = buildContext([int(0), real(0.5), int(1), real(0.25)]);
+
+  const result = KHandler(ctx);
+
+  assert(result.ok);
+  const current = GraphicsStateStack.current(result.value.graphicsStateStack);
+  expect(current.strokeColor).toEqual(Color.cmyk(0, 0.5, 1, 0.25));
+});
+
+test("初期 fillColor=rgb(0.7, 0.8, 0.9) を seed しても K 実行後 fill 系は完全一致で保持される", () => {
+  const operandStack = OperandStack.create();
+  OperandStack.push(operandStack, real(0.2));
+  OperandStack.push(operandStack, real(0.4));
+  OperandStack.push(operandStack, real(0.6));
+  OperandStack.push(operandStack, real(0.8));
+  const baseStack = GraphicsStateStack.create();
+  const base = GraphicsStateStack.current(baseStack);
+  const seeded = GraphicsState.update(base, {
+    fillColor: Color.rgb(0.7, 0.8, 0.9),
+    fillColorSpace: ColorSpace.deviceRGB(),
+  });
+  const graphicsStateStack = GraphicsStateStack.replaceCurrent(
+    baseStack,
+    seeded,
+  );
+
+  const result = KHandler({ operandStack, graphicsStateStack });
+
+  assert(result.ok);
+  const current = GraphicsStateStack.current(result.value.graphicsStateStack);
+  expect(current.fillColor).toEqual(Color.rgb(0.7, 0.8, 0.9));
+  expect(current.fillColorSpace).toEqual(ColorSpace.deviceRGB());
+  expect(current.strokeColor).toEqual(Color.cmyk(0.2, 0.4, 0.6, 0.8));
+});
+
+test("成功時 pop で operand stack が空になる (depth 0)", () => {
+  const ctx = buildContext([real(0.2), real(0.4), real(0.6), real(0.8)]);
+
+  const result = KHandler(ctx);
+
+  assert(result.ok);
+  expect(OperandStack.depth(result.value.operandStack)).toBe(0);
+});
+
+test("operand stack に余剰要素 (5 個) がある場合、末尾 4 個だけ pop し残り 1 個 (42) は保持", () => {
+  const extra = int(42);
+  const ctx = buildContext([extra, real(0.2), real(0.4), real(0.6), real(0.8)]);
+
+  const result = KHandler(ctx);
+
+  assert(result.ok);
+  const current = GraphicsStateStack.current(result.value.graphicsStateStack);
+  expect(current.strokeColor).toEqual(Color.cmyk(0.2, 0.4, 0.6, 0.8));
+  expect(OperandStack.depth(result.value.operandStack)).toBe(1);
+  const top = OperandStack.peek(result.value.operandStack);
+  assert(top.some);
+  expect(top.value).toEqual(extra);
+});
+
+test("成功時 result.value.operandStack は context.operandStack と同一参照", () => {
+  const ctx = buildContext([real(0.2), real(0.4), real(0.6), real(0.8)]);
+
+  const result = KHandler(ctx);
+
+  assert(result.ok);
+  expect(result.value.operandStack).toBe(ctx.operandStack);
+});
+
+test("成功時 fillColor / fillColorSpace は不変", () => {
+  const ctx = buildContext([real(0.2), real(0.4), real(0.6), real(0.8)]);
+  const before = GraphicsStateStack.current(ctx.graphicsStateStack);
+
+  const result = KHandler(ctx);
+
+  assert(result.ok);
+  const after = GraphicsStateStack.current(result.value.graphicsStateStack);
+  expect(after.fillColor).toEqual(before.fillColor);
+  expect(after.fillColorSpace).toEqual(before.fillColorSpace);
+});
+
+test("成功時 ctm / lineWidth / lineCap / lineJoin / miterLimit / currentPath は不変", () => {
+  const ctx = buildContext([real(0.2), real(0.4), real(0.6), real(0.8)]);
+  const before = GraphicsStateStack.current(ctx.graphicsStateStack);
+
+  const result = KHandler(ctx);
+
+  assert(result.ok);
+  const after = GraphicsStateStack.current(result.value.graphicsStateStack);
+  expect(after.ctm).toEqual(before.ctm);
+  expect(after.lineWidth).toBe(before.lineWidth);
+  expect(after.lineCap).toBe(before.lineCap);
+  expect(after.lineJoin).toBe(before.lineJoin);
+  expect(after.miterLimit).toBe(before.miterLimit);
+  expect(after.currentPath).toEqual(before.currentPath);
+});
+
+test.each([
+  { label: "negative c", c: -0.1, m: 0, y: 0, k: 0 },
+  { label: "negative k", c: 0, m: 0, y: 0, k: -1 },
+  { label: "c > 1", c: 1.5, m: 0, y: 0, k: 0 },
+  { label: "k > 1", c: 0, m: 0, y: 0, k: 2 },
+])("境界値 $label は検証せず Color.cmyk にそのまま透過する", ({
+  c,
+  m,
+  y,
+  k,
+}) => {
+  const ctx = buildContext([real(c), real(m), real(y), real(k)]);
+
+  const result = KHandler(ctx);
+
+  assert(result.ok);
+  const current = GraphicsStateStack.current(result.value.graphicsStateStack);
+  expect(current.strokeColor).toEqual(Color.cmyk(c, m, y, k));
+});
+
+test("NaN operand を渡しても handler はエラーを返さず Color.cmyk の各成分が NaN になる", () => {
+  const ctx = buildContext([
+    real(Number.NaN),
+    real(Number.NaN),
+    real(Number.NaN),
+    real(Number.NaN),
+  ]);
+
+  const result = KHandler(ctx);
+
+  assert(result.ok);
+  const current = GraphicsStateStack.current(result.value.graphicsStateStack);
+  assert(current.strokeColor.kind === "cmyk");
+  expect(Number.isNaN(current.strokeColor.c)).toBe(true);
+  expect(Number.isNaN(current.strokeColor.m)).toBe(true);
+  expect(Number.isNaN(current.strokeColor.y)).toBe(true);
+  expect(Number.isNaN(current.strokeColor.k)).toBe(true);
+});
+
+test("+Infinity / -Infinity operand を渡しても handler はエラーを返さず Color.cmyk にそのまま透過する", () => {
+  const ctx = buildContext([
+    real(Number.POSITIVE_INFINITY),
+    real(Number.NEGATIVE_INFINITY),
+    real(Number.POSITIVE_INFINITY),
+    real(Number.NEGATIVE_INFINITY),
+  ]);
+
+  const result = KHandler(ctx);
+
+  assert(result.ok);
+  const current = GraphicsStateStack.current(result.value.graphicsStateStack);
+  assert(current.strokeColor.kind === "cmyk");
+  expect(current.strokeColor.c).toBe(Number.POSITIVE_INFINITY);
+  expect(current.strokeColor.m).toBe(Number.NEGATIVE_INFINITY);
+  expect(current.strokeColor.y).toBe(Number.POSITIVE_INFINITY);
+  expect(current.strokeColor.k).toBe(Number.NEGATIVE_INFINITY);
+});

--- a/packages/core/src/content-stream/operators/color/cmyk/__tests__/stroke.basic.test.ts
+++ b/packages/core/src/content-stream/operators/color/cmyk/__tests__/stroke.basic.test.ts
@@ -3,9 +3,14 @@ import type { PdfObject } from "../../../../../pdf/types/pdf-types/index";
 import {
   Color,
   ColorSpace,
+  CurrentPath,
   GraphicsState,
   GraphicsStateStack,
+  LineCap,
+  LineJoin,
+  Matrix,
 } from "../../../../graphics-state/index";
+import { PathSegment } from "../../../../graphics-state/path-segment/index";
 import { OperandStack } from "../../../../operand-stack/index";
 import type { OperatorHandlerContext } from "../../../../operator-registry/index";
 import { KHandler } from "../stroke";
@@ -131,20 +136,44 @@ test("成功時 fillColor / fillColorSpace は不変", () => {
   expect(after.fillColorSpace).toEqual(before.fillColorSpace);
 });
 
-test("成功時 ctm / lineWidth / lineCap / lineJoin / miterLimit / currentPath は不変", () => {
-  const ctx = buildContext([real(0.2), real(0.4), real(0.6), real(0.8)]);
-  const before = GraphicsStateStack.current(ctx.graphicsStateStack);
+test("成功時 非デフォルトの ctm / lineWidth / lineCap / lineJoin / miterLimit / currentPath を seed しても全て不変", () => {
+  const operandStack = OperandStack.create();
+  OperandStack.push(operandStack, real(0.2));
+  OperandStack.push(operandStack, real(0.4));
+  OperandStack.push(operandStack, real(0.6));
+  OperandStack.push(operandStack, real(0.8));
 
-  const result = KHandler(ctx);
+  const baseStack = GraphicsStateStack.create();
+  const base = GraphicsStateStack.current(baseStack);
+  const seededCtm = Matrix.create(2, 0, 0, 3, 10, 20);
+  const seededPath = CurrentPath.append(
+    CurrentPath.append(CurrentPath.empty(), PathSegment.moveTo(1, 2)),
+    PathSegment.lineTo(3, 4),
+  );
+  const seeded = GraphicsState.update(base, {
+    ctm: seededCtm,
+    lineWidth: 2.5,
+    lineCap: LineCap.create(1),
+    lineJoin: LineJoin.create(2),
+    miterLimit: 4,
+    currentPath: seededPath,
+  });
+  const graphicsStateStack = GraphicsStateStack.replaceCurrent(
+    baseStack,
+    seeded,
+  );
+
+  const result = KHandler({ operandStack, graphicsStateStack });
 
   assert(result.ok);
   const after = GraphicsStateStack.current(result.value.graphicsStateStack);
-  expect(after.ctm).toEqual(before.ctm);
-  expect(after.lineWidth).toBe(before.lineWidth);
-  expect(after.lineCap).toBe(before.lineCap);
-  expect(after.lineJoin).toBe(before.lineJoin);
-  expect(after.miterLimit).toBe(before.miterLimit);
-  expect(after.currentPath).toEqual(before.currentPath);
+  expect(after.ctm).toEqual(seededCtm);
+  expect(after.lineWidth).toBe(2.5);
+  expect(after.lineCap).toBe(LineCap.create(1));
+  expect(after.lineJoin).toBe(LineJoin.create(2));
+  expect(after.miterLimit).toBe(4);
+  expect(after.currentPath).toEqual(seededPath);
+  expect(after.strokeColor).toEqual(Color.cmyk(0.2, 0.4, 0.6, 0.8));
 });
 
 test.each([

--- a/packages/core/src/content-stream/operators/color/cmyk/__tests__/stroke.error.test.ts
+++ b/packages/core/src/content-stream/operators/color/cmyk/__tests__/stroke.error.test.ts
@@ -1,0 +1,193 @@
+import { assert, expect, test } from "vitest";
+import type { PdfObject } from "../../../../../pdf/types/pdf-types/index";
+import { GraphicsStateStack } from "../../../../graphics-state/index";
+import { OperandStack } from "../../../../operand-stack/index";
+import type { OperatorHandlerContext } from "../../../../operator-registry/index";
+import { KHandler } from "../stroke";
+
+// 入力配列は push 順 = content stream 出現順 (c, m, y, k)。
+// pop は LIFO なので handler 内では k, y, m, c の順で取り出される。
+const buildContext = (operands: PdfObject[]): OperatorHandlerContext => {
+  const operandStack = OperandStack.create();
+  for (const operand of operands) {
+    OperandStack.push(operandStack, operand);
+  }
+  const graphicsStateStack = GraphicsStateStack.create();
+  return { operandStack, graphicsStateStack };
+};
+
+const real = (value: number): PdfObject => ({ type: "real", value });
+
+test.each([
+  { operands: [] as PdfObject[], actual: 0 },
+  { operands: [real(0.1)], actual: 1 },
+  { operands: [real(0.1), real(0.2)], actual: 2 },
+  { operands: [real(0.1), real(0.2), real(0.3)], actual: 3 },
+])("operand $actual 個のとき OPERATOR_OPERAND_MISSING を返し actual = $actual", ({
+  operands,
+  actual,
+}) => {
+  const ctx = buildContext(operands);
+
+  const result = KHandler(ctx);
+
+  assert(!result.ok);
+  assert(result.error.code === "OPERATOR_OPERAND_MISSING");
+  expect(result.error.operatorName).toBe("K");
+  expect(result.error.required).toBe(4);
+  expect(result.error.actual).toBe(actual);
+  expect(result.error.message).toBe(
+    `Operator 'K' requires 4 operand(s), got ${actual}`,
+  );
+});
+
+const nonNumericOperands: Array<{ label: string; operand: PdfObject }> = [
+  { label: "name", operand: { type: "name", value: "Foo" } },
+  { label: "boolean", operand: { type: "boolean", value: true } },
+  {
+    label: "string",
+    operand: {
+      type: "string",
+      value: new Uint8Array([0x61]),
+      encoding: "literal",
+    },
+  },
+  { label: "null", operand: { type: "null" } },
+  { label: "array", operand: { type: "array", elements: [] } },
+  { label: "dictionary", operand: { type: "dictionary", entries: new Map() } },
+  {
+    label: "indirect-ref",
+    operand: { type: "indirect-ref", objectNumber: 1, generationNumber: 0 },
+  },
+  {
+    label: "stream",
+    operand: {
+      type: "stream",
+      dictionary: { type: "dictionary", entries: new Map() },
+      data: new Uint8Array(),
+    },
+  },
+];
+
+test.each(
+  nonNumericOperands,
+)("k 位置 (top) に $label が来たら OPERATOR_OPERAND_TYPE_MISMATCH を返す", ({
+  label,
+  operand,
+}) => {
+  const ctx = buildContext([real(0.1), real(0.2), real(0.3), operand]);
+
+  const result = KHandler(ctx);
+
+  assert(!result.ok);
+  assert(result.error.code === "OPERATOR_OPERAND_TYPE_MISMATCH");
+  expect(result.error.operatorName).toBe("K");
+  expect(result.error.expected).toBe("number");
+  expect(result.error.actual).toBe(label);
+  expect(result.error.message).toBe(
+    `Operator 'K' expected number operand, got ${label}`,
+  );
+});
+
+test.each([
+  {
+    position: "y",
+    label: "name",
+    operands: [
+      real(0.1),
+      real(0.2),
+      { type: "name", value: "Foo" } as PdfObject,
+      real(0.4),
+    ],
+  },
+  {
+    position: "m",
+    label: "boolean",
+    operands: [
+      real(0.1),
+      { type: "boolean", value: true } as PdfObject,
+      real(0.3),
+      real(0.4),
+    ],
+  },
+  {
+    position: "c",
+    label: "string",
+    operands: [
+      {
+        type: "string",
+        value: new Uint8Array([0x61]),
+        encoding: "literal",
+      } as PdfObject,
+      real(0.2),
+      real(0.3),
+      real(0.4),
+    ],
+  },
+])("$position 位置に $label が来たら TYPE_MISMATCH を返し actual=$label", ({
+  label,
+  operands,
+}) => {
+  const ctx = buildContext(operands);
+
+  const result = KHandler(ctx);
+
+  assert(!result.ok);
+  assert(result.error.code === "OPERATOR_OPERAND_TYPE_MISMATCH");
+  expect(result.error.operatorName).toBe("K");
+  expect(result.error.actual).toBe(label);
+});
+
+test.each([
+  { operands: [real(0.1)], actual: 1 },
+  { operands: [real(0.1), real(0.2)], actual: 2 },
+  { operands: [real(0.1), real(0.2), real(0.3)], actual: 3 },
+])("MISSING 時 ($actual 個入り) に pop 済み operand は復元しない (depth=0)", ({
+  operands,
+  actual,
+}) => {
+  const ctx = buildContext(operands);
+  const beforeDepth = OperandStack.depth(ctx.operandStack);
+
+  const result = KHandler(ctx);
+
+  assert(!result.ok);
+  assert(result.error.code === "OPERATOR_OPERAND_MISSING");
+  expect(beforeDepth).toBe(actual);
+  expect(result.error.actual).toBe(actual);
+  expect(OperandStack.depth(ctx.operandStack)).toBe(0);
+});
+
+test("TYPE_MISMATCH (k 位置 = name) のとき depth は 4 → 3 (1 個 pop 済み)", () => {
+  const ctx = buildContext([
+    real(0.1),
+    real(0.2),
+    real(0.3),
+    { type: "name", value: "Foo" },
+  ]);
+  const beforeDepth = OperandStack.depth(ctx.operandStack);
+
+  const result = KHandler(ctx);
+
+  assert(!result.ok);
+  assert(result.error.code === "OPERATOR_OPERAND_TYPE_MISMATCH");
+  expect(beforeDepth).toBe(4);
+  expect(OperandStack.depth(ctx.operandStack)).toBe(3);
+});
+
+test("TYPE_MISMATCH (c 位置 = name) のとき depth は 4 → 0 (4 個全 pop 済み)", () => {
+  const ctx = buildContext([
+    { type: "name", value: "Foo" },
+    real(0.2),
+    real(0.3),
+    real(0.4),
+  ]);
+  const beforeDepth = OperandStack.depth(ctx.operandStack);
+
+  const result = KHandler(ctx);
+
+  assert(!result.ok);
+  assert(result.error.code === "OPERATOR_OPERAND_TYPE_MISMATCH");
+  expect(beforeDepth).toBe(4);
+  expect(OperandStack.depth(ctx.operandStack)).toBe(0);
+});

--- a/packages/core/src/content-stream/operators/color/cmyk/__tests__/stroke.integration.test.ts
+++ b/packages/core/src/content-stream/operators/color/cmyk/__tests__/stroke.integration.test.ts
@@ -1,0 +1,55 @@
+import { assert, expect, test } from "vitest";
+import {
+  Color,
+  ColorSpace,
+  GraphicsStateStack,
+} from "../../../../graphics-state/index";
+import { ContentStreamInterpreter } from "../../../../interpreter/index";
+import { OperatorRegistry } from "../../../../operator-registry/index";
+import { KHandler } from "../stroke";
+
+const encode = (s: string): Uint8Array => new TextEncoder().encode(s);
+
+test("`0.5 0.5 0.5 0.5 K` を実行すると strokeColor=Color.cmyk(0.5, 0.5, 0.5, 0.5) に更新される", () => {
+  const registered = OperatorRegistry.register(
+    OperatorRegistry.create(),
+    "K",
+    KHandler,
+  );
+  assert(registered.ok);
+
+  const result = ContentStreamInterpreter.execute({
+    data: encode("0.5 0.5 0.5 0.5 K"),
+    registry: registered.value,
+  });
+  assert(result.ok);
+  expect(result.value.warnings).toEqual([]);
+
+  const current = GraphicsStateStack.current(
+    result.value.context.graphicsStateStack,
+  );
+  expect(current.strokeColor).toEqual(Color.cmyk(0.5, 0.5, 0.5, 0.5));
+  expect(current.strokeColorSpace).toEqual(ColorSpace.deviceCMYK());
+});
+
+test("整数 `1 0 0 0 K` を実行すると strokeColor=Color.cmyk(1, 0, 0, 0) になり warnings は空", () => {
+  const registered = OperatorRegistry.register(
+    OperatorRegistry.create(),
+    "K",
+    KHandler,
+  );
+  assert(registered.ok);
+
+  const result = ContentStreamInterpreter.execute({
+    data: encode("1 0 0 0 K"),
+    registry: registered.value,
+  });
+  assert(result.ok);
+  expect(result.value.warnings).toEqual([]);
+
+  const current = GraphicsStateStack.current(
+    result.value.context.graphicsStateStack,
+  );
+  expect(current.strokeColor).toEqual(Color.cmyk(1, 0, 0, 0));
+  expect(current.strokeColorSpace).toEqual(ColorSpace.deviceCMYK());
+});

--- a/packages/core/src/content-stream/operators/color/cmyk/stroke.ts
+++ b/packages/core/src/content-stream/operators/color/cmyk/stroke.ts
@@ -1,0 +1,84 @@
+import type { PdfError } from "../../../../pdf/errors/index";
+import { err, ok } from "../../../../utils/result/index";
+import {
+  Color,
+  ColorSpace,
+  GraphicsState,
+  GraphicsStateStack,
+} from "../../../graphics-state/index";
+import { OperandStack } from "../../../operand-stack/index";
+import type {
+  OperatorHandler,
+  OperatorHandlerContext,
+} from "../../../operator-registry/index";
+import { NumericPdfObject } from "../../graphics-state/numeric-pdf-object";
+
+const OPERATOR_NAME = "K";
+const OPERAND_COUNT = 4;
+
+/**
+ * PDF §8.6.5.3 `K c m y k` operator (DeviceCMYK stroke color) のハンドラ。
+ *
+ * operand stack から `c m y k` 4 個を pop し、`Color.cmyk(c, m, y, k)` と
+ * `ColorSpace.deviceCMYK()` を生成して GraphicsState の strokeColor /
+ * strokeColorSpace を同時更新する。
+ *
+ * - operand 不足のとき `OPERATOR_OPERAND_MISSING` を返す
+ *   `actual` には pop に成功した個数 (= 0, 1, 2, 3) を入れる
+ * - operand が integer / real 以外のとき `OPERATOR_OPERAND_TYPE_MISMATCH` を返す
+ * - 値域 (`NaN` / `Infinity` / 負値 / >1.0) は本 handler では検証しない
+ * - エラー時に operand stack の部分消費は復元しない (既存ハンドラ規約)
+ *
+ * @param context - 実行コンテキスト (operand stack / graphics state stack)
+ * @returns 成功なら更新後コンテキスト、失敗なら PdfError
+ */
+export const KHandler: OperatorHandler = (context: OperatorHandlerContext) => {
+  const popped: NumericPdfObject[] = [];
+  for (let i = 0; i < OPERAND_COUNT; i++) {
+    const result = OperandStack.pop(context.operandStack);
+    if (!result.some) {
+      const error: PdfError = {
+        code: "OPERATOR_OPERAND_MISSING",
+        message: `Operator '${OPERATOR_NAME}' requires ${OPERAND_COUNT} operand(s), got ${i}`,
+        operatorName: OPERATOR_NAME,
+        required: OPERAND_COUNT,
+        actual: i,
+      };
+      return err(error);
+    }
+    const operand = result.value;
+    if (!NumericPdfObject.is(operand)) {
+      const error: PdfError = {
+        code: "OPERATOR_OPERAND_TYPE_MISMATCH",
+        message: `Operator '${OPERATOR_NAME}' expected number operand, got ${operand.type}`,
+        operatorName: OPERATOR_NAME,
+        expected: "number",
+        actual: operand.type,
+      };
+      return err(error);
+    }
+    popped.push(operand);
+  }
+
+  const [c, m, y, k] = popped
+    .slice()
+    .reverse()
+    .map((operand) => operand.value);
+
+  const strokeColor = Color.cmyk(c, m, y, k);
+  const strokeColorSpace = ColorSpace.deviceCMYK();
+  const current = GraphicsStateStack.current(context.graphicsStateStack);
+  const next = GraphicsState.update(current, {
+    strokeColor,
+    strokeColorSpace,
+  });
+  const graphicsStateStack = GraphicsStateStack.replaceCurrent(
+    context.graphicsStateStack,
+    next,
+  );
+
+  return ok({
+    operandStack: context.operandStack,
+    graphicsStateStack,
+  });
+};

--- a/packages/core/src/content-stream/operators/color/cmyk/stroke.ts
+++ b/packages/core/src/content-stream/operators/color/cmyk/stroke.ts
@@ -17,7 +17,7 @@ const OPERATOR_NAME = "K";
 const OPERAND_COUNT = 4;
 
 /**
- * PDF §8.6.5.3 `K c m y k` operator (DeviceCMYK stroke color) のハンドラ。
+ * PDF §8.6.5.4 `K c m y k` operator (DeviceCMYK stroke color) のハンドラ。
  *
  * operand stack から `c m y k` 4 個を pop し、`Color.cmyk(c, m, y, k)` と
  * `ColorSpace.deviceCMYK()` を生成して GraphicsState の strokeColor /

--- a/packages/core/src/content-stream/operators/color/color-operators/__tests__/color-operators.basic.test.ts
+++ b/packages/core/src/content-stream/operators/color/color-operators/__tests__/color-operators.basic.test.ts
@@ -3,11 +3,12 @@ import {
   type OperatorHandler,
   OperatorRegistry,
 } from "../../../../operator-registry/index";
-import { GHandler, gHandler, registerColorOperators } from "../index";
+import { GHandler, gHandler, KHandler, registerColorOperators } from "../index";
 
 test.each<readonly [string, OperatorHandler]>([
   ["G", GHandler],
   ["g", gHandler],
+  ["K", KHandler],
 ])("registerColorOperators は %s に対応する handler を登録する", (name, expectedHandler) => {
   const result = registerColorOperators(OperatorRegistry.create());
   assert(result.ok);
@@ -22,4 +23,5 @@ test("registerColorOperators の戻り値は ok で OperatorRegistry を保持�
   assert(result.ok);
   expect(OperatorRegistry.has(result.value, "G")).toBe(true);
   expect(OperatorRegistry.has(result.value, "g")).toBe(true);
+  expect(OperatorRegistry.has(result.value, "K")).toBe(true);
 });

--- a/packages/core/src/content-stream/operators/color/color-operators/__tests__/color-operators.error.test.ts
+++ b/packages/core/src/content-stream/operators/color/color-operators/__tests__/color-operators.error.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, assert, expect, test, vi } from "vitest";
 import { OperatorRegistry } from "../../../../operator-registry/index";
-import { GHandler, gHandler, registerColorOperators } from "../index";
+import { GHandler, gHandler, KHandler, registerColorOperators } from "../index";
 
 afterEach(() => {
   vi.restoreAllMocks();
@@ -42,4 +42,23 @@ test("g 重複時、reduce は途中で短絡し register は ['G', 'g'] で止�
   expect(result.error.operatorName).toBe("g");
   const calledNames = registerSpy.mock.calls.map((call) => call[1]);
   expect(calledNames).toEqual(["G", "g"]);
+});
+
+test("K 重複時、reduce は K で短絡し register は ['G', 'g', 'K'] で止まる", () => {
+  const seed = OperatorRegistry.register(
+    OperatorRegistry.create(),
+    "K",
+    KHandler,
+  );
+  assert(seed.ok);
+
+  const registerSpy = vi.spyOn(OperatorRegistry, "register");
+  const result = registerColorOperators(seed.value);
+
+  assert(!result.ok);
+  expect(result.error.code).toBe("OPERATOR_ALREADY_REGISTERED");
+  assert(result.error.code === "OPERATOR_ALREADY_REGISTERED");
+  expect(result.error.operatorName).toBe("K");
+  const calledNames = registerSpy.mock.calls.map((call) => call[1]);
+  expect(calledNames).toEqual(["G", "g", "K"]);
 });

--- a/packages/core/src/content-stream/operators/color/color-operators/__tests__/color-operators.integration.test.ts
+++ b/packages/core/src/content-stream/operators/color/color-operators/__tests__/color-operators.integration.test.ts
@@ -45,3 +45,21 @@ test("0.5 g を実行すると fillColor が Color.gray(0.5) に更新される"
   expect(current.fillColor).toEqual(Color.gray(0.5));
   expect(current.fillColorSpace).toEqual(ColorSpace.deviceGray());
 });
+
+test("0.5 0.5 0.5 0.5 K を実行すると strokeColor が Color.cmyk(0.5, 0.5, 0.5, 0.5) に更新される", () => {
+  const registered = registerColorOperators(OperatorRegistry.create());
+  assert(registered.ok);
+
+  const result = ContentStreamInterpreter.execute({
+    data: encode("0.5 0.5 0.5 0.5 K"),
+    registry: registered.value,
+  });
+  assert(result.ok);
+  expect(result.value.warnings).toEqual([]);
+
+  const current = GraphicsStateStack.current(
+    result.value.context.graphicsStateStack,
+  );
+  expect(current.strokeColor).toEqual(Color.cmyk(0.5, 0.5, 0.5, 0.5));
+  expect(current.strokeColorSpace).toEqual(ColorSpace.deviceCMYK());
+});

--- a/packages/core/src/content-stream/operators/color/color-operators/index.ts
+++ b/packages/core/src/content-stream/operators/color/color-operators/index.ts
@@ -3,19 +3,22 @@ import type { Result } from "../../../../utils/result/index";
 import { flatMap, ok } from "../../../../utils/result/index";
 import type { OperatorHandler } from "../../../operator-registry/index";
 import { OperatorRegistry } from "../../../operator-registry/index";
+import { KHandler } from "../cmyk/stroke";
 import { gHandler } from "../gray/fill";
 import { GHandler } from "../gray/stroke";
 
+export { KHandler } from "../cmyk/stroke";
 export { gHandler } from "../gray/fill";
 export { GHandler } from "../gray/stroke";
 
 const COLOR_OPERATORS: ReadonlyArray<readonly [string, OperatorHandler]> = [
   ["G", GHandler],
   ["g", gHandler],
+  ["K", KHandler],
 ];
 
 /**
- * Color operator (G / g) を OperatorRegistry に一括登録するヘルパ (暫定 G/g 版)。
+ * Color operator (G / g / K) を OperatorRegistry に一括登録するヘルパ (G/g/K 版)。
  *
  * fail-fast: いずれかの register が Err を返した時点で reduce 内 flatMap が
  * 短絡し、後続 operator の register は呼ばれない。


### PR DESCRIPTION
## 概要

spec-063 (Issue #214)。PDF §8.6.5.3 の `K c m y k` operator (DeviceCMYK stroke color) を content stream interpreter で実行可能にする。operand stack から 4 個の数値を pop し、GraphicsState の `strokeColor` / `strokeColorSpace` を `Color.cmyk(c, m, y, k)` / `ColorSpace.deviceCMYK()` で同時更新する。

## 変更の種類

- ✨ New Feature (`KHandler` 本体 + registry 登録)
- 🧪 Tests (basic / error / integration 3 ファイル + color-operators registry テスト拡張)

## 追加した内容

- `packages/core/src/content-stream/operators/color/cmyk/stroke.ts` — `KHandler` 本体 (RG handler 同型、`OPERAND_COUNT=4`)
- `packages/core/src/content-stream/operators/color/cmyk/__tests__/stroke.basic.test.ts` — 正常系 (値マッピング / 余剰 operand / fill/graphics-state 不変 / 境界値 / NaN / Infinity 透過 / 非デフォルト graphics state seed)
- `packages/core/src/content-stream/operators/color/cmyk/__tests__/stroke.error.test.ts` — 異常系 (operand 0/1/2/3 個 MISSING / 8 型の TYPE_MISMATCH / 各位置の TYPE_MISMATCH / 部分消費非復元)
- `packages/core/src/content-stream/operators/color/cmyk/__tests__/stroke.integration.test.ts` — registry 直接登録 → interpreter で `0.5 0.5 0.5 0.5 K` / `1 0 0 0 K` 実行

## 変更した内容

- `packages/core/src/content-stream/operators/color/color-operators/index.ts` — `KHandler` を import / re-export、`COLOR_OPERATORS` に `["K", KHandler]` を追加、JSDoc 文言を G/g/K 版に更新
- `packages/core/src/content-stream/operators/color/color-operators/__tests__/color-operators.{basic,error,integration}.test.ts` — K のケース追加 (basic: lookup / has、error: 重複登録 fail-fast `["G","g","K"]`、integration: `registerColorOperators` 経由で `0.5 0.5 0.5 0.5 K`)

## システム図

```mermaid
flowchart TD
    Stream["content stream: 0.5 0.5 0.5 0.5 K"] --> Parse[ContentStreamInterpreter.execute]
    Parse -->|push numerics| OS[OperandStack]
    Parse -->|operator K| Lookup["OperatorRegistry.lookup('K')"]
    Lookup --> KH["KHandler [NEW]"]

    KH -->|pop x4 LIFO: k, y, m, c| OS
    KH --> Build["Color.cmyk(c, m, y, k)<br/>ColorSpace.deviceCMYK()"]
    Build --> Update["GraphicsState.update<br/>strokeColor / strokeColorSpace"]
    Update --> Replace["GraphicsStateStack.replaceCurrent"]
    Replace --> Result[Result.ok updated context]

    KH -.->|operand 不足| Missing[OPERATOR_OPERAND_MISSING]
    KH -.->|非数値| Mismatch[OPERATOR_OPERAND_TYPE_MISMATCH]

    style KH fill:#e1f5ff,stroke:#0288d1
    style Build fill:#e1f5ff,stroke:#0288d1
```

## 関連 spec / Issue

- spec: `.plugin-workspace/.specs/063-k-operator-handler/`
- Closes #214

## テスト

- `pnpm --filter @pdfmod/core test`: **149 files / 2088 tests passed** (regression なし、新規 17 ケース追加)
- `pnpm --filter @pdfmod/core build`: ✅ 成功 (134.05 kB)
- `pnpm lint` (workspace root, biome + oxlint): ✅ 0 errors (`packages/core` 単体には lint スクリプトなし)
- Codex レビュー (`codex exec` 経由):
  - review-001: B9 (`ctm` / `lineWidth` / `lineCap` / `lineJoin` / `miterLimit` / `currentPath` 不変) テストがデフォルト state を比較していた問題を Should Fix として指摘
  - 修正コミット `32f5e72` で `Matrix.create(2, 0, 0, 3, 10, 20)` / `LineCap.create(1)` / `LineJoin.create(2)` / `miterLimit=4` / 非空 `CurrentPath` を seed する形に書き直し
  - review-002: **問題なし** で確定

## レビューポイント

- pop が LIFO であることから handler 内で `[k, y, m, c]` の順で取得 → `.slice().reverse()` で `[c, m, y, k]` に並び替えている (RG handler と同じ規約)
- 値域 (NaN / Infinity / 負値 / >1.0) は本 handler では検証せず、CS/cs 側責務に委ねる (basic B11〜B14 で透過動作を担保)
- エラー時に operand stack の部分消費は復元しない (既存ハンドラ規約、error E7/E8 で depth 比較により担保)
- `COLOR_OPERATORS` の登録順は `G → g → K`。重複登録時の fail-fast 検証で `calledNames === ["G", "g", "K"]` を assert している
- 次 Issue (#215: `k` lowercase = DeviceCMYK fill) は `cmyk/fill.ts` を同ディレクトリに追加するだけで済む構成にしている (本 PR スコープ外)