### PR TITLE
✨ [New Feature]: #239 Ts オペレータハンドラ（text rise）を実装

### DIFF
--- a/packages/core/src/content-stream/operators/text/ts/__tests__/ts.basic.test.ts
+++ b/packages/core/src/content-stream/operators/text/ts/__tests__/ts.basic.test.ts
@@ -1,0 +1,124 @@
+import { assert, expect, test } from "vitest";
+import type { PdfObject } from "../../../../../pdf/types/pdf-types/index";
+import {
+  GraphicsState,
+  GraphicsStateStack,
+  TextState,
+} from "../../../../graphics-state/index";
+import { OperandStack } from "../../../../operand-stack/index";
+import type { OperatorHandlerContext } from "../../../../operator-registry/index";
+import { tsHandler } from "../index";
+
+const buildContext = (operands: PdfObject[]): OperatorHandlerContext => {
+  const operandStack = OperandStack.create();
+  for (const operand of operands) {
+    OperandStack.push(operandStack, operand);
+  }
+  const graphicsStateStack = GraphicsStateStack.create();
+  return { operandStack, graphicsStateStack };
+};
+
+test("正値 '3 Ts' で rise が 3 に更新される", () => {
+  const context = buildContext([{ type: "integer", value: 3 }]);
+  const result = tsHandler(context);
+
+  assert(result.ok);
+  const current = GraphicsStateStack.current(result.value.graphicsStateStack);
+  expect(current.textState.rise).toBe(3);
+});
+
+test("負値 '-2 Ts' で rise が -2 に更新される", () => {
+  const context = buildContext([{ type: "integer", value: -2 }]);
+  const result = tsHandler(context);
+
+  assert(result.ok);
+  const current = GraphicsStateStack.current(result.value.graphicsStateStack);
+  expect(current.textState.rise).toBe(-2);
+});
+
+test("非0 の rise に '0 Ts' を適用すると 0 にリセットされる", () => {
+  const first = tsHandler(buildContext([{ type: "integer", value: 3 }]));
+  assert(first.ok);
+
+  const reset = tsHandler({
+    operandStack: buildContext([{ type: "integer", value: 0 }]).operandStack,
+    graphicsStateStack: first.value.graphicsStateStack,
+  });
+
+  assert(reset.ok);
+  const current = GraphicsStateStack.current(reset.value.graphicsStateStack);
+  expect(current.textState.rise).toBe(0);
+});
+
+test("小数 '1.5 Ts'（real）で rise が 1.5 に更新される", () => {
+  const context = buildContext([{ type: "real", value: 1.5 }]);
+  const result = tsHandler(context);
+
+  assert(result.ok);
+  const current = GraphicsStateStack.current(result.value.graphicsStateStack);
+  expect(current.textState.rise).toBe(1.5);
+});
+
+test.each<[string, PdfObject, number]>([
+  ["NaN", { type: "real", value: Number.NaN }, Number.NaN],
+  [
+    "Infinity",
+    { type: "real", value: Number.POSITIVE_INFINITY },
+    Number.POSITIVE_INFINITY,
+  ],
+])("境界値 '%s' の operand も値域検証せず rise に格納する", (_label, operand, expected) => {
+  const context = buildContext([operand]);
+  const result = tsHandler(context);
+
+  assert(result.ok);
+  const current = GraphicsStateStack.current(result.value.graphicsStateStack);
+  expect(current.textState.rise).toBe(expected);
+});
+
+test("rise 更新時、非デフォルト値の他フィールドは保持される", () => {
+  const seeded = GraphicsStateStack.create();
+  const current = GraphicsStateStack.current(seeded);
+  const seededTextState = TextState.update(current.textState, {
+    charSpace: 4,
+    wordSpace: 5,
+    leading: 7,
+  });
+  const graphicsStateStack = GraphicsStateStack.replaceCurrent(
+    seeded,
+    GraphicsState.update(current, { textState: seededTextState }),
+  );
+  const result = tsHandler({
+    operandStack: buildContext([{ type: "integer", value: 3 }]).operandStack,
+    graphicsStateStack,
+  });
+
+  assert(result.ok);
+  const after = GraphicsStateStack.current(
+    result.value.graphicsStateStack,
+  ).textState;
+  expect(after.rise).toBe(3);
+  expect(after.charSpace).toBe(4);
+  expect(after.wordSpace).toBe(5);
+  expect(after.leading).toBe(7);
+});
+
+test("成功時に operand が消費され depth が 0 になる", () => {
+  const context = buildContext([{ type: "integer", value: 3 }]);
+  const result = tsHandler(context);
+
+  assert(result.ok);
+  expect(OperandStack.depth(result.value.operandStack)).toBe(0);
+});
+
+test("余剰 operand があっても末尾 1 個のみ pop する", () => {
+  const context = buildContext([
+    { type: "integer", value: 1 },
+    { type: "integer", value: 2 },
+  ]);
+  const result = tsHandler(context);
+
+  assert(result.ok);
+  const current = GraphicsStateStack.current(result.value.graphicsStateStack);
+  expect(current.textState.rise).toBe(2);
+  expect(OperandStack.depth(result.value.operandStack)).toBe(1);
+});

--- a/packages/core/src/content-stream/operators/text/ts/__tests__/ts.error.test.ts
+++ b/packages/core/src/content-stream/operators/text/ts/__tests__/ts.error.test.ts
@@ -1,0 +1,71 @@
+import { assert, expect, test } from "vitest";
+import type { PdfObject } from "../../../../../pdf/types/pdf-types/index";
+import { GraphicsStateStack } from "../../../../graphics-state/index";
+import { OperandStack } from "../../../../operand-stack/index";
+import type { OperatorHandlerContext } from "../../../../operator-registry/index";
+import { tsHandler } from "../index";
+
+const buildContext = (operands: PdfObject[]): OperatorHandlerContext => {
+  const operandStack = OperandStack.create();
+  for (const operand of operands) {
+    OperandStack.push(operandStack, operand);
+  }
+  const graphicsStateStack = GraphicsStateStack.create();
+  return { operandStack, graphicsStateStack };
+};
+
+test("operand が 0 個のとき OPERATOR_OPERAND_MISSING を返す", () => {
+  const context = buildContext([]);
+  const result = tsHandler(context);
+
+  assert(!result.ok);
+  assert(result.error.code === "OPERATOR_OPERAND_MISSING");
+  expect(result.error.operatorName).toBe("Ts");
+  expect(result.error.required).toBe(1);
+  expect(result.error.actual).toBe(0);
+  expect(result.error.message).toBe(
+    "Operator 'Ts' requires 1 operand(s), got 0",
+  );
+});
+
+test.each<[string, PdfObject]>([
+  ["name", { type: "name", value: "F1" }],
+  ["boolean", { type: "boolean", value: true }],
+  ["null", { type: "null" }],
+  [
+    "string",
+    { type: "string", value: new Uint8Array([0x61]), encoding: "literal" },
+  ],
+  ["array", { type: "array", elements: [] }],
+  ["dictionary", { type: "dictionary", entries: new Map() }],
+  [
+    "indirect-ref",
+    { type: "indirect-ref", objectNumber: 1, generationNumber: 0 },
+  ],
+])("operand が %s のとき OPERATOR_OPERAND_TYPE_MISMATCH を返す", (typeName, operand) => {
+  const context = buildContext([operand]);
+  const result = tsHandler(context);
+
+  assert(!result.ok);
+  assert(result.error.code === "OPERATOR_OPERAND_TYPE_MISMATCH");
+  expect(result.error.operatorName).toBe("Ts");
+  expect(result.error.expected).toBe("number");
+  expect(result.error.actual).toBe(typeName);
+  expect(result.error.message).toBe(
+    `Operator 'Ts' expected number operand, got ${typeName}`,
+  );
+});
+
+test("MISMATCH 後も部分消費した operand は復元せず、余剰 operand のみ残る", () => {
+  const surplus: PdfObject = { type: "integer", value: 99 };
+  const context = buildContext([surplus, { type: "name", value: "F1" }]);
+
+  const result = tsHandler(context);
+
+  assert(!result.ok);
+  assert(result.error.code === "OPERATOR_OPERAND_TYPE_MISMATCH");
+  expect(OperandStack.depth(context.operandStack)).toBe(1);
+  const top = OperandStack.peek(context.operandStack);
+  assert(top.some);
+  expect(top.value).toEqual(surplus);
+});

--- a/packages/core/src/content-stream/operators/text/ts/index.ts
+++ b/packages/core/src/content-stream/operators/text/ts/index.ts
@@ -1,0 +1,72 @@
+import type { PdfError } from "../../../../pdf/errors/index";
+import { err, ok } from "../../../../utils/result/index";
+import {
+  GraphicsState,
+  GraphicsStateStack,
+  TextState,
+} from "../../../graphics-state/index";
+import { OperandStack } from "../../../operand-stack/index";
+import type {
+  OperatorHandler,
+  OperatorHandlerContext,
+} from "../../../operator-registry/index";
+import { NumericPdfObject } from "../../graphics-state/numeric-pdf-object/index";
+
+const OPERATOR_NAME = "Ts";
+
+/**
+ * PDF §9.3.7 `Ts` operator (text rise) のハンドラ。
+ * operand を 1 個 pop し、number であれば `textState.rise` を更新する。
+ * rise は text space units の垂直オフセット（正値=上付き / 負値=下付き）。
+ *
+ * - operand stack が空なら `OPERATOR_OPERAND_MISSING` を返す
+ * - 末尾が number 以外なら `OPERATOR_OPERAND_TYPE_MISMATCH` を返す
+ * - 値域検証はしない（負値・小数・`0`・`NaN`・`Infinity` をそのまま格納する）
+ * - 値は変換せず raw number をそのまま保存する（font size・horizontal scaling・
+ *   text matrix の適用は描画時の別責務）
+ * - エラー時に部分消費した operand stack は復元しない（既存ハンドラ規約）
+ * - `Ts` は BT/ET の外でも呼べるため `textObject.active` は検査しない
+ *
+ * @param context - 実行コンテキスト (operand stack / graphics state stack)
+ * @returns 成功なら更新後コンテキスト、失敗なら PdfError
+ */
+export const tsHandler: OperatorHandler = (context: OperatorHandlerContext) => {
+  const popped = OperandStack.pop(context.operandStack);
+  if (!popped.some) {
+    const error: PdfError = {
+      code: "OPERATOR_OPERAND_MISSING",
+      message: `Operator '${OPERATOR_NAME}' requires 1 operand(s), got 0`,
+      operatorName: OPERATOR_NAME,
+      required: 1,
+      actual: 0,
+    };
+    return err(error);
+  }
+
+  const operand = popped.value;
+  if (!NumericPdfObject.is(operand)) {
+    const error: PdfError = {
+      code: "OPERATOR_OPERAND_TYPE_MISMATCH",
+      message: `Operator '${OPERATOR_NAME}' expected number operand, got ${operand.type}`,
+      operatorName: OPERATOR_NAME,
+      expected: "number",
+      actual: operand.type,
+    };
+    return err(error);
+  }
+
+  const current = GraphicsStateStack.current(context.graphicsStateStack);
+  const nextTextState = TextState.update(current.textState, {
+    rise: operand.value,
+  });
+  const next = GraphicsState.update(current, { textState: nextTextState });
+  const graphicsStateStack = GraphicsStateStack.replaceCurrent(
+    context.graphicsStateStack,
+    next,
+  );
+
+  return ok({
+    operandStack: context.operandStack,
+    graphicsStateStack,
+  });
+};


### PR DESCRIPTION
## 概要

PDF コンテンツストリームのテキスト状態オペレータ `Ts`（text rise, ISO 32000-1 §9.3.7）のハンドラを新規実装しました。operand 1個（number）を pop して `TextState.rise`（上付き=正値 / 下付き=負値 の垂直オフセット、text space units）を更新します。既存の同型ハンドラ Tc/Tw/TL を雛形にした純関数ハンドラです。

## 変更の種類

- ✨ 新機能（既存ファイルの変更なし・新規3ファイルの追加のみ）

## 詳細な変更内容

### 追加ファイル

| ファイル | 内容 |
|---|---|
| `packages/core/src/content-stream/operators/text/ts/index.ts` | `tsHandler` 本体（72行） |
| `.../ts/__tests__/ts.basic.test.ts` | 成功系テスト9件 |
| `.../ts/__tests__/ts.error.test.ts` | 失敗系テスト9件 |

### 仕様の要点

- **値域チェックなし**: `Tr`（0..7 の値域チェックあり）と異なり、`NaN`/`Infinity`/負値/小数を無検証で受理（ISO §9.3.7 の rise は値域制約のないオフセット）
- **real を受理**: `NumericPdfObject.is`（integer/real）を使用
- **throw 禁止**: 全分岐が `Result`（`ok()`/`err()`）
- **エラー時 operand 非復元**: 既存ハンドラ規約に統一
- **スコープ外**: オペレータレジストリ登録、`TextState.rise` フィールド追加（依存 #232 で実装済み）は含めない

## システム図

```mermaid
flowchart TD
    A[tsHandler context] --> B[OperandStack.pop]
    B -->|None| C[err: OPERATOR_OPERAND_MISSING<br/>required=1, actual=0]
    B -->|Some operand| D{NumericPdfObject.is}
    D -->|false 非number| E[err: OPERATOR_OPERAND_TYPE_MISMATCH<br/>expected=number, actual=type]
    D -->|true integer/real| F[TextState.update rise=operand.value]
    F --> G[GraphicsState.update]
    G --> H[GraphicsStateStack.replaceCurrent]
    H --> I[ok: 更新後 context]
    style F fill:#d4f4dd,stroke:#2e7d32
```

## 関連Issue

- Closes #239
- Refs #228（親 Epic: Phase 4-D — Text Block & Text State Operators）

## テスト

- `pnpm --filter @pdfmod/core test` → **Test Files 170 passed / Tests 2326 passed**（+18、リグレッションなし）
- `tsc --noEmit` → エラーなし
- `biome check` → 0 errors / `oxlint` → 0 warnings, 0 errors / `format:check` → OK
- 網羅: 正値/負値/0/小数/NaN/Infinity/他フィールド保持/depth/余剰 operand（basic）、MISSING/TYPE_MISMATCH 7種/非復元（error）

## レビューポイント

- 値域チェックを行わない点は**意図的**（`Tr` の値域分岐をコピーしていない）
- error テストの型網羅は既存 `tl`/`tz` と統一（`stream` 型は operand 非到達のため除外）
- spec-based-code-review 実施済み: **CRITICAL 0 / WARNING 0 / PROTECTED 10**、DoD **12/12** 充足

🤖 Generated with [Claude Code](https://claude.com/claude-code)