### PR TITLE
✨ [New Feature]: Tw オペレータハンドラ（word spacing）を実装

### DIFF
--- a/packages/core/src/content-stream/operators/text/tw/__tests__/tw.basic.test.ts
+++ b/packages/core/src/content-stream/operators/text/tw/__tests__/tw.basic.test.ts
@@ -1,0 +1,106 @@
+import { assert, expect, test } from "vitest";
+import type { PdfObject } from "../../../../../pdf/types/pdf-types/index";
+import {
+  GraphicsState,
+  GraphicsStateStack,
+  TextState,
+} from "../../../../graphics-state/index";
+import { OperandStack } from "../../../../operand-stack/index";
+import type { OperatorHandlerContext } from "../../../../operator-registry/index";
+import { twHandler } from "../index";
+
+const buildContext = (operands: PdfObject[]): OperatorHandlerContext => {
+  const operandStack = OperandStack.create();
+  for (const operand of operands) {
+    OperandStack.push(operandStack, operand);
+  }
+  const graphicsStateStack = GraphicsStateStack.create();
+  return { operandStack, graphicsStateStack };
+};
+
+test("'5 Tw' で wordSpace が 5 に更新される", () => {
+  const context = buildContext([{ type: "integer", value: 5 }]);
+  const result = twHandler(context);
+
+  assert(result.ok);
+  const current = GraphicsStateStack.current(result.value.graphicsStateStack);
+  expect(current.textState.wordSpace).toBe(5);
+});
+
+test("非0 の wordSpace に '0 Tw' を適用すると 0 にリセットされる", () => {
+  const first = twHandler(buildContext([{ type: "integer", value: 5 }]));
+  assert(first.ok);
+
+  const reset = twHandler({
+    operandStack: buildContext([{ type: "integer", value: 0 }]).operandStack,
+    graphicsStateStack: first.value.graphicsStateStack,
+  });
+
+  assert(reset.ok);
+  const current = GraphicsStateStack.current(reset.value.graphicsStateStack);
+  expect(current.textState.wordSpace).toBe(0);
+});
+
+test.each<[string, PdfObject, number]>([
+  ["小数", { type: "real", value: 2.5 }, 2.5],
+  ["負値", { type: "real", value: -2.5 }, -2.5],
+  ["NaN", { type: "real", value: Number.NaN }, Number.NaN],
+  [
+    "Infinity",
+    { type: "real", value: Number.POSITIVE_INFINITY },
+    Number.POSITIVE_INFINITY,
+  ],
+])("境界値 '%s' の operand も値域検証せず wordSpace に格納する", (_label, operand, expected) => {
+  const context = buildContext([operand]);
+  const result = twHandler(context);
+
+  assert(result.ok);
+  const current = GraphicsStateStack.current(result.value.graphicsStateStack);
+  expect(current.textState.wordSpace).toBe(expected);
+});
+
+test("wordSpace 更新時、非デフォルト値の他フィールドは保持される", () => {
+  const seeded = GraphicsStateStack.create();
+  const current = GraphicsStateStack.current(seeded);
+  const seededTextState = TextState.update(current.textState, {
+    charSpace: 3,
+    leading: 7,
+  });
+  const graphicsStateStack = GraphicsStateStack.replaceCurrent(
+    seeded,
+    GraphicsState.update(current, { textState: seededTextState }),
+  );
+  const result = twHandler({
+    operandStack: buildContext([{ type: "integer", value: 5 }]).operandStack,
+    graphicsStateStack,
+  });
+
+  assert(result.ok);
+  const after = GraphicsStateStack.current(
+    result.value.graphicsStateStack,
+  ).textState;
+  expect(after.wordSpace).toBe(5);
+  expect(after.charSpace).toBe(3);
+  expect(after.leading).toBe(7);
+});
+
+test("成功時に operand が消費され depth が 0 になる", () => {
+  const context = buildContext([{ type: "integer", value: 5 }]);
+  const result = twHandler(context);
+
+  assert(result.ok);
+  expect(OperandStack.depth(result.value.operandStack)).toBe(0);
+});
+
+test("余剰 operand があっても末尾 1 個のみ pop する", () => {
+  const context = buildContext([
+    { type: "integer", value: 1 },
+    { type: "integer", value: 5 },
+  ]);
+  const result = twHandler(context);
+
+  assert(result.ok);
+  const current = GraphicsStateStack.current(result.value.graphicsStateStack);
+  expect(current.textState.wordSpace).toBe(5);
+  expect(OperandStack.depth(result.value.operandStack)).toBe(1);
+});

--- a/packages/core/src/content-stream/operators/text/tw/__tests__/tw.error.test.ts
+++ b/packages/core/src/content-stream/operators/text/tw/__tests__/tw.error.test.ts
@@ -1,0 +1,66 @@
+import { assert, expect, test } from "vitest";
+import type { PdfObject } from "../../../../../pdf/types/pdf-types/index";
+import { GraphicsStateStack } from "../../../../graphics-state/index";
+import { OperandStack } from "../../../../operand-stack/index";
+import type { OperatorHandlerContext } from "../../../../operator-registry/index";
+import { twHandler } from "../index";
+
+const buildContext = (operands: PdfObject[]): OperatorHandlerContext => {
+  const operandStack = OperandStack.create();
+  for (const operand of operands) {
+    OperandStack.push(operandStack, operand);
+  }
+  const graphicsStateStack = GraphicsStateStack.create();
+  return { operandStack, graphicsStateStack };
+};
+
+test("operand が 0 個のとき OPERATOR_OPERAND_MISSING を返す", () => {
+  const context = buildContext([]);
+  const result = twHandler(context);
+
+  assert(!result.ok);
+  assert(result.error.code === "OPERATOR_OPERAND_MISSING");
+  expect(result.error.operatorName).toBe("Tw");
+  expect(result.error.required).toBe(1);
+  expect(result.error.actual).toBe(0);
+  expect(result.error.message).toBe(
+    "Operator 'Tw' requires 1 operand(s), got 0",
+  );
+});
+
+test.each<[string, PdfObject]>([
+  ["name", { type: "name", value: "F1" }],
+  ["boolean", { type: "boolean", value: true }],
+  ["null", { type: "null" }],
+  [
+    "string",
+    { type: "string", value: new Uint8Array([0x61]), encoding: "literal" },
+  ],
+  ["array", { type: "array", elements: [] }],
+])("operand が %s のとき OPERATOR_OPERAND_TYPE_MISMATCH を返す", (typeName, operand) => {
+  const context = buildContext([operand]);
+  const result = twHandler(context);
+
+  assert(!result.ok);
+  assert(result.error.code === "OPERATOR_OPERAND_TYPE_MISMATCH");
+  expect(result.error.operatorName).toBe("Tw");
+  expect(result.error.expected).toBe("number");
+  expect(result.error.actual).toBe(typeName);
+  expect(result.error.message).toBe(
+    `Operator 'Tw' expected number operand, got ${typeName}`,
+  );
+});
+
+test("MISMATCH 後も部分消費した operand は復元せず、余剰 operand のみ残る", () => {
+  const surplus: PdfObject = { type: "integer", value: 99 };
+  const context = buildContext([surplus, { type: "name", value: "F1" }]);
+
+  const result = twHandler(context);
+
+  assert(!result.ok);
+  assert(result.error.code === "OPERATOR_OPERAND_TYPE_MISMATCH");
+  expect(OperandStack.depth(context.operandStack)).toBe(1);
+  const top = OperandStack.peek(context.operandStack);
+  assert(top.some);
+  expect(top.value).toEqual(surplus);
+});

--- a/packages/core/src/content-stream/operators/text/tw/index.ts
+++ b/packages/core/src/content-stream/operators/text/tw/index.ts
@@ -1,0 +1,69 @@
+import type { PdfError } from "../../../../pdf/errors/index";
+import { err, ok } from "../../../../utils/result/index";
+import {
+  GraphicsState,
+  GraphicsStateStack,
+  TextState,
+} from "../../../graphics-state/index";
+import { OperandStack } from "../../../operand-stack/index";
+import type {
+  OperatorHandler,
+  OperatorHandlerContext,
+} from "../../../operator-registry/index";
+import { NumericPdfObject } from "../../graphics-state/numeric-pdf-object/index";
+
+const OPERATOR_NAME = "Tw";
+
+/**
+ * PDF §9.3.3 `Tw` operator (word spacing) のハンドラ。
+ * operand を 1 個 pop し、number であれば `textState.wordSpace` を更新する。
+ *
+ * - operand stack が空なら `OPERATOR_OPERAND_MISSING` を返す
+ * - 末尾が number 以外なら `OPERATOR_OPERAND_TYPE_MISMATCH` を返す
+ * - 値域検証はしない（負値・小数・`0`・`NaN`・`Infinity` をそのまま格納する）
+ * - エラー時に部分消費した operand stack は復元しない（既存ハンドラ規約）
+ * - `Tw` は BT/ET の外でも呼べるため `textObject.active` は検査しない
+ *
+ * @param context - 実行コンテキスト (operand stack / graphics state stack)
+ * @returns 成功なら更新後コンテキスト、失敗なら PdfError
+ */
+export const twHandler: OperatorHandler = (context: OperatorHandlerContext) => {
+  const popped = OperandStack.pop(context.operandStack);
+  if (!popped.some) {
+    const error: PdfError = {
+      code: "OPERATOR_OPERAND_MISSING",
+      message: `Operator '${OPERATOR_NAME}' requires 1 operand(s), got 0`,
+      operatorName: OPERATOR_NAME,
+      required: 1,
+      actual: 0,
+    };
+    return err(error);
+  }
+
+  const operand = popped.value;
+  if (!NumericPdfObject.is(operand)) {
+    const error: PdfError = {
+      code: "OPERATOR_OPERAND_TYPE_MISMATCH",
+      message: `Operator '${OPERATOR_NAME}' expected number operand, got ${operand.type}`,
+      operatorName: OPERATOR_NAME,
+      expected: "number",
+      actual: operand.type,
+    };
+    return err(error);
+  }
+
+  const current = GraphicsStateStack.current(context.graphicsStateStack);
+  const nextTextState = TextState.update(current.textState, {
+    wordSpace: operand.value,
+  });
+  const next = GraphicsState.update(current, { textState: nextTextState });
+  const graphicsStateStack = GraphicsStateStack.replaceCurrent(
+    context.graphicsStateStack,
+    next,
+  );
+
+  return ok({
+    operandStack: context.operandStack,
+    graphicsStateStack,
+  });
+};


### PR DESCRIPTION
## 概要

PDF content stream のテキストオペレータ `Tw`（word spacing, ISO 32000-1 §9.3.3）のハンドラ `twHandler` を新規追加する。既存 `Tc`（character spacing, #250, §9.3.2）と完全に同一 shape のため、`tcHandler` の **4 点置換**による忠実なクローンとして導出した（新規発明ロジックゼロ）。ディスパッチャ登録（`OperatorRegistry.register`）は本 Issue スコープ外（後続 Issue）。

## 変更の種類

✨ New Feature / 🧪 Tests

## 追加した内容

- `packages/core/src/content-stream/operators/text/tw/index.ts` — `twHandler` を export
- `packages/core/src/content-stream/operators/text/tw/__tests__/tw.basic.test.ts` — 正常系・境界値・状態保持・状態整合（9 ケース）
- `packages/core/src/content-stream/operators/text/tw/__tests__/tw.error.test.ts` — operand 不足・型不一致・stack 非復元（7 ケース）

`tcHandler` からの差分は 4 点のみ: `OPERATOR_NAME="Tw"` / JSDoc §9.3.3・word spacing / 更新フィールド `charSpace`→`wordSpace` / テストの operator 名・フィールド名・期待値。

## システム図

```mermaid
flowchart TD
    Start["twHandler(context)"] --> Pop["OperandStack.pop"]
    Pop -->|"some === false"| Missing["err: OPERATOR_OPERAND_MISSING<br/>operatorName:Tw / required:1 / actual:0"]
    Pop -->|"some === true"| TypeCheck{"NumericPdfObject.is(operand)"}
    TypeCheck -->|"false"| Mismatch["err: OPERATOR_OPERAND_TYPE_MISMATCH<br/>expected:number / actual:type"]
    TypeCheck -->|"true (integer/real)"| Update["TextState.update(textState, { wordSpace: operand.value })<br/>→ GraphicsState.update → replaceCurrent"]
    Update --> Ok["ok({ operandStack, graphicsStateStack })"]
    style Update fill:#1f6feb,color:#fff
```

## 関連 spec / Issue

- spec: `.plugin-workspace/.specs/archive/001-tw-operator-handler`
- Closes #235

## テスト

- `pnpm --filter @pdfmod/core test` → **162 files / 2247 tests passed**（tw 単体: basic 9 + error 7 = 16）
- `tsc --noEmit` → エラーなし
- `pnpm lint`（Biome + oxlint）→ 319 files / 0 warnings / 0 errors
- spec-review（performance / design / spec-alignment の 3 エージェント並列レビュー）→ CRITICAL 0 / WARNING 0 / INFO 1 / PROTECTED 7、DoD 12/12 充足
- Codex レビュー → 問題なし

## レビューポイント

- `tcHandler` の 4 点置換が漏れなく適用され、`Tc`/`charSpace`/`tcHandler` 識別子の取り残しがないこと
- throw を使わず全エラーパスが `err(...)` を返すこと（throw 禁止規約）
- 値域検証なし（`0`/負値/小数/`NaN`/`Infinity` をそのまま `wordSpace` に格納）が `0 Tw` リセット動作と整合していること
- 状態保持テストの `charSpace` seed は「`Tw` が他フィールドを破壊しない」検証のための意図的 seed（コピペ残しではない）

🤖 Generated with [Claude Code](https://claude.com/claude-code)