### PR TITLE
✨ [New Feature]: #237 TL オペレータハンドラ（text leading）を実装

### DIFF
--- a/packages/core/src/content-stream/operators/text/tl/__tests__/tl.basic.test.ts
+++ b/packages/core/src/content-stream/operators/text/tl/__tests__/tl.basic.test.ts
@@ -1,0 +1,106 @@
+import { assert, expect, test } from "vitest";
+import type { PdfObject } from "../../../../../pdf/types/pdf-types/index";
+import {
+  GraphicsState,
+  GraphicsStateStack,
+  TextState,
+} from "../../../../graphics-state/index";
+import { OperandStack } from "../../../../operand-stack/index";
+import type { OperatorHandlerContext } from "../../../../operator-registry/index";
+import { tlHandler } from "../index";
+
+const buildContext = (operands: PdfObject[]): OperatorHandlerContext => {
+  const operandStack = OperandStack.create();
+  for (const operand of operands) {
+    OperandStack.push(operandStack, operand);
+  }
+  const graphicsStateStack = GraphicsStateStack.create();
+  return { operandStack, graphicsStateStack };
+};
+
+test("'14 TL' で leading が 14 に更新される", () => {
+  const context = buildContext([{ type: "integer", value: 14 }]);
+  const result = tlHandler(context);
+
+  assert(result.ok);
+  const current = GraphicsStateStack.current(result.value.graphicsStateStack);
+  expect(current.textState.leading).toBe(14);
+});
+
+test("非0 の leading に '0 TL' を適用すると 0 にリセットされる", () => {
+  const first = tlHandler(buildContext([{ type: "integer", value: 14 }]));
+  assert(first.ok);
+
+  const reset = tlHandler({
+    operandStack: buildContext([{ type: "integer", value: 0 }]).operandStack,
+    graphicsStateStack: first.value.graphicsStateStack,
+  });
+
+  assert(reset.ok);
+  const current = GraphicsStateStack.current(reset.value.graphicsStateStack);
+  expect(current.textState.leading).toBe(0);
+});
+
+test.each<[string, PdfObject, number]>([
+  ["小数", { type: "real", value: 1.5 }, 1.5],
+  ["負値", { type: "real", value: -2.5 }, -2.5],
+  ["NaN", { type: "real", value: Number.NaN }, Number.NaN],
+  [
+    "Infinity",
+    { type: "real", value: Number.POSITIVE_INFINITY },
+    Number.POSITIVE_INFINITY,
+  ],
+])("境界値 '%s' の operand も値域検証せず leading に格納する", (_label, operand, expected) => {
+  const context = buildContext([operand]);
+  const result = tlHandler(context);
+
+  assert(result.ok);
+  const current = GraphicsStateStack.current(result.value.graphicsStateStack);
+  expect(current.textState.leading).toBe(expected);
+});
+
+test("leading 更新時、非デフォルト値の他フィールドは保持される", () => {
+  const seeded = GraphicsStateStack.create();
+  const current = GraphicsStateStack.current(seeded);
+  const seededTextState = TextState.update(current.textState, {
+    charSpace: 5,
+    wordSpace: 7,
+  });
+  const graphicsStateStack = GraphicsStateStack.replaceCurrent(
+    seeded,
+    GraphicsState.update(current, { textState: seededTextState }),
+  );
+  const result = tlHandler({
+    operandStack: buildContext([{ type: "integer", value: 3 }]).operandStack,
+    graphicsStateStack,
+  });
+
+  assert(result.ok);
+  const after = GraphicsStateStack.current(
+    result.value.graphicsStateStack,
+  ).textState;
+  expect(after.leading).toBe(3);
+  expect(after.charSpace).toBe(5);
+  expect(after.wordSpace).toBe(7);
+});
+
+test("成功時に operand が消費され depth が 0 になる", () => {
+  const context = buildContext([{ type: "integer", value: 14 }]);
+  const result = tlHandler(context);
+
+  assert(result.ok);
+  expect(OperandStack.depth(result.value.operandStack)).toBe(0);
+});
+
+test("余剰 operand があっても末尾 1 個のみ pop する", () => {
+  const context = buildContext([
+    { type: "integer", value: 1 },
+    { type: "integer", value: 2 },
+  ]);
+  const result = tlHandler(context);
+
+  assert(result.ok);
+  const current = GraphicsStateStack.current(result.value.graphicsStateStack);
+  expect(current.textState.leading).toBe(2);
+  expect(OperandStack.depth(result.value.operandStack)).toBe(1);
+});

--- a/packages/core/src/content-stream/operators/text/tl/__tests__/tl.error.test.ts
+++ b/packages/core/src/content-stream/operators/text/tl/__tests__/tl.error.test.ts
@@ -1,0 +1,71 @@
+import { assert, expect, test } from "vitest";
+import type { PdfObject } from "../../../../../pdf/types/pdf-types/index";
+import { GraphicsStateStack } from "../../../../graphics-state/index";
+import { OperandStack } from "../../../../operand-stack/index";
+import type { OperatorHandlerContext } from "../../../../operator-registry/index";
+import { tlHandler } from "../index";
+
+const buildContext = (operands: PdfObject[]): OperatorHandlerContext => {
+  const operandStack = OperandStack.create();
+  for (const operand of operands) {
+    OperandStack.push(operandStack, operand);
+  }
+  const graphicsStateStack = GraphicsStateStack.create();
+  return { operandStack, graphicsStateStack };
+};
+
+test("operand が 0 個のとき OPERATOR_OPERAND_MISSING を返す", () => {
+  const context = buildContext([]);
+  const result = tlHandler(context);
+
+  assert(!result.ok);
+  assert(result.error.code === "OPERATOR_OPERAND_MISSING");
+  expect(result.error.operatorName).toBe("TL");
+  expect(result.error.required).toBe(1);
+  expect(result.error.actual).toBe(0);
+  expect(result.error.message).toBe(
+    "Operator 'TL' requires 1 operand(s), got 0",
+  );
+});
+
+test.each<[string, PdfObject]>([
+  ["name", { type: "name", value: "F1" }],
+  ["boolean", { type: "boolean", value: true }],
+  ["null", { type: "null" }],
+  [
+    "string",
+    { type: "string", value: new Uint8Array([0x61]), encoding: "literal" },
+  ],
+  ["array", { type: "array", elements: [] }],
+  ["dictionary", { type: "dictionary", entries: new Map() }],
+  [
+    "indirect-ref",
+    { type: "indirect-ref", objectNumber: 1, generationNumber: 0 },
+  ],
+])("operand が %s のとき OPERATOR_OPERAND_TYPE_MISMATCH を返す", (typeName, operand) => {
+  const context = buildContext([operand]);
+  const result = tlHandler(context);
+
+  assert(!result.ok);
+  assert(result.error.code === "OPERATOR_OPERAND_TYPE_MISMATCH");
+  expect(result.error.operatorName).toBe("TL");
+  expect(result.error.expected).toBe("number");
+  expect(result.error.actual).toBe(typeName);
+  expect(result.error.message).toBe(
+    `Operator 'TL' expected number operand, got ${typeName}`,
+  );
+});
+
+test("MISMATCH 後も部分消費した operand は復元せず、余剰 operand のみ残る", () => {
+  const surplus: PdfObject = { type: "integer", value: 99 };
+  const context = buildContext([surplus, { type: "name", value: "F1" }]);
+
+  const result = tlHandler(context);
+
+  assert(!result.ok);
+  assert(result.error.code === "OPERATOR_OPERAND_TYPE_MISMATCH");
+  expect(OperandStack.depth(context.operandStack)).toBe(1);
+  const top = OperandStack.peek(context.operandStack);
+  assert(top.some);
+  expect(top.value).toEqual(surplus);
+});

--- a/packages/core/src/content-stream/operators/text/tl/index.ts
+++ b/packages/core/src/content-stream/operators/text/tl/index.ts
@@ -1,0 +1,70 @@
+import type { PdfError } from "../../../../pdf/errors/index";
+import { err, ok } from "../../../../utils/result/index";
+import {
+  GraphicsState,
+  GraphicsStateStack,
+  TextState,
+} from "../../../graphics-state/index";
+import { OperandStack } from "../../../operand-stack/index";
+import type {
+  OperatorHandler,
+  OperatorHandlerContext,
+} from "../../../operator-registry/index";
+import { NumericPdfObject } from "../../graphics-state/numeric-pdf-object/index";
+
+const OPERATOR_NAME = "TL";
+
+/**
+ * PDF §9.3.5 `TL` operator (text leading) のハンドラ。
+ * operand を 1 個 pop し、number であれば `textState.leading` を更新する。
+ * leading は後続の `T*` / `TD` / `'` / `"` で参照される。
+ *
+ * - operand stack が空なら `OPERATOR_OPERAND_MISSING` を返す
+ * - 末尾が number 以外なら `OPERATOR_OPERAND_TYPE_MISMATCH` を返す
+ * - 値域検証はしない（負値・小数・`0`・`NaN`・`Infinity` をそのまま格納する）
+ * - エラー時に部分消費した operand stack は復元しない（既存ハンドラ規約）
+ * - `TL` は BT/ET の外でも呼べるため `textObject.active` は検査しない
+ *
+ * @param context - 実行コンテキスト (operand stack / graphics state stack)
+ * @returns 成功なら更新後コンテキスト、失敗なら PdfError
+ */
+export const tlHandler: OperatorHandler = (context: OperatorHandlerContext) => {
+  const popped = OperandStack.pop(context.operandStack);
+  if (!popped.some) {
+    const error: PdfError = {
+      code: "OPERATOR_OPERAND_MISSING",
+      message: `Operator '${OPERATOR_NAME}' requires 1 operand(s), got 0`,
+      operatorName: OPERATOR_NAME,
+      required: 1,
+      actual: 0,
+    };
+    return err(error);
+  }
+
+  const operand = popped.value;
+  if (!NumericPdfObject.is(operand)) {
+    const error: PdfError = {
+      code: "OPERATOR_OPERAND_TYPE_MISMATCH",
+      message: `Operator '${OPERATOR_NAME}' expected number operand, got ${operand.type}`,
+      operatorName: OPERATOR_NAME,
+      expected: "number",
+      actual: operand.type,
+    };
+    return err(error);
+  }
+
+  const current = GraphicsStateStack.current(context.graphicsStateStack);
+  const nextTextState = TextState.update(current.textState, {
+    leading: operand.value,
+  });
+  const next = GraphicsState.update(current, { textState: nextTextState });
+  const graphicsStateStack = GraphicsStateStack.replaceCurrent(
+    context.graphicsStateStack,
+    next,
+  );
+
+  return ok({
+    operandStack: context.operandStack,
+    graphicsStateStack,
+  });
+};


### PR DESCRIPTION
## 概要

PDF §9.3.5 のテキスト状態オペレータ `TL leading`（行送り）のハンドラを新規追加する。operand を 1 個（number）pop し `textState.leading` を更新する。`leading` は後続フェーズの `T*` / `TD` / `'` / `"` で参照される。throw 禁止で結果はすべて `Result` 型として返す。構造は兄弟ハンドラ `twHandler`（word spacing）とほぼ同一で、状態更新先を `TextState.update(..., { leading })` に差し替えたもの。

## 変更内容

### 🎯 変更の種類

- [x] ✨ 新機能 (New feature)
- [x] 🚨 テスト追加/修正 (Tests)

### 📝 詳細な変更内容

#### 追加された機能・修正

- `tlHandler: OperatorHandler` を新規実装（`OPERATOR_NAME = "TL"`）
- 成功パス: `OperandStack.pop` → `NumericPdfObject.is` → `TextState.update({ leading })` → `GraphicsState.update` → `GraphicsStateStack.replaceCurrent` → `ok(...)`
- operand 不足は `OPERATOR_OPERAND_MISSING`、非数値は `OPERATOR_OPERAND_TYPE_MISMATCH` を `err` で返却
- 値域検証はしない（負値・小数・`0`・`NaN`・`Infinity` をそのまま格納）
- エラー時に部分消費した operand stack は復元しない（既存ハンドラ規約）

#### 変更されたファイル

- `packages/core/src/content-stream/operators/text/tl/index.ts`（新規・実装）
- `packages/core/src/content-stream/operators/text/tl/__tests__/tl.basic.test.ts`（新規・正常系/境界値 9 tests）
- `packages/core/src/content-stream/operators/text/tl/__tests__/tl.error.test.ts`（新規・異常系 9 tests）

#### 削除されたファイル・機能

- なし

## 📊 システム図

### 状態マシン / フロー図

```mermaid
flowchart TD
    A[tlHandler context] --> B[OperandStack.pop]
    B -->|None| E1[err: OPERATOR_OPERAND_MISSING]:::new
    B -->|Some operand| C{NumericPdfObject.is}
    C -->|false| E2[err: OPERATOR_OPERAND_TYPE_MISMATCH]:::new
    C -->|true| D["TextState.update({ leading })"]:::new
    D --> F["GraphicsState.update({ textState })"]
    F --> G[GraphicsStateStack.replaceCurrent]
    G --> H["ok({ operandStack, graphicsStateStack })"]:::new

    classDef new fill:#ffe4b5,stroke:#d97706,stroke-width:2px
```

### データフロー

```
context: { operandStack, graphicsStateStack }
    ↓
OperandStack.pop ─→ Option<PdfObject>
    ↓ (some)
NumericPdfObject.is ─→ narrow: operand.value: number
    ↓
GraphicsStateStack.current ─→ current: GraphicsState
    ↓
TextState.update(current.textState, { leading: operand.value })  [NEW]
    ↓  (charSpace / wordSpace / fontName 等は不変コピー)
GraphicsState.update(current, { textState })
    ↓
GraphicsStateStack.replaceCurrent
    ↓
ok({ operandStack, graphicsStateStack })
```

## 📋 関連 Issue

- Closes #237
- Refs #228 (Epic: PDF解析パイプライン Phase 4-D)

## 🧪 テスト

### テスト実行方法

```bash
pnpm --filter @pdfmod/core test
```

### テスト項目

- [x] 単体テスト (Unit tests)

### テスト結果

- `tl` 18 tests green（basic 9 / error 9）
- `@pdfmod/core` 全体: 166 ファイル / 2284 tests green（リグレッションなし）
- `tsc --noEmit`（typecheck）pass
- biome / oxlint pass
- Codex CLI コードレビュー: 問題なし（全観点で指摘なし）

## 🔍 レビューポイント

- 兄弟ハンドラ `twHandler` の最小差分コピー（`wordSpace` → `leading`、`OPERATOR_NAME` / export 名 / JSDoc の置換のみ）であること
- 値域検証を行わず `NaN` / `Infinity` 等もそのまま格納する仕様（Tc/Tw/Tz 規約準拠）であること
- エラー時に pop 済み operand を復元しない挙動（既存ハンドラ規約）であること

## ⚠️ 破壊的変更

- [ ] この変更は既存の API に破壊的変更を含みます

破壊的変更なし。新規 3 ファイル追加のみで既存型・関数の変更なし。

### 注意事項

- ハンドラ登録（`OperatorRegistry.register` / `text-operators` アグリゲータ）は本 Issue スコープ外（別 Issue #242 で対応）。本 PR では未配線。

## ✅ チェックリスト

- [x] コードレビューの準備ができている
- [x] テストが正常に実行される
- [x] コミットメッセージが適切な形式で書かれている
- [x] PR 本文に Issue 連携キーワードを記載
- [x] セルフレビューを実施した
- [x] 破壊的変更なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)