### PR TITLE
✨ [New Feature]: TextState 型と companion object を追加

### DIFF
--- a/packages/core/src/content-stream/graphics-state/index.ts
+++ b/packages/core/src/content-stream/graphics-state/index.ts
@@ -8,3 +8,4 @@ export { Matrix } from "./matrix";
 export { GraphicsStateStack } from "./stack";
 export { TextObject } from "./text-object";
 export { TextRenderingMode } from "./text-rendering-mode";
+export { TextState } from "./text-state";

--- a/packages/core/src/content-stream/graphics-state/text-state/__tests__/text-state.basic.test.ts
+++ b/packages/core/src/content-stream/graphics-state/text-state/__tests__/text-state.basic.test.ts
@@ -1,0 +1,75 @@
+import { expect, test } from "vitest";
+import { none, some } from "../../../../utils/option/index";
+import { TextRenderingMode, TextState } from "../../index";
+
+test("createはPDF §9.3 デフォルト値を返す", () => {
+  const state = TextState.create();
+  expect(state).toEqual({
+    charSpace: 0,
+    wordSpace: 0,
+    horizontalScaling: 100,
+    leading: 0,
+    fontName: none,
+    fontSize: 0,
+    renderingMode: TextRenderingMode.create(TextRenderingMode.FILL),
+    rise: 0,
+  });
+});
+
+test("updateは指定したフィールドだけを書き換える", () => {
+  const state = TextState.create();
+  const updated = TextState.update(state, { charSpace: 2 });
+  expect(updated.charSpace).toBe(2);
+});
+
+test("updateは未指定フィールドを保持する", () => {
+  const state = TextState.create();
+  const updated = TextState.update(state, { charSpace: 2 });
+  expect(updated.wordSpace).toBe(state.wordSpace);
+  expect(updated.horizontalScaling).toBe(state.horizontalScaling);
+  expect(updated.fontName).toBe(state.fontName);
+  expect(updated.renderingMode).toBe(state.renderingMode);
+});
+
+test("updateは元のstateを変更しない", () => {
+  const state = TextState.create();
+  TextState.update(state, { charSpace: 2, fontName: some("F1") });
+  expect(state.charSpace).toBe(0);
+  expect(state.fontName).toBe(none);
+});
+
+test("updateは新しいインスタンスを返す", () => {
+  const state = TextState.create();
+  const updated = TextState.update(state, { charSpace: 2 });
+  expect(updated).not.toBe(state);
+});
+
+test.each([
+  ["charSpace", { charSpace: 3 }],
+  ["wordSpace", { wordSpace: 5 }],
+  ["horizontalScaling", { horizontalScaling: 90 }],
+  ["leading", { leading: 12 }],
+  ["fontName", { fontName: some("F1") }],
+  ["fontSize", { fontSize: 14 }],
+  [
+    "renderingMode",
+    { renderingMode: TextRenderingMode.create(TextRenderingMode.STROKE) },
+  ],
+  ["rise", { rise: 4 }],
+] as const)("update(state, %s) は該当フィールドだけ書き換える", (_label, partial) => {
+  const state = TextState.create();
+  const updated = TextState.update(state, partial);
+  expect(updated).toEqual({ ...state, ...partial });
+});
+
+test('update({ fontName: some("F1") }) は none から some へ遷移する', () => {
+  const state = TextState.create();
+  const updated = TextState.update(state, { fontName: some("F1") });
+  expect(updated.fontName).toEqual(some("F1"));
+});
+
+test("updateはundefinedの明示指定で既存フィールドを壊さない", () => {
+  const state = TextState.update(TextState.create(), { charSpace: 7 });
+  const updated = TextState.update(state, { charSpace: undefined });
+  expect(updated.charSpace).toBe(7);
+});

--- a/packages/core/src/content-stream/graphics-state/text-state/index.ts
+++ b/packages/core/src/content-stream/graphics-state/text-state/index.ts
@@ -1,0 +1,85 @@
+import type { Brand } from "../../../utils/brand/index";
+import type { Option } from "../../../utils/option/index";
+import { none } from "../../../utils/option/index";
+import { TextRenderingMode } from "../text-rendering-mode";
+
+declare const TextStateBrand: unique symbol;
+
+type TextStateFields = {
+  readonly charSpace: number; // Tc, default 0
+  readonly wordSpace: number; // Tw, default 0
+  readonly horizontalScaling: number; // Tz, default 100 (= 100%)
+  readonly leading: number; // TL, default 0
+  readonly fontName: Option<string>; // Tf font name, default none
+  readonly fontSize: number; // Tf font size, default 0
+  readonly renderingMode: TextRenderingMode; // Tr, default FILL (0)
+  readonly rise: number; // Ts, default 0
+};
+
+/**
+ * PDF コンテンツストリーム実行時のテキスト状態パラメータ
+ * (ISO 32000-1:2008 §9.3 Table 105 / §9.3.6)。
+ * 全フィールドは readonly。更新は TextState.update で新インスタンスを生成する。
+ */
+export type TextState = Brand<TextStateFields, typeof TextStateBrand>;
+
+type TextStatePartial = Partial<TextStateFields>;
+
+export const TextState = {
+  /**
+   * PDF 仕様 §9.3 デフォルト値で TextState を生成する。
+   *   charSpace         = 0
+   *   wordSpace         = 0
+   *   horizontalScaling = 100
+   *   leading           = 0
+   *   fontName          = none
+   *   fontSize          = 0
+   *   renderingMode     = FILL (0)
+   *   rise              = 0
+   *
+   * @returns デフォルト値で初期化された TextState
+   */
+  create(): TextState {
+    return {
+      charSpace: 0,
+      wordSpace: 0,
+      horizontalScaling: 100,
+      leading: 0,
+      fontName: none,
+      fontSize: 0,
+      renderingMode: TextRenderingMode.create(TextRenderingMode.FILL),
+      rise: 0,
+    } as unknown as TextState;
+  },
+
+  /**
+   * partial で指定したフィールドだけを書き換えた新しい TextState を返す。
+   * 元の state は変更されない。同一参照は返さない。
+   *
+   * @param state - 元の TextState
+   * @param partial - 書き換えたいフィールドの部分集合
+   * @returns 浅いマージで生成された新しい TextState
+   */
+  update(state: TextState, partial: TextStatePartial): TextState {
+    return {
+      charSpace:
+        partial.charSpace !== undefined ? partial.charSpace : state.charSpace,
+      wordSpace:
+        partial.wordSpace !== undefined ? partial.wordSpace : state.wordSpace,
+      horizontalScaling:
+        partial.horizontalScaling !== undefined
+          ? partial.horizontalScaling
+          : state.horizontalScaling,
+      leading: partial.leading !== undefined ? partial.leading : state.leading,
+      fontName:
+        partial.fontName !== undefined ? partial.fontName : state.fontName,
+      fontSize:
+        partial.fontSize !== undefined ? partial.fontSize : state.fontSize,
+      renderingMode:
+        partial.renderingMode !== undefined
+          ? partial.renderingMode
+          : state.renderingMode,
+      rise: partial.rise !== undefined ? partial.rise : state.rise,
+    } as unknown as TextState;
+  },
+} as const;


### PR DESCRIPTION
## 概要

spec 069-text-state。PDF §9.3 のテキスト state setter operator (Tc/Tw/Tz/TL/Tf/Tr/Ts) で設定する operator-settable subset の 8 フィールドを保持する readonly な `TextState` 型と companion object (`create()` / `update()`) を `@pdfmod/core` に追加する。後続の Phase 4-D テキスト state setter operator が `update` で部分更新するための基盤。

> `Tk` (text knockout) は operator ではなく `gs`（ExtGState）経由で設定されるため本 PR では対象外。

## 変更の種類

- ✨ New Feature（純粋な新規追加。破壊的変更なし）

## 追加した内容

- `packages/core/src/content-stream/graphics-state/text-state/index.ts`
  - `TextStateFields`（8 フィールド全 readonly）/ `TextState = Brand<...>` / companion object
  - `create()` — §9.3 デフォルト値で生成（charSpace=0, wordSpace=0, horizontalScaling=100, leading=0, fontName=none, fontSize=0, renderingMode=FILL, rise=0）
  - `update(state, partial)` — フィールド列挙の三項マージで浅く部分更新。元 state 非破壊、新インスタンスを返す
- `packages/core/src/content-stream/graphics-state/text-state/__tests__/text-state.basic.test.ts`
  - フラット `test` 構造（describe 不使用）の Vitest ユニットテスト 8 シナリオ（`test.each` 含む全 15 ケース）

## 変更した内容

- `packages/core/src/content-stream/graphics-state/index.ts`
  - barrel に `export { TextState } from "./text-state";` を 1 行追加（ルート `packages/core/src/index.ts` は不変）

## システム図

```mermaid
flowchart TD
    create["TextState.create()<br/>(§9.3 デフォルト値)"] --> s0["TextState s0"]
    s0 -->|"update(s0, partial)"| s1["TextState s1<br/>= s0 ∪ partial<br/>(新インスタンス)"]
    s1 -->|"update(s1, partial')"| s2["... 連鎖生成 ..."]
    s0 -.->|"非破壊: s0 は不変"| s0

    style create fill:#e8f5e9,stroke:#43a047
    style s1 fill:#e3f2fd,stroke:#1e88e5
```

## 関連 spec / Issue

- spec: `.plugin-workspace/.specs/069-text-state`
- Refs #231

## テスト

- `pnpm --filter @pdfmod/core test` → **155 files / 2185 tests passed**（新規 15 ケース含む）
- `pnpm --filter @pdfmod/core build` → 成功（型生成含む）
- ルート `packages/core/src/index.ts` に差分なし（スコープ境界遵守）を `git diff` で確認
- Codex CLI レビュー → **問題なし**（整合性・品質・エッジケース・セキュリティ・パフォーマンスいずれも指摘なし）

## レビューポイント

- `fontName: Option<string>`（Tf 前は `none`）+ `fontSize: number`（デフォルト 0 を sentinel 扱い）の非対称設計は Issue #231 で確定した方針に従う意図的なもの
- 実装パターンは既存 `GraphicsState` を 1:1 で踏襲（Brand + create() デフォルト固定 + update() フィールド列挙の三項マージ + `as unknown as T` キャスト）
- スコープは `TextState` 単体追加のみ。GraphicsState への埋め込み・各 state setter operator 対応は後続 Issue

🤖 Generated with [Claude Code](https://claude.com/claude-code)