### PR TITLE
✨ [New Feature]: #215 k operator handler (DeviceCMYK fill) を実装

### DIFF
--- a/packages/core/src/content-stream/operators/color/cmyk/__tests__/fill.basic.test.ts
+++ b/packages/core/src/content-stream/operators/color/cmyk/__tests__/fill.basic.test.ts
@@ -1,0 +1,235 @@
+import { assert, expect, test } from "vitest";
+import type { PdfObject } from "../../../../../pdf/types/pdf-types/index";
+import {
+  Color,
+  ColorSpace,
+  CurrentPath,
+  GraphicsState,
+  GraphicsStateStack,
+  LineCap,
+  LineJoin,
+  Matrix,
+} from "../../../../graphics-state/index";
+import { PathSegment } from "../../../../graphics-state/path-segment/index";
+import { OperandStack } from "../../../../operand-stack/index";
+import type { OperatorHandlerContext } from "../../../../operator-registry/index";
+import { kHandler } from "../fill";
+
+// 入力配列は push 順 = content stream 出現順 (c, m, y, k)。
+// pop は LIFO なので handler 内では k, y, m, c の順で取り出される。
+const buildContext = (operands: PdfObject[]): OperatorHandlerContext => {
+  const operandStack = OperandStack.create();
+  for (const operand of operands) {
+    OperandStack.push(operandStack, operand);
+  }
+  const graphicsStateStack = GraphicsStateStack.create();
+  return { operandStack, graphicsStateStack };
+};
+
+const real = (value: number): PdfObject => ({ type: "real", value });
+const int = (value: number): PdfObject => ({ type: "integer", value });
+
+test("`1 0 0 0 k` で fillColor=Color.cmyk(1, 0, 0, 0) / fillColorSpace=deviceCMYK() になる", () => {
+  const ctx = buildContext([real(1), real(0), real(0), real(0)]);
+
+  const result = kHandler(ctx);
+
+  assert(result.ok);
+  const current = GraphicsStateStack.current(result.value.graphicsStateStack);
+  expect(current.fillColor).toEqual(Color.cmyk(1, 0, 0, 0));
+  expect(current.fillColorSpace).toEqual(ColorSpace.deviceCMYK());
+});
+
+test.each([
+  { label: "0.2 0.4 0.6 0.8", c: 0.2, m: 0.4, y: 0.6, k: 0.8 },
+  { label: "all zero", c: 0, m: 0, y: 0, k: 0 },
+  { label: "all one", c: 1, m: 1, y: 1, k: 1 },
+])("値 $label が Color.cmyk にそのまま反映される", ({ c, m, y, k }) => {
+  const ctx = buildContext([real(c), real(m), real(y), real(k)]);
+
+  const result = kHandler(ctx);
+
+  assert(result.ok);
+  const current = GraphicsStateStack.current(result.value.graphicsStateStack);
+  expect(current.fillColor).toEqual(Color.cmyk(c, m, y, k));
+  expect(current.fillColorSpace).toEqual(ColorSpace.deviceCMYK());
+});
+
+test("integer/real 混在 operand でも Color.cmyk が正しく組み立てられる", () => {
+  const ctx = buildContext([int(0), real(0.5), int(1), real(0.25)]);
+
+  const result = kHandler(ctx);
+
+  assert(result.ok);
+  const current = GraphicsStateStack.current(result.value.graphicsStateStack);
+  expect(current.fillColor).toEqual(Color.cmyk(0, 0.5, 1, 0.25));
+});
+
+test("初期 strokeColor=rgb(0.7, 0.8, 0.9) を seed しても k 実行後 stroke 系は完全一致で保持される", () => {
+  const operandStack = OperandStack.create();
+  OperandStack.push(operandStack, real(0.2));
+  OperandStack.push(operandStack, real(0.4));
+  OperandStack.push(operandStack, real(0.6));
+  OperandStack.push(operandStack, real(0.8));
+  const baseStack = GraphicsStateStack.create();
+  const base = GraphicsStateStack.current(baseStack);
+  const seeded = GraphicsState.update(base, {
+    strokeColor: Color.rgb(0.7, 0.8, 0.9),
+    strokeColorSpace: ColorSpace.deviceRGB(),
+  });
+  const graphicsStateStack = GraphicsStateStack.replaceCurrent(
+    baseStack,
+    seeded,
+  );
+
+  const result = kHandler({ operandStack, graphicsStateStack });
+
+  assert(result.ok);
+  const current = GraphicsStateStack.current(result.value.graphicsStateStack);
+  expect(current.strokeColor).toEqual(Color.rgb(0.7, 0.8, 0.9));
+  expect(current.strokeColorSpace).toEqual(ColorSpace.deviceRGB());
+  expect(current.fillColor).toEqual(Color.cmyk(0.2, 0.4, 0.6, 0.8));
+});
+
+test("成功時 pop で operand stack が空になる (depth 0)", () => {
+  const ctx = buildContext([real(0.2), real(0.4), real(0.6), real(0.8)]);
+
+  const result = kHandler(ctx);
+
+  assert(result.ok);
+  expect(OperandStack.depth(result.value.operandStack)).toBe(0);
+});
+
+test("operand stack に余剰要素 (5 個) がある場合、末尾 4 個だけ pop し残り 1 個 (42) は保持", () => {
+  const extra = int(42);
+  const ctx = buildContext([extra, real(0.2), real(0.4), real(0.6), real(0.8)]);
+
+  const result = kHandler(ctx);
+
+  assert(result.ok);
+  const current = GraphicsStateStack.current(result.value.graphicsStateStack);
+  expect(current.fillColor).toEqual(Color.cmyk(0.2, 0.4, 0.6, 0.8));
+  expect(OperandStack.depth(result.value.operandStack)).toBe(1);
+  const top = OperandStack.peek(result.value.operandStack);
+  assert(top.some);
+  expect(top.value).toEqual(extra);
+});
+
+test("成功時 result.value.operandStack は context.operandStack と同一参照", () => {
+  const ctx = buildContext([real(0.2), real(0.4), real(0.6), real(0.8)]);
+
+  const result = kHandler(ctx);
+
+  assert(result.ok);
+  expect(result.value.operandStack).toBe(ctx.operandStack);
+});
+
+test("成功時 strokeColor / strokeColorSpace は不変", () => {
+  const ctx = buildContext([real(0.2), real(0.4), real(0.6), real(0.8)]);
+  const before = GraphicsStateStack.current(ctx.graphicsStateStack);
+
+  const result = kHandler(ctx);
+
+  assert(result.ok);
+  const after = GraphicsStateStack.current(result.value.graphicsStateStack);
+  expect(after.strokeColor).toEqual(before.strokeColor);
+  expect(after.strokeColorSpace).toEqual(before.strokeColorSpace);
+});
+
+test("成功時 非デフォルトの ctm / lineWidth / lineCap / lineJoin / miterLimit / currentPath を seed しても全て不変", () => {
+  const operandStack = OperandStack.create();
+  OperandStack.push(operandStack, real(0.2));
+  OperandStack.push(operandStack, real(0.4));
+  OperandStack.push(operandStack, real(0.6));
+  OperandStack.push(operandStack, real(0.8));
+
+  const baseStack = GraphicsStateStack.create();
+  const base = GraphicsStateStack.current(baseStack);
+  const seededCtm = Matrix.create(2, 0, 0, 3, 10, 20);
+  const seededPath = CurrentPath.append(
+    CurrentPath.append(CurrentPath.empty(), PathSegment.moveTo(1, 2)),
+    PathSegment.lineTo(3, 4),
+  );
+  const seeded = GraphicsState.update(base, {
+    ctm: seededCtm,
+    lineWidth: 2.5,
+    lineCap: LineCap.create(1),
+    lineJoin: LineJoin.create(2),
+    miterLimit: 4,
+    currentPath: seededPath,
+  });
+  const graphicsStateStack = GraphicsStateStack.replaceCurrent(
+    baseStack,
+    seeded,
+  );
+
+  const result = kHandler({ operandStack, graphicsStateStack });
+
+  assert(result.ok);
+  const after = GraphicsStateStack.current(result.value.graphicsStateStack);
+  expect(after.ctm).toEqual(seededCtm);
+  expect(after.lineWidth).toBe(2.5);
+  expect(after.lineCap).toBe(LineCap.create(1));
+  expect(after.lineJoin).toBe(LineJoin.create(2));
+  expect(after.miterLimit).toBe(4);
+  expect(after.currentPath).toEqual(seededPath);
+  expect(after.fillColor).toEqual(Color.cmyk(0.2, 0.4, 0.6, 0.8));
+});
+
+test.each([
+  { label: "negative c", c: -0.1, m: 0, y: 0, k: 0 },
+  { label: "negative k", c: 0, m: 0, y: 0, k: -1 },
+  { label: "c > 1", c: 1.5, m: 0, y: 0, k: 0 },
+  { label: "k > 1", c: 0, m: 0, y: 0, k: 2 },
+])("境界値 $label は検証せず Color.cmyk にそのまま透過する", ({
+  c,
+  m,
+  y,
+  k,
+}) => {
+  const ctx = buildContext([real(c), real(m), real(y), real(k)]);
+
+  const result = kHandler(ctx);
+
+  assert(result.ok);
+  const current = GraphicsStateStack.current(result.value.graphicsStateStack);
+  expect(current.fillColor).toEqual(Color.cmyk(c, m, y, k));
+});
+
+test("NaN operand を渡しても handler はエラーを返さず Color.cmyk の各成分が NaN になる", () => {
+  const ctx = buildContext([
+    real(Number.NaN),
+    real(Number.NaN),
+    real(Number.NaN),
+    real(Number.NaN),
+  ]);
+
+  const result = kHandler(ctx);
+
+  assert(result.ok);
+  const current = GraphicsStateStack.current(result.value.graphicsStateStack);
+  assert(current.fillColor.kind === "cmyk");
+  expect(Number.isNaN(current.fillColor.c)).toBe(true);
+  expect(Number.isNaN(current.fillColor.m)).toBe(true);
+  expect(Number.isNaN(current.fillColor.y)).toBe(true);
+  expect(Number.isNaN(current.fillColor.k)).toBe(true);
+});
+
+test("+Infinity / -Infinity operand を渡しても handler はエラーを返さず Color.cmyk にそのまま透過する", () => {
+  const ctx = buildContext([
+    real(Number.POSITIVE_INFINITY),
+    real(Number.NEGATIVE_INFINITY),
+    real(Number.POSITIVE_INFINITY),
+    real(Number.NEGATIVE_INFINITY),
+  ]);
+
+  const result = kHandler(ctx);
+
+  assert(result.ok);
+  const current = GraphicsStateStack.current(result.value.graphicsStateStack);
+  assert(current.fillColor.kind === "cmyk");
+  expect(current.fillColor.c).toBe(Number.POSITIVE_INFINITY);
+  expect(current.fillColor.m).toBe(Number.NEGATIVE_INFINITY);
+  expect(current.fillColor.y).toBe(Number.POSITIVE_INFINITY);
+  expect(current.fillColor.k).toBe(Number.NEGATIVE_INFINITY);
+});

--- a/packages/core/src/content-stream/operators/color/cmyk/__tests__/fill.error.test.ts
+++ b/packages/core/src/content-stream/operators/color/cmyk/__tests__/fill.error.test.ts
@@ -1,0 +1,193 @@
+import { assert, expect, test } from "vitest";
+import type { PdfObject } from "../../../../../pdf/types/pdf-types/index";
+import { GraphicsStateStack } from "../../../../graphics-state/index";
+import { OperandStack } from "../../../../operand-stack/index";
+import type { OperatorHandlerContext } from "../../../../operator-registry/index";
+import { kHandler } from "../fill";
+
+// 入力配列は push 順 = content stream 出現順 (c, m, y, k)。
+// pop は LIFO なので handler 内では k, y, m, c の順で取り出される。
+const buildContext = (operands: PdfObject[]): OperatorHandlerContext => {
+  const operandStack = OperandStack.create();
+  for (const operand of operands) {
+    OperandStack.push(operandStack, operand);
+  }
+  const graphicsStateStack = GraphicsStateStack.create();
+  return { operandStack, graphicsStateStack };
+};
+
+const real = (value: number): PdfObject => ({ type: "real", value });
+
+test.each([
+  { operands: [] as PdfObject[], actual: 0 },
+  { operands: [real(0.1)], actual: 1 },
+  { operands: [real(0.1), real(0.2)], actual: 2 },
+  { operands: [real(0.1), real(0.2), real(0.3)], actual: 3 },
+])("operand $actual 個のとき OPERATOR_OPERAND_MISSING を返し actual = $actual", ({
+  operands,
+  actual,
+}) => {
+  const ctx = buildContext(operands);
+
+  const result = kHandler(ctx);
+
+  assert(!result.ok);
+  assert(result.error.code === "OPERATOR_OPERAND_MISSING");
+  expect(result.error.operatorName).toBe("k");
+  expect(result.error.required).toBe(4);
+  expect(result.error.actual).toBe(actual);
+  expect(result.error.message).toBe(
+    `Operator 'k' requires 4 operand(s), got ${actual}`,
+  );
+});
+
+const nonNumericOperands: Array<{ label: string; operand: PdfObject }> = [
+  { label: "name", operand: { type: "name", value: "Foo" } },
+  { label: "boolean", operand: { type: "boolean", value: true } },
+  {
+    label: "string",
+    operand: {
+      type: "string",
+      value: new Uint8Array([0x61]),
+      encoding: "literal",
+    },
+  },
+  { label: "null", operand: { type: "null" } },
+  { label: "array", operand: { type: "array", elements: [] } },
+  { label: "dictionary", operand: { type: "dictionary", entries: new Map() } },
+  {
+    label: "indirect-ref",
+    operand: { type: "indirect-ref", objectNumber: 1, generationNumber: 0 },
+  },
+  {
+    label: "stream",
+    operand: {
+      type: "stream",
+      dictionary: { type: "dictionary", entries: new Map() },
+      data: new Uint8Array(),
+    },
+  },
+];
+
+test.each(
+  nonNumericOperands,
+)("k 位置 (top) に $label が来たら OPERATOR_OPERAND_TYPE_MISMATCH を返す", ({
+  label,
+  operand,
+}) => {
+  const ctx = buildContext([real(0.1), real(0.2), real(0.3), operand]);
+
+  const result = kHandler(ctx);
+
+  assert(!result.ok);
+  assert(result.error.code === "OPERATOR_OPERAND_TYPE_MISMATCH");
+  expect(result.error.operatorName).toBe("k");
+  expect(result.error.expected).toBe("number");
+  expect(result.error.actual).toBe(label);
+  expect(result.error.message).toBe(
+    `Operator 'k' expected number operand, got ${label}`,
+  );
+});
+
+test.each([
+  {
+    position: "y",
+    label: "name",
+    operands: [
+      real(0.1),
+      real(0.2),
+      { type: "name", value: "Foo" } as PdfObject,
+      real(0.4),
+    ],
+  },
+  {
+    position: "m",
+    label: "boolean",
+    operands: [
+      real(0.1),
+      { type: "boolean", value: true } as PdfObject,
+      real(0.3),
+      real(0.4),
+    ],
+  },
+  {
+    position: "c",
+    label: "string",
+    operands: [
+      {
+        type: "string",
+        value: new Uint8Array([0x61]),
+        encoding: "literal",
+      } as PdfObject,
+      real(0.2),
+      real(0.3),
+      real(0.4),
+    ],
+  },
+])("$position 位置に $label が来たら TYPE_MISMATCH を返し actual=$label", ({
+  label,
+  operands,
+}) => {
+  const ctx = buildContext(operands);
+
+  const result = kHandler(ctx);
+
+  assert(!result.ok);
+  assert(result.error.code === "OPERATOR_OPERAND_TYPE_MISMATCH");
+  expect(result.error.operatorName).toBe("k");
+  expect(result.error.actual).toBe(label);
+});
+
+test.each([
+  { operands: [real(0.1)], actual: 1 },
+  { operands: [real(0.1), real(0.2)], actual: 2 },
+  { operands: [real(0.1), real(0.2), real(0.3)], actual: 3 },
+])("MISSING 時 ($actual 個入り) に pop 済み operand は復元しない (depth=0)", ({
+  operands,
+  actual,
+}) => {
+  const ctx = buildContext(operands);
+  const beforeDepth = OperandStack.depth(ctx.operandStack);
+
+  const result = kHandler(ctx);
+
+  assert(!result.ok);
+  assert(result.error.code === "OPERATOR_OPERAND_MISSING");
+  expect(beforeDepth).toBe(actual);
+  expect(result.error.actual).toBe(actual);
+  expect(OperandStack.depth(ctx.operandStack)).toBe(0);
+});
+
+test("TYPE_MISMATCH (k 位置 = name) のとき depth は 4 → 3 (1 個 pop 済み)", () => {
+  const ctx = buildContext([
+    real(0.1),
+    real(0.2),
+    real(0.3),
+    { type: "name", value: "Foo" },
+  ]);
+  const beforeDepth = OperandStack.depth(ctx.operandStack);
+
+  const result = kHandler(ctx);
+
+  assert(!result.ok);
+  assert(result.error.code === "OPERATOR_OPERAND_TYPE_MISMATCH");
+  expect(beforeDepth).toBe(4);
+  expect(OperandStack.depth(ctx.operandStack)).toBe(3);
+});
+
+test("TYPE_MISMATCH (c 位置 = name) のとき depth は 4 → 0 (4 個全 pop 済み)", () => {
+  const ctx = buildContext([
+    { type: "name", value: "Foo" },
+    real(0.2),
+    real(0.3),
+    real(0.4),
+  ]);
+  const beforeDepth = OperandStack.depth(ctx.operandStack);
+
+  const result = kHandler(ctx);
+
+  assert(!result.ok);
+  assert(result.error.code === "OPERATOR_OPERAND_TYPE_MISMATCH");
+  expect(beforeDepth).toBe(4);
+  expect(OperandStack.depth(ctx.operandStack)).toBe(0);
+});

--- a/packages/core/src/content-stream/operators/color/cmyk/__tests__/fill.integration.test.ts
+++ b/packages/core/src/content-stream/operators/color/cmyk/__tests__/fill.integration.test.ts
@@ -1,0 +1,79 @@
+import { assert, expect, test } from "vitest";
+import {
+  Color,
+  ColorSpace,
+  GraphicsStateStack,
+} from "../../../../graphics-state/index";
+import { ContentStreamInterpreter } from "../../../../interpreter/index";
+import { OperatorRegistry } from "../../../../operator-registry/index";
+import { kHandler } from "../fill";
+
+const encode = (s: string): Uint8Array => new TextEncoder().encode(s);
+
+test("`0.5 0.5 0.5 0.5 k` を実行すると fillColor=Color.cmyk(0.5, 0.5, 0.5, 0.5) に更新される", () => {
+  const registered = OperatorRegistry.register(
+    OperatorRegistry.create(),
+    "k",
+    kHandler,
+  );
+  assert(registered.ok);
+
+  const result = ContentStreamInterpreter.execute({
+    data: encode("0.5 0.5 0.5 0.5 k"),
+    registry: registered.value,
+  });
+  assert(result.ok);
+  expect(result.value.warnings).toEqual([]);
+
+  const current = GraphicsStateStack.current(
+    result.value.context.graphicsStateStack,
+  );
+  expect(current.fillColor).toEqual(Color.cmyk(0.5, 0.5, 0.5, 0.5));
+  expect(current.fillColorSpace).toEqual(ColorSpace.deviceCMYK());
+});
+
+test("整数 `1 0 0 0 k` を実行すると fillColor=Color.cmyk(1, 0, 0, 0) になり warnings は空", () => {
+  const registered = OperatorRegistry.register(
+    OperatorRegistry.create(),
+    "k",
+    kHandler,
+  );
+  assert(registered.ok);
+
+  const result = ContentStreamInterpreter.execute({
+    data: encode("1 0 0 0 k"),
+    registry: registered.value,
+  });
+  assert(result.ok);
+  expect(result.value.warnings).toEqual([]);
+
+  const current = GraphicsStateStack.current(
+    result.value.context.graphicsStateStack,
+  );
+  expect(current.fillColor).toEqual(Color.cmyk(1, 0, 0, 0));
+  expect(current.fillColorSpace).toEqual(ColorSpace.deviceCMYK());
+});
+
+test("`0.5 0.5 0.5 0.5 k` 実行後、strokeColor / strokeColorSpace は初期値のまま", () => {
+  const registered = OperatorRegistry.register(
+    OperatorRegistry.create(),
+    "k",
+    kHandler,
+  );
+  assert(registered.ok);
+
+  const baseStack = GraphicsStateStack.create();
+  const initial = GraphicsStateStack.current(baseStack);
+
+  const result = ContentStreamInterpreter.execute({
+    data: encode("0.5 0.5 0.5 0.5 k"),
+    registry: registered.value,
+  });
+  assert(result.ok);
+
+  const current = GraphicsStateStack.current(
+    result.value.context.graphicsStateStack,
+  );
+  expect(current.strokeColor).toEqual(initial.strokeColor);
+  expect(current.strokeColorSpace).toEqual(initial.strokeColorSpace);
+});

--- a/packages/core/src/content-stream/operators/color/cmyk/fill.ts
+++ b/packages/core/src/content-stream/operators/color/cmyk/fill.ts
@@ -1,0 +1,84 @@
+import type { PdfError } from "../../../../pdf/errors/index";
+import { err, ok } from "../../../../utils/result/index";
+import {
+  Color,
+  ColorSpace,
+  GraphicsState,
+  GraphicsStateStack,
+} from "../../../graphics-state/index";
+import { OperandStack } from "../../../operand-stack/index";
+import type {
+  OperatorHandler,
+  OperatorHandlerContext,
+} from "../../../operator-registry/index";
+import { NumericPdfObject } from "../../graphics-state/numeric-pdf-object";
+
+const OPERATOR_NAME = "k";
+const OPERAND_COUNT = 4;
+
+/**
+ * PDF §8.6.5.4 `k c m y k` operator (DeviceCMYK nonstroking/fill color) のハンドラ。
+ *
+ * operand stack から `c m y k` 4 個を pop し、`Color.cmyk(c, m, y, k)` と
+ * `ColorSpace.deviceCMYK()` を生成して GraphicsState の fillColor /
+ * fillColorSpace を同時更新する。
+ *
+ * - operand 不足のとき `OPERATOR_OPERAND_MISSING` を返す
+ *   `actual` には pop に成功した個数 (= 0, 1, 2, 3) を入れる
+ * - operand が integer / real 以外のとき `OPERATOR_OPERAND_TYPE_MISMATCH` を返す
+ * - 値域 (`NaN` / `Infinity` / 負値 / >1.0) は本 handler では検証しない
+ * - エラー時に operand stack の部分消費は復元しない (既存ハンドラ規約)
+ *
+ * @param context - 実行コンテキスト (operand stack / graphics state stack)
+ * @returns 成功なら更新後コンテキスト、失敗なら PdfError
+ */
+export const kHandler: OperatorHandler = (context: OperatorHandlerContext) => {
+  const popped: NumericPdfObject[] = [];
+  for (let i = 0; i < OPERAND_COUNT; i++) {
+    const result = OperandStack.pop(context.operandStack);
+    if (!result.some) {
+      const error: PdfError = {
+        code: "OPERATOR_OPERAND_MISSING",
+        message: `Operator '${OPERATOR_NAME}' requires ${OPERAND_COUNT} operand(s), got ${i}`,
+        operatorName: OPERATOR_NAME,
+        required: OPERAND_COUNT,
+        actual: i,
+      };
+      return err(error);
+    }
+    const operand = result.value;
+    if (!NumericPdfObject.is(operand)) {
+      const error: PdfError = {
+        code: "OPERATOR_OPERAND_TYPE_MISMATCH",
+        message: `Operator '${OPERATOR_NAME}' expected number operand, got ${operand.type}`,
+        operatorName: OPERATOR_NAME,
+        expected: "number",
+        actual: operand.type,
+      };
+      return err(error);
+    }
+    popped.push(operand);
+  }
+
+  const [c, m, y, k] = popped
+    .slice()
+    .reverse()
+    .map((operand) => operand.value);
+
+  const fillColor = Color.cmyk(c, m, y, k);
+  const fillColorSpace = ColorSpace.deviceCMYK();
+  const current = GraphicsStateStack.current(context.graphicsStateStack);
+  const next = GraphicsState.update(current, {
+    fillColor,
+    fillColorSpace,
+  });
+  const graphicsStateStack = GraphicsStateStack.replaceCurrent(
+    context.graphicsStateStack,
+    next,
+  );
+
+  return ok({
+    operandStack: context.operandStack,
+    graphicsStateStack,
+  });
+};

--- a/packages/core/src/content-stream/operators/color/color-operators/__tests__/color-operators.basic.test.ts
+++ b/packages/core/src/content-stream/operators/color/color-operators/__tests__/color-operators.basic.test.ts
@@ -3,12 +3,19 @@ import {
   type OperatorHandler,
   OperatorRegistry,
 } from "../../../../operator-registry/index";
-import { GHandler, gHandler, KHandler, registerColorOperators } from "../index";
+import {
+  GHandler,
+  gHandler,
+  KHandler,
+  kHandler,
+  registerColorOperators,
+} from "../index";
 
 test.each<readonly [string, OperatorHandler]>([
   ["G", GHandler],
   ["g", gHandler],
   ["K", KHandler],
+  ["k", kHandler],
 ])("registerColorOperators は %s に対応する handler を登録する", (name, expectedHandler) => {
   const result = registerColorOperators(OperatorRegistry.create());
   assert(result.ok);
@@ -24,4 +31,5 @@ test("registerColorOperators の戻り値は ok で OperatorRegistry を保持�
   expect(OperatorRegistry.has(result.value, "G")).toBe(true);
   expect(OperatorRegistry.has(result.value, "g")).toBe(true);
   expect(OperatorRegistry.has(result.value, "K")).toBe(true);
+  expect(OperatorRegistry.has(result.value, "k")).toBe(true);
 });

--- a/packages/core/src/content-stream/operators/color/color-operators/__tests__/color-operators.error.test.ts
+++ b/packages/core/src/content-stream/operators/color/color-operators/__tests__/color-operators.error.test.ts
@@ -1,6 +1,12 @@
 import { afterEach, assert, expect, test, vi } from "vitest";
 import { OperatorRegistry } from "../../../../operator-registry/index";
-import { GHandler, gHandler, KHandler, registerColorOperators } from "../index";
+import {
+  GHandler,
+  gHandler,
+  KHandler,
+  kHandler,
+  registerColorOperators,
+} from "../index";
 
 afterEach(() => {
   vi.restoreAllMocks();
@@ -61,4 +67,23 @@ test("K 重複時、reduce は K で短絡し register は ['G', 'g', 'K'] で�
   expect(result.error.operatorName).toBe("K");
   const calledNames = registerSpy.mock.calls.map((call) => call[1]);
   expect(calledNames).toEqual(["G", "g", "K"]);
+});
+
+test("k 重複時、reduce は k で短絡し register は ['G', 'g', 'K', 'k'] で止まる", () => {
+  const seed = OperatorRegistry.register(
+    OperatorRegistry.create(),
+    "k",
+    kHandler,
+  );
+  assert(seed.ok);
+
+  const registerSpy = vi.spyOn(OperatorRegistry, "register");
+  const result = registerColorOperators(seed.value);
+
+  assert(!result.ok);
+  expect(result.error.code).toBe("OPERATOR_ALREADY_REGISTERED");
+  assert(result.error.code === "OPERATOR_ALREADY_REGISTERED");
+  expect(result.error.operatorName).toBe("k");
+  const calledNames = registerSpy.mock.calls.map((call) => call[1]);
+  expect(calledNames).toEqual(["G", "g", "K", "k"]);
 });

--- a/packages/core/src/content-stream/operators/color/color-operators/__tests__/color-operators.integration.test.ts
+++ b/packages/core/src/content-stream/operators/color/color-operators/__tests__/color-operators.integration.test.ts
@@ -63,3 +63,21 @@ test("0.5 0.5 0.5 0.5 K を実行すると strokeColor が Color.cmyk(0.5, 0.5, 
   expect(current.strokeColor).toEqual(Color.cmyk(0.5, 0.5, 0.5, 0.5));
   expect(current.strokeColorSpace).toEqual(ColorSpace.deviceCMYK());
 });
+
+test("0.5 0.5 0.5 0.5 k を実行すると fillColor が Color.cmyk(0.5, 0.5, 0.5, 0.5) に更新される", () => {
+  const registered = registerColorOperators(OperatorRegistry.create());
+  assert(registered.ok);
+
+  const result = ContentStreamInterpreter.execute({
+    data: encode("0.5 0.5 0.5 0.5 k"),
+    registry: registered.value,
+  });
+  assert(result.ok);
+  expect(result.value.warnings).toEqual([]);
+
+  const current = GraphicsStateStack.current(
+    result.value.context.graphicsStateStack,
+  );
+  expect(current.fillColor).toEqual(Color.cmyk(0.5, 0.5, 0.5, 0.5));
+  expect(current.fillColorSpace).toEqual(ColorSpace.deviceCMYK());
+});

--- a/packages/core/src/content-stream/operators/color/color-operators/index.ts
+++ b/packages/core/src/content-stream/operators/color/color-operators/index.ts
@@ -3,10 +3,12 @@ import type { Result } from "../../../../utils/result/index";
 import { flatMap, ok } from "../../../../utils/result/index";
 import type { OperatorHandler } from "../../../operator-registry/index";
 import { OperatorRegistry } from "../../../operator-registry/index";
+import { kHandler } from "../cmyk/fill";
 import { KHandler } from "../cmyk/stroke";
 import { gHandler } from "../gray/fill";
 import { GHandler } from "../gray/stroke";
 
+export { kHandler } from "../cmyk/fill";
 export { KHandler } from "../cmyk/stroke";
 export { gHandler } from "../gray/fill";
 export { GHandler } from "../gray/stroke";
@@ -15,10 +17,11 @@ const COLOR_OPERATORS: ReadonlyArray<readonly [string, OperatorHandler]> = [
   ["G", GHandler],
   ["g", gHandler],
   ["K", KHandler],
+  ["k", kHandler],
 ];
 
 /**
- * Color operator (G / g / K) を OperatorRegistry に一括登録するヘルパ (G/g/K 版)。
+ * Color operator (G / g / K / k) を OperatorRegistry に一括登録するヘルパ (G/g/K/k 版)。
  *
  * fail-fast: いずれかの register が Err を返した時点で reduce 内 flatMap が
  * 短絡し、後続 operator の register は呼ばれない。


### PR DESCRIPTION
## 概要

spec-064-k-lowercase-operator-handler。PDF §8.6.5.4 の `k c m y k` operator (DeviceCMYK nonstroking/fill color) を実装し、operand stack から 4 値 pop して GraphicsState の `fillColor` / `fillColorSpace` を同時更新する。既存 `KHandler` (stroke, #214) を fill 側にミラーした追加実装。

## 変更の種類

- ✨ New Feature
- 🧪 Tests

## 追加した内容

- `packages/core/src/content-stream/operators/color/cmyk/fill.ts` — `kHandler` (DeviceCMYK fill, §8.6.5.4)
- `packages/core/src/content-stream/operators/color/cmyk/__tests__/fill.basic.test.ts` — 正常系（単独 / `test.each` / 不変性 / stack 状態 / 境界値 / NaN・Infinity 透過）
- `packages/core/src/content-stream/operators/color/cmyk/__tests__/fill.error.test.ts` — 異常系（operand 不足 0/1/2/3、非数値 8 種、c/m/y/k 位置別 TYPE_MISMATCH、stack 復元なし）
- `packages/core/src/content-stream/operators/color/cmyk/__tests__/fill.integration.test.ts` — `OperatorRegistry.register("k", kHandler)` 単独経由の interpreter 統合テスト
- `color-operators.error.test.ts` に **k 重複時 fail-fast** テストを新規追加（`['G','g','K','k']` の 4 回 register を確認）

## 変更した内容

- `packages/core/src/content-stream/operators/color/color-operators/index.ts` — `COLOR_OPERATORS` 配列に `["k", kHandler]` を追加、`kHandler` を import / re-export、JSDoc を `(G / g / K / k)` に更新
- `color-operators.basic.test.ts` — `test.each` / `has` 確認に `k` を追加
- `color-operators.integration.test.ts` — `0.5 0.5 0.5 0.5 k` → `fillColor=cmyk(0.5,0.5,0.5,0.5)` テストを追加

> 既存 K 重複ケース (`toHaveBeenCalledTimes(3)`) は維持（K で fail-fast）。

## システム図

\`\`\`mermaid
flowchart TD
    Start([ContentStreamInterpreter]) --> Lookup[OperatorRegistry.lookup k]
    Lookup --> KH[kHandler context]:::new
    KH --> Pop{pop 4 values}
    Pop -- None --> Miss[err OPERATOR_OPERAND_MISSING<br/>actual=i]
    Pop -- non-numeric --> Type[err OPERATOR_OPERAND_TYPE_MISMATCH<br/>expected=number]
    Pop -- 4 numbers --> Unpack[reverse to c, m, y, k]
    Unpack --> Build[Color.cmyk c,m,y,k<br/>ColorSpace.deviceCMYK]
    Build --> Update[GraphicsState.update fillColor / fillColorSpace<br/>stroke 系は不変]:::changed
    Update --> Replace[GraphicsStateStack.replaceCurrent]
    Replace --> OK([ok operandStack, graphicsStateStack])

    classDef new fill:#e6ffed,stroke:#0a7d2c,stroke-width:2px
    classDef changed fill:#fff4d6,stroke:#a87d00,stroke-width:2px
\`\`\`

## 関連 spec / Issue

- spec: \`.plugin-workspace/.specs/064-k-lowercase-operator-handler/\`
- Closes #215

## テスト

\`\`\`
pnpm --filter @pdfmod/core test
→ Test Files  152 passed (152)
  Tests       2131 passed (2131)

pnpm --filter @pdfmod/core build
→ vite build && tsc -p tsconfig.build.json --emitDeclarationOnly
  ✓ built in 490ms
  dist/content-stream/operators/color/cmyk/fill.d.ts に kHandler 出力を確認
\`\`\`

新規テストファイル 3 件と registry テスト 3 件の差分すべて green。既存 KHandler / GHandler / gHandler 等にリグレッションなし。

## レビューポイント

- **`stroke.ts` との差分最小性** — `OPERATOR_NAME` / 書込先フィールド (`fillColor` / `fillColorSpace`) / JSDoc の `nonstroking/fill` 語句以外はミラー
- **PDF §8.6.5.4 準拠** — DeviceCMYK fill operator。値域検証 (NaN / Infinity / 負値 / >1.0) は handler 層で透過（上位レイヤ #208 に委ねる方針、既存 K/G/g/RG/rg と統一）
- **エラー時 operand stack は復元しない** — 既存全 handler と同一規約
- **k 重複ケースの fail-fast** — `['G','g','K','k']` の 4 回 register で短絡。既存 K 重複ケース (3 回) は不変
- **規約遵守** — throw / null / `T | undefined` / describe / セクションコメント (`// 追加:` 等) は新規・修正コード中に存在せず