### PR TITLE
✨ [New Feature]: #260 PdfError 型（code + position + message）を pdfmod-core に追加

### DIFF
--- a/rust/crates/core/src/error.rs
+++ b/rust/crates/core/src/error.rs
@@ -1,9 +1,7 @@
 //! PDF 処理のエラー型を定義するモジュール。
 //!
-//! エラーの種類を表す分類タグ `PdfErrorCode` を提供する。位置・メッセージ等の
-//! 詳細情報を保持する `PdfError` など他のエラー型は後続 Issue で追加する。
+//! エラーの種類を表す分類タグ `PdfErrorCode` と、種別に発生位置・補足メッセージ等の
+//! 詳細情報を添えた文脈付きエラー値 `PdfError` を提供する。
 
+pub mod pdf_error;
 pub mod pdf_error_code;
-
-// 後続 Issue でエラー型のサブモジュールを追加する:
-// pub mod pdf_error;

--- a/rust/crates/core/src/error/pdf_error.rs
+++ b/rust/crates/core/src/error/pdf_error.rs
@@ -1,0 +1,293 @@
+//! PDF 処理で発生したエラーを文脈付きで表す `PdfError` を定義するモジュール。
+//!
+//! エラー種別 `PdfErrorCode`(#259) に、発生位置 `ByteOffset`(#257) と補足メッセージを
+//! 任意で添えて束ねる「文脈付きエラー値」。`Result<T, PdfError>` の失敗側として返し、
+//! panic ではなく型でエラーを伝播するための基盤型（Issue #260, Epic #251）。
+//!
+//! 設計意図:
+//! - `position` / `message` は両方 `Option`（位置不明・メッセージ不要なエラーも表現可能）。
+//! - `message` は所有 `String`（`format!` で動的に値・期待トークン等を埋め込める。std のみで完結）。
+//! - 構築はビルダー風: `new(code)` を基点に `with_position` / `with_message` を任意で重ねる。
+//! - `Copy` は付与しない（`String` を保持するため不可）。`Debug, Clone, PartialEq, Eq` のみ derive。
+//! - `Display` を手実装し、`{code:?}` を流用して種別を表示する（`PdfErrorCode` への
+//!   `Display` 追加は #259 スコープのため行わない）。位置・メッセージは Some のときだけ
+//!   連結し、None の要素は記号ごと省略する。
+//! - `std::error::Error` を実装する（`Box<dyn Error>` と相互運用可能）。`source()` は当面
+//!   下位エラーを保持しないためデフォルト実装（`None`）のままとする。
+//! - 外部 crate 依存ゼロ（`thiserror` 等は使わず std のみで実装）。
+
+use std::error::Error;
+use std::fmt;
+
+use crate::byte_offset::ByteOffset;
+use crate::error::pdf_error_code::PdfErrorCode;
+
+/// PDF 処理で発生したエラーを種別・位置・メッセージで表す文脈付きエラー値。
+///
+/// `code` は必須、`position` と `message` は任意（`Option`）。`Result<T, PdfError>` の
+/// `E` として用いる。`String` を保持するため `Copy` は持たない。
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PdfError {
+    code: PdfErrorCode,
+    position: Option<ByteOffset>,
+    message: Option<String>,
+}
+
+impl PdfError {
+    /// エラー種別 `code` のみを持つ `PdfError` を生成する。
+    ///
+    /// 位置・メッセージは `None`。必要に応じて `with_position` / `with_message` で付与する。
+    pub fn new(code: PdfErrorCode) -> PdfError {
+        PdfError {
+            code,
+            position: None,
+            message: None,
+        }
+    }
+
+    /// 発生位置 `position` を付与した `PdfError` を返す（ビルダー風、self を消費）。
+    ///
+    /// 複数回呼び出した場合は**後勝ち**で上書きする（最後に渡した値が残る）。
+    pub fn with_position(mut self, position: ByteOffset) -> PdfError {
+        self.position = Some(position);
+        self
+    }
+
+    /// 補足メッセージ `message` を付与した `PdfError` を返す（ビルダー風、self を消費）。
+    ///
+    /// `impl Into<String>` を受け、`&str` / `String` / `format!` の結果をそのまま渡せる。
+    /// 無検証（空文字列もそのまま受理する）。複数回呼び出した場合は**後勝ち**で上書きする。
+    pub fn with_message(mut self, message: impl Into<String>) -> PdfError {
+        self.message = Some(message.into());
+        self
+    }
+
+    /// エラー種別を返す（`PdfErrorCode` は `Copy` のため値返し）。
+    pub fn code(&self) -> PdfErrorCode {
+        self.code
+    }
+
+    /// 発生位置を返す（未設定なら `None`。`ByteOffset` は `Copy` のため値返し）。
+    pub fn position(&self) -> Option<ByteOffset> {
+        self.position
+    }
+
+    /// 補足メッセージを `Option<&str>` として返す（未設定なら `None`）。
+    pub fn message(&self) -> Option<&str> {
+        self.message.as_deref()
+    }
+}
+
+impl fmt::Display for PdfError {
+    /// "{code:?}" を基点に、position があれば " at byte N"、message があれば ": <message>"
+    /// を連結する。None の要素は記号ごと省略し、余分な記号を出さない。
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{:?}", self.code)?;
+        if let Some(position) = self.position {
+            write!(f, " at byte {}", position.value())?;
+        }
+        if let Some(message) = &self.message {
+            write!(f, ": {}", message)?;
+        }
+        Ok(())
+    }
+}
+
+impl Error for PdfError {
+    // source() はデフォルト実装（None）のまま。下位エラーの連鎖は後続 Issue で対応する。
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // 正常系: new(code) のみで構築すると code() は指定種別を返し、position()/message() は None。
+    #[test]
+    fn new_sets_code_and_leaves_position_and_message_none() {
+        let err = PdfError::new(PdfErrorCode::UnexpectedEof);
+        assert_eq!(err.code(), PdfErrorCode::UnexpectedEof);
+        assert_eq!(err.position(), None);
+        assert_eq!(err.message(), None);
+    }
+
+    // 正常系: with_position で位置を付与すると position() が Some(指定 ByteOffset) を返す。
+    #[test]
+    fn with_position_sets_position() {
+        let err = PdfError::new(PdfErrorCode::UnexpectedToken).with_position(ByteOffset::new(12));
+        assert_eq!(err.position(), Some(ByteOffset::new(12)));
+        assert_eq!(err.message(), None);
+    }
+
+    // 正常系: with_message でメッセージを付与すると message() が Some(指定文字列) を返す。
+    #[test]
+    fn with_message_sets_message() {
+        let err = PdfError::new(PdfErrorCode::InvalidNumber).with_message("bad number");
+        assert_eq!(err.message(), Some("bad number"));
+        assert_eq!(err.position(), None);
+    }
+
+    // 正常系: with_position と with_message を連鎖すると全フィールドが指定値を返す。
+    #[test]
+    fn builder_chain_sets_all_fields() {
+        let err = PdfError::new(PdfErrorCode::InvalidSyntax)
+            .with_position(ByteOffset::new(7))
+            .with_message("oops");
+        assert_eq!(err.code(), PdfErrorCode::InvalidSyntax);
+        assert_eq!(err.position(), Some(ByteOffset::new(7)));
+        assert_eq!(err.message(), Some("oops"));
+    }
+
+    // 正常系: with_message は &str / String / format! 結果（impl Into<String>）を受理できる。
+    #[test]
+    fn with_message_accepts_into_string_sources() {
+        let from_str = PdfError::new(PdfErrorCode::UnexpectedEof).with_message("literal");
+        let from_string =
+            PdfError::new(PdfErrorCode::UnexpectedEof).with_message(String::from("owned"));
+        let from_format =
+            PdfError::new(PdfErrorCode::UnexpectedEof).with_message(format!("tok={}", 1));
+        assert_eq!(from_str.message(), Some("literal"));
+        assert_eq!(from_string.message(), Some("owned"));
+        assert_eq!(from_format.message(), Some("tok=1"));
+    }
+
+    // 正常系（上書き）: with_position/with_message を複数回呼ぶと後勝ちで最後の値が残る。
+    #[test]
+    fn builder_methods_overwrite_with_last_value() {
+        let err = PdfError::new(PdfErrorCode::UnexpectedEof)
+            .with_position(ByteOffset::new(1))
+            .with_position(ByteOffset::new(2))
+            .with_message("first")
+            .with_message("last");
+        assert_eq!(err.position(), Some(ByteOffset::new(2)));
+        assert_eq!(err.message(), Some("last"));
+    }
+
+    // 正常系（Display）: position/message なしのときは種別名のみを出力し、余分な記号を出さない。
+    #[test]
+    fn display_with_code_only() {
+        let err = PdfError::new(PdfErrorCode::UnexpectedEof);
+        assert_eq!(format!("{}", err), "UnexpectedEof");
+    }
+
+    // 正常系（Display）: position ありのときは " at byte N" を連結する。
+    #[test]
+    fn display_with_position() {
+        let err = PdfError::new(PdfErrorCode::UnexpectedEof).with_position(ByteOffset::new(12));
+        assert_eq!(format!("{}", err), "UnexpectedEof at byte 12");
+    }
+
+    // 正常系（Display）: message のみのときは ": <message>" を連結し、" at byte" は出さない。
+    #[test]
+    fn display_with_message_only() {
+        let err = PdfError::new(PdfErrorCode::UnexpectedToken).with_message("unexpected");
+        assert_eq!(format!("{}", err), "UnexpectedToken: unexpected");
+    }
+
+    // 正常系（Display）: 全要素ありのときは "{code:?} at byte N: <message>" 形式になる。
+    #[test]
+    fn display_with_all_fields() {
+        let err = PdfError::new(PdfErrorCode::UnexpectedEof)
+            .with_position(ByteOffset::new(12))
+            .with_message("eof");
+        assert_eq!(format!("{}", err), "UnexpectedEof at byte 12: eof");
+    }
+
+    // 境界値（Display）: 空文字列メッセージ Some("") を無検証で受理し ":" の後が空になる。
+    #[test]
+    fn display_with_empty_message() {
+        let err = PdfError::new(PdfErrorCode::UnexpectedEof).with_message("");
+        assert_eq!(err.message(), Some(""));
+        assert_eq!(format!("{}", err), "UnexpectedEof: ");
+    }
+
+    // 正常系（等価）: 同一の code/position/message を持つ 2 値は == で等価になる。
+    #[test]
+    fn equal_errors_are_equal() {
+        let a = PdfError::new(PdfErrorCode::InvalidSyntax).with_position(ByteOffset::new(1));
+        let b = PdfError::new(PdfErrorCode::InvalidSyntax).with_position(ByteOffset::new(1));
+        assert_eq!(a, b);
+    }
+
+    // 異常系（非等価）: code / position / message のいずれかが異なれば != で非等価になる。
+    #[test]
+    fn errors_differing_in_any_field_are_not_equal() {
+        let base = PdfError::new(PdfErrorCode::InvalidSyntax)
+            .with_position(ByteOffset::new(1))
+            .with_message("m");
+        // code 違い
+        assert_ne!(
+            base,
+            PdfError::new(PdfErrorCode::InvalidNumber)
+                .with_position(ByteOffset::new(1))
+                .with_message("m")
+        );
+        // position 違い（Some(1) ↔ Some(2) の値違い）
+        assert_ne!(
+            base,
+            PdfError::new(PdfErrorCode::InvalidSyntax)
+                .with_position(ByteOffset::new(2))
+                .with_message("m")
+        );
+        // position 違い（Some ↔ None）
+        assert_ne!(
+            base,
+            PdfError::new(PdfErrorCode::InvalidSyntax).with_message("m")
+        );
+        // message 違い（"m" ↔ "n" の値違い）
+        assert_ne!(
+            base,
+            PdfError::new(PdfErrorCode::InvalidSyntax)
+                .with_position(ByteOffset::new(1))
+                .with_message("n")
+        );
+        // message 違い（Some ↔ None）
+        assert_ne!(
+            base,
+            PdfError::new(PdfErrorCode::InvalidSyntax).with_position(ByteOffset::new(1))
+        );
+    }
+
+    // エッジケース（trait）: &dyn std::error::Error として扱え、Display 経由で文字列化できる。
+    #[test]
+    fn usable_as_dyn_error_ref() {
+        let err = PdfError::new(PdfErrorCode::UnexpectedEof);
+        let dyn_err: &dyn std::error::Error = &err;
+        assert!(!dyn_err.to_string().is_empty());
+    }
+
+    // エッジケース（trait）: Box<dyn std::error::Error> へアップキャストでき to_string() が Display と一致する。
+    #[test]
+    fn usable_as_boxed_dyn_error() {
+        let err = PdfError::new(PdfErrorCode::UnexpectedEof).with_position(ByteOffset::new(12));
+        let expected = err.to_string();
+        let boxed: Box<dyn std::error::Error> = Box::new(err);
+        assert_eq!(boxed.to_string(), expected);
+    }
+
+    // エッジケース（trait）: 下位エラー連鎖は当面ないため source() は None を返す。
+    #[test]
+    fn source_is_none() {
+        use std::error::Error;
+        let err = PdfError::new(PdfErrorCode::UnexpectedEof);
+        assert!(err.source().is_none());
+    }
+
+    // エッジケース（trait）: Result<(), Box<dyn Error>> の中で ? 演算子により PdfError が自動変換されて伝播する。
+    #[test]
+    fn propagates_via_question_mark_into_boxed_error() {
+        fn do_parse() -> Result<(), Box<dyn std::error::Error>> {
+            Err(PdfError::new(PdfErrorCode::UnexpectedEof).with_position(ByteOffset::new(3)))?;
+            Ok(())
+        }
+        let result = do_parse();
+        assert!(result.is_err());
+        let boxed = result.unwrap_err();
+        // 元の PdfError と同じ Display 文字列であることで中身が保たれていることを確認する
+        assert_eq!(
+            boxed.to_string(),
+            PdfError::new(PdfErrorCode::UnexpectedEof)
+                .with_position(ByteOffset::new(3))
+                .to_string()
+        );
+    }
+}


### PR DESCRIPTION
## 概要

PDF 処理で発生したエラーを `Result<T, PdfError>` の失敗側として返すための文脈付きエラー型 `PdfError` を `pdfmod-core` に追加します。エラー種別（`PdfErrorCode`）に加え、発生位置（`ByteOffset`）と補足メッセージを任意で保持し、panic ではなく型による失敗表現と `Box<dyn Error>` への相互運用を可能にする基盤型です。

破壊的変更はありません（実コードからの `PdfError` 参照は 0 件の純粋な新規型追加）。

## 変更内容

### 🎯 変更の種類

- [x] ✨ 新機能 (New feature)

### 📝 詳細な変更内容

#### 追加された機能
- `PdfError` 構造体（`code` 必須 / `position`・`message` は任意の `Option`、derive `Debug, Clone, PartialEq, Eq`）
- ビルダー風構築: `new(code)` を基点に `with_position` / `with_message`（`impl Into<String>`、後勝ち上書き）
- 3 アクセサ: `code()` / `position()` / `message()`（フィールドは private）
- `Display` 手実装: `{code:?}[ at byte N][: <message>]` 形式（None 要素は記号ごと省略、空文字列は無検証連結）
- `std::error::Error` 実装（`&dyn Error` / `Box<dyn Error>` へアップキャスト可能、`source()` は当面 `None`）
- 外部 crate 依存ゼロ（std のみ。`thiserror` 等は不使用）

#### 変更されたファイル
- `rust/crates/core/src/error.rs` — `pub mod pdf_error;` を有効化し、モジュール doc を `PdfErrorCode` / `PdfError` 両方を提供する説明へ更新
- `rust/crates/core/src/error/pdf_error.rs` — **新規**。型本体・ビルダー・アクセサ・`Display`・`Error` 実装 + colocated テスト17件

## 📊 システム図

### PdfError の構築と Display 整形

\`\`\`mermaid
flowchart TD
    New["PdfError::new(code)"] --> Base["BASE: code指定 / position=None / message=None"]
    Base -->|".with_position(o)"| P["position = Some(o)"]
    Base -->|".with_message(s)"| M["message = Some(s)"]
    P --> Built["BUILT（Result&lt;T, PdfError&gt; の E）"]:::new
    M --> Built
    Base --> Built
    Built --> Disp["Display::fmt"]
    Disp --> D1["{code:?} を出力"]
    D1 -->|"position=Some"| D2["+ ' at byte N'"]
    D1 -->|"message=Some"| D3["+ ': message'"]
    classDef new fill:#ffe4b5,stroke:#d97706,stroke-width:2px
\`\`\`

### データフロー

\`\`\`
解析レイヤ（呼び出し側・本PR範囲外）
    │ エラー発生箇所で構築
    ▼
PdfError::new(PdfErrorCode)                 [NEW]
    ├─ .with_position(ByteOffset)
    └─ .with_message(impl Into<String>)
    ▼
Result<T, PdfError> の Err として ? で伝播
    ├─ アクセサ経由で上位が分岐: code() / position() / message()
    └─ Box<dyn std::error::Error> へアップキャスト → Display で人間可読文字列へ
\`\`\`

## 📋 関連 Issue

- Refs #260（親 Epic: #251 / 依存: #257・#259[解消済]）

## 🧪 テスト

### テスト実行方法
\`\`\`bash
cd rust && cargo test -p pdfmod-core
\`\`\`

### テスト項目
- [x] 単体テスト (Unit tests) — colocated `#[cfg(test)] mod tests` 17件

### テスト結果
- `cargo test -p pdfmod-core`: **55 passed / 0 failed**（pdf_error 17件 + 既存テスト全グリーン）
- `cargo build -p pdfmod-core`: 成功（警告なし）
- `cargo clippy`: 警告ゼロ
- `cargo fmt --check`: 変更ファイル（`error.rs` / `pdf_error.rs`）は差分なし

検証観点: 構築（ビルダー風 / 任意フィールド省略）・3アクセサ・Display 整形の全分岐（位置/メッセージ有無・空文字列）・等価/非等価判定・`&dyn Error` / `Box<dyn Error>` アップキャスト・`?` 自動変換・`source()` が None。

## 🔍 レビューポイント
- `Display` 整形仕様: `{code:?}` の Debug 流用（`PdfErrorCode` への `Display` 追加は #259 スコープのため意図的に回避）、None 要素の記号ごと省略
- `Copy` 非付与（`String` 保持のため言語上不可。既存 newtype との非対称は意図的）
- `source()` を `None` のままにしている点（下位エラー連鎖は後続 Issue スコープ）
- 外部 crate 依存ゼロの維持（`Cargo.toml` 未変更）

## ⚠️ 破壊的変更
- [ ] なし（純粋な新規型追加。実コードからの既存 `PdfError` 参照は 0 件）

## ✅ チェックリスト
- [x] テストが正常に実行される（55 passed）
- [x] コミットメッセージが適切な形式
- [x] 本文に Refs #260 を記載
- [x] セルフレビュー実施（Codex CLI + spec-based-code-review 3エージェント: CRITICAL/WARNING 0件）
- [x] 破壊的変更なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)