### PR TITLE
✨ [New Feature]: ObjectNumber newtype を pdfmod-core に追加

### DIFF
--- a/rust/crates/core/src/object.rs
+++ b/rust/crates/core/src/object.rs
@@ -4,6 +4,8 @@
 //! array / dictionary / stream / null / indirect reference）を表す型を
 //! 後続 Issue で追加する。
 
+pub mod object_number;
+
 // 後続 Issue で各オブジェクト型をサブモジュールとして追加する（以下は例の一部）:
 // pub mod boolean;
 // pub mod numeric;

--- a/rust/crates/core/src/object/object_number.rs
+++ b/rust/crates/core/src/object/object_number.rs
@@ -1,0 +1,112 @@
+//! PDF の間接オブジェクトを識別するオブジェクト番号 `ObjectNumber` を定義するモジュール。
+//!
+//! 裸の `u64` と取り違えないための newtype。間接参照・xref エントリ・キャッシュキーの
+//! 構成要素として用いる。生成は無検証（infallible）で、0 や `u64::MAX` も無条件に受理する。
+//! 0（フリーリスト先頭の予約番号）の特別扱いは xref レイヤ（R2）に委譲する。
+
+/// PDF オブジェクト番号。間接オブジェクトを一意に識別する非負整数のラッパ。
+///
+/// 内部表現は `u64`（spec §4.4 の u32 とは意図的に乖離。Issue #255 指定）。
+/// 値ラッパであり `Copy`。等価・順序・ハッシュは内部 `u64` の自然な振る舞いに従う。
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct ObjectNumber(u64);
+
+impl ObjectNumber {
+    /// 与えられた `u64` から `ObjectNumber` を生成する。
+    ///
+    /// 無検証（infallible）。0 や `u64::MAX` を含む任意の値を受理する。
+    pub fn new(n: u64) -> ObjectNumber {
+        ObjectNumber(n)
+    }
+
+    /// 内部のオブジェクト番号を `u64` として取り出す。
+    pub fn value(&self) -> u64 {
+        self.0
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+    use std::collections::HashSet;
+
+    #[test]
+    fn new_then_value_roundtrips() {
+        for n in [0, 1, 42, u64::MAX] {
+            assert_eq!(ObjectNumber::new(n).value(), n);
+        }
+    }
+
+    #[test]
+    fn accepts_zero() {
+        assert_eq!(ObjectNumber::new(0).value(), 0);
+    }
+
+    #[test]
+    fn accepts_one() {
+        assert_eq!(ObjectNumber::new(1).value(), 1);
+    }
+
+    #[test]
+    fn accepts_u64_max() {
+        assert_eq!(ObjectNumber::new(u64::MAX).value(), u64::MAX);
+    }
+
+    #[test]
+    fn equal_numbers_are_equal() {
+        assert_eq!(ObjectNumber::new(7), ObjectNumber::new(7));
+    }
+
+    #[test]
+    fn different_numbers_are_not_equal() {
+        assert_ne!(ObjectNumber::new(7), ObjectNumber::new(8));
+    }
+
+    #[test]
+    fn orders_by_inner_value() {
+        assert!(ObjectNumber::new(1) < ObjectNumber::new(2));
+        assert!(ObjectNumber::new(3) > ObjectNumber::new(2));
+    }
+
+    #[test]
+    fn sorts_in_ascending_order() {
+        let mut numbers = [
+            ObjectNumber::new(3),
+            ObjectNumber::new(1),
+            ObjectNumber::new(2),
+        ];
+        numbers.sort();
+        assert_eq!(
+            numbers,
+            [
+                ObjectNumber::new(1),
+                ObjectNumber::new(2),
+                ObjectNumber::new(3),
+            ]
+        );
+    }
+
+    #[test]
+    fn is_copy_so_original_stays_usable() {
+        let original = ObjectNumber::new(5);
+        let copied = original;
+        assert_eq!(original.value(), 5);
+        assert_eq!(original, copied);
+    }
+
+    #[test]
+    fn works_as_hash_map_key() {
+        let mut map = HashMap::new();
+        map.insert(ObjectNumber::new(10), "ten");
+        assert_eq!(map.get(&ObjectNumber::new(10)), Some(&"ten"));
+    }
+
+    #[test]
+    fn equal_keys_collapse_in_hash_set() {
+        let mut set = HashSet::new();
+        set.insert(ObjectNumber::new(3));
+        set.insert(ObjectNumber::new(3));
+        assert_eq!(set.len(), 1);
+    }
+}


### PR DESCRIPTION
## 概要

spec 073-object-number。PDF の間接オブジェクトを識別するオブジェクト番号を、裸の `u64` と取り違えない専用型 `ObjectNumber(u64)` として `pdfmod-core` に導入する。Rust Phase R0（基盤オブジェクトモデル, Epic #251）における最初の識別子型であり、後続の `GenerationNumber` (#256) / `ByteOffset` (#257) / `ObjectId` (#258) の雛形となる。

## 変更の種類

- ✨ New Feature（新機能 / 純粋な新規追加・破壊的変更なし）

## 追加した内容

- `rust/crates/core/src/object/object_number.rs`（新規）
  - `ObjectNumber(u64)` newtype。内部フィールドは private で `new` / `value` 経由でのみアクセス可能
  - `new(n: u64)` は**無検証（infallible）**。0 や `u64::MAX` も無条件に受理する（0 の特別扱いは xref レイヤ R2 #253 に委譲）
  - `#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]` により HashMap キー・xref ソートに利用可能
  - 同ファイル末尾に `#[cfg(test)] mod tests`（11 ケース: ラウンドトリップ / 境界値 0・1・u64::MAX / 等価・非等価 / 順序・ソート / Copy / HashMap・HashSet キー）

## 変更した内容

- `rust/crates/core/src/object.rs`
  - `pub mod object_number;` を 1 行追加し、サブモジュールをコンパイル経路に乗せる

## システム図

\`\`\`mermaid
flowchart LR
    src["u64<br/>(パーサ / xref エントリ由来)"] -->|"ObjectNumber::new(n)<br/>無検証 / infallible"| obj

    subgraph obj["ObjectNumber [NEW]<br/>不変・Copy・1 word = u64"]
      direction TB
    end

    obj -->|"value()"| out["u64<br/>(生の値が必要な箇所へ)"]
    obj -->|"Hash + Eq"| key["HashMap / HashSet キー"]
    obj -->|"Ord"| sort["xref ソート整列"]
    obj -->|"構成要素"| oid["将来の ObjectId (#258)"]

    style obj fill:#e8f5e9,stroke:#2e7d32
\`\`\`

## 関連 spec / Issue

- spec: \`.plugin-workspace/.specs/073-object-number\`
- Refs #255

## テスト

> ⚠️ **`cargo test` は本 worktree 環境では未実行**。現在のコンテナは Rust 環境（#249）導入前のビルドのままで C リンカ（`cc`）が存在せず、テストバイナリのリンクができないため。devcontainer の Dockerfile 自体は `build-essential` を導入済みで正しく、**コンテナ再ビルド後に `cargo test` で確定する**運用とする（Dockerfile への変更は不要と確認済み）。

この PR 時点で確認できた範囲:

- `cargo check -p pdfmod-core --tests` → 終了コード 0（`mod tests` を含む型/借用検査が通過）
- 以前のセッションで `cargo build` / `cargo clippy --all-targets -- -D warnings` が警告ゼロ通過済み
- `rust/crates/core/Cargo.toml` の `[dependencies]` が空のまま（外部 crate 追加なし）

再ビルド後に実行予定:

\`\`\`bash
cd rust && cargo test -p pdfmod-core object_number
\`\`\`

`object::object_number::tests::` 配下の 11 テストが列挙・パスすることを確認する（spec のテスト列挙確認 = `pub mod object_number;` 追記漏れによる「0 件素通り」防止を兼ねる）。

## レビューポイント

- 内部表現は **`u64`**（spec §4.4 の u32 とは Issue #255 指定により**意図的に乖離**）
- `new` は**無検証 / infallible** — `Result` / `Option` / エラー型は一切使わない設計（TS 版 `ObjectNumber.create()` の検証ありミラーはしない）
- 再エクスポート（`pdfmod_core::object::ObjectNumber` の短縮パス）は本 PR では行わず、canonical path `pdfmod_core::object::object_number::ObjectNumber` のみ。短縮の要否は `ObjectId` (#258) 実装時に判断
- ロールバックはファイル削除 + `object.rs` の 1 行除去で完全に戻せる純粋追加

🤖 Generated with [Claude Code](https://claude.com/claude-code)