### PR TITLE
✨ [New Feature]: #216 color-operators registry に RG/rg を追加 (6 operator 構成へ)

### DIFF
--- a/packages/core/src/content-stream/operators/color/color-operators/__tests__/color-operators.basic.test.ts
+++ b/packages/core/src/content-stream/operators/color/color-operators/__tests__/color-operators.basic.test.ts
@@ -8,12 +8,16 @@ import {
   gHandler,
   KHandler,
   kHandler,
+  RGHandler,
   registerColorOperators,
+  rgHandler,
 } from "../index";
 
 test.each<readonly [string, OperatorHandler]>([
   ["G", GHandler],
   ["g", gHandler],
+  ["RG", RGHandler],
+  ["rg", rgHandler],
   ["K", KHandler],
   ["k", kHandler],
 ])("registerColorOperators は %s に対応する handler を登録する", (name, expectedHandler) => {
@@ -30,6 +34,8 @@ test("registerColorOperators の戻り値は ok で OperatorRegistry を保持�
   assert(result.ok);
   expect(OperatorRegistry.has(result.value, "G")).toBe(true);
   expect(OperatorRegistry.has(result.value, "g")).toBe(true);
+  expect(OperatorRegistry.has(result.value, "RG")).toBe(true);
+  expect(OperatorRegistry.has(result.value, "rg")).toBe(true);
   expect(OperatorRegistry.has(result.value, "K")).toBe(true);
   expect(OperatorRegistry.has(result.value, "k")).toBe(true);
 });

--- a/packages/core/src/content-stream/operators/color/color-operators/__tests__/color-operators.error.test.ts
+++ b/packages/core/src/content-stream/operators/color/color-operators/__tests__/color-operators.error.test.ts
@@ -5,7 +5,9 @@ import {
   gHandler,
   KHandler,
   kHandler,
+  RGHandler,
   registerColorOperators,
+  rgHandler,
 } from "../index";
 
 afterEach(() => {
@@ -50,7 +52,45 @@ test("g 重複時、reduce は途中で短絡し register は ['G', 'g'] で止�
   expect(calledNames).toEqual(["G", "g"]);
 });
 
-test("K 重複時、reduce は K で短絡し register は ['G', 'g', 'K'] で止まる", () => {
+test("RG 重複時、reduce は RG で短絡し register は ['G', 'g', 'RG'] で止まる", () => {
+  const seed = OperatorRegistry.register(
+    OperatorRegistry.create(),
+    "RG",
+    RGHandler,
+  );
+  assert(seed.ok);
+
+  const registerSpy = vi.spyOn(OperatorRegistry, "register");
+  const result = registerColorOperators(seed.value);
+
+  assert(!result.ok);
+  expect(result.error.code).toBe("OPERATOR_ALREADY_REGISTERED");
+  assert(result.error.code === "OPERATOR_ALREADY_REGISTERED");
+  expect(result.error.operatorName).toBe("RG");
+  const calledNames = registerSpy.mock.calls.map((call) => call[1]);
+  expect(calledNames).toEqual(["G", "g", "RG"]);
+});
+
+test("rg 重複時、reduce は rg で短絡し register は ['G', 'g', 'RG', 'rg'] で止まる", () => {
+  const seed = OperatorRegistry.register(
+    OperatorRegistry.create(),
+    "rg",
+    rgHandler,
+  );
+  assert(seed.ok);
+
+  const registerSpy = vi.spyOn(OperatorRegistry, "register");
+  const result = registerColorOperators(seed.value);
+
+  assert(!result.ok);
+  expect(result.error.code).toBe("OPERATOR_ALREADY_REGISTERED");
+  assert(result.error.code === "OPERATOR_ALREADY_REGISTERED");
+  expect(result.error.operatorName).toBe("rg");
+  const calledNames = registerSpy.mock.calls.map((call) => call[1]);
+  expect(calledNames).toEqual(["G", "g", "RG", "rg"]);
+});
+
+test("K 重複時、reduce は K で短絡し register は ['G', 'g', 'RG', 'rg', 'K'] で止まる", () => {
   const seed = OperatorRegistry.register(
     OperatorRegistry.create(),
     "K",
@@ -66,10 +106,10 @@ test("K 重複時、reduce は K で短絡し register は ['G', 'g', 'K'] で�
   assert(result.error.code === "OPERATOR_ALREADY_REGISTERED");
   expect(result.error.operatorName).toBe("K");
   const calledNames = registerSpy.mock.calls.map((call) => call[1]);
-  expect(calledNames).toEqual(["G", "g", "K"]);
+  expect(calledNames).toEqual(["G", "g", "RG", "rg", "K"]);
 });
 
-test("k 重複時、reduce は k で短絡し register は ['G', 'g', 'K', 'k'] で止まる", () => {
+test("k 重複時、reduce は k で短絡し register は ['G', 'g', 'RG', 'rg', 'K', 'k'] で止まる", () => {
   const seed = OperatorRegistry.register(
     OperatorRegistry.create(),
     "k",
@@ -85,5 +125,5 @@ test("k 重複時、reduce は k で短絡し register は ['G', 'g', 'K', 'k'] 
   assert(result.error.code === "OPERATOR_ALREADY_REGISTERED");
   expect(result.error.operatorName).toBe("k");
   const calledNames = registerSpy.mock.calls.map((call) => call[1]);
-  expect(calledNames).toEqual(["G", "g", "K", "k"]);
+  expect(calledNames).toEqual(["G", "g", "RG", "rg", "K", "k"]);
 });

--- a/packages/core/src/content-stream/operators/color/color-operators/__tests__/color-operators.integration.test.ts
+++ b/packages/core/src/content-stream/operators/color/color-operators/__tests__/color-operators.integration.test.ts
@@ -46,6 +46,62 @@ test("0.5 g を実行すると fillColor が Color.gray(0.5) に更新される"
   expect(current.fillColorSpace).toEqual(ColorSpace.deviceGray());
 });
 
+test("0 0 1 RG を実行すると strokeColor が Color.rgb(0, 0, 1) に更新される", () => {
+  const registered = registerColorOperators(OperatorRegistry.create());
+  assert(registered.ok);
+
+  const result = ContentStreamInterpreter.execute({
+    data: encode("0 0 1 RG"),
+    registry: registered.value,
+  });
+  assert(result.ok);
+  expect(result.value.warnings).toEqual([]);
+
+  const current = GraphicsStateStack.current(
+    result.value.context.graphicsStateStack,
+  );
+  expect(current.strokeColor).toEqual(Color.rgb(0, 0, 1));
+  expect(current.strokeColorSpace).toEqual(ColorSpace.deviceRGB());
+});
+
+test("1 0 0 rg を実行すると fillColor が Color.rgb(1, 0, 0) に更新される", () => {
+  const registered = registerColorOperators(OperatorRegistry.create());
+  assert(registered.ok);
+
+  const result = ContentStreamInterpreter.execute({
+    data: encode("1 0 0 rg"),
+    registry: registered.value,
+  });
+  assert(result.ok);
+  expect(result.value.warnings).toEqual([]);
+
+  const current = GraphicsStateStack.current(
+    result.value.context.graphicsStateStack,
+  );
+  expect(current.fillColor).toEqual(Color.rgb(1, 0, 0));
+  expect(current.fillColorSpace).toEqual(ColorSpace.deviceRGB());
+});
+
+test("1 0 0 rg 0 0 1 RG を実行すると fillColor と strokeColor が両方更新される", () => {
+  const registered = registerColorOperators(OperatorRegistry.create());
+  assert(registered.ok);
+
+  const result = ContentStreamInterpreter.execute({
+    data: encode("1 0 0 rg 0 0 1 RG"),
+    registry: registered.value,
+  });
+  assert(result.ok);
+  expect(result.value.warnings).toEqual([]);
+
+  const current = GraphicsStateStack.current(
+    result.value.context.graphicsStateStack,
+  );
+  expect(current.fillColor).toEqual(Color.rgb(1, 0, 0));
+  expect(current.fillColorSpace).toEqual(ColorSpace.deviceRGB());
+  expect(current.strokeColor).toEqual(Color.rgb(0, 0, 1));
+  expect(current.strokeColorSpace).toEqual(ColorSpace.deviceRGB());
+});
+
 test("0.5 0.5 0.5 0.5 K を実行すると strokeColor が Color.cmyk(0.5, 0.5, 0.5, 0.5) に更新される", () => {
   const registered = registerColorOperators(OperatorRegistry.create());
   assert(registered.ok);

--- a/packages/core/src/content-stream/operators/color/color-operators/index.ts
+++ b/packages/core/src/content-stream/operators/color/color-operators/index.ts
@@ -7,21 +7,27 @@ import { kHandler } from "../cmyk/fill";
 import { KHandler } from "../cmyk/stroke";
 import { gHandler } from "../gray/fill";
 import { GHandler } from "../gray/stroke";
+import { rgHandler } from "../rgb/fill";
+import { RGHandler } from "../rgb/stroke";
 
 export { kHandler } from "../cmyk/fill";
 export { KHandler } from "../cmyk/stroke";
 export { gHandler } from "../gray/fill";
 export { GHandler } from "../gray/stroke";
+export { rgHandler } from "../rgb/fill";
+export { RGHandler } from "../rgb/stroke";
 
 const COLOR_OPERATORS: ReadonlyArray<readonly [string, OperatorHandler]> = [
   ["G", GHandler],
   ["g", gHandler],
+  ["RG", RGHandler],
+  ["rg", rgHandler],
   ["K", KHandler],
   ["k", kHandler],
 ];
 
 /**
- * Color operator (G / g / K / k) を OperatorRegistry に一括登録するヘルパ (G/g/K/k 版)。
+ * Color operator (G / g / RG / rg / K / k) を OperatorRegistry に一括登録するヘルパ。
  *
  * fail-fast: いずれかの register が Err を返した時点で reduce 内 flatMap が
  * 短絡し、後続 operator の register は呼ばれない。


### PR DESCRIPTION
## 概要

spec-066 (Phase 4-C, Issue #216)。`color-operators/index.ts` の `COLOR_OPERATORS` 配列に **RG / rg (RGB)** を追加し、Issue 本文 design (`G, g, RG, rg, K, k` の 6 個) と一致させる。配列順序変更に伴う既存 K/k error テスト期待値の更新と、basic / error / integration 各テストへの RG/rg ケース追加を含む。

親 Epic: #206

## 変更の種類

- ✨ [New Feature]: 新機能 (RG/rg を registry に登録)
- 🧪 [Tests]: テスト追加 (basic / error / integration)

## 追加した内容

- `index.ts`: `RGHandler` / `rgHandler` の `import` と `re-export`、`COLOR_OPERATORS` 配列に `["RG", RGHandler]` / `["rg", rgHandler]` を `g` と `K` の間に挿入
- `basic.test.ts`: `test.each` に RG/rg 2 行、`has` 確認に 2 expect 追加
- `error.test.ts`: RG seed / rg seed 重複時の fail-fast テスト 2 件追加
- `integration.test.ts`: `0 0 1 RG` 単独 / `1 0 0 rg` 単独 / `1 0 0 rg 0 0 1 RG` 合成の 3 件追加

## 変更した内容

- `index.ts`: JSDoc を `(G / g / RG / rg / K / k) を ... ヘルパ。` に更新 (「(G/g/K/k 版)」サフィックス削除)
- `error.test.ts`: 既存 K テストの `calledNames` 期待値を `["G","g","K"]` → `["G","g","RG","rg","K"]` に、k テストを `["G","g","K","k"]` → `["G","g","RG","rg","K","k"]` に更新

## システム図

\`\`\`mermaid
flowchart TD
    Seed["OperatorRegistry (seed)"] --> Acc["acc = ok(seed)"]
    Acc --> G["STEP_G: register('G', GHandler)"]
    G -- ok --> Lower["STEP_g: register('g', gHandler)"]
    Lower -- ok --> RG["STEP_RG: register('RG', RGHandler) [NEW]"]
    RG -- ok --> Rg["STEP_rg: register('rg', rgHandler) [NEW]"]
    Rg -- ok --> K["STEP_K: register('K', KHandler)"]
    K -- ok --> Lk["STEP_k: register('k', kHandler)"]
    Lk -- ok --> Done["Ok(registry with all 6 ops)"]

    G -- err --> Err["Err(OPERATOR_ALREADY_REGISTERED, name)"]
    Lower -- err --> Err
    RG -- err --> Err
    Rg -- err --> Err
    K -- err --> Err
    Lk -- err --> Err

    style RG fill:#fff4b3
    style Rg fill:#fff4b3
\`\`\`

## 関連 spec / Issue

- spec: `.plugin-workspace/.specs/066-color-operators-registry-helper/`
- Closes #216
- Refs #206 (親 Epic)

## テスト

- `pnpm --filter @pdfmod/core test`: **2138 passed (152 files)** ✅
- `pnpm --filter @pdfmod/core build`: **成功** (vite + tsc emitDeclarationOnly) ✅
- Lint (oxlint / biome): warnings/errors なし
- Codex レビュー (`code-review/review-001.md`): **問題なし**

color-operators 関連内訳:
- basic: 7 tests (test.each 6 + has 確認 1)
- error: 6 tests (G / g / RG / rg / K / k の fail-fast)
- integration: 7 tests (G / g / RG 単独 / rg 単独 / 合成 / K / k)

## レビューポイント

- `COLOR_OPERATORS` の配列順序 (`G, g, RG, rg, K, k`) が `index.ts` / JSDoc / `basic.test.each` / `error.test` の `calledNames` 期待値の 4 箇所で同期しているか
- 既存 4-A (`registerGraphicsStateOperators`) / 4-B (`registerPathOperators`) と同一スタイル (`reduce + flatMap` + `ReadonlyArray<readonly [string, OperatorHandler]>`) を維持しているか