### PR TITLE
✨ [New Feature]: #259 PdfErrorCode enum を pdfmod-core に追加

### DIFF
--- a/rust/crates/core/src/error.rs
+++ b/rust/crates/core/src/error.rs
@@ -5,4 +5,4 @@
 
 // 後続 Issue でエラー型のサブモジュールを追加する:
 // pub mod pdf_error;
-// pub mod pdf_error_code;
+pub mod pdf_error_code;

--- a/rust/crates/core/src/error.rs
+++ b/rust/crates/core/src/error.rs
@@ -1,8 +1,9 @@
 //! PDF 処理のエラー型を定義するモジュール。
 //!
-//! PdfError / PdfErrorCode など、PDF パース・処理で発生する
-//! エラーを表す型を後続 Issue で追加する。
+//! エラーの種類を表す分類タグ `PdfErrorCode` を提供する。位置・メッセージ等の
+//! 詳細情報を保持する `PdfError` など他のエラー型は後続 Issue で追加する。
+
+pub mod pdf_error_code;
 
 // 後続 Issue でエラー型のサブモジュールを追加する:
 // pub mod pdf_error;
-pub mod pdf_error_code;

--- a/rust/crates/core/src/error/pdf_error_code.rs
+++ b/rust/crates/core/src/error/pdf_error_code.rs
@@ -1,0 +1,80 @@
+//! PDF 解析で発生するエラーの種類を表す `PdfErrorCode` を定義するモジュール。
+//!
+//! レクサー・パーサ・xref・リゾルバの各段階で起こりうるエラーを分類する
+//! タグ型。データを持たない unit variant のみで構成し、位置・メッセージ等の
+//! 詳細情報は後続の `PdfError`(#260) 側が保持する。本タスクでは R0／R1
+//! （レクサー・パーサ段階）の最小バリアント集合のみを定義する（Issue #259）。
+
+/// PDF 解析エラーの分類タグ。
+///
+/// 各バリアントはエラーの「種類」のみを表し、付随情報は持たない（unit variant）。
+/// 軽量な分類タグとして `Copy` 可能。等価判定（`PartialEq`/`Eq`）は同一バリアントか
+/// 否かに従う。順序・ハッシュは用途上不要のため derive しない（Issue #259 指定。
+/// 既存 newtype の `Hash`/`PartialOrd`/`Ord` を持たない点が意図的な差異）。
+/// 将来のフェーズ（xref／リゾルバ）でバリアントを追加していく方針。
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PdfErrorCode {
+    /// 入力の途中で予期せず終端（EOF）に達した。
+    UnexpectedEof,
+    /// 文法上その位置に現れてはならないトークンを検出した。
+    UnexpectedToken,
+    /// 数値として解釈できない入力を検出した。
+    InvalidNumber,
+    /// PDF の構文規則に違反する入力を検出した。
+    InvalidSyntax,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn same_variants_are_equal() {
+        // 同一バリアント同士は == で等価と判定される（PartialEq/Eq の確認）
+        assert_eq!(PdfErrorCode::UnexpectedEof, PdfErrorCode::UnexpectedEof);
+    }
+
+    #[test]
+    fn different_variants_are_not_equal() {
+        // 異なるバリアントは != で非等価と判定される
+        assert_ne!(PdfErrorCode::UnexpectedEof, PdfErrorCode::UnexpectedToken);
+    }
+
+    #[test]
+    fn all_distinct_variants_are_mutually_not_equal() {
+        // 4 バリアントを総当たりで比較し、同一インデックスのみ等価・他は非等価であることを確認する
+        let variants = [
+            PdfErrorCode::UnexpectedEof,
+            PdfErrorCode::UnexpectedToken,
+            PdfErrorCode::InvalidNumber,
+            PdfErrorCode::InvalidSyntax,
+        ];
+        for (i, a) in variants.iter().enumerate() {
+            for (j, b) in variants.iter().enumerate() {
+                if i == j {
+                    assert_eq!(a, b);
+                } else {
+                    assert_ne!(a, b);
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn is_copy_so_original_stays_usable() {
+        // Copy derive によりコピー後も元の値がムーブされず再使用できることを確認する
+        let original = PdfErrorCode::InvalidSyntax;
+        let copied = original;
+        assert_eq!(original, PdfErrorCode::InvalidSyntax);
+        assert_eq!(original, copied);
+    }
+
+    #[test]
+    fn debug_format_contains_variant_name() {
+        // Debug 出力が各バリアント名を含むことを確認する
+        assert!(format!("{:?}", PdfErrorCode::UnexpectedEof).contains("UnexpectedEof"));
+        assert!(format!("{:?}", PdfErrorCode::UnexpectedToken).contains("UnexpectedToken"));
+        assert!(format!("{:?}", PdfErrorCode::InvalidNumber).contains("InvalidNumber"));
+        assert!(format!("{:?}", PdfErrorCode::InvalidSyntax).contains("InvalidSyntax"));
+    }
+}


### PR DESCRIPTION
## 概要

PDF 解析（レクサー・パーサ・xref・リゾルバ）で発生するエラーの種類を表す分類タグ `PdfErrorCode`（unit-variant enum）を `pdfmod-core` に追加します。後続の `PdfError`(#260) がこの enum を保持して利用するため、その共通基盤を先に定義します。R0／R1（レクサー・パーサ段階）で必要な最小限のバリアントから始めます。

## 変更内容

### 🎯 変更の種類

- [x] ✨ 新機能 (New feature)
- [x] 📖 ドキュメント更新 (Documentation) — レビュー指摘対応

### 📝 詳細な変更内容

#### 追加された機能・修正

- `pub enum PdfErrorCode`（unit variant のみ）を定義
  - バリアント: `UnexpectedEof` / `UnexpectedToken` / `InvalidNumber` / `InvalidSyntax`
  - derive: `Debug, Clone, Copy, PartialEq, Eq`（`Hash` / `PartialOrd` / `Ord` は付けない）
  - `#[non_exhaustive]` は付与しない（現状利用者ゼロ・crate 内部のみ・0.x 前提のため許容）
  - モジュール `//!`・型 `///`・各バリアント `///` に日本語 doc コメントを付与
- テスト 5 件を追加（等価性 / 非等価性 / 4 バリアント網羅 / Copy / Debug）
- **レビュー指摘対応**: `error.rs` のモジュール `//!` doc を実態に合わせ更新（`PdfErrorCode` は提供済み・`PdfError` 等が後続、と明記。`commit b8d577c`）

#### 変更されたファイル

- `rust/crates/core/src/error/pdf_error_code.rs`（新規）
- `rust/crates/core/src/error.rs`（`pub mod pdf_error_code;` 有効化 + モジュール doc 更新）

#### 削除されたファイル・機能

- なし

## 📊 システム図

### データフロー

```mermaid
flowchart TD
    Lib["lib.rs<br/>pub mod error（既存・編集不要）"] --> ErrMod["error.rs<br/>pub mod pdf_error_code（本PRで有効化）"]
    ErrMod --> Mod["error/pdf_error_code.rs<br/>pub enum PdfErrorCode"]:::new
    Mod --> V1["UnexpectedEof"]:::new
    Mod --> V2["UnexpectedToken"]:::new
    Mod --> V3["InvalidNumber"]:::new
    Mod --> V4["InvalidSyntax"]:::new

    classDef new fill:#ffe4b5,stroke:#d97706,stroke-width:2px
```

## 📋 関連 Issue

- Refs #259
- blocked by #254 / 親Epic #251 / 後続 #260（`PdfError`）

## 🧪 テスト

### テスト実行方法

```bash
cd rust && cargo test -p pdfmod-core pdf_error_code
```

### テスト項目

- [x] 単体テスト (Unit tests)

### テスト結果

- `cargo build -p pdfmod-core` ✅
- `cargo test -p pdfmod-core` ✅ 38 passed（うち本PRの 5 件: 等価性 / 非等価性 / 網羅 / Copy / Debug）
- `cargo clippy -p pdfmod-core -- -D warnings` ✅ 警告なし
- `cargo fmt --check`（本PRの変更ファイル）✅
- CI（`ci` / `coverage-comment`）✅ pass

## 🔍 レビューポイント

- enum 前例がリポジトリに存在しないため、各バリアントへの日本語 `///` doc コメントの体裁を本PRで確立しています
- `Hash` / `PartialOrd` / `Ord` を derive しない点が既存 newtype との意図的な差異です
- `#[non_exhaustive]` を付与しない判断（探索後ヒアリングで確定）

## ⚠️ 破壊的変更

- [ ] この変更は既存の API に破壊的変更を含みます

破壊的変更なし。純粋な pub API の追加のみで、本 enum を import している既存コードはゼロです。

🤖 Generated with [Claude Code](https://claude.com/claude-code)