### PR TITLE
✨ [New Feature]: Tf オペレータハンドラ（font and font size）を実装

### DIFF
--- a/packages/core/src/content-stream/operators/text/tf/__tests__/tf.basic.test.ts
+++ b/packages/core/src/content-stream/operators/text/tf/__tests__/tf.basic.test.ts
@@ -1,0 +1,109 @@
+import { assert, expect, test } from "vitest";
+import type { PdfObject } from "../../../../../pdf/types/pdf-types/index";
+import { GraphicsStateStack } from "../../../../graphics-state/index";
+import { OperandStack } from "../../../../operand-stack/index";
+import type { OperatorHandlerContext } from "../../../../operator-registry/index";
+import { tfHandler } from "../index";
+
+const buildContext = (operands: PdfObject[]): OperatorHandlerContext => {
+  const operandStack = OperandStack.create();
+  for (const operand of operands) {
+    OperandStack.push(operandStack, operand);
+  }
+  const graphicsStateStack = GraphicsStateStack.create();
+  return { operandStack, graphicsStateStack };
+};
+
+test("/F1 12 Tf で fontName=some('F1'), fontSize=12 に更新される", () => {
+  const ctx = buildContext([
+    { type: "name", value: "F1" },
+    { type: "integer", value: 12 },
+  ]);
+
+  const result = tfHandler(ctx);
+
+  assert(result.ok);
+  const current = GraphicsStateStack.current(result.value.graphicsStateStack);
+  assert(current.textState.fontName.some);
+  expect(current.textState.fontName.value).toBe("F1");
+  expect(current.textState.fontSize).toBe(12);
+});
+
+test("size が real(10.5) でも fontName=some('F2'), fontSize=10.5 に更新される", () => {
+  const ctx = buildContext([
+    { type: "name", value: "F2" },
+    { type: "real", value: 10.5 },
+  ]);
+
+  const result = tfHandler(ctx);
+
+  assert(result.ok);
+  const current = GraphicsStateStack.current(result.value.graphicsStateStack);
+  assert(current.textState.fontName.some);
+  expect(current.textState.fontName.value).toBe("F2");
+  expect(current.textState.fontSize).toBe(10.5);
+});
+
+test("font 値が空文字でも fontName=some('') に更新される", () => {
+  const ctx = buildContext([
+    { type: "name", value: "" },
+    { type: "integer", value: 12 },
+  ]);
+
+  const result = tfHandler(ctx);
+
+  assert(result.ok);
+  const current = GraphicsStateStack.current(result.value.graphicsStateStack);
+  assert(current.textState.fontName.some);
+  expect(current.textState.fontName.value).toBe("");
+});
+
+test("fontName/fontSize 更新後も textState の他フィールドは不変", () => {
+  const ctx = buildContext([
+    { type: "name", value: "F1" },
+    { type: "integer", value: 12 },
+  ]);
+  const before = GraphicsStateStack.current(ctx.graphicsStateStack).textState;
+
+  const result = tfHandler(ctx);
+
+  assert(result.ok);
+  const after = GraphicsStateStack.current(
+    result.value.graphicsStateStack,
+  ).textState;
+  expect(after.charSpace).toBe(before.charSpace);
+  expect(after.wordSpace).toBe(before.wordSpace);
+  expect(after.horizontalScaling).toBe(before.horizontalScaling);
+  expect(after.leading).toBe(before.leading);
+  expect(after.renderingMode).toBe(before.renderingMode);
+  expect(after.rise).toBe(before.rise);
+});
+
+test("成功時に operand が 2 個とも消費され depth が 0 になる", () => {
+  const ctx = buildContext([
+    { type: "name", value: "F1" },
+    { type: "integer", value: 12 },
+  ]);
+
+  const result = tfHandler(ctx);
+
+  assert(result.ok);
+  expect(OperandStack.depth(result.value.operandStack)).toBe(0);
+});
+
+test("余剰 operand は残り、Tf は末尾 2 個のみ消費する", () => {
+  const surplus: PdfObject = { type: "integer", value: 99 };
+  const ctx = buildContext([
+    surplus,
+    { type: "name", value: "F1" },
+    { type: "integer", value: 12 },
+  ]);
+
+  const result = tfHandler(ctx);
+
+  assert(result.ok);
+  expect(OperandStack.depth(result.value.operandStack)).toBe(1);
+  const top = OperandStack.peek(result.value.operandStack);
+  assert(top.some);
+  expect(top.value).toEqual(surplus);
+});

--- a/packages/core/src/content-stream/operators/text/tf/__tests__/tf.error.test.ts
+++ b/packages/core/src/content-stream/operators/text/tf/__tests__/tf.error.test.ts
@@ -1,0 +1,134 @@
+import { assert, expect, test } from "vitest";
+import type { PdfObject } from "../../../../../pdf/types/pdf-types/index";
+import { GraphicsStateStack } from "../../../../graphics-state/index";
+import { OperandStack } from "../../../../operand-stack/index";
+import type { OperatorHandlerContext } from "../../../../operator-registry/index";
+import { tfHandler } from "../index";
+
+const buildContext = (operands: PdfObject[]): OperatorHandlerContext => {
+  const operandStack = OperandStack.create();
+  for (const operand of operands) {
+    OperandStack.push(operandStack, operand);
+  }
+  const graphicsStateStack = GraphicsStateStack.create();
+  return { operandStack, graphicsStateStack };
+};
+
+test("operand 0 個では MISSING（required:2, actual:0）を返す", () => {
+  const ctx = buildContext([]);
+
+  const result = tfHandler(ctx);
+
+  assert(!result.ok);
+  assert(result.error.code === "OPERATOR_OPERAND_MISSING");
+  expect(result.error.operatorName).toBe("Tf");
+  expect(result.error.required).toBe(2);
+  expect(result.error.actual).toBe(0);
+  expect(result.error.message).toBe(
+    "Operator 'Tf' requires 2 operand(s), got 0",
+  );
+});
+
+test("有効な数値 1 個のみでは MISSING（required:2, actual:1）を返す", () => {
+  const ctx = buildContext([{ type: "integer", value: 12 }]);
+
+  const result = tfHandler(ctx);
+
+  assert(!result.ok);
+  assert(result.error.code === "OPERATOR_OPERAND_MISSING");
+  expect(result.error.operatorName).toBe("Tf");
+  expect(result.error.required).toBe(2);
+  expect(result.error.actual).toBe(1);
+  expect(result.error.message).toBe(
+    "Operator 'Tf' requires 2 operand(s), got 1",
+  );
+});
+
+test("size 位置が非数値なら MISMATCH（expected:'number', actual:'name'）を返す", () => {
+  const ctx = buildContext([
+    { type: "name", value: "F1" },
+    { type: "name", value: "X" },
+  ]);
+
+  const result = tfHandler(ctx);
+
+  assert(!result.ok);
+  assert(result.error.code === "OPERATOR_OPERAND_TYPE_MISMATCH");
+  expect(result.error.operatorName).toBe("Tf");
+  expect(result.error.expected).toBe("number");
+  expect(result.error.actual).toBe("name");
+  expect(result.error.message).toBe(
+    "Operator 'Tf' expected number operand, got name",
+  );
+});
+
+test("頂上=数値・その下=boolean なら MISMATCH（expected:'name', actual:'boolean'）を返す", () => {
+  const ctx = buildContext([
+    { type: "boolean", value: true },
+    { type: "integer", value: 12 },
+  ]);
+
+  const result = tfHandler(ctx);
+
+  assert(!result.ok);
+  assert(result.error.code === "OPERATOR_OPERAND_TYPE_MISMATCH");
+  expect(result.error.operatorName).toBe("Tf");
+  expect(result.error.expected).toBe("name");
+  expect(result.error.actual).toBe("boolean");
+  expect(result.error.message).toBe(
+    "Operator 'Tf' expected name operand, got boolean",
+  );
+});
+
+test.each<[string, PdfObject]>([
+  ["boolean", { type: "boolean", value: true }],
+  ["null", { type: "null" }],
+  [
+    "string",
+    { type: "string", value: new Uint8Array([0x61]), encoding: "literal" },
+  ],
+  ["integer", { type: "integer", value: 1 }],
+  ["array", { type: "array", elements: [] }],
+])("font 位置が %s なら MISMATCH（expected:'name'）を返す", (type, fontOperand) => {
+  const ctx = buildContext([fontOperand, { type: "integer", value: 12 }]);
+
+  const result = tfHandler(ctx);
+
+  assert(!result.ok);
+  assert(result.error.code === "OPERATOR_OPERAND_TYPE_MISMATCH");
+  expect(result.error.expected).toBe("name");
+  expect(result.error.actual).toBe(type);
+});
+
+test("MISSING actual:1 後も部分消費した operand は復元せず depth=0", () => {
+  const ctx = buildContext([{ type: "integer", value: 12 }]);
+
+  const result = tfHandler(ctx);
+
+  assert(!result.ok);
+  expect(OperandStack.depth(ctx.operandStack)).toBe(0);
+});
+
+test("MISMATCH 'number' 後は size 位置のみ pop され depth=1", () => {
+  const ctx = buildContext([
+    { type: "name", value: "F1" },
+    { type: "name", value: "X" },
+  ]);
+
+  const result = tfHandler(ctx);
+
+  assert(!result.ok);
+  expect(OperandStack.depth(ctx.operandStack)).toBe(1);
+});
+
+test("MISMATCH 'name' 後は size・font とも pop され（非復元）depth=0", () => {
+  const ctx = buildContext([
+    { type: "boolean", value: true },
+    { type: "integer", value: 12 },
+  ]);
+
+  const result = tfHandler(ctx);
+
+  assert(!result.ok);
+  expect(OperandStack.depth(ctx.operandStack)).toBe(0);
+});

--- a/packages/core/src/content-stream/operators/text/tf/index.ts
+++ b/packages/core/src/content-stream/operators/text/tf/index.ts
@@ -1,0 +1,98 @@
+import type { PdfError } from "../../../../pdf/errors/index";
+import { PdfName } from "../../../../pdf/types/pdf-types/index";
+import { some } from "../../../../utils/option/index";
+import { err, ok } from "../../../../utils/result/index";
+import {
+  GraphicsState,
+  GraphicsStateStack,
+  TextState,
+} from "../../../graphics-state/index";
+import { OperandStack } from "../../../operand-stack/index";
+import type {
+  OperatorHandler,
+  OperatorHandlerContext,
+} from "../../../operator-registry/index";
+import { NumericPdfObject } from "../../graphics-state/numeric-pdf-object/index";
+
+const OPERATOR_NAME = "Tf";
+const OPERAND_COUNT = 2;
+
+/**
+ * PDF §9.3.1 `Tf` operator (font and font size) のハンドラ。
+ *
+ * operand (PDF 順): `font` (name) `size` (number)。スタック頂上は size のため
+ * size → font の順に 2 回 pop し、`textState.fontName` / `textState.fontSize` を更新する。
+ *
+ * - operand 不足: `OPERATOR_OPERAND_MISSING`（actual = pop 成功数 / required = 2）
+ * - 型不一致: `OPERATOR_OPERAND_TYPE_MISMATCH`（size は "number"、font は "name"）
+ * - エラー時に部分消費した operand stack は復元しない（既存ハンドラ規約）
+ * - `Tf` は BT/ET の外でも呼べるため `textObject.active` は検査しない
+ *
+ * @param context - 実行コンテキスト (operand stack / graphics state stack)
+ * @returns 成功なら更新後コンテキスト、失敗なら PdfError
+ */
+export const tfHandler: OperatorHandler = (context: OperatorHandlerContext) => {
+  const poppedSize = OperandStack.pop(context.operandStack);
+  if (!poppedSize.some) {
+    const error: PdfError = {
+      code: "OPERATOR_OPERAND_MISSING",
+      message: `Operator '${OPERATOR_NAME}' requires ${OPERAND_COUNT} operand(s), got 0`,
+      operatorName: OPERATOR_NAME,
+      required: OPERAND_COUNT,
+      actual: 0,
+    };
+    return err(error);
+  }
+
+  const size = poppedSize.value;
+  if (!NumericPdfObject.is(size)) {
+    const error: PdfError = {
+      code: "OPERATOR_OPERAND_TYPE_MISMATCH",
+      message: `Operator '${OPERATOR_NAME}' expected number operand, got ${size.type}`,
+      operatorName: OPERATOR_NAME,
+      expected: "number",
+      actual: size.type,
+    };
+    return err(error);
+  }
+
+  const poppedFont = OperandStack.pop(context.operandStack);
+  if (!poppedFont.some) {
+    const error: PdfError = {
+      code: "OPERATOR_OPERAND_MISSING",
+      message: `Operator '${OPERATOR_NAME}' requires ${OPERAND_COUNT} operand(s), got 1`,
+      operatorName: OPERATOR_NAME,
+      required: OPERAND_COUNT,
+      actual: 1,
+    };
+    return err(error);
+  }
+
+  const font = poppedFont.value;
+  if (!PdfName.is(font)) {
+    const error: PdfError = {
+      code: "OPERATOR_OPERAND_TYPE_MISMATCH",
+      message: `Operator '${OPERATOR_NAME}' expected name operand, got ${font.type}`,
+      operatorName: OPERATOR_NAME,
+      expected: "name",
+      actual: font.type,
+    };
+    return err(error);
+  }
+
+  const current = GraphicsStateStack.current(context.graphicsStateStack);
+  const nextTextState = TextState.update(current.textState, {
+    fontName: some(font.value),
+    fontSize: size.value,
+  });
+  const next = GraphicsState.update(current, { textState: nextTextState });
+  const graphicsStateStack = GraphicsStateStack.replaceCurrent(
+    context.graphicsStateStack,
+    next,
+  );
+
+  return ok({
+    operandStack: context.operandStack,
+    graphicsStateStack,
+  });
+};

--- a/packages/core/src/pdf/types/pdf-types/__tests__/pdf-name.basic.test.ts
+++ b/packages/core/src/pdf/types/pdf-types/__tests__/pdf-name.basic.test.ts
@@ -1,0 +1,37 @@
+import { expect, test } from "vitest";
+import type { PdfObject } from "../index";
+import { PdfName } from "../index";
+
+test.each<[string, PdfObject]>([
+  ["name 空文字", { type: "name", value: "" }],
+  ["name 通常値", { type: "name", value: "F1" }],
+])("PdfName.is は %s に対して true を返す", (_label, operand) => {
+  expect(PdfName.is(operand)).toBe(true);
+});
+
+test.each<[string, PdfObject]>([
+  ["null", { type: "null" }],
+  ["boolean", { type: "boolean", value: true }],
+  ["integer", { type: "integer", value: 1 }],
+  ["real", { type: "real", value: 1.5 }],
+  [
+    "string",
+    { type: "string", value: new Uint8Array([0x61]), encoding: "literal" },
+  ],
+  ["array", { type: "array", elements: [] }],
+  ["dictionary", { type: "dictionary", entries: new Map() }],
+  [
+    "indirect-ref",
+    { type: "indirect-ref", objectNumber: 1, generationNumber: 0 },
+  ],
+  [
+    "stream",
+    {
+      type: "stream",
+      dictionary: { type: "dictionary", entries: new Map() },
+      data: new Uint8Array(),
+    },
+  ],
+])("PdfName.is は %s に対して false を返す", (_label, operand) => {
+  expect(PdfName.is(operand)).toBe(false);
+});

--- a/packages/core/src/pdf/types/pdf-types/index.ts
+++ b/packages/core/src/pdf/types/pdf-types/index.ts
@@ -100,6 +100,24 @@ export interface PdfName {
 }
 
 /**
+ * `PdfName` の判定関数を束ねた companion object。
+ * 型と value を同一識別子で公開する declaration merging パターン
+ * (`NumericPdfObject` と同流儀)。`.create()` はカテゴリ系 union ではないため追加しない。
+ */
+export const PdfName = {
+  /**
+   * PdfObject が name オブジェクトであるかを判定する type guard。
+   * Tf など name operand を取るオペレータが共通で行う型チェック。
+   *
+   * @param operand - 判定対象の PdfObject
+   * @returns name なら true
+   */
+  is(operand: PdfObject): operand is PdfName {
+    return operand.type === "name";
+  },
+} as const;
+
+/**
  * 配列オブジェクト (ISO 32000 7.3.6)。
  * 要素は PdfValue に限定され、stream を含むことはできない。
  */


### PR DESCRIPTION
## 概要

spec 071-tf-operator-handler。PDF §9.3.1 のテキストオペレータ `Tf`（font and font size）のハンドラを新規実装する。operand stack から `size`(number) と `font`(PdfName) を pop し、現在の GraphicsState の `textState.fontName` / `textState.fontSize` を更新して `GraphicsStateStack.replaceCurrent` で新 state を積む。あわせて name operand 用の共通 type guard `PdfName.is()` を新設する。

## 変更の種類

- ✨ New Feature（`tfHandler` / `PdfName.is()` の新設）
- 🧪 Tests（正常系・異常系・型ガードの runtime テスト）

## 追加した内容

- `packages/core/src/content-stream/operators/text/tf/index.ts` — `tfHandler` 本体
- `packages/core/src/pdf/types/pdf-types/index.ts` — `PdfName` companion object + `.is()` 型ガード（declaration merging、`NumericPdfObject` と同流儀。`.create()` は追加しない）
- `packages/core/src/content-stream/operators/text/tf/__tests__/tf.basic.test.ts` — 正常系（6 tests）
- `packages/core/src/content-stream/operators/text/tf/__tests__/tf.error.test.ts` — 異常系（12 tests）
- `packages/core/src/pdf/types/pdf-types/__tests__/pdf-name.basic.test.ts` — `PdfName.is()` runtime テスト（11 tests）

## システム図

`tfHandler(context)` の処理フロー。スタック頂上は size のため size → font の順に pop する。

```mermaid
flowchart TD
    start([tfHandler context]) --> popSize["OperandStack.pop ①= size 頂上"]
    popSize -->|none| missing0["err: MISSING required:2 actual:0"]
    popSize -->|some| chkSize{"NumericPdfObject.is size?"}
    chkSize -->|false| mismatchNum["err: MISMATCH expected:number"]
    chkSize -->|true| popFont["OperandStack.pop ②= font name"]
    popFont -->|none| missing1["err: MISSING required:2 actual:1"]
    popFont -->|some| chkFont{"PdfName.is font?"}
    chkFont -->|false| mismatchName["err: MISMATCH expected:name"]
    chkFont -->|true| update["TextState.update fontName=some, fontSize<br/>→ GraphicsState.update<br/>→ GraphicsStateStack.replaceCurrent"]
    update --> okEnd([ok: operandStack / graphicsStateStack])

    style popSize fill:#e3f2fd
    style popFont fill:#e3f2fd
    style update fill:#c8e6c9
```

## 関連 spec / Issue

- spec: `.plugin-workspace/.specs/071-tf-operator-handler`
- Closes #233（親 Epic: #228 / blocked by #232 は解消済み）

## テスト

- `pnpm --filter @pdfmod/core test` — **158 files / 2215 tests 全 green**（新規 3 ファイル / 29 tests 含む。既存リグレッションなし）
- `pnpm --filter @pdfmod/core build` — 成功
- `pnpm --filter @pdfmod/core typecheck` — 成功
- oxlint — 0 errors
- Codex レビュー — **「問題なし」**（Codex 自身が対象 3 ファイル 29 tests を再実行し green を確認）

## レビューポイント

- **pop 順が load-bearing**: `/F1 12 Tf` は頂上が size。1 回目 pop = size（`NumericPdfObject.is`）→ 2 回目 pop = font（`PdfName.is`）の順。型が混在するため cm 風ループにはしていない。
- **エラー時の operand stack 部分消費は復元しない**（既存ハンドラ規約。`actual` は pop 成功個数）。テストで MISMATCH "number" 後 depth=1 / "name" 後 depth=0 を実機確認済み。
- **throw 禁止・全 Result**、値の有無は `Option`（`fontName` は `some(font.value)`）。
- `Tf` は単体ハンドラとして実装（operator registry への登録は本 spec のスコープ外＝論点2→A）。end-to-end 実行は後続の wiring タスクで対応。
- テストは describe 不使用フラット構造、各ファイル冒頭にローカル `buildContext`（共通 util 化しない規約に準拠）。