### PR TITLE
[#229] TextRenderingMode 型を追加

### DIFF
--- a/packages/core/src/content-stream/graphics-state/index.ts
+++ b/packages/core/src/content-stream/graphics-state/index.ts
@@ -6,3 +6,4 @@ export { LineCap } from "./line-cap";
 export { LineJoin } from "./line-join";
 export { Matrix } from "./matrix";
 export { GraphicsStateStack } from "./stack";
+export { TextRenderingMode } from "./text-rendering-mode";

--- a/packages/core/src/content-stream/graphics-state/text-rendering-mode/__tests__/text-rendering-mode.basic.test.ts
+++ b/packages/core/src/content-stream/graphics-state/text-rendering-mode/__tests__/text-rendering-mode.basic.test.ts
@@ -1,0 +1,28 @@
+import { expect, test } from "vitest";
+import { TextRenderingMode } from "../../text-rendering-mode";
+
+test.each([0, 1, 2, 3, 4, 5, 6, 7] as const)("create(%d)はnを保持する", (n) => {
+  expect(TextRenderingMode.create(n)).toBe(n);
+});
+
+test("TextRenderingMode.allowed は [0,1,2,3,4,5,6,7] を保持する", () => {
+  expect(TextRenderingMode.allowed).toEqual([0, 1, 2, 3, 4, 5, 6, 7]);
+});
+
+test.each([
+  0, 1, 2, 3, 4, 5, 6, 7,
+] as const)("TextRenderingMode.isValid(%d) は true を返す", (n) => {
+  expect(TextRenderingMode.isValid(n)).toBe(true);
+});
+
+test.each([
+  8,
+  -1,
+  1.5,
+  Number.NaN,
+  Number.POSITIVE_INFINITY,
+  Number.NEGATIVE_INFINITY,
+  Number.MAX_SAFE_INTEGER,
+])("TextRenderingMode.isValid(%s) は false を返す", (n) => {
+  expect(TextRenderingMode.isValid(n)).toBe(false);
+});

--- a/packages/core/src/content-stream/graphics-state/text-rendering-mode/index.ts
+++ b/packages/core/src/content-stream/graphics-state/text-rendering-mode/index.ts
@@ -1,0 +1,54 @@
+import type { Brand } from "../../../utils/brand/index";
+
+declare const TextRenderingModeBrand: unique symbol;
+
+type TextRenderingModeValue = 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7;
+
+/**
+ * PDF 仕様 §9.3.6 の text rendering mode。
+ * 0 = Fill (グリフを塗りつぶす, デフォルト)
+ * 1 = Stroke (グリフの輪郭線のみ描画)
+ * 2 = Fill, then stroke (塗りつぶした上に輪郭線を描画)
+ * 3 = Invisible (描画しない, 検索/選択用)
+ * 4 = Fill, then add to path for clipping (塗りつぶし後、クリッピングパスへ追加)
+ * 5 = Stroke, then add to path for clipping (輪郭線描画後、クリッピングパスへ追加)
+ * 6 = Fill, then stroke, then add to path for clipping (塗+線後、クリッピングパスへ追加)
+ * 7 = Add text to path for clipping (描画なしでクリッピングパスへ追加)
+ *
+ * Brand の基底型を 0|1|2|3|4|5|6|7 リテラル union に絞り categorical domain を型レベルで保持する。
+ */
+export type TextRenderingMode = Brand<
+  TextRenderingModeValue,
+  typeof TextRenderingModeBrand
+>;
+
+export const TextRenderingMode = {
+  /**
+   * PDF §9.3.6 が定める text rendering mode の許容値 (0=Fill 〜 7=Add to path for clipping)。
+   * `readonly [0,1,2,3,4,5,6,7]` のリテラル tuple 型を保持しつつ
+   * `readonly number[]` への代入互換性を `satisfies` で静的検査する。
+   * categorical operand を扱う `PdfError` の `allowed: readonly number[]` に直接渡せる。
+   */
+  allowed: [0, 1, 2, 3, 4, 5, 6, 7] as const satisfies readonly number[],
+
+  /**
+   * 任意の number が text rendering mode の許容値 (0〜7 の整数) かを判定する型ガード。
+   * `true` を返した先で `n` は `0 | 1 | 2 | 3 | 4 | 5 | 6 | 7` に narrow される。
+   *
+   * @param n - 検査対象の数値
+   * @returns n が 0〜7 のいずれかの整数なら true
+   */
+  isValid(n: number): n is TextRenderingModeValue {
+    return Number.isInteger(n) && n >= 0 && n <= 7;
+  },
+
+  /**
+   * 0〜7 のいずれかを TextRenderingMode として返す。
+   *
+   * @param n - text rendering mode (0=Fill / 1=Stroke / 2=Fill+Stroke / 3=Invisible / 4=Fill+Clip / 5=Stroke+Clip / 6=Fill+Stroke+Clip / 7=Clip only)
+   * @returns Brand 付き TextRenderingMode
+   */
+  create(n: TextRenderingModeValue): TextRenderingMode {
+    return n as TextRenderingMode;
+  },
+} as const;

--- a/packages/core/src/content-stream/graphics-state/text-rendering-mode/index.ts
+++ b/packages/core/src/content-stream/graphics-state/text-rendering-mode/index.ts
@@ -2,7 +2,22 @@ import type { Brand } from "../../../utils/brand/index";
 
 declare const TextRenderingModeBrand: unique symbol;
 
-type TextRenderingModeValue = 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7;
+/**
+ * PDF §9.3.6 で定義される text rendering mode の名前付き定数。
+ * 各 key は PDF.js / poppler 等の慣用名を踏襲。
+ */
+const Mode = {
+  FILL: 0,
+  STROKE: 1,
+  FILL_STROKE: 2,
+  INVISIBLE: 3,
+  FILL_CLIP: 4,
+  STROKE_CLIP: 5,
+  FILL_STROKE_CLIP: 6,
+  CLIP: 7,
+} as const satisfies Record<string, number>;
+
+type TextRenderingModeValue = (typeof Mode)[keyof typeof Mode];
 
 /**
  * PDF 仕様 §9.3.6 の text rendering mode。
@@ -23,29 +38,55 @@ export type TextRenderingMode = Brand<
 >;
 
 export const TextRenderingMode = {
+  /** PDF §9.3.6 Mode 0 — グリフを塗りつぶす (デフォルト)。 */
+  FILL: Mode.FILL,
+  /** PDF §9.3.6 Mode 1 — グリフの輪郭線のみ描画。 */
+  STROKE: Mode.STROKE,
+  /** PDF §9.3.6 Mode 2 — 塗りつぶした上に輪郭線を描画。 */
+  FILL_STROKE: Mode.FILL_STROKE,
+  /** PDF §9.3.6 Mode 3 — 描画しない (検索/選択用)。 */
+  INVISIBLE: Mode.INVISIBLE,
+  /** PDF §9.3.6 Mode 4 — 塗りつぶし後、クリッピングパスへ追加。 */
+  FILL_CLIP: Mode.FILL_CLIP,
+  /** PDF §9.3.6 Mode 5 — 輪郭線描画後、クリッピングパスへ追加。 */
+  STROKE_CLIP: Mode.STROKE_CLIP,
+  /** PDF §9.3.6 Mode 6 — 塗+線後、クリッピングパスへ追加。 */
+  FILL_STROKE_CLIP: Mode.FILL_STROKE_CLIP,
+  /** PDF §9.3.6 Mode 7 — 描画なしでクリッピングパスへ追加。 */
+  CLIP: Mode.CLIP,
+
   /**
-   * PDF §9.3.6 が定める text rendering mode の許容値 (0=Fill 〜 7=Add to path for clipping)。
+   * PDF §9.3.6 が定める text rendering mode の許容値 (FILL 〜 CLIP)。
    * `readonly [0,1,2,3,4,5,6,7]` のリテラル tuple 型を保持しつつ
    * `readonly number[]` への代入互換性を `satisfies` で静的検査する。
    * categorical operand を扱う `PdfError` の `allowed: readonly number[]` に直接渡せる。
    */
-  allowed: [0, 1, 2, 3, 4, 5, 6, 7] as const satisfies readonly number[],
+  allowed: [
+    Mode.FILL,
+    Mode.STROKE,
+    Mode.FILL_STROKE,
+    Mode.INVISIBLE,
+    Mode.FILL_CLIP,
+    Mode.STROKE_CLIP,
+    Mode.FILL_STROKE_CLIP,
+    Mode.CLIP,
+  ] as const satisfies readonly number[],
 
   /**
-   * 任意の number が text rendering mode の許容値 (0〜7 の整数) かを判定する型ガード。
-   * `true` を返した先で `n` は `0 | 1 | 2 | 3 | 4 | 5 | 6 | 7` に narrow される。
+   * 任意の number が text rendering mode の許容値 (FILL〜CLIP の整数) かを判定する型ガード。
+   * `true` を返した先で `n` は `TextRenderingModeValue` に narrow される。
    *
    * @param n - 検査対象の数値
-   * @returns n が 0〜7 のいずれかの整数なら true
+   * @returns n が FILL〜CLIP のいずれかの整数なら true
    */
   isValid(n: number): n is TextRenderingModeValue {
-    return Number.isInteger(n) && n >= 0 && n <= 7;
+    return Number.isInteger(n) && n >= Mode.FILL && n <= Mode.CLIP;
   },
 
   /**
-   * 0〜7 のいずれかを TextRenderingMode として返す。
+   * FILL〜CLIP のいずれかを TextRenderingMode として返す。
    *
-   * @param n - text rendering mode (0=Fill / 1=Stroke / 2=Fill+Stroke / 3=Invisible / 4=Fill+Clip / 5=Stroke+Clip / 6=Fill+Stroke+Clip / 7=Clip only)
+   * @param n - text rendering mode (FILL / STROKE / FILL_STROKE / INVISIBLE / FILL_CLIP / STROKE_CLIP / FILL_STROKE_CLIP / CLIP)
    * @returns Brand 付き TextRenderingMode
    */
   create(n: TextRenderingModeValue): TextRenderingMode {

--- a/packages/core/src/content-stream/graphics-state/text-rendering-mode/index.ts
+++ b/packages/core/src/content-stream/graphics-state/text-rendering-mode/index.ts
@@ -1,4 +1,5 @@
 import type { Brand } from "../../../utils/brand/index";
+import type { ValueOf } from "../../../utils/types/utility-type";
 
 declare const TextRenderingModeBrand: unique symbol;
 
@@ -17,7 +18,7 @@ const Mode = {
   CLIP: 7,
 } as const satisfies Record<string, number>;
 
-type TextRenderingModeValue = (typeof Mode)[keyof typeof Mode];
+type TextRenderingModeValue = ValueOf<typeof Mode>;
 
 /**
  * PDF 仕様 §9.3.6 の text rendering mode。

--- a/packages/core/src/utils/index.ts
+++ b/packages/core/src/utils/index.ts
@@ -1,3 +1,4 @@
 export type { Brand } from "./brand/index";
 export * as Option from "./option/index";
 export * as Result from "./result/index";
+export type { ValueOf } from "./types/utility-type";

--- a/packages/core/src/utils/types/utility-type.ts
+++ b/packages/core/src/utils/types/utility-type.ts
@@ -1,0 +1,14 @@
+/**
+ * オブジェクト型のすべての value 型を union として取り出すユーティリティ型。
+ * `as const` で定義した定数オブジェクトから categorical な literal union を
+ * 導出する用途で使う (`(typeof Obj)[keyof typeof Obj]` の省略形)。
+ *
+ * @typeParam T - object 型
+ *
+ * @example
+ * ```ts
+ * const Mode = { A: 0, B: 1 } as const;
+ * type ModeValue = ValueOf<typeof Mode>; // 0 | 1
+ * ```
+ */
+export type ValueOf<T> = T[keyof T];


### PR DESCRIPTION
## 概要

PDF §9.3.6 が定める text rendering mode (0〜7 の 8 値) を、既存 `LineCap` / `LineJoin` と同型の Brand + companion object パターンで `packages/core/src/content-stream/graphics-state/text-rendering-mode/` に新規追加する。

Phase 4-D テキストオブジェクト基盤 (#228) のうち、型本体・型ガード・factory・許容値配列のみを切り出した最小単位の PR。`Tr` operator handler や `GraphicsState.textState` への組み込みは後続 Issue で対応する。

## 変更の種類

- ✨ 新機能

## 詳細な変更内容

### 追加

- `packages/core/src/content-stream/graphics-state/text-rendering-mode/index.ts` — 型本体 + companion object (`allowed` / `isValid` / `create`)
- `packages/core/src/content-stream/graphics-state/text-rendering-mode/__tests__/text-rendering-mode.basic.test.ts` — basic スイート (24 ケース)

### 変更

- `packages/core/src/content-stream/graphics-state/index.ts` — `Matrix` の直後・`GraphicsStateStack` の直前に `TextRenderingMode` の re-export を 1 行追加

## システム図

```
                           TextRenderingMode (Brand<0|1|2|3|4|5|6|7>)
                                          │
        ┌──────────┬──────────┬──────────┼──────────┬──────────┬──────────┬──────────┐
        ▼          ▼          ▼          ▼          ▼          ▼          ▼          ▼
      [0]        [1]        [2]        [3]        [4]        [5]        [6]        [7]
      Fill      Stroke     Fill+      Invis-     Fill+      Stroke+    Fill+      Clip
                          Stroke      ible       Clip       Clip       Stroke+    only
                                                                       Clip
```

```
[ユーザー / 後続 Tr handler]
        │ number (検証前)
        ▼
TextRenderingMode.isValid(n) ── false ──▶ 呼び出し側で PdfError 組立 (本 PR 範囲外)
        │ true (n は 0..7 に narrow)
        ▼
TextRenderingMode.create(n) ── Brand 付き値に昇格
        │
        ▼
[GraphicsState.textState.renderingMode]   ◀── 組み込みは後続 Issue
```

## 設計判断

### `isValid` を `Number.isInteger + range` で実装した根拠

`LineCap` / `LineJoin` は 3 値の `===` 列挙だが、本型は 8 値あるため `===` 列挙は冗長で読みづらい。`allowed.includes(n)` は型ガード化のために cast が必要で純度を損なう。`Number.isInteger(n) && n >= 0 && n <= 7` であれば 1 行で完結し、`NaN` / `Infinity` / 小数を漏れなく除外できる。詳細は spec の §8 (代替案検討) を参照。

### `no-magic-numbers` 警告について

oxlint の `no-magic-numbers` ルールが現在 `ignore: [-1, 0, 1, 2]` のため、PDF §9.3.6 のリテラル 3〜7 が warn レベルで報告される。oxlint は warn では exit 0 のため CI には影響しない (確認済み)。仕様由来の categorical コードに対する lint 設定見直しは別 PR とする。

## 関連Issue

- Closes #229
- Parent Epic: Refs #228

## テスト

```bash
pnpm --filter @pdfmod/core test      # 2162 tests passed
pnpm --filter @pdfmod/core build     # 成功
pnpm --filter @pdfmod/core typecheck # 成功
```

basic テストブロック (24 ケース):
- `create(n)` が n を保持する (8 ケース)
- `allowed` が `[0,1,2,3,4,5,6,7]` を保持する (1 ケース)
- `isValid(n)` が許容値 8 通りで true (8 ケース)
- `isValid(n)` が拒否値 (8, -1, 1.5, NaN, ±Infinity, MAX_SAFE_INTEGER) で false (7 ケース)

## レビューポイント

- `TextRenderingModeValue` をローカル型に切り出した点 (`isValid` の戻り型と `create` の引数型で重複を避けるため、`export` はしない)
- `isValid` を `Number.isInteger + range` で実装した点 (LineCap/LineJoin との実装差分の根拠を spec §8 にまとめてある)
- barrel 再エクスポートの順序 (既存の `Matrix` → `GraphicsStateStack` 間に挿入)

## チェックリスト

- [x] コードレビューの準備完了
- [x] テスト正常実行
- [x] 適切なコミットメッセージ
- [x] IssueがPRにLinked (Closes #229)
- [x] セルフレビュー実施