### PR TITLE
✨ [New Feature]: #228 Tz オペレータハンドラ（horizontal scaling）を実装

### DIFF
--- a/packages/core/src/content-stream/operators/text/tz/__tests__/tz.basic.test.ts
+++ b/packages/core/src/content-stream/operators/text/tz/__tests__/tz.basic.test.ts
@@ -1,0 +1,110 @@
+import { assert, expect, test } from "vitest";
+import type { PdfObject } from "../../../../../pdf/types/pdf-types/index";
+import {
+  GraphicsState,
+  GraphicsStateStack,
+  TextState,
+} from "../../../../graphics-state/index";
+import { OperandStack } from "../../../../operand-stack/index";
+import type { OperatorHandlerContext } from "../../../../operator-registry/index";
+import { tzHandler } from "../index";
+
+const buildContext = (operands: PdfObject[]): OperatorHandlerContext => {
+  const operandStack = OperandStack.create();
+  for (const operand of operands) {
+    OperandStack.push(operandStack, operand);
+  }
+  const graphicsStateStack = GraphicsStateStack.create();
+  return { operandStack, graphicsStateStack };
+};
+
+test("'150 Tz' で horizontalScaling が 150 に更新される", () => {
+  const context = buildContext([{ type: "integer", value: 150 }]);
+  const result = tzHandler(context);
+
+  assert(result.ok);
+  const current = GraphicsStateStack.current(result.value.graphicsStateStack);
+  expect(current.textState.horizontalScaling).toBe(150);
+});
+
+test("'100 Tz' で horizontalScaling が 100（等倍）になる", () => {
+  const result = tzHandler(buildContext([{ type: "integer", value: 100 }]));
+
+  assert(result.ok);
+  const current = GraphicsStateStack.current(result.value.graphicsStateStack);
+  expect(current.textState.horizontalScaling).toBe(100);
+});
+
+test.each<[string, PdfObject, number]>([
+  ["小数", { type: "real", value: 87.5 }, 87.5],
+  ["負値", { type: "real", value: -50 }, -50],
+  [
+    "Infinity",
+    { type: "real", value: Number.POSITIVE_INFINITY },
+    Number.POSITIVE_INFINITY,
+  ],
+])("境界値 '%s' の operand も値域検証せず horizontalScaling にそのまま格納する", (_label, operand, expected) => {
+  const context = buildContext([operand]);
+  const result = tzHandler(context);
+
+  assert(result.ok);
+  const current = GraphicsStateStack.current(result.value.graphicsStateStack);
+  expect(current.textState.horizontalScaling).toBe(expected);
+});
+
+test("NaN の operand も値域検証せず horizontalScaling にそのまま格納する", () => {
+  const context = buildContext([{ type: "real", value: Number.NaN }]);
+  const result = tzHandler(context);
+
+  assert(result.ok);
+  const current = GraphicsStateStack.current(result.value.graphicsStateStack);
+  expect(Number.isNaN(current.textState.horizontalScaling)).toBe(true);
+});
+
+test("horizontalScaling 更新時、非デフォルト値の他フィールドは保持される", () => {
+  const seeded = GraphicsStateStack.create();
+  const current = GraphicsStateStack.current(seeded);
+  const seededTextState = TextState.update(current.textState, {
+    charSpace: 3,
+    wordSpace: 5,
+    leading: 7,
+  });
+  const graphicsStateStack = GraphicsStateStack.replaceCurrent(
+    seeded,
+    GraphicsState.update(current, { textState: seededTextState }),
+  );
+  const result = tzHandler({
+    operandStack: buildContext([{ type: "integer", value: 150 }]).operandStack,
+    graphicsStateStack,
+  });
+
+  assert(result.ok);
+  const after = GraphicsStateStack.current(
+    result.value.graphicsStateStack,
+  ).textState;
+  expect(after.horizontalScaling).toBe(150);
+  expect(after.charSpace).toBe(3);
+  expect(after.wordSpace).toBe(5);
+  expect(after.leading).toBe(7);
+});
+
+test("成功時に operand が消費され depth が 0 になる", () => {
+  const context = buildContext([{ type: "integer", value: 150 }]);
+  const result = tzHandler(context);
+
+  assert(result.ok);
+  expect(OperandStack.depth(result.value.operandStack)).toBe(0);
+});
+
+test("余剰 operand があっても末尾 1 個のみ pop する", () => {
+  const context = buildContext([
+    { type: "integer", value: 1 },
+    { type: "integer", value: 150 },
+  ]);
+  const result = tzHandler(context);
+
+  assert(result.ok);
+  const current = GraphicsStateStack.current(result.value.graphicsStateStack);
+  expect(current.textState.horizontalScaling).toBe(150);
+  expect(OperandStack.depth(result.value.operandStack)).toBe(1);
+});

--- a/packages/core/src/content-stream/operators/text/tz/__tests__/tz.error.test.ts
+++ b/packages/core/src/content-stream/operators/text/tz/__tests__/tz.error.test.ts
@@ -1,0 +1,71 @@
+import { assert, expect, test } from "vitest";
+import type { PdfObject } from "../../../../../pdf/types/pdf-types/index";
+import { GraphicsStateStack } from "../../../../graphics-state/index";
+import { OperandStack } from "../../../../operand-stack/index";
+import type { OperatorHandlerContext } from "../../../../operator-registry/index";
+import { tzHandler } from "../index";
+
+const buildContext = (operands: PdfObject[]): OperatorHandlerContext => {
+  const operandStack = OperandStack.create();
+  for (const operand of operands) {
+    OperandStack.push(operandStack, operand);
+  }
+  const graphicsStateStack = GraphicsStateStack.create();
+  return { operandStack, graphicsStateStack };
+};
+
+test("operand が 0 個のとき OPERATOR_OPERAND_MISSING を返す", () => {
+  const context = buildContext([]);
+  const result = tzHandler(context);
+
+  assert(!result.ok);
+  assert(result.error.code === "OPERATOR_OPERAND_MISSING");
+  expect(result.error.operatorName).toBe("Tz");
+  expect(result.error.required).toBe(1);
+  expect(result.error.actual).toBe(0);
+  expect(result.error.message).toBe(
+    "Operator 'Tz' requires 1 operand(s), got 0",
+  );
+});
+
+test.each<[string, PdfObject]>([
+  ["name", { type: "name", value: "F1" }],
+  ["boolean", { type: "boolean", value: true }],
+  ["null", { type: "null" }],
+  [
+    "string",
+    { type: "string", value: new Uint8Array([0x61]), encoding: "literal" },
+  ],
+  ["array", { type: "array", elements: [] }],
+  ["dictionary", { type: "dictionary", entries: new Map() }],
+  [
+    "indirect-ref",
+    { type: "indirect-ref", objectNumber: 1, generationNumber: 0 },
+  ],
+])("operand が %s のとき OPERATOR_OPERAND_TYPE_MISMATCH を返す", (typeName, operand) => {
+  const context = buildContext([operand]);
+  const result = tzHandler(context);
+
+  assert(!result.ok);
+  assert(result.error.code === "OPERATOR_OPERAND_TYPE_MISMATCH");
+  expect(result.error.operatorName).toBe("Tz");
+  expect(result.error.expected).toBe("number");
+  expect(result.error.actual).toBe(typeName);
+  expect(result.error.message).toBe(
+    `Operator 'Tz' expected number operand, got ${typeName}`,
+  );
+});
+
+test("MISMATCH 後も部分消費した operand は復元せず、余剰 operand のみ残る", () => {
+  const surplus: PdfObject = { type: "integer", value: 99 };
+  const context = buildContext([surplus, { type: "name", value: "F1" }]);
+
+  const result = tzHandler(context);
+
+  assert(!result.ok);
+  assert(result.error.code === "OPERATOR_OPERAND_TYPE_MISMATCH");
+  expect(OperandStack.depth(context.operandStack)).toBe(1);
+  const top = OperandStack.peek(context.operandStack);
+  assert(top.some);
+  expect(top.value).toEqual(surplus);
+});

--- a/packages/core/src/content-stream/operators/text/tz/index.ts
+++ b/packages/core/src/content-stream/operators/text/tz/index.ts
@@ -1,0 +1,71 @@
+import type { PdfError } from "../../../../pdf/errors/index";
+import { err, ok } from "../../../../utils/result/index";
+import {
+  GraphicsState,
+  GraphicsStateStack,
+  TextState,
+} from "../../../graphics-state/index";
+import { OperandStack } from "../../../operand-stack/index";
+import type {
+  OperatorHandler,
+  OperatorHandlerContext,
+} from "../../../operator-registry/index";
+import { NumericPdfObject } from "../../graphics-state/numeric-pdf-object/index";
+
+/** PDF §9.3.4 horizontal scaling オペレータ名（PDF 表記の大小を保持）。 */
+const OPERATOR_NAME = "Tz";
+
+/**
+ * PDF §9.3.4 `Tz scale` operator (horizontal scaling) のハンドラ。
+ * operand を 1 個 pop し、number であれば `textState.horizontalScaling` を更新する。
+ *
+ * - operand stack が空なら `OPERATOR_OPERAND_MISSING` を返す
+ * - 末尾が number 以外なら `OPERATOR_OPERAND_TYPE_MISMATCH` を返す
+ * - 値はパーセントそのまま格納する（150→150、100→100＝等倍）。正規化（÷100）はしない
+ * - 値域検証はしない（負値・小数・`NaN`・`Infinity` をそのまま格納する）
+ * - エラー時に部分消費した operand stack は復元しない（既存ハンドラ規約）
+ * - `Tz` は BT/ET の外でも呼べるため `textObject.active` は検査しない
+ *
+ * @param context - 実行コンテキスト (operand stack / graphics state stack)
+ * @returns 成功なら更新後コンテキスト、失敗なら PdfError
+ */
+export const tzHandler: OperatorHandler = (context: OperatorHandlerContext) => {
+  const popped = OperandStack.pop(context.operandStack);
+  if (!popped.some) {
+    const error: PdfError = {
+      code: "OPERATOR_OPERAND_MISSING",
+      message: `Operator '${OPERATOR_NAME}' requires 1 operand(s), got 0`,
+      operatorName: OPERATOR_NAME,
+      required: 1,
+      actual: 0,
+    };
+    return err(error);
+  }
+
+  const operand = popped.value;
+  if (!NumericPdfObject.is(operand)) {
+    const error: PdfError = {
+      code: "OPERATOR_OPERAND_TYPE_MISMATCH",
+      message: `Operator '${OPERATOR_NAME}' expected number operand, got ${operand.type}`,
+      operatorName: OPERATOR_NAME,
+      expected: "number",
+      actual: operand.type,
+    };
+    return err(error);
+  }
+
+  const current = GraphicsStateStack.current(context.graphicsStateStack);
+  const nextTextState = TextState.update(current.textState, {
+    horizontalScaling: operand.value,
+  });
+  const next = GraphicsState.update(current, { textState: nextTextState });
+  const graphicsStateStack = GraphicsStateStack.replaceCurrent(
+    context.graphicsStateStack,
+    next,
+  );
+
+  return ok({
+    operandStack: context.operandStack,
+    graphicsStateStack,
+  });
+};


### PR DESCRIPTION
## 概要

PDF コンテンツストリーム §9.3.4 `Tz scale` オペレータのハンドラ `tzHandler` を `@pdfmod/core` に追加します。operand 1 個（number）を pop し、`TextState.horizontalScaling` をパーセント値そのままで更新します（`150 Tz`→150、`100 Tz`→100=等倍）。正規化・値域検証は行いません。既存 `twHandler` の確立済みパターンを踏襲した純粋な新規追加で、既存ファイルへの変更はありません。

## 変更内容

### 🎯 変更の種類

- [x] ✨ 新機能 (New feature)
- [x] 🚨 テスト追加/修正 (Tests)

### 📝 詳細な変更内容

#### 追加された機能・修正

- `tzHandler`: operand pop → `NumericPdfObject.is` で number 検査 → `TextState.horizontalScaling` を更新。throw を使わず全経路 `Result`（`ok` / `err`）を返す
- エラーは既存 2 種のみ使用: operand 不足 → `OPERATOR_OPERAND_MISSING`、number 以外 → `OPERATOR_OPERAND_TYPE_MISMATCH`
- 値域検証なし（小数・負値・NaN・Infinity をそのまま格納）。型不一致時に pop 済み operand は復元しない（既存ハンドラ規約）
- `Tz` は BT/ET の外でも呼べるため `textObject.active` は検査しない

#### 変更されたファイル

- `packages/core/src/content-stream/operators/text/tz/index.ts` [NEW] — ハンドラ本体
- `packages/core/src/content-stream/operators/text/tz/__tests__/tz.basic.test.ts` [NEW] — 正常系 9 tests
- `packages/core/src/content-stream/operators/text/tz/__tests__/tz.error.test.ts` [NEW] — 異常系 9 tests

#### 削除されたファイル・機能

- なし

> **スコープ外（本 PR では実施しない）**: `registerTextOperators` / registry 登録 / root export の配線は Epic #228 の別 Issue に委ねます。

## 📊 システム図

### 状態マシン / フロー図

\`\`\`mermaid
flowchart TD
    Start([Tz オペレータ呼び出し]) --> Pop[OperandStack.pop]:::new
    Pop -->|none 空| Missing[err: OPERATOR_OPERAND_MISSING<br/>required=1 / actual=0]:::new
    Pop -->|some operand| TypeCheck{NumericPdfObject.is}:::new
    TypeCheck -->|false 非number| Mismatch[err: OPERATOR_OPERAND_TYPE_MISMATCH<br/>expected=number / actual=type<br/>※pop済み1個は復元しない]:::new
    TypeCheck -->|true integer/real| Update[TextState.update<br/>horizontalScaling = operand.value<br/>※パーセントそのまま・値域検証なし]:::new
    Update --> Replace[GraphicsState.update → replaceCurrent]:::new
    Replace --> Ok([ok: operandStack / graphicsStateStack]):::new

    classDef new fill:#ffe4b5,stroke:#d97706,stroke-width:2px
\`\`\`

## 📋 関連 Issue

- Refs #228（Epic: テキストオペレータ群）

## 🧪 テスト

### テスト実行方法

\`\`\`bash
pnpm --filter @pdfmod/core test
\`\`\`

### テスト項目

- [x] 単体テスト (Unit tests)

### テスト結果

- `pnpm --filter @pdfmod/core test`: **2266 passed**（164 files、新規 tz 18 tests 含む）
- `pnpm --filter @pdfmod/core typecheck`: passed
- `pnpm run lint`（biome + oxlint）: 0 errors
- Codex CLI レビュー: **問題なし**

#### カバーしたケース

- 正常系: `150 Tz`→拡大 / `100 Tz`→等倍 / real(87.5) / 他フィールド保持 / depth=0 / 余剰 operand は末尾 1 個のみ pop
- 境界値: 負値 / NaN / Infinity をそのまま格納（値域検証なし）
- 異常系: operand 不足 → MISSING、非 number 7 種（name/boolean/null/string/array/dictionary/indirect-ref）→ TYPE_MISMATCH、型不一致後の部分消費非復元

## 🔍 レビューポイント

- `horizontalScaling` をパーセントそのまま格納する仕様（正規化 ÷100 をしない）で問題ないか
- 値域検証を行わない方針（既存 `tw` と同方針）で問題ないか
- 既存 `twHandler` とのパターン整合性

## ⚠️ 破壊的変更

- [ ] この変更は既存の API に破壊的変更を含みます（→ なし。純粋な新規追加）

## ✅ チェックリスト

- [x] コードレビューの準備ができている
- [x] テストが正常に実行される
- [x] コミットメッセージが適切な形式で書かれている
- [x] PR 本文に `Refs #228` で Issue が記載されている
- [x] セルフレビューを実施した（Codex レビューで「問題なし」）
- [x] 破壊的変更なし（純粋な新規追加）

🤖 Generated with [Claude Code](https://claude.com/claude-code)