### PR TITLE
✨ [New Feature]: #230 TextObject 型と companion object を追加

### DIFF
--- a/packages/core/src/content-stream/graphics-state/index.ts
+++ b/packages/core/src/content-stream/graphics-state/index.ts
@@ -6,4 +6,5 @@ export { LineCap } from "./line-cap";
 export { LineJoin } from "./line-join";
 export { Matrix } from "./matrix";
 export { GraphicsStateStack } from "./stack";
+export { TextObject } from "./text-object";
 export { TextRenderingMode } from "./text-rendering-mode";

--- a/packages/core/src/content-stream/graphics-state/text-object/__tests__/text-object.basic.test.ts
+++ b/packages/core/src/content-stream/graphics-state/text-object/__tests__/text-object.basic.test.ts
@@ -1,0 +1,56 @@
+import { expect, test } from "vitest";
+import { Matrix } from "../../matrix";
+import { TextObject } from "../../text-object";
+
+test("inactive() は active=false で両 matrix が identity の TextObject を返す", () => {
+  const state = TextObject.inactive();
+  expect(state.active).toBe(false);
+  expect(state.textMatrix).toEqual(Matrix.identity());
+  expect(state.textLineMatrix).toEqual(Matrix.identity());
+});
+
+test("begin() は active=true で両 matrix が identity の TextObject を返す", () => {
+  const state = TextObject.begin();
+  expect(state.active).toBe(true);
+  expect(state.textMatrix).toEqual(Matrix.identity());
+  expect(state.textLineMatrix).toEqual(Matrix.identity());
+});
+
+test("end(active) は active=false に戻し両 matrix を identity に戻す", () => {
+  const active = TextObject.begin();
+  const ended = TextObject.end(active);
+  expect(ended.active).toBe(false);
+  expect(ended.textMatrix).toEqual(Matrix.identity());
+  expect(ended.textLineMatrix).toEqual(Matrix.identity());
+});
+
+test("end は非 identity matrix を持つ state からも matrix を identity に戻す", () => {
+  const dirty = {
+    active: true,
+    textMatrix: [2, 0, 0, 2, 10, 20] as const,
+    textLineMatrix: [3, 0, 0, 3, 30, 40] as const,
+  } as unknown as TextObject;
+  const ended = TextObject.end(dirty);
+  expect(ended.active).toBe(false);
+  expect(ended.textMatrix).toEqual(Matrix.identity());
+  expect(ended.textLineMatrix).toEqual(Matrix.identity());
+});
+
+test("end(inactive) は冪等で active=false かつ両 matrix が identity のままを返す", () => {
+  const ended = TextObject.end(TextObject.inactive());
+  expect(ended.active).toBe(false);
+  expect(ended.textMatrix).toEqual(Matrix.identity());
+  expect(ended.textLineMatrix).toEqual(Matrix.identity());
+});
+
+test("isActive(begin()) は true を返す", () => {
+  expect(TextObject.isActive(TextObject.begin())).toBe(true);
+});
+
+test("isActive(inactive()) は false を返す", () => {
+  expect(TextObject.isActive(TextObject.inactive())).toBe(false);
+});
+
+test("isActive(end(begin())) は false を返す", () => {
+  expect(TextObject.isActive(TextObject.end(TextObject.begin()))).toBe(false);
+});

--- a/packages/core/src/content-stream/graphics-state/text-object/index.ts
+++ b/packages/core/src/content-stream/graphics-state/text-object/index.ts
@@ -53,18 +53,14 @@ export const TextObject = {
    * `active = false` に戻し、両 matrix を identity に戻す。
    * 既に inactive な state に対しても冪等 (同値の inactive を返す)。
    *
-   * 現在は state を参照しない。Phase 4-E で matrix 更新ロジックが入った際の
-   * シグネチャを保つために state を受け取る形にしてある。
+   * 現在は state を参照せず `inactive()` に委譲する。Phase 4-E で matrix
+   * 更新ロジックが入った際のシグネチャを保つために state を受け取る形にしてある。
    *
    * @param _state - 終了対象の TextObject (現在は読まない)
    * @returns 非アクティブな TextObject (`inactive()` と同値)
    */
   end(_state: TextObject): TextObject {
-    return {
-      active: false,
-      textMatrix: Matrix.identity(),
-      textLineMatrix: Matrix.identity(),
-    } as unknown as TextObject;
+    return TextObject.inactive();
   },
   /**
    * `state.active` を読み出す predicate (アクセサ)。

--- a/packages/core/src/content-stream/graphics-state/text-object/index.ts
+++ b/packages/core/src/content-stream/graphics-state/text-object/index.ts
@@ -1,0 +1,80 @@
+import type { Brand } from "../../../utils/brand/index";
+import { Matrix } from "../matrix";
+
+declare const TextObjectBrand: unique symbol;
+
+type TextObjectFields = {
+  readonly active: boolean;
+  readonly textMatrix: Matrix;
+  readonly textLineMatrix: Matrix;
+};
+
+/**
+ * PDF コンテンツストリームの `BT` 〜 `ET` で囲まれるテキストオブジェクト状態
+ * (ISO 32000-1:2008 §9.4.1)。
+ *
+ * - `active` : `BT` 〜 `ET` の間で `true`、それ以外で `false`。
+ * - `textMatrix`     : 現在のテキスト行列 (ISO 32000-1:2008 §9.4.2)。
+ * - `textLineMatrix` : 現在のテキスト行の行列 (同 §9.4.2)。
+ *
+ * Phase 4-E の `Td` / `TD` / `Tm` / `T*` で matrix を更新する基盤となる。
+ */
+export type TextObject = Brand<TextObjectFields, typeof TextObjectBrand>;
+
+export const TextObject = {
+  /**
+   * 非アクティブな TextObject を返す。`BT` 未到達時の初期状態に相当する。
+   * `active = false`、`textMatrix` / `textLineMatrix` は `Matrix.identity()`。
+   *
+   * @returns 非アクティブな TextObject
+   */
+  inactive(): TextObject {
+    return {
+      active: false,
+      textMatrix: Matrix.identity(),
+      textLineMatrix: Matrix.identity(),
+    } as unknown as TextObject;
+  },
+  /**
+   * `BT` operator (ISO 32000-1:2008 §9.4.1) でテキストオブジェクトを開始する。
+   * `active = true` に切り替え、`textMatrix` / `textLineMatrix` を identity に初期化する。
+   *
+   * @returns アクティブな TextObject
+   */
+  begin(): TextObject {
+    return {
+      active: true,
+      textMatrix: Matrix.identity(),
+      textLineMatrix: Matrix.identity(),
+    } as unknown as TextObject;
+  },
+  /**
+   * `ET` operator (ISO 32000-1:2008 §9.4.1) でテキストオブジェクトを終了する。
+   * `active = false` に戻し、両 matrix を identity に戻す。
+   * 既に inactive な state に対しても冪等 (同値の inactive を返す)。
+   *
+   * 現在は state を参照しない。Phase 4-E で matrix 更新ロジックが入った際の
+   * シグネチャを保つために state を受け取る形にしてある。
+   *
+   * @param _state - 終了対象の TextObject (現在は読まない)
+   * @returns 非アクティブな TextObject (`inactive()` と同値)
+   */
+  end(_state: TextObject): TextObject {
+    return {
+      active: false,
+      textMatrix: Matrix.identity(),
+      textLineMatrix: Matrix.identity(),
+    } as unknown as TextObject;
+  },
+  /**
+   * `state.active` を読み出す predicate (アクセサ)。
+   * 戻り値は `boolean` で、TypeScript の型ナローイングは行わない
+   * (`active`/`inactive` の判別可能 union 型は未定義のため)。
+   *
+   * @param state - 判定対象の TextObject
+   * @returns `state.active` が `true` なら `true`
+   */
+  isActive(state: TextObject): boolean {
+    return state.active;
+  },
+} as const;


### PR DESCRIPTION
## 概要

spec-068。PDF コンテンツストリームの `BT` 〜 `ET` で囲まれるテキストオブジェクト状態（ISO 32000-1:2008 §9.4.1）を `TextRenderingMode` (#229) と同型の Brand + companion object パターンで `packages/core/src/content-stream/graphics-state/text-object/` に新規追加する。本 PR は型と companion object のみで、`BT`/`ET` operator handler や `GraphicsState` 本体への組み込みは行わない（後続 Phase 4-D / 4-E の責務）。

## 変更の種類

- ✨ [New Feature]: 新機能

## 追加した内容

- `packages/core/src/content-stream/graphics-state/text-object/index.ts`
  - `type TextObject = Brand<TextObjectFields, typeof TextObjectBrand>`
  - companion object: `inactive()` / `begin()` / `end(state)` / `isActive(state)`
- `packages/core/src/content-stream/graphics-state/text-object/__tests__/text-object.basic.test.ts`
  - basic スイート 8 ケース（inactive / begin / end-from-active / end-matrix-reset / end-from-inactive / isActive × 3）

## 変更した内容

- `packages/core/src/content-stream/graphics-state/index.ts`
  - 末尾（`TextRenderingMode` の直後）に `export { TextObject } from "./text-object";` を追加

## システム図

```mermaid
flowchart LR
    Factory["TextObject companion"]
    Inactive["inactive<br/>active=false<br/>textMatrix=identity<br/>textLineMatrix=identity"]
    Active["active<br/>active=true<br/>textMatrix=identity<br/>textLineMatrix=identity"]

    Factory -- "inactive()" --> Inactive
    Factory -- "begin() [BT]" --> Active
    Active -- "end(state) [ET]" --> Inactive
    Inactive -- "end(state) (冪等)" --> Inactive

    Future["Phase 4-E:<br/>Td / TD / Tm / T*<br/>(matrix 更新)"]
    Active -.後続 spec.-> Future

    style Active fill:#e6f7ff,stroke:#0366d6
    style Inactive fill:#f6f8fa,stroke:#586069
    style Future fill:#fff5b1,stroke:#b08800,stroke-dasharray: 4 4
```

## 関連 spec / Issue

- spec: `.plugin-workspace/.specs/068-text-object-type`
- Closes #230
- Refs #228（Parent Epic: Phase 4-D テキストオブジェクト基盤）

## テスト

```
pnpm --filter @pdfmod/core test       → 154 files / 2170 tests passed（新規 8 ケース含む）
pnpm --filter @pdfmod/core typecheck  → エラーなし
pnpm --filter @pdfmod/core build      → 成功
pnpm lint                              → 0 errors
```

t-wada 式 TDD（Red → Green → Refactor）で 7 サイクル実施:
1. `inactive()` — Red→Green
2. `begin()` — Red→Green
3. `end(active)` — Red→Green
4. `end()` matrix リセット（非 identity 入力） — 三角測量
5. `end(inactive)` 冪等性 — 三角測量
6. `isActive()` 3 ケース
7. Refactor（JSDoc 整備 + companion 整列）

Codex レビューは本セッションでは未実施（memory feedback「Codex レビューは最後にまとめて実施する」に従い、後続でまとめて実施予定）。

## レビューポイント

- **`end(_state)` の引数予約**: 現在 state を読まず inactive 形を返すが、Phase 4-E (`Td`/`TD`/`Tm`/`T*`) で matrix 更新ロジックが入った際のシグネチャ互換性のために `state: TextObject` を残している（implementation-plan §5.1 案 A 採用）
- **companion 一括 import 規約**: `import { TextObject } from "../../graphics-state"` 一発で型と factory がすべて解決される（`feedback_companion_object_import`）
- **predicate の集約**: `isActive` は standalone export ではなく companion 内に集約（`feedback_companion_for_type_guards`）
- **Brand プロパティを runtime で検査していない**: テストは `__brand` の存在を `expect` しない（`feedback_no_runtime_type_test`）
- **テストはフラット構造**: `describe` 不使用、セクションコメントなし（`feedback_no_section_comments`）