### PR TITLE
🧪 [Tests]: TextState の重複する update テストを削除

### DIFF
--- a/packages/core/src/content-stream/graphics-state/text-state/__tests__/text-state.basic.test.ts
+++ b/packages/core/src/content-stream/graphics-state/text-state/__tests__/text-state.basic.test.ts
@@ -16,12 +16,6 @@ test("createはPDF §9.3 デフォルト値を返す", () => {
   });
 });
 
-test("updateは指定したフィールドだけを書き換える", () => {
-  const state = TextState.create();
-  const updated = TextState.update(state, { charSpace: 2 });
-  expect(updated.charSpace).toBe(2);
-});
-
 test("updateは未指定フィールドを保持する", () => {
   const state = TextState.create();
   const updated = TextState.update(state, { charSpace: 2 });
@@ -60,12 +54,6 @@ test.each([
   const state = TextState.create();
   const updated = TextState.update(state, partial);
   expect(updated).toEqual({ ...state, ...partial });
-});
-
-test('update({ fontName: some("F1") }) は none から some へ遷移する', () => {
-  const state = TextState.create();
-  const updated = TextState.update(state, { fontName: some("F1") });
-  expect(updated.fontName).toEqual(some("F1"));
 });
 
 test("updateはundefinedの明示指定で既存フィールドを壊さない", () => {


### PR DESCRIPTION
## 概要

#245 (TextState) でマージ済みの `text-state.basic.test.ts` から、`test.each`（全 8 フィールドの whole-object 比較）が完全にカバーしている冗長な単体テスト 2 件を削除する。テストのみの後追いクリーンアップで、プロダクションコードの変更はなし。

## 変更の種類

- 🧪 Tests（重複テストの削除）

## 削除した内容

- `"updateは指定したフィールドだけを書き換える"` — `charSpace` 更新は `test.each` の `charSpace` ケース（`toEqual({ ...state, charSpace })`）が包含
- `"update({ fontName: some(\"F1\") }) は none から some へ遷移する"` — デフォルト `state.fontName` が `none` のため、`test.each` の `fontName` ケースがそのまま none→some 遷移を検証している

## 変更した内容

- なし（残したテストの挙動は不変）

## 残したテスト（重複ではない）

- `"updateは未指定フィールドを保持する"` — `.toBe` で**参照保持**を検証。`test.each` の構造比較 (`toEqual`) では担保できない別の保証のため維持
- `"updateは元のstateを変更しない"` / `"updateは新しいインスタンスを返す"` / `test.each`（全 8 フィールド）/ `"undefined の明示指定で既存フィールドを壊さない"`

## 関連 spec / Issue

- spec: `.plugin-workspace/.specs/069-text-state`
- Refs #231（#245 のフォローアップ）

## テスト

- `pnpm --filter @pdfmod/core test text-state` → **13 passed**（15 → 13、削除した 2 件以外は不変）
- 削除対象は既存 `test.each` が包含することを確認済み

## レビューポイント

- 削除した 2 テストが本当に `test.each` でカバーされているか（`charSpace` ケース / `fontName` ケース）
- 参照保持テスト (`.toBe`) を残した判断（構造比較とは別保証）

🤖 Generated with [Claude Code](https://claude.com/claude-code)