### PR TITLE
✨ [New Feature]: pdfmod-core に object / error モジュール骨格を導入

### DIFF
--- a/rust/crates/core/src/error.rs
+++ b/rust/crates/core/src/error.rs
@@ -1,0 +1,8 @@
+//! PDF 処理のエラー型を定義するモジュール。
+//!
+//! PdfError / PdfErrorCode など、PDF パース・処理で発生する
+//! エラーを表す型を後続 Issue で追加する。
+
+// 後続 Issue でエラー型のサブモジュールを追加する:
+// pub mod pdf_error;
+// pub mod pdf_error_code;

--- a/rust/crates/core/src/lib.rs
+++ b/rust/crates/core/src/lib.rs
@@ -8,5 +8,7 @@
 //! - **外部 crate 依存ゼロ**。Rust 標準ライブラリ (`std`) のみを使う。
 //! - **`Result` / `Option` は std のものをそのまま使う**（自作しない）。
 //!
-//! 本クレートは現在 **環境構築のみ**（空の crate root）。
 //! 各モジュールの実装は後続 PR で追加する。
+
+pub mod object;
+pub mod error;

--- a/rust/crates/core/src/object.rs
+++ b/rust/crates/core/src/object.rs
@@ -4,7 +4,7 @@
 //! array / dictionary / stream / null / indirect reference）を表す型を
 //! 後続 Issue で追加する。
 
-// 後続 Issue で各オブジェクト型のサブモジュールを追加する:
+// 後続 Issue で各オブジェクト型をサブモジュールとして追加する（以下は例の一部）:
 // pub mod boolean;
 // pub mod numeric;
 // pub mod string;

--- a/rust/crates/core/src/object.rs
+++ b/rust/crates/core/src/object.rs
@@ -1,0 +1,10 @@
+//! PDF オブジェクト型を定義するモジュール。
+//!
+//! ISO 32000 の PDF オブジェクト（boolean / numeric / string / name /
+//! array / dictionary / stream / null / indirect reference）を表す型を
+//! 後続 Issue で追加する。
+
+// 後続 Issue で各オブジェクト型のサブモジュールを追加する:
+// pub mod boolean;
+// pub mod numeric;
+// pub mod string;


### PR DESCRIPTION
## 概要

spec-073 (Issue #254)。`pdfmod-core` crate に最初のモジュール骨格を導入する。`lib.rs` に `pub mod object;` `pub mod error;` を宣言し、非 mod.rs スタイルで `object.rs` / `error.rs` を新規作成する。型・実行ロジックは含めず、doc コメントと後続 Issue 用のコメントアウトされたプレースホルダのみを配置する（テストは後続 Issue で各型実装と同時に追加）。

## 変更の種類

- ✨ New Feature（モジュール骨格の導入）

## 追加した内容

- `rust/crates/core/src/object.rs` — PDF オブジェクト型モジュール。doc コメント + コメントアウトされたサブモジュールプレースホルダ
- `rust/crates/core/src/error.rs` — PDF エラー型モジュール。doc コメント + コメントアウトされたサブモジュールプレースホルダ

## 変更した内容

- `rust/crates/core/src/lib.rs` — `pub mod object;` `pub mod error;` を追加。「空の crate root」記述を削除

## システム図

```mermaid
flowchart TD
    lib["lib.rs (crate root)"]
    obj["object.rs [NEW]<br/>//! doc + コメントアウト済み placeholder"]
    err["error.rs [NEW]<br/>//! doc + コメントアウト済み placeholder"]
    lib -->|"pub mod object; [NEW]"| obj
    lib -->|"pub mod error; [NEW]"| err
    style obj fill:#e6ffe6
    style err fill:#e6ffe6
```

## 関連 spec / Issue

- spec: `.plugin-workspace/.specs/073-rust-core-crate-skeleton`
- 親 Epic: #251
- Closes #254

## テスト

骨格 PR のため本 PR にユニットテストは含めない（型・関数・分岐が存在せず検証可能な振る舞いがないため。後続 Issue で各型実装と同時に t-wada TDD ベースで追加予定）。受け入れ基準はビルドと lint の通過。

- `cargo build`（rust/）→ 成功
- `cargo clippy --all-targets`（rust/）→ warning なし
- `cargo clippy --all-targets -- -D warnings`（codex レビュー時に実行）→ 成功
- push 前フックの `pnpm lint` → 通過
- Codex レビュー（spec-implement）→ **問題なし**（実装計画との整合・不在条件・ビルド/lint をすべて確認）

## レビューポイント

- **非 mod.rs スタイルの維持**: 後続 Issue は `object.rs` を残したまま `object/<name>.rs` を隣に追加する。`object/mod.rs` への退行は禁止
- **プレースホルダのコメントアウト**: 実体ファイルの無い `pub mod` を生かすとビルドが「file not found for module」で失敗するため、骨格段階では必ずコメントアウトしている
- **外部依存ゼロ**: `Cargo.toml` の `[dependencies]` は空のまま（std のみ）