### PR TITLE
✨ [New Feature]: #228 Tr オペレータハンドラ（text rendering mode）を実装

### DIFF
--- a/packages/core/src/content-stream/operators/text/tr/__tests__/tr.basic.test.ts
+++ b/packages/core/src/content-stream/operators/text/tr/__tests__/tr.basic.test.ts
@@ -1,0 +1,83 @@
+import { assert, expect, test } from "vitest";
+import type { PdfObject } from "../../../../../pdf/types/pdf-types/index";
+import {
+  GraphicsState,
+  GraphicsStateStack,
+  TextRenderingMode,
+  TextState,
+} from "../../../../graphics-state/index";
+import { OperandStack } from "../../../../operand-stack/index";
+import type { OperatorHandlerContext } from "../../../../operator-registry/index";
+import { trHandler } from "../index";
+
+const buildContext = (operands: PdfObject[]): OperatorHandlerContext => {
+  const operandStack = OperandStack.create();
+  for (const operand of operands) {
+    OperandStack.push(operandStack, operand);
+  }
+  const graphicsStateStack = GraphicsStateStack.create();
+  return { operandStack, graphicsStateStack };
+};
+
+test.each([
+  { value: 0 },
+  { value: 2 },
+  { value: 7 },
+] as const)("'$value Tr' で renderingMode が create($value) に更新される", ({
+  value,
+}) => {
+  const context = buildContext([{ type: "integer", value }]);
+  const result = trHandler(context);
+
+  assert(result.ok);
+  const current = GraphicsStateStack.current(result.value.graphicsStateStack);
+  expect(current.textState.renderingMode).toBe(TextRenderingMode.create(value));
+});
+
+test("renderingMode 更新時、非デフォルト値の他フィールドは保持される", () => {
+  const seeded = GraphicsStateStack.create();
+  const current = GraphicsStateStack.current(seeded);
+  const seededTextState = TextState.update(current.textState, {
+    charSpace: 3,
+    horizontalScaling: 150,
+    leading: 7,
+  });
+  const graphicsStateStack = GraphicsStateStack.replaceCurrent(
+    seeded,
+    GraphicsState.update(current, { textState: seededTextState }),
+  );
+  const result = trHandler({
+    operandStack: buildContext([{ type: "integer", value: 2 }]).operandStack,
+    graphicsStateStack,
+  });
+
+  assert(result.ok);
+  const after = GraphicsStateStack.current(
+    result.value.graphicsStateStack,
+  ).textState;
+  expect(after.renderingMode).toBe(TextRenderingMode.create(2));
+  expect(after.charSpace).toBe(3);
+  expect(after.horizontalScaling).toBe(150);
+  expect(after.leading).toBe(7);
+});
+
+test("成功時に operand が消費され depth が 0 になる", () => {
+  const context = buildContext([{ type: "integer", value: 0 }]);
+  const result = trHandler(context);
+
+  assert(result.ok);
+  expect(OperandStack.depth(result.value.operandStack)).toBe(0);
+});
+
+test("余剰 operand があっても末尾 1 個のみ pop する", () => {
+  const context = buildContext([
+    { type: "integer", value: 5 },
+    { type: "integer", value: 3 },
+  ]);
+  const result = trHandler(context);
+
+  assert(result.ok);
+  const current = GraphicsStateStack.current(result.value.graphicsStateStack);
+  expect(current.textState.renderingMode).toBe(TextRenderingMode.create(3));
+  expect(OperandStack.depth(result.value.operandStack)).toBe(1);
+});

--- a/packages/core/src/content-stream/operators/text/tr/__tests__/tr.error.test.ts
+++ b/packages/core/src/content-stream/operators/text/tr/__tests__/tr.error.test.ts
@@ -1,0 +1,169 @@
+import { assert, expect, test } from "vitest";
+import type { PdfObject } from "../../../../../pdf/types/pdf-types/index";
+import {
+  GraphicsState,
+  GraphicsStateStack,
+  TextRenderingMode,
+  TextState,
+} from "../../../../graphics-state/index";
+import { OperandStack } from "../../../../operand-stack/index";
+import type { OperatorHandlerContext } from "../../../../operator-registry/index";
+import { trHandler } from "../index";
+
+const buildContext = (operands: PdfObject[]): OperatorHandlerContext => {
+  const operandStack = OperandStack.create();
+  for (const operand of operands) {
+    OperandStack.push(operandStack, operand);
+  }
+  const graphicsStateStack = GraphicsStateStack.create();
+  return { operandStack, graphicsStateStack };
+};
+
+test("operand が 0 個のとき OPERATOR_OPERAND_MISSING を返す", () => {
+  const context = buildContext([]);
+  const result = trHandler(context);
+
+  assert(!result.ok);
+  assert(result.error.code === "OPERATOR_OPERAND_MISSING");
+  expect(result.error.operatorName).toBe("Tr");
+  expect(result.error.required).toBe(1);
+  expect(result.error.actual).toBe(0);
+  expect(result.error.message).toBe(
+    "Operator 'Tr' requires 1 operand(s), got 0",
+  );
+});
+
+test.each<[string, PdfObject]>([
+  ["name", { type: "name", value: "F1" }],
+  ["boolean", { type: "boolean", value: true }],
+  ["null", { type: "null" }],
+  [
+    "string",
+    { type: "string", value: new Uint8Array([0x61]), encoding: "literal" },
+  ],
+  ["array", { type: "array", elements: [] }],
+  ["dictionary", { type: "dictionary", entries: new Map() }],
+  [
+    "indirect-ref",
+    { type: "indirect-ref", objectNumber: 1, generationNumber: 0 },
+  ],
+])("operand が %s のとき OPERATOR_OPERAND_TYPE_MISMATCH を返す", (typeName, operand) => {
+  const context = buildContext([operand]);
+  const result = trHandler(context);
+
+  assert(!result.ok);
+  assert(result.error.code === "OPERATOR_OPERAND_TYPE_MISMATCH");
+  expect(result.error.operatorName).toBe("Tr");
+  expect(result.error.expected).toBe("integer");
+  expect(result.error.actual).toBe(typeName);
+  expect(result.error.message).toBe(
+    `Operator 'Tr' expected integer operand, got ${typeName}`,
+  );
+});
+
+test.each<[string, number]>([
+  ["3.14", 3.14],
+  ["3.0", 3.0],
+])("real %s（非整数型）は VALUE ではなく TYPE_MISMATCH を返す", (_label, value) => {
+  const context = buildContext([{ type: "real", value }]);
+  const result = trHandler(context);
+
+  assert(!result.ok);
+  assert(result.error.code === "OPERATOR_OPERAND_TYPE_MISMATCH");
+  expect(result.error.expected).toBe("integer");
+  expect(result.error.actual).toBe("real");
+});
+
+test.each<[string, number]>([
+  ["上限超過 8", 8],
+  ["下限未満 -1", -1],
+  ["巨大値 MAX_SAFE_INTEGER", Number.MAX_SAFE_INTEGER],
+])("integer 値域外 %s のとき OPERATOR_OPERAND_VALUE_OUT_OF_RANGE を返す", (_label, value) => {
+  const context = buildContext([{ type: "integer", value }]);
+  const result = trHandler(context);
+
+  assert(!result.ok);
+  assert(result.error.code === "OPERATOR_OPERAND_VALUE_OUT_OF_RANGE");
+  expect(result.error.operatorName).toBe("Tr");
+  expect(result.error.allowed).toEqual([0, 1, 2, 3, 4, 5, 6, 7]);
+  expect(result.error.actual).toBe(value);
+});
+
+test("integer 8 のとき message が LineCap と同形式になる", () => {
+  const context = buildContext([{ type: "integer", value: 8 }]);
+  const result = trHandler(context);
+
+  assert(!result.ok);
+  assert(result.error.code === "OPERATOR_OPERAND_VALUE_OUT_OF_RANGE");
+  expect(result.error.message).toBe(
+    "Operator 'Tr' operand value 8 is out of range, expected one of [0, 1, 2, 3, 4, 5, 6, 7]",
+  );
+});
+
+test("TYPE_MISMATCH 後も部分消費した operand は復元せず、余剰 operand のみ残る", () => {
+  const surplus: PdfObject = { type: "integer", value: 5 };
+  const context = buildContext([surplus, { type: "name", value: "F1" }]);
+
+  const result = trHandler(context);
+
+  assert(!result.ok);
+  assert(result.error.code === "OPERATOR_OPERAND_TYPE_MISMATCH");
+  expect(OperandStack.depth(context.operandStack)).toBe(1);
+  const top = OperandStack.peek(context.operandStack);
+  assert(top.some);
+  expect(top.value).toEqual(surplus);
+});
+
+test("VALUE_OUT_OF_RANGE 後も部分消費した operand は復元せず、余剰 operand のみ残る", () => {
+  const surplus: PdfObject = { type: "integer", value: 5 };
+  const context = buildContext([surplus, { type: "integer", value: 8 }]);
+
+  const result = trHandler(context);
+
+  assert(!result.ok);
+  assert(result.error.code === "OPERATOR_OPERAND_VALUE_OUT_OF_RANGE");
+  expect(OperandStack.depth(context.operandStack)).toBe(1);
+  const top = OperandStack.peek(context.operandStack);
+  assert(top.some);
+  expect(top.value).toEqual(surplus);
+});
+
+// 事前に renderingMode を非デフォルト値（create(2)=FILL_STROKE）へ設定した context を構築する。
+// デフォルト FILL(0) へのリセットという不正実装を検出するため、非デフォルト起点が必須。
+const seedFillStroke = (): OperatorHandlerContext => {
+  const stack = GraphicsStateStack.create();
+  const current = GraphicsStateStack.current(stack);
+  const textState = TextState.update(current.textState, {
+    renderingMode: TextRenderingMode.create(TextRenderingMode.FILL_STROKE),
+  });
+  const graphicsStateStack = GraphicsStateStack.replaceCurrent(
+    stack,
+    GraphicsState.update(current, { textState }),
+  );
+  return { operandStack: OperandStack.create(), graphicsStateStack };
+};
+
+test.each<[string, PdfObject, string]>([
+  [
+    "TYPE_MISMATCH(name)",
+    { type: "name", value: "F1" },
+    "OPERATOR_OPERAND_TYPE_MISMATCH",
+  ],
+  [
+    "VALUE_OUT_OF_RANGE(8)",
+    { type: "integer", value: 8 },
+    "OPERATOR_OPERAND_VALUE_OUT_OF_RANGE",
+  ],
+])("%s 失敗後も renderingMode は事前設定 create(2) のまま不変", (_label, operand, code) => {
+  const context = seedFillStroke();
+  OperandStack.push(context.operandStack, operand);
+
+  const result = trHandler(context);
+
+  assert(!result.ok);
+  assert(result.error.code === code);
+  const after = GraphicsStateStack.current(
+    context.graphicsStateStack,
+  ).textState;
+  expect(after.renderingMode).toBe(TextRenderingMode.create(2));
+});

--- a/packages/core/src/content-stream/operators/text/tr/index.ts
+++ b/packages/core/src/content-stream/operators/text/tr/index.ts
@@ -1,0 +1,84 @@
+import type { PdfError } from "../../../../pdf/errors/index";
+import { err, ok } from "../../../../utils/result/index";
+import {
+  GraphicsState,
+  GraphicsStateStack,
+  TextRenderingMode,
+  TextState,
+} from "../../../graphics-state/index";
+import { OperandStack } from "../../../operand-stack/index";
+import type {
+  OperatorHandler,
+  OperatorHandlerContext,
+} from "../../../operator-registry/index";
+
+/** PDF §9.3.6 text rendering mode オペレータ名（PDF 表記の大小を保持）。 */
+const OPERATOR_NAME = "Tr";
+
+/**
+ * PDF §9.3.6 `Tr render` operator (text rendering mode) のハンドラ。
+ * operand を 1 個 pop し、0〜7 の integer であれば
+ * `textState.renderingMode` を `TextRenderingMode.create(n)` で更新する。
+ *
+ * - operand stack が空なら `OPERATOR_OPERAND_MISSING` を返す
+ * - 末尾が integer 以外（real / name / boolean / array / ...）なら
+ *   `OPERATOR_OPERAND_TYPE_MISMATCH` を返す（real 3.14 / 3.0 も TYPE_MISMATCH）
+ * - 末尾 integer の値が 0〜7 以外（8 / -1 / MAX_SAFE_INTEGER 等）なら
+ *   `OPERATOR_OPERAND_VALUE_OUT_OF_RANGE` を返す（`allowed = TextRenderingMode.allowed`）
+ * - エラー時に部分消費した operand stack は復元しない（既存ハンドラ規約）
+ * - `Tr` は BT/ET の外でも呼べるため `textObject.active` は検査しない
+ *
+ * @param context - 実行コンテキスト (operand stack / graphics state stack)
+ * @returns 成功なら更新後コンテキスト、失敗なら PdfError
+ */
+export const trHandler: OperatorHandler = (context: OperatorHandlerContext) => {
+  const popped = OperandStack.pop(context.operandStack);
+  if (!popped.some) {
+    const error: PdfError = {
+      code: "OPERATOR_OPERAND_MISSING",
+      message: `Operator '${OPERATOR_NAME}' requires 1 operand(s), got 0`,
+      operatorName: OPERATOR_NAME,
+      required: 1,
+      actual: 0,
+    };
+    return err(error);
+  }
+
+  const operand = popped.value;
+  if (operand.type !== "integer") {
+    const error: PdfError = {
+      code: "OPERATOR_OPERAND_TYPE_MISMATCH",
+      message: `Operator '${OPERATOR_NAME}' expected integer operand, got ${operand.type}`,
+      operatorName: OPERATOR_NAME,
+      expected: "integer",
+      actual: operand.type,
+    };
+    return err(error);
+  }
+
+  const value = operand.value;
+  if (!TextRenderingMode.isValid(value)) {
+    const error: PdfError = {
+      code: "OPERATOR_OPERAND_VALUE_OUT_OF_RANGE",
+      message: `Operator '${OPERATOR_NAME}' operand value ${value} is out of range, expected one of [${TextRenderingMode.allowed.join(", ")}]`,
+      operatorName: OPERATOR_NAME,
+      allowed: TextRenderingMode.allowed,
+      actual: value,
+    };
+    return err(error);
+  }
+
+  const renderingMode = TextRenderingMode.create(value);
+  const current = GraphicsStateStack.current(context.graphicsStateStack);
+  const nextTextState = TextState.update(current.textState, { renderingMode });
+  const next = GraphicsState.update(current, { textState: nextTextState });
+  const graphicsStateStack = GraphicsStateStack.replaceCurrent(
+    context.graphicsStateStack,
+    next,
+  );
+
+  return ok({
+    operandStack: context.operandStack,
+    graphicsStateStack,
+  });
+};


### PR DESCRIPTION
## 概要

PDF §9.3.6 のテキストオペレータ `Tr`（text rendering mode）のハンドラを新規実装しました。オペランドスタックから integer (0〜7) を 1 個 pop し、`textState.renderingMode` を `TextRenderingMode.create(n)` で不変更新します。検証ロジックは LineCap `J` の三段階パターン、state 更新は Tz/TL の不変更新パターンを踏襲しています。

## 変更内容

### 🎯 変更の種類

- [x] ✨ 新機能 (New feature)
- [x] 🚨 テスト追加/修正 (Tests)

### 📝 詳細な変更内容

#### 追加された機能・修正

- `Tr` オペレータハンドラ `trHandler` を新規追加（named export、`OPERATOR_NAME = "Tr"`）
- 三段階検証: `MISSING` → `TYPE_MISMATCH` → `VALUE_OUT_OF_RANGE`
- real（3.14 / 3.0）は **TYPE_MISMATCH**、integer 値域外（8 / -1）は **VALUE_OUT_OF_RANGE** に分類
- `throw` を一切使わず、すべて `Result<OperatorHandlerContext, PdfError>` を返却

#### 変更されたファイル

- `[NEW]` `packages/core/src/content-stream/operators/text/tr/index.ts` — ハンドラ本体
- `[NEW]` `packages/core/src/content-stream/operators/text/tr/__tests__/tr.basic.test.ts` — 正常系テスト（6件）
- `[NEW]` `packages/core/src/content-stream/operators/text/tr/__tests__/tr.error.test.ts` — 異常系テスト（18件）

#### 削除されたファイル・機能

- なし

## 📊 システム図

### 状態マシン / フロー図

```mermaid
flowchart TD
    Start([Tr 実行]) --> Pop[OperandStack.pop]
    Pop -->|some == false| Missing[ERR: OPERATOR_OPERAND_MISSING]:::new
    Pop -->|some == true| CheckType{type === integer ?}
    CheckType -->|no: name/real/etc| Mismatch[ERR: OPERATOR_OPERAND_TYPE_MISMATCH]:::new
    CheckType -->|yes| CheckRange{isValid 0..7 ?}
    CheckRange -->|no: 8 / -1 / 巨大値| OutOfRange[ERR: OPERATOR_OPERAND_VALUE_OUT_OF_RANGE]:::new
    CheckRange -->|yes| Update[renderingMode を不変更新]:::new
    Missing --> ErrEnd([err PdfError])
    Mismatch --> ErrEnd
    OutOfRange --> ErrEnd
    Update --> OkEnd([ok context'])

    classDef new fill:#ffe4b5,stroke:#d97706,stroke-width:2px
```

### データフロー

```
trHandler(context)
    ↓
OperandStack.pop(context.operandStack)        [NEW] operand を 1 個取り出し
    ↓ (検証) type !== "integer"  → TYPE_MISMATCH
    ↓ (検証) !TextRenderingMode.isValid(value) → VALUE_OUT_OF_RANGE
TextRenderingMode.create(value)               [NEW] Brand 化
    ↓
GraphicsStateStack.current(stack)
    ↓
TextState.update(textState, { renderingMode }) [NEW] 不変更新
    ↓
GraphicsState.update(current, { textState })
    ↓
GraphicsStateStack.replaceCurrent(stack, next)
    ↓
ok({ operandStack, graphicsStateStack })
```

## 📋 関連 Issue

- Refs #228（親 Epic）

## 🧪 テスト

### テスト実行方法

```bash
pnpm --filter @pdfmod/core test
pnpm --filter @pdfmod/core typecheck
```

### テスト項目

- [x] 単体テスト (Unit tests) — tr.basic（6件）/ tr.error（18件）
- [x] 型チェック (typecheck)
- [x] Lint (biome + oxlint)

### テスト結果

- `test`: 168 files / **2308 passed**（新規 24 件含む、リグレッションなし）
- `typecheck`: green
- `lint`: 0 errors / 0 warnings
- spec-based code review（performance / design / spec-alignment 3並列）: CRITICAL 0 / WARNING 0、DoD 全 12 項目充足

## 🔍 レビューポイント

- 検証順序が LineCap `J` と同形式か（特に real を VALUE ではなく TYPE_MISMATCH に分類している点）
- エラー時に operand stack の部分消費を復元しない既存規約に沿っているか
- レジストリ登録・`TextRenderingMode` 型作成はスコープ外（既存実装を利用）

## ⚠️ 破壊的変更

- [ ] この変更は既存の API に破壊的変更を含みます

新規ファイル 3 つの追加のみで、破壊的変更はありません。