### PR TITLE
✨ [New Feature]: #256 GenerationNumber(u16) newtype を pdfmod-core に追加

### DIFF
--- a/rust/crates/core/src/object.rs
+++ b/rust/crates/core/src/object.rs
@@ -4,6 +4,7 @@
 //! array / dictionary / stream / null / indirect reference）を表す型を
 //! 後続 Issue で追加する。
 
+pub mod generation_number;
 pub mod object_number;
 
 // 後続 Issue で各オブジェクト型をサブモジュールとして追加する（以下は例の一部）:

--- a/rust/crates/core/src/object/generation_number.rs
+++ b/rust/crates/core/src/object/generation_number.rs
@@ -33,6 +33,8 @@ mod tests {
     use std::collections::HashMap;
     use std::collections::HashSet;
 
+    // 正常系（往復）: new(n) で包んだ値を value() で取り出すと入力 n と一致する。
+    // 代表値 [0, 1, 42, u16::MAX] で生成と取り出しが無損失（ラウンドトリップ）であることを確認する。
     #[test]
     fn new_then_value_roundtrips() {
         for n in [0, 1, 42, u16::MAX] {
@@ -40,37 +42,44 @@ mod tests {
         }
     }
 
+    // 境界値: 0（フリーオブジェクトの予約世代）を無検証で受理し、value() が 0 を返す。
     #[test]
     fn accepts_zero() {
         assert_eq!(GenerationNumber::new(0).value(), 0);
     }
 
+    // 境界値: 1（最小の「使用中」通常世代）を受理し、value() が 1 を返す。
     #[test]
     fn accepts_one() {
         assert_eq!(GenerationNumber::new(1).value(), 1);
     }
 
+    // 境界値: u16::MAX（= 65535、ISO 32000-1 §7.5.4 の世代上限）を受理し、範囲上限を取り出せる。
     #[test]
     fn accepts_u16_max() {
         assert_eq!(GenerationNumber::new(u16::MAX).value(), u16::MAX);
     }
 
+    // 正常系（等価）: 同じ u16 から生成した 2 値は == で等価になる（PartialEq/Eq が内部値に委譲）。
     #[test]
     fn equal_numbers_are_equal() {
         assert_eq!(GenerationNumber::new(7), GenerationNumber::new(7));
     }
 
+    // 正常系（非等価）: 異なる u16 から生成した 2 値は != で非等価になる。
     #[test]
     fn different_numbers_are_not_equal() {
         assert_ne!(GenerationNumber::new(7), GenerationNumber::new(8));
     }
 
+    // 正常系（順序）: < / > による大小比較が内部 u16 の大小と一致する（PartialOrd/Ord が内部値に委譲）。
     #[test]
     fn orders_by_inner_value() {
         assert!(GenerationNumber::new(1) < GenerationNumber::new(2));
         assert!(GenerationNumber::new(3) > GenerationNumber::new(2));
     }
 
+    // 正常系（ソート）: 配列を sort() すると内部 u16 の昇順に並ぶ（Ord により [3,1,2] → [1,2,3]）。
     #[test]
     fn sorts_in_ascending_order() {
         let mut numbers = [
@@ -89,6 +98,7 @@ mod tests {
         );
     }
 
+    // エッジケース（Copy）: 代入でコピーしても元の値はムーブされず、コピーと等価のまま使い続けられる。
     #[test]
     fn is_copy_so_original_stays_usable() {
         let original = GenerationNumber::new(5);
@@ -97,6 +107,7 @@ mod tests {
         assert_eq!(original, copied);
     }
 
+    // 正常系（HashMap キー）: HashMap のキーとして使え、同値キーで get すると挿入値を取得できる（Hash + Eq）。
     #[test]
     fn works_as_hash_map_key() {
         let mut map = HashMap::new();
@@ -104,6 +115,7 @@ mod tests {
         assert_eq!(map.get(&GenerationNumber::new(10)), Some(&"ten"));
     }
 
+    // エッジケース（HashSet 折りたたみ）: 同値を 2 回挿入しても要素数は 1 になる（同値が 1 つに折りたたまれる）。
     #[test]
     fn equal_keys_collapse_in_hash_set() {
         let mut set = HashSet::new();

--- a/rust/crates/core/src/object/generation_number.rs
+++ b/rust/crates/core/src/object/generation_number.rs
@@ -1,0 +1,114 @@
+//! PDF の間接オブジェクトの世代を表す世代番号 `GenerationNumber` を定義するモジュール。
+//!
+//! 裸の `u16` や隣接する `ObjectNumber` と取り違えないための newtype。
+//! 間接参照・xref エントリ・`ObjectId`（#258）の構成要素として用いる。
+//! 生成は無検証（infallible）で、0 や `u16::MAX`（= 65535）も無条件に受理する。
+//! 0（フリーリスト先頭の予約世代）の特別扱い・世代不一致判定は xref レイヤ（後続）に委譲する。
+
+/// PDF 世代番号。間接オブジェクトの世代（削除・再利用の管理）を表す整数のラッパ。
+///
+/// 内部表現は `u16`。仕様範囲 `0..=65535`（ISO 32000-1 §7.5.4）が `u16` の定義域と
+/// 一致するため、型自体が仕様範囲を保証する（範囲外値は型レベルで表現不能）。
+/// 値ラッパであり `Copy`。等価・順序・ハッシュは内部 `u16` の自然な振る舞いに従う。
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct GenerationNumber(u16);
+
+impl GenerationNumber {
+    /// 与えられた `u16` から `GenerationNumber` を生成する。
+    ///
+    /// 無検証（infallible）。0 や `u16::MAX`（= 65535）を含む任意の値を受理する。
+    pub fn new(n: u16) -> GenerationNumber {
+        GenerationNumber(n)
+    }
+
+    /// 内部の世代番号を `u16` として取り出す。
+    pub fn value(&self) -> u16 {
+        self.0
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+    use std::collections::HashSet;
+
+    #[test]
+    fn new_then_value_roundtrips() {
+        for n in [0, 1, 42, u16::MAX] {
+            assert_eq!(GenerationNumber::new(n).value(), n);
+        }
+    }
+
+    #[test]
+    fn accepts_zero() {
+        assert_eq!(GenerationNumber::new(0).value(), 0);
+    }
+
+    #[test]
+    fn accepts_one() {
+        assert_eq!(GenerationNumber::new(1).value(), 1);
+    }
+
+    #[test]
+    fn accepts_u16_max() {
+        assert_eq!(GenerationNumber::new(u16::MAX).value(), u16::MAX);
+    }
+
+    #[test]
+    fn equal_numbers_are_equal() {
+        assert_eq!(GenerationNumber::new(7), GenerationNumber::new(7));
+    }
+
+    #[test]
+    fn different_numbers_are_not_equal() {
+        assert_ne!(GenerationNumber::new(7), GenerationNumber::new(8));
+    }
+
+    #[test]
+    fn orders_by_inner_value() {
+        assert!(GenerationNumber::new(1) < GenerationNumber::new(2));
+        assert!(GenerationNumber::new(3) > GenerationNumber::new(2));
+    }
+
+    #[test]
+    fn sorts_in_ascending_order() {
+        let mut numbers = [
+            GenerationNumber::new(3),
+            GenerationNumber::new(1),
+            GenerationNumber::new(2),
+        ];
+        numbers.sort();
+        assert_eq!(
+            numbers,
+            [
+                GenerationNumber::new(1),
+                GenerationNumber::new(2),
+                GenerationNumber::new(3),
+            ]
+        );
+    }
+
+    #[test]
+    fn is_copy_so_original_stays_usable() {
+        let original = GenerationNumber::new(5);
+        let copied = original;
+        assert_eq!(original.value(), 5);
+        assert_eq!(original, copied);
+    }
+
+    #[test]
+    fn works_as_hash_map_key() {
+        let mut map = HashMap::new();
+        map.insert(GenerationNumber::new(10), "ten");
+        assert_eq!(map.get(&GenerationNumber::new(10)), Some(&"ten"));
+    }
+
+    #[test]
+    fn equal_keys_collapse_in_hash_set() {
+        let mut set = HashSet::new();
+        set.insert(GenerationNumber::new(3));
+        set.insert(GenerationNumber::new(3));
+        assert_eq!(set.len(), 1);
+    }
+}


### PR DESCRIPTION
## 概要

PDF の世代番号（generation number, ISO 32000-1 §7.5.4 で `0`〜`65535`）を表す専用型 `GenerationNumber(u16)` を `pdfmod-core` に追加します。裸の整数や隣接する `ObjectNumber` と取り違えないための newtype として導入し、後続の `ObjectId`（#258）の構成要素とします。先行実装 `ObjectNumber`（#255）を完全に踏襲しました。

純粋な追加（新規ファイル 1 + `object.rs` への `pub mod` 1 行）で、既存ファイルの挙動には影響しません。

## 変更内容

### 🎯 変更の種類

- [x] ✨ 新機能 (New feature)

### 📝 詳細な変更内容

#### 追加された機能・修正

- `GenerationNumber(u16)` newtype を定義（`#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]`）
- `new(n: u16) -> GenerationNumber`（無検証 / infallible）と `value(&self) -> u16` を実装
- 内部表現を `u16` とし、仕様範囲 `0..=65535` を型レベルで保証（範囲外は表現不能 = 実行時バリデーション不要）
- フラット構造の `#[cfg(test)] mod tests` を 11 本追加（往復 / 境界値 0・1・65535 / 等価・非等価 / 順序・ソート / Copy / HashMap キー / HashSet 折りたたみ）

#### 変更されたファイル

- `rust/crates/core/src/object/generation_number.rs`（新規）
- `rust/crates/core/src/object.rs`（`pub mod generation_number;` を追記）

#### 削除されたファイル・機能

- なし

## 📊 システム図

### データフロー

```mermaid
flowchart TD
    Caller["呼び出し側が u16 を保持<br/>(xref パーサ / ObjectId 構築 #258)"]
    Caller -->|"GenerationNumber::new(n: u16)<br/>無検証 / infallible"| GN["GenerationNumber(u16) [NEW]<br/>値ラッパ・Copy・任意の u16 を受理"]
    GN -->|".value()"| Out["u16 を取り出す（往復一致）"]
    GN -->|"== / < / >"| Cmp["内部 u16 に委譲した比較・順序"]
    GN -->|"Hash / Ord"| Key["HashMap キー / HashSet 同値折りたたみ / sort 昇順"]
    Out --> Next["後続 #258 ObjectId の構成要素"]
    Cmp --> Next
    Key --> Next

    classDef new fill:#ffe4b5,stroke:#d97706,stroke-width:2px
    class GN new
```

### モジュール構成

```
rust/crates/core/src/object.rs
    └─ pub mod generation_number;   [NEW] 1 行追記
            ↓
rust/crates/core/src/object/generation_number.rs  [NEW]
    ├─ pub struct GenerationNumber(u16)
    ├─ new(n: u16) -> Self  (infallible)
    └─ value(&self) -> u16

依存: std のみ（外部 crate 依存ゼロ）
lib.rs: root re-export は行わない（ObjectNumber と一貫）
```

## 📋 関連 Issue

- Refs #256
- 後続: `ObjectId` #258 の構成要素（Epic #251）

## 🧪 テスト

### テスト実行方法

```bash
# rust/ で実行
cargo build -p pdfmod-core
cargo test -p pdfmod-core generation_number
cargo test            # ワークスペース全体（リグレッション確認）
```

### テスト項目

- [x] 単体テスト (Unit tests)

### テスト結果

- `cargo build -p pdfmod-core`: 成功
- `cargo test -p pdfmod-core generation_number`: **11 passed**
- `cargo test`（ワークスペース全体）: **22 passed**（ObjectNumber 11 + GenerationNumber 11）、リグレッションなし
- `rustfmt --check`（変更2ファイル）: clean

> Rust CI ジョブが存在しないため、上記はローカル実行で確認しています（CI への Rust ジョブ追加は本 PR のスコープ外）。

## 🔍 レビューポイント

- 内部表現に `u16` を採用した設計判断（仕様範囲 `0..=65535` と定義域が一致するため型自体が範囲を保証）
- `new` を無検証（infallible）とし `Result`/`Option`・エラー型を導入しない点
- `ObjectNumber`（#255）との API・derive の完全一致（後続 #258 `ObjectId` が両 newtype を合成可能な形）
- `object.rs` のモジュール宣言順（rustfmt の辞書順に従い `generation_number` を先に配置）

## ⚠️ 破壊的変更

- [ ] この変更は既存の API に破壊的変更を含みます

破壊的変更はありません（純粋な追加）。

## ✅ チェックリスト

- [x] コードレビューの準備ができている
- [x] テストが正常に実行される
- [x] コミットメッセージが適切な形式で書かれている
- [x] PR 本文に `Refs #256` で Issue が記載されている
- [x] セルフレビューを実施した（spec-review: CRITICAL/WARNING 0 件）
- [x] 破壊的変更なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)