### PR TITLE
✨ [New Feature]: #257 ByteOffset newtype を pdfmod-core に追加

### DIFF
--- a/rust/crates/core/src/byte_offset.rs
+++ b/rust/crates/core/src/byte_offset.rs
@@ -1,0 +1,112 @@
+//! PDF ファイル内のバイトオフセット（先頭からの位置）を表す `ByteOffset` を定義するモジュール。
+//!
+//! 裸の `u64` と取り違えないための newtype。xref が指す間接オブジェクトのファイル内位置などの
+//! 構成要素として用いる。生成は無検証（infallible）で、0（ファイル先頭）や `u64::MAX` も
+//! 無条件に受理する。値の妥当性検証（ファイルサイズ超過等）は xref レイヤ（R2）に委譲する。
+
+/// PDF ファイル内のバイトオフセット。ファイル先頭からの位置を表す非負整数のラッパ。
+///
+/// 内部表現は `u64`（Issue #257 指定）。
+/// 値ラッパであり `Copy`。等価・順序・ハッシュは内部 `u64` の自然な振る舞いに従う。
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct ByteOffset(u64);
+
+impl ByteOffset {
+    /// 与えられた `u64` から `ByteOffset` を生成する。
+    ///
+    /// 無検証（infallible）。0 や `u64::MAX` を含む任意の値を受理する。
+    pub fn new(n: u64) -> ByteOffset {
+        ByteOffset(n)
+    }
+
+    /// 内部のバイトオフセットを `u64` として取り出す。
+    pub fn value(&self) -> u64 {
+        self.0
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+    use std::collections::HashSet;
+
+    #[test]
+    fn new_then_value_roundtrips() {
+        for n in [0, 1, 42, u64::MAX] {
+            assert_eq!(ByteOffset::new(n).value(), n);
+        }
+    }
+
+    #[test]
+    fn accepts_zero() {
+        assert_eq!(ByteOffset::new(0).value(), 0);
+    }
+
+    #[test]
+    fn accepts_one() {
+        assert_eq!(ByteOffset::new(1).value(), 1);
+    }
+
+    #[test]
+    fn accepts_u64_max() {
+        assert_eq!(ByteOffset::new(u64::MAX).value(), u64::MAX);
+    }
+
+    #[test]
+    fn equal_offsets_are_equal() {
+        assert_eq!(ByteOffset::new(7), ByteOffset::new(7));
+    }
+
+    #[test]
+    fn different_offsets_are_not_equal() {
+        assert_ne!(ByteOffset::new(7), ByteOffset::new(8));
+    }
+
+    #[test]
+    fn orders_by_inner_value() {
+        assert!(ByteOffset::new(1) < ByteOffset::new(2));
+        assert!(ByteOffset::new(3) > ByteOffset::new(2));
+    }
+
+    #[test]
+    fn sorts_in_ascending_order() {
+        let mut offsets = [
+            ByteOffset::new(3),
+            ByteOffset::new(1),
+            ByteOffset::new(2),
+        ];
+        offsets.sort();
+        assert_eq!(
+            offsets,
+            [
+                ByteOffset::new(1),
+                ByteOffset::new(2),
+                ByteOffset::new(3),
+            ]
+        );
+    }
+
+    #[test]
+    fn is_copy_so_original_stays_usable() {
+        let original = ByteOffset::new(5);
+        let copied = original;
+        assert_eq!(original.value(), 5);
+        assert_eq!(original, copied);
+    }
+
+    #[test]
+    fn works_as_hash_map_key() {
+        let mut map = HashMap::new();
+        map.insert(ByteOffset::new(10), "ten");
+        assert_eq!(map.get(&ByteOffset::new(10)), Some(&"ten"));
+    }
+
+    #[test]
+    fn equal_keys_collapse_in_hash_set() {
+        let mut set = HashSet::new();
+        set.insert(ByteOffset::new(3));
+        set.insert(ByteOffset::new(3));
+        assert_eq!(set.len(), 1);
+    }
+}

--- a/rust/crates/core/src/byte_offset.rs
+++ b/rust/crates/core/src/byte_offset.rs
@@ -33,6 +33,7 @@ mod tests {
 
     #[test]
     fn new_then_value_roundtrips() {
+        // 代表値（0 / 1 / 42 / u64::MAX）を new で包んで value で取り出すと、生成時の値と一致することを確認する
         for n in [0, 1, 42, u64::MAX] {
             assert_eq!(ByteOffset::new(n).value(), n);
         }
@@ -40,37 +41,44 @@ mod tests {
 
     #[test]
     fn accepts_zero() {
+        // ファイル先頭を表す 0 が無検証で受理され、値が保持されることを確認する
         assert_eq!(ByteOffset::new(0).value(), 0);
     }
 
     #[test]
     fn accepts_one() {
+        // 1 が無検証で受理され、値が保持されることを確認する
         assert_eq!(ByteOffset::new(1).value(), 1);
     }
 
     #[test]
     fn accepts_u64_max() {
+        // 最大値 u64::MAX も無検証で受理され、値が保持されることを確認する
         assert_eq!(ByteOffset::new(u64::MAX).value(), u64::MAX);
     }
 
     #[test]
     fn equal_offsets_are_equal() {
+        // 同一値から生成した 2 つが == で等価と判定されることを確認する
         assert_eq!(ByteOffset::new(7), ByteOffset::new(7));
     }
 
     #[test]
     fn different_offsets_are_not_equal() {
+        // 異なる値から生成した 2 つが != で非等価と判定されることを確認する
         assert_ne!(ByteOffset::new(7), ByteOffset::new(8));
     }
 
     #[test]
     fn orders_by_inner_value() {
+        // 大小比較（< / >）が内部 u64 の自然順に従うことを確認する
         assert!(ByteOffset::new(1) < ByteOffset::new(2));
         assert!(ByteOffset::new(3) > ByteOffset::new(2));
     }
 
     #[test]
     fn sorts_in_ascending_order() {
+        // 順不同の配列を sort() すると内部 u64 の昇順に並ぶことを確認する
         let mut offsets = [
             ByteOffset::new(3),
             ByteOffset::new(1),
@@ -89,6 +97,7 @@ mod tests {
 
     #[test]
     fn is_copy_so_original_stays_usable() {
+        // Copy セマンティクスにより、別変数へ複製した後も元の変数が引き続き使用可能なことを確認する
         let original = ByteOffset::new(5);
         let copied = original;
         assert_eq!(original.value(), 5);
@@ -97,6 +106,7 @@ mod tests {
 
     #[test]
     fn works_as_hash_map_key() {
+        // HashMap のキーとして機能し、同値キーで挿入した値を取得できることを確認する
         let mut map = HashMap::new();
         map.insert(ByteOffset::new(10), "ten");
         assert_eq!(map.get(&ByteOffset::new(10)), Some(&"ten"));
@@ -104,6 +114,7 @@ mod tests {
 
     #[test]
     fn equal_keys_collapse_in_hash_set() {
+        // 同値を HashSet に 2 回挿入しても等価キーが 1 件に畳まれることを確認する
         let mut set = HashSet::new();
         set.insert(ByteOffset::new(3));
         set.insert(ByteOffset::new(3));

--- a/rust/crates/core/src/lib.rs
+++ b/rust/crates/core/src/lib.rs
@@ -12,3 +12,4 @@
 
 pub mod object;
 pub mod error;
+pub mod byte_offset;


### PR DESCRIPTION
## 概要

PDF ファイル内のバイトオフセット（先頭からの位置）を表す newtype `ByteOffset(u64)` を `@pdfmod/core`（Rust）に追加します。xref が指す間接オブジェクトのファイル内位置などで、裸の `u64` と取り違えないための専用型を提供します。既存の `ObjectNumber`（`src/object/object_number.rs`）と完全に同形の設計です。

## 変更内容

### 🎯 変更の種類

- [x] ✨ 新機能 (New feature)

### 📝 詳細な変更内容

#### 追加された機能・修正

- `ByteOffset(u64)` タプル newtype を新規追加
  - `new(n: u64) -> ByteOffset`（**無検証・infallible**。`0` / `1` / `u64::MAX` を含む任意値を無条件受理）
  - `value(&self) -> u64`（内部値の取り出し）
  - derive 8 種: `Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord`（`ObjectNumber` と同一セット）
- 値の妥当性検証（ファイルサイズ超過等）は上位の xref レイヤ（R2）に委譲

#### 変更されたファイル

- `rust/crates/core/src/byte_offset.rs`（新規） — 型定義 + `new`/`value` API + 11 ユニットテスト
- `rust/crates/core/src/lib.rs` — `pub mod byte_offset;` を 1 行追加（crate root に登録）

#### 削除されたファイル・機能

- なし

## 📊 システム図

### データフロー

```mermaid
flowchart TD
    Caller([xref レイヤ等が算出した u64]) --> New["ByteOffset::new(n)\n無検証ラップ"]:::new
    New --> Inner["ByteOffset(内部 u64)\nタプル newtype・Copy"]:::new
    Inner --> Value["value(&self) -> u64"]:::new
    Inner --> Ord["Ord / PartialOrd\n内部 u64 に委譲"]:::new
    Inner --> Hash["Eq + Hash\n内部 u64 に委譲"]:::new
    Value --> Out([u64 を呼び出し元へ返却])
    Ord --> Sorted([昇順ソート等の順序付きコレクション])
    Hash --> Map["HashMap&lt;ByteOffset, V&gt; のキー / HashSet 要素"]

    classDef new fill:#ffe4b5,stroke:#d97706,stroke-width:2px
```

> 配置方針: `ObjectNumber` は `object/` 配下だが、`ByteOffset` は PDF オブジェクトではなく**ファイル内位置のプリミティブ**のため、トップレベルモジュール `src/byte_offset.rs` に独立配置している。

## 📋 関連 Issue

- Refs #257 (Phase R0 / 親 Epic #251, blocked by #254)

## 🧪 テスト

### テスト実行方法

```bash
cargo test --manifest-path rust/Cargo.toml
```

### テスト項目

- [x] 単体テスト (Unit tests) — `byte_offset.rs` 内 colocated `#[cfg(test)] mod tests`（フラット構造・std アサーションのみ）

### テスト結果

`cargo test` で **22 件全パス**（ByteOffset 11 + 既存 ObjectNumber 11、リグレッションなし）。`cargo build` も警告なく成功。

11 テストの内訳:
- ラウンドトリップ（`[0, 1, 42, u64::MAX]`）
- 境界値: `0`（ファイル先頭）/ `1` / `u64::MAX` の受理
- 等価比較（等しい / 等しくない）
- 順序比較（`<` / `>`）・昇順ソート
- `Copy` セマンティクス（複製後も元が使える）
- `HashMap` キー / `HashSet` での等価キー畳み込み

## 🔍 レビューポイント

- **破壊的変更なし**: 新規ファイル 1 つ + `lib.rs` への 1 行追加のみ。`grep -rn "ByteOffset" rust/` は `byte_offset.rs` 内に閉じており既存コードへの波及なし。
- **外部依存ゼロ維持**: `rust/Cargo.toml` / `crates/core/Cargo.toml` の `[dependencies]` は空のまま（本 crate の設計制約）。
- **無検証生成（infallible）**: `new` は `Result`/`Option` を返さない。妥当性検証は上位 xref レイヤ（R2）に委譲する設計。
- **検証手段**: CI は pnpm/TypeScript 専用で Rust ジョブが無いため、受け入れ確認（`cargo build`/`cargo test`）はローカル検証で担保。Codex CLI レビューでも「問題なし」。

## ✅ チェックリスト

- [x] コードレビューの準備ができている
- [x] テストが正常に実行される（cargo test 22 件パス）
- [x] ドキュメント更新（doc コメント `//!` / `///` を記述）
- [x] コミットメッセージが適切な形式で書かれている
- [x] PR 本文に `Refs #257` を記載
- [x] セルフレビューを実施した
- [x] 破壊的変更なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)