### PR TITLE
🔧 [Config]: biome の worktree 除外をアンカー付きパターンに修正

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -11,7 +11,7 @@
       "packages/*/tsconfig*.json",
       "vitest*.ts",
       ".storybook/**",
-      "!**/.claude/worktrees"
+      "!.claude/worktrees"
     ]
   },
   "formatter": {


### PR DESCRIPTION
## 概要

worktree 内から `pnpm lint`（`biome check .`）を実行すると **必ず失敗する**問題を修正します。push 前フックが lint を走らせるため、`.claude/worktrees/` 配下の worktree からは push が常にブロックされていました。

## 原因

biome.json の除外パターン `!**/.claude/worktrees` は先頭 `**/` によりどの階層の `.claude/worktrees` にもマッチします。worktree の絶対パスは `/.../.claude/worktrees/<name>` のためこのパターン配下に入り、**worktree 全体が除外**されます。結果、biome は対象 0 件となり「No files were processed」でエラー終了していました。

```
× No files were processed in the specified paths.
  These paths were provided but ignored:
  - .
```

## 修正

config ディレクトリ基準のアンカー付きパターン `!.claude/worktrees` に変更します。

```diff
-      "!**/.claude/worktrees"
+      "!.claude/worktrees"
```

- **main リポジトリ基準**: `.claude/worktrees` を従来通り除外（nested config 回避という元の目的は維持）
- **worktree 内**: worktree 自身のファイルが除外されなくなり、正しく lint 対象になる

## 確認

- worktree 内で `biome check .` → **316 ファイルを処理・エラーゼロ**（修正前は 0 files でエラー）
- 本ブランチを push 前フックの lint が通過

## 変更種類

- [x] 設定（lint config）

## 影響範囲

- lint 設定のみ。アプリ・ライブラリのコードには影響なし。
