### PR TITLE
✨ [New Feature]: #261 PdfName newtype を pdfmod-core に追加

### DIFF
--- a/rust/crates/core/src/object.rs
+++ b/rust/crates/core/src/object.rs
@@ -5,6 +5,7 @@
 //! 後続 Issue で追加する。
 
 pub mod generation_number;
+pub mod name;
 pub mod object_number;
 
 // 後続 Issue で各オブジェクト型をサブモジュールとして追加する（以下は例の一部）:

--- a/rust/crates/core/src/object/name.rs
+++ b/rust/crates/core/src/object/name.rs
@@ -1,0 +1,182 @@
+//! PDF 名前オブジェクト (`/Name`) を表す `PdfName` を定義するモジュール。
+//!
+//! 裸の `Vec<u8>` と取り違えないための newtype。辞書キー・フィルタ名・
+//! リソース名などの構成要素として用いる。`#XX` 16進エスケープのデコードは
+//! レクサー（Epic R1）の責務であり、本型は**デコード後**の名前本体バイト列を
+//! 保持する（`/` 接頭辞は含めない）。生成は無検証（infallible）で、空名や
+//! NUL・非UTF-8 を含む任意のバイト列も無条件に受理する。名前の妥当性検証は
+//! 上位レイヤ（パーサ／オブジェクト層）に委譲する。
+
+/// PDF 名前オブジェクト。名前本体のバイト列を保持するラッパ。
+///
+/// 内部表現は `Vec<u8>`（Issue #261 指定）。`#XX` デコード後は NUL (`0x00`) や
+/// 非UTF-8 (`0x80`) など任意の8ビット値を含みうるため、UTF-8 前提の `String`
+/// ではなくバイト列で保持する。ヒープ確保を伴うため `Copy` は不可（既存 newtype
+/// 3兄弟と異なり `Copy` を derive しない）。複製が必要な場合は `clone()` を使う。
+/// 等価・順序・ハッシュは内部 `Vec<u8>` の自然な振る舞い（バイト列の辞書順／
+/// 完全一致）に従う。
+#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct PdfName(Vec<u8>);
+
+impl PdfName {
+    /// 与えられたバイト列から `PdfName` を生成する。
+    ///
+    /// 無検証（infallible）。空のバイト列や NUL・非UTF-8 を含む任意のバイト列を
+    /// 無条件に受理する。呼び出し側が**デコード済み**バイト列を渡す契約であり、
+    /// 本型は `#XX` デコードも妥当性検証も行わない（検証は lexer/parser 層に委譲）。
+    pub fn new(bytes: impl Into<Vec<u8>>) -> PdfName {
+        PdfName(bytes.into())
+    }
+
+    /// 内部の名前本体を `&[u8]`（バイトスライス）として取り出す。
+    ///
+    /// バイト列をそのまま返すため、非UTF-8 バイトを含む名前も忠実に扱える。
+    pub fn as_bytes(&self) -> &[u8] {
+        &self.0
+    }
+
+    /// 内部の名前を `&str` として取り出す。
+    ///
+    /// UTF-8 として解釈できる場合のみ `Some(&str)` を返し、非UTF-8 バイトを含む
+    /// 場合は `None` を返す（panic しない）。空名は `Some("")` を返す。
+    pub fn as_str(&self) -> Option<&str> {
+        std::str::from_utf8(&self.0).ok()
+    }
+}
+
+impl From<&str> for PdfName {
+    /// `&str` リテラルから `PdfName` を生成する ergonomic な構築経路。
+    ///
+    /// `new(impl Into<Vec<u8>>)` でも `PdfName::new("Type")` のように構築できるが、
+    /// 本 `From<&str>` は `PdfName::from("Type")` / `.into()` という慣習的な変換経路を
+    /// 提供する目的で実装する（唯一の文字列構築経路ではない）。
+    /// 例: `PdfName::from("Type")` の `as_bytes()` は `b"Type"` と一致する。
+    fn from(s: &str) -> PdfName {
+        PdfName(s.as_bytes().to_vec())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+    use std::collections::HashSet;
+
+    #[test]
+    fn new_then_as_bytes_roundtrips() {
+        // new に渡したバイト列が as_bytes でそのまま取り出せることを確認する
+        let name = PdfName::new(b"Type".to_vec());
+        assert_eq!(name.as_bytes(), b"Type");
+    }
+
+    #[test]
+    fn from_str_builds_name() {
+        // &str リテラルから From で生成すると as_bytes がそのバイト列に一致することを確認する
+        assert_eq!(PdfName::from("Type").as_bytes(), b"Type");
+    }
+
+    #[test]
+    fn clone_preserves_bytes_and_equals_original() {
+        // Copy ではなく Clone で複製でき、複製のバイト列が元と一致し == で等価になることを確認する
+        let original = PdfName::from("Type");
+        let cloned = original.clone();
+        assert_eq!(cloned.as_bytes(), original.as_bytes());
+        assert_eq!(cloned, original);
+    }
+
+    #[test]
+    fn as_str_returns_some_for_ascii() {
+        // ASCII 名は as_str で Some(&str) として読み取れることを確認する
+        assert_eq!(PdfName::from("Type").as_str(), Some("Type"));
+    }
+
+    #[test]
+    fn as_str_returns_some_for_multibyte_utf8() {
+        // 多バイトUTF-8（日本語）の名前も UTF-8 として妥当なら Some を返すことを確認する
+        assert_eq!(PdfName::from("名前").as_str(), Some("名前"));
+    }
+
+    #[test]
+    fn empty_name_has_empty_bytes() {
+        // 空名（PDF 仕様上有効な空名 `/`）を無検証で受理し as_bytes が空になることを確認する
+        let name = PdfName::new(Vec::new());
+        assert!(name.as_bytes().is_empty());
+    }
+
+    #[test]
+    fn empty_name_as_str_is_some_empty() {
+        // 空名の as_str は空文字列で Some("") を返すことを確認する
+        assert_eq!(PdfName::new(Vec::new()).as_str(), Some(""));
+    }
+
+    #[test]
+    fn preserves_nul_byte() {
+        // NUL バイト（#00 デコード結果）を無検証で忠実に保持することを確認する
+        assert_eq!(PdfName::new(vec![0x00]).as_bytes(), &[0x00]);
+    }
+
+    #[test]
+    fn preserves_non_utf8_byte() {
+        // 非UTF-8 バイト（0x80）を無検証で忠実に保持することを確認する
+        assert_eq!(PdfName::new(vec![0x80]).as_bytes(), &[0x80]);
+    }
+
+    #[test]
+    fn as_str_returns_none_for_non_utf8_byte() {
+        // 非UTF-8 の単独バイト（0x80）の as_str は panic せず None を返すことを確認する
+        assert_eq!(PdfName::new(vec![0x80]).as_str(), None);
+    }
+
+    #[test]
+    fn as_str_returns_none_for_invalid_multibyte_sequence() {
+        // 不正なマルチバイト UTF-8 列（0xC0 0x80）の as_str も安全に None を返すことを確認する
+        assert_eq!(PdfName::new(vec![0xC0, 0x80]).as_str(), None);
+    }
+
+    #[test]
+    fn equal_names_are_equal() {
+        // 同一バイト列から生成した 2 つの PdfName が == で等価になることを確認する
+        assert_eq!(PdfName::from("Type"), PdfName::from("Type"));
+    }
+
+    #[test]
+    fn different_names_are_not_equal() {
+        // 異なるバイト列から生成した 2 つの PdfName が != で非等価になることを確認する
+        assert_ne!(PdfName::from("Type"), PdfName::from("Font"));
+    }
+
+    #[test]
+    fn orders_by_inner_bytes() {
+        // 順序はバイト列の辞書順（"A" < "B"）に従うことを確認する
+        assert!(PdfName::from("A") < PdfName::from("B"));
+        assert!(PdfName::from("B") > PdfName::from("A"));
+    }
+
+    #[test]
+    fn sorts_in_ascending_byte_order() {
+        // 順不同の PdfName 配列を sort するとバイト列辞書順の昇順に並ぶことを確認する
+        let mut names = [PdfName::from("C"), PdfName::from("A"), PdfName::from("B")];
+        names.sort();
+        assert_eq!(
+            names,
+            [PdfName::from("A"), PdfName::from("B"), PdfName::from("C")]
+        );
+    }
+
+    #[test]
+    fn works_as_hash_map_key() {
+        // HashMap のキーとして使え、同値の別インスタンスへの参照で挿入値を取得できることを確認する
+        let mut map = HashMap::new();
+        map.insert(PdfName::from("Type"), "catalog");
+        assert_eq!(map.get(&PdfName::from("Type")), Some(&"catalog"));
+    }
+
+    #[test]
+    fn equal_keys_collapse_in_hash_set() {
+        // 同値 PdfName を HashSet に 2 回挿入すると要素数が 1 に畳まれることを確認する
+        let mut set = HashSet::new();
+        set.insert(PdfName::from("Type"));
+        set.insert(PdfName::from("Type"));
+        assert_eq!(set.len(), 1);
+    }
+}


### PR DESCRIPTION
## 概要

PDF 名前オブジェクト (`/Name`) を表す基礎 newtype `PdfName` を `@pdfmod/core`（`rust/crates/core`）に追加します。辞書キー・フィルタ名・リソース名などに使われる基礎型で、後続の `PdfObject` の名前ケース (#263) と `PdfDictionary` のキー (#264) の構成要素になります。

`#XX` 16進エスケープのデコードはレクサー（Epic R1）の責務であり、本型は**デコード後**の名前本体バイト列を保持する値ラッパに徹します（無検証 infallible、妥当性検証は上位レイヤに委譲）。

## 変更の種類

- [x] ✨ 新機能 (New feature)

## 詳細な変更内容

### 追加された機能

- `PdfName(Vec<u8>)` 型（`object/name.rs`）
  - `new(impl Into<Vec<u8>>)` — 無検証（infallible）でバイト列から生成
  - `as_bytes() -> &[u8]` — 忠実な生バイトアクセス（非UTF-8 も保持）
  - `as_str() -> Option<&str>` — UTF-8 のときのみ `Some`、非UTF-8 は `None`（panic しない）
  - `impl From<&str>` — ergonomic な構築経路
  - derive: `Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord`（`Copy` は非 derive）

### 設計上のポイント

- **内部表現は `Vec<u8>`**（`String` ではない）: `#XX` デコード後は NUL (`0x00`) や非UTF-8 (`0x80`) など任意の8ビット値を含みうるため。PDF 1.7 仕様も名前を「任意の8ビット値の列」と定義。
- **`Copy` は非 derive**: `Vec<u8>` はヒープ確保のため `Copy` 不可。複製は `clone()`（doc コメントに理由を明記）。
- **`From<Vec<u8>>` / `From<&[u8]>` / `Display` は非実装（YAGNI）**: バイト列からの構築は `new` が吸収。シリアライズ規約はシリアライズ層導入時に決定。

### 変更されたファイル

- `rust/crates/core/src/object/name.rs` **[NEW]** — `PdfName` 本体＋colocated テスト17件（日本語コメント付き）
- `rust/crates/core/src/object.rs` **[MODIFY]** — `pub mod name;` をアルファベット順で1行追加（`lib.rs` は無変更）

### 削除されたファイル・機能

- なし

## 📊 システム図

### `PdfName` のライフサイクル（生成 → 保持 → 取り出し）

```mermaid
flowchart TD
    Bytes["入力バイト列<br/>(レクサーが #XX デコード済)"] -->|"impl Into&lt;Vec&lt;u8&gt;&gt;"| New["PdfName::new()<br/>(無検証/infallible)"]
    Str["&amp;str リテラル"] -->|"s.as_bytes().to_vec()"| From["PdfName::from()<br/>(From&lt;&amp;str&gt;)"]
    New --> Val["PdfName(Vec&lt;u8&gt;)<br/>名前本体バイト列を保持"]:::new
    From --> Val
    Val --> AsBytes["as_bytes() → &amp;[u8]<br/>(忠実な生バイト)"]
    Val --> AsStr["as_str() → from_utf8(...)"]
    AsStr -->|"UTF-8 として妥当"| Some["Some(&amp;str)<br/>(空名は Some(&quot;&quot;))"]
    AsStr -->|"非UTF-8 (例 0x80)"| None["None<br/>(panic せず安全に失敗)"]

    classDef new fill:#ffe4b5,stroke:#d97706,stroke-width:2px
```

## 📋 関連 Issue

- Closes #261

## 🧪 テスト

### テスト実行方法

```bash
cargo test -p pdfmod-core
cargo build -p pdfmod-core
cargo clippy -p pdfmod-core --all-targets -- -D warnings
```

### テスト項目

- [x] 単体テスト (Unit tests) — colocated `#[cfg(test)] mod tests` 17件
- [x] 手動テスト (Manual testing) — build / clippy / fmt

### テスト結果

- `cargo test -p pdfmod-core`: **55 passed; 0 failed**（PdfName 17件 ＋ 既存 newtype 38件、リグレッションなし）
- `cargo build -p pdfmod-core`: 警告なく成功
- `cargo clippy --all-targets -- -D warnings`: 警告なし
- `rustfmt --check`（`name.rs` 単体）: 差分なし

網羅したテストシナリオ: roundtrip / `From<&str>` / `Clone` / `as_str`（ASCII・多バイトUTF-8・空名・非UTF-8単独・不正マルチバイト）/ 空名 `as_bytes` / NUL・`0x80` 保持 / `==`・`!=` / `Ord`・`sort` / `HashMap` キー / `HashSet` 同値畳み込み。

## 🔍 レビューポイント

- 内部表現に `Vec<u8>` を採用し `Copy` を非 derive とした判断（spec 忠実性・任意8ビット保持のため。doc コメント L14-15 に明記）
- `as_str()` が非UTF-8 で panic せず `None` を返す安全設計（`std::str::from_utf8(...).ok()`）
- `From<&str>` のみ実装し `Display` / `From<Vec<u8>>` を非実装とした YAGNI 判断

## ⚠️ 破壊的変更

- [ ] この変更は既存の API に破壊的変更を含みます

新規型の純粋追加のみで、既存 API の変更はありません。

## ✅ チェックリスト

- [x] コードレビューの準備ができている
- [x] テストが正常に実行される
- [x] コミットメッセージが適切な形式で書かれている
- [x] PR 本文に Issue が記載されている（Closes #261）
- [x] セルフレビューを実施した（spec-based-code-review: CRITICAL/WARNING 0件）
- [x] 破壊的変更なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)