### PR TITLE
✨ [New Feature]: GraphicsState に textState / textObject フィールドを追加

### DIFF
--- a/packages/core/src/content-stream/graphics-state/graphics-state/__tests__/graphics-state.basic.test.ts
+++ b/packages/core/src/content-stream/graphics-state/graphics-state/__tests__/graphics-state.basic.test.ts
@@ -7,6 +7,8 @@ import {
   LineCap,
   LineJoin,
   Matrix,
+  TextObject,
+  TextState,
 } from "../../index";
 import { PathSegment } from "../../path-segment";
 
@@ -23,6 +25,8 @@ test("createはPDF仕様準拠のデフォルト値を返す", () => {
     fillColor: Color.defaultBlack(),
     strokeColorSpace: ColorSpace.deviceGray(),
     fillColorSpace: ColorSpace.deviceGray(),
+    textState: TextState.create(),
+    textObject: TextObject.inactive(),
   });
 });
 
@@ -73,6 +77,12 @@ test.each([
   ["fillColor", { fillColor: Color.cmyk(0, 1, 1, 0) }],
   ["strokeColorSpace", { strokeColorSpace: ColorSpace.deviceRGB() }],
   ["fillColorSpace", { fillColorSpace: ColorSpace.deviceCMYK() }],
+  [
+    "textState",
+    { textState: TextState.update(TextState.create(), { charSpace: 2 }) },
+  ],
+  ["textObject", { textObject: TextObject.begin() }],
+  ["empty", {}],
 ] as const)("update(state, %s) は該当フィールドだけ書き換える", (_label, partial) => {
   const state = GraphicsState.create();
   const updated = GraphicsState.update(state, partial);
@@ -109,6 +119,8 @@ test("updateはundefinedの明示指定で既存フィールドを壊さない",
   const fillColor = Color.cmyk(0, 1, 1, 0);
   const strokeColorSpace = ColorSpace.deviceRGB();
   const fillColorSpace = ColorSpace.deviceCMYK();
+  const textState = TextState.update(TextState.create(), { charSpace: 2 });
+  const textObject = TextObject.begin();
   const state = GraphicsState.update(GraphicsState.create(), {
     lineWidth: 2.0,
     miterLimit: 5.0,
@@ -117,6 +129,8 @@ test("updateはundefinedの明示指定で既存フィールドを壊さない",
     fillColor,
     strokeColorSpace,
     fillColorSpace,
+    textState,
+    textObject,
   });
   const updated = GraphicsState.update(state, {
     lineWidth: undefined,
@@ -126,6 +140,8 @@ test("updateはundefinedの明示指定で既存フィールドを壊さない",
     fillColor: undefined,
     strokeColorSpace: undefined,
     fillColorSpace: undefined,
+    textState: undefined,
+    textObject: undefined,
   });
   expect(updated.lineWidth).toBe(2.0);
   expect(updated.miterLimit).toBe(5.0);
@@ -134,4 +150,6 @@ test("updateはundefinedの明示指定で既存フィールドを壊さない",
   expect(updated.fillColor).toBe(fillColor);
   expect(updated.strokeColorSpace).toBe(strokeColorSpace);
   expect(updated.fillColorSpace).toBe(fillColorSpace);
+  expect(updated.textState).toBe(textState);
+  expect(updated.textObject).toBe(textObject);
 });

--- a/packages/core/src/content-stream/graphics-state/graphics-state/index.ts
+++ b/packages/core/src/content-stream/graphics-state/graphics-state/index.ts
@@ -5,6 +5,8 @@ import { CurrentPath } from "../current-path";
 import { LineCap } from "../line-cap";
 import { LineJoin } from "../line-join";
 import { Matrix } from "../matrix";
+import { TextObject } from "../text-object";
+import { TextState } from "../text-state";
 
 declare const GraphicsStateBrand: unique symbol;
 
@@ -19,6 +21,8 @@ type GraphicsStateFields = {
   readonly fillColor: Color;
   readonly strokeColorSpace: ColorSpace;
   readonly fillColorSpace: ColorSpace;
+  readonly textState: TextState;
+  readonly textObject: TextObject;
 };
 
 /**
@@ -45,6 +49,8 @@ export const GraphicsState = {
    *   fillColor        = defaultBlack (DeviceGray gray=0)
    *   strokeColorSpace = DeviceGray
    *   fillColorSpace   = DeviceGray
+   *   textState        = TextState.create()
+   *   textObject       = TextObject.inactive()
    *
    * @returns デフォルト値で初期化された GraphicsState
    */
@@ -60,6 +66,8 @@ export const GraphicsState = {
       fillColor: Color.defaultBlack(),
       strokeColorSpace: ColorSpace.deviceGray(),
       fillColorSpace: ColorSpace.deviceGray(),
+      textState: TextState.create(),
+      textObject: TextObject.inactive(),
     } as unknown as GraphicsState;
   },
 
@@ -101,6 +109,12 @@ export const GraphicsState = {
         partial.fillColorSpace !== undefined
           ? partial.fillColorSpace
           : state.fillColorSpace,
+      textState:
+        partial.textState !== undefined ? partial.textState : state.textState,
+      textObject:
+        partial.textObject !== undefined
+          ? partial.textObject
+          : state.textObject,
     } as unknown as GraphicsState;
   },
 } as const;


### PR DESCRIPTION
## 概要

spec `070-graphics-state-text-fields` / Issue #232。`GraphicsState` 型へ `textState: TextState`(#231) と `textObject: TextObject`(#230) の 2 フィールドを追加し、`create()` のデフォルト値と `update()` の浅いマージに統合する。Phase 4-D としてテキスト描画状態を GraphicsState に内包する基盤を整える。**本 PR のスコープは 2 フィールド追加のみで、BT/ET ハンドラ実装は含まない（将来 Issue）。**

## 変更の種類

- ✨ New Feature（型の拡大・破壊的変更なし）
- 🧪 Tests

## 追加した内容

- `GraphicsStateFields` 型に `readonly textState: TextState` / `readonly textObject: TextObject`
- `create()` のデフォルト: `textState = TextState.create()` / `textObject = TextObject.inactive()`（JSDoc のデフォルト値リストにも追記）
- `update()` の浅いマージに 2 フィールド（既存と同一の三項演算子明示マージ）
- `graphics-state.basic.test.ts` にテスト追記（新規ファイルは作らない）:
  - create デフォルトに textState / textObject を含む
  - update で textState / textObject を非デフォルト値へ丸ごと差し替え（A1: 浅いマージ）
  - 空 partial `{}` で全フィールド保持（境界値）
  - `undefined` 明示指定でも textState / textObject を保持（三項分岐を直接カバー）

## 変更した内容

- 既存 GraphicsState ハンドラ（cm/q/Q/w/… 等）は**変更なし**。型 / create / update への追加のみ。

## システム図

```mermaid
flowchart TD
    C["GraphicsState.create()"] --> D{"デフォルト値"}
    D --> E["既存10フィールド<br/>ctm / lineWidth / …"]
    D --> F["textState = TextState.create()"]:::new
    D --> G["textObject = TextObject.inactive()"]:::new
    E --> S["current: GraphicsState"]
    F --> S
    G --> S

    S --> U["GraphicsState.update(current, partial)"]
    U --> M{"フィールドごと三項マージ<br/>partial.x !== undefined ? partial.x : state.x"}
    M --> N["next: GraphicsState（新インスタンス, 非破壊）"]
    M -.->|"textState/textObject 未指定なら保持"| N

    classDef new fill:#dff5dd,stroke:#2e7d32,stroke-width:2px;
```

## 関連 spec / Issue

- spec: `.plugin-workspace/.specs/070-graphics-state-text-fields`
- Closes #232（親 Epic: #228、依存: #231 / #230 いずれもマージ済み）

## テスト

- `pnpm --filter @pdfmod/core test` → **155 files / 2186 tests passed**
- `pnpm --filter @pdfmod/core build` → 成功
- `pnpm --filter @pdfmod/core typecheck`（`tsc --noEmit`・テストファイル含む）→ エラーなし
- `pnpm lint`（biome + oxlint）→ 0 errors
- 既存統合テスト（`interpreter.dispatch` / `graphics-state-operators.integration`）は**無修正で** green
- Codex レビュー（spec-implement）→ **問題なし**

## レビューポイント

- **A1（textState の浅いマージ意味論）**: `update({ textState })` は textState を丸ごと差し替える浅いマージ。内部のネストマージは行わない（既存全フィールドと同一方式）。
- **スタイル例外**: プロジェクト規約は「三項演算子より if」だが、既存 `update` が全フィールド三項演算子で統一されているため一貫性優先で既存スタイルを踏襲。
- 偽陽性回避: 差し替え系テストは default と区別できる非デフォルト fixture（textState は `charSpace: 2`、textObject は `begin()`）を使用。

🤖 Generated with [Claude Code](https://claude.com/claude-code)