### PR TITLE
✨ [New Feature]: #240 BT オペレータハンドラ（begin text object）を実装

### DIFF
--- a/packages/core/src/content-stream/operators/text/bt/__tests__/bt.basic.test.ts
+++ b/packages/core/src/content-stream/operators/text/bt/__tests__/bt.basic.test.ts
@@ -1,0 +1,76 @@
+import { assert, expect, test } from "vitest";
+import type { PdfObject } from "../../../../../pdf/types/pdf-types/index";
+import {
+  GraphicsStateStack,
+  Matrix,
+  TextObject,
+} from "../../../../graphics-state/index";
+import { OperandStack } from "../../../../operand-stack/index";
+import type { OperatorHandlerContext } from "../../../../operator-registry/index";
+import { btHandler } from "../index";
+
+const real = (value: number): PdfObject => ({ type: "real", value });
+
+// inactive な初期 GraphicsState を持つ context を組み立てる（h.basic.test.ts と同形）
+const buildContext = (operands: PdfObject[] = []): OperatorHandlerContext => {
+  const operandStack = OperandStack.create();
+  for (const operand of operands) {
+    OperandStack.push(operandStack, operand);
+  }
+  const graphicsStateStack = GraphicsStateStack.create();
+  return { operandStack, graphicsStateStack };
+};
+
+test("初期 inactive 状態で BT を実行すると textObject.active が true へ遷移する", () => {
+  const ctx = buildContext();
+
+  const result = btHandler(ctx);
+
+  assert(result.ok);
+  const current = GraphicsStateStack.current(result.value.graphicsStateStack);
+  expect(TextObject.isActive(current.textObject)).toBe(true);
+});
+
+test("BT 成功時 textMatrix / textLineMatrix が identity に初期化される", () => {
+  const ctx = buildContext();
+
+  const result = btHandler(ctx);
+
+  assert(result.ok);
+  const current = GraphicsStateStack.current(result.value.graphicsStateStack);
+  expect(current.textObject.textMatrix).toEqual(Matrix.identity());
+  expect(current.textObject.textLineMatrix).toEqual(Matrix.identity());
+});
+
+test("BT は textObject 以外の graphics state（ctm / lineWidth）を変更しない", () => {
+  const ctx = buildContext();
+  const before = GraphicsStateStack.current(ctx.graphicsStateStack);
+
+  const result = btHandler(ctx);
+
+  assert(result.ok);
+  const after = GraphicsStateStack.current(result.value.graphicsStateStack);
+  expect(after.ctm).toEqual(before.ctm);
+  expect(after.lineWidth).toBe(before.lineWidth);
+});
+
+test("operand stack が空でも BT は成功し、空・同一参照のまま返る", () => {
+  const ctx = buildContext();
+
+  const result = btHandler(ctx);
+
+  assert(result.ok);
+  expect(OperandStack.depth(result.value.operandStack)).toBe(0);
+  expect(result.value.operandStack).toBe(ctx.operandStack);
+});
+
+test("operand stack に余剰要素があっても BT は pop しない（depth 不変・同一参照）", () => {
+  const ctx = buildContext([real(1), real(2), real(3)]);
+  const depthBefore = OperandStack.depth(ctx.operandStack);
+
+  const result = btHandler(ctx);
+
+  assert(result.ok);
+  expect(OperandStack.depth(result.value.operandStack)).toBe(depthBefore);
+  expect(result.value.operandStack).toBe(ctx.operandStack);
+});

--- a/packages/core/src/content-stream/operators/text/bt/__tests__/bt.error.test.ts
+++ b/packages/core/src/content-stream/operators/text/bt/__tests__/bt.error.test.ts
@@ -1,0 +1,72 @@
+import { assert, expect, test } from "vitest";
+import type { PdfObject } from "../../../../../pdf/types/pdf-types/index";
+import {
+  GraphicsState,
+  GraphicsStateStack,
+  TextObject,
+} from "../../../../graphics-state/index";
+import { OperandStack } from "../../../../operand-stack/index";
+import type { OperatorHandlerContext } from "../../../../operator-registry/index";
+import { btHandler } from "../index";
+
+const real = (value: number): PdfObject => ({ type: "real", value });
+
+// 既に active な textObject を持つ context を組み立てる（二重ネスト BT の再現）。
+// operands を渡せば operand stack に積んだ状態を再現でき、エラー時の非 pop 検証に使える。
+const buildActiveContext = (
+  operands: PdfObject[] = [],
+): OperatorHandlerContext => {
+  const operandStack = OperandStack.create();
+  for (const operand of operands) {
+    OperandStack.push(operandStack, operand);
+  }
+  const activeState = GraphicsState.update(GraphicsState.create(), {
+    textObject: TextObject.begin(),
+  });
+  const graphicsStateStack = GraphicsStateStack.replaceCurrent(
+    GraphicsStateStack.create(),
+    activeState,
+  );
+  return { operandStack, graphicsStateStack };
+};
+
+test("active=true の状態で BT を実行すると OPERATOR_ILLEGAL_STATE を返す", () => {
+  const ctx = buildActiveContext();
+
+  const result = btHandler(ctx);
+
+  assert(!result.ok);
+  assert(result.error.code === "OPERATOR_ILLEGAL_STATE");
+  expect(result.error.operatorName).toBe("BT");
+  expect(result.error.message).toBe(
+    "BT: text object already active (nested BT/ET is not allowed)",
+  );
+});
+
+test("エラー時 operand stack は pop されない（余剰要素があっても depth 不変・同一参照）", () => {
+  const ctx = buildActiveContext([real(1), real(2)]);
+  const operandStackBefore = ctx.operandStack;
+  const depthBefore = OperandStack.depth(ctx.operandStack);
+
+  const result = btHandler(ctx);
+
+  assert(!result.ok);
+  expect(ctx.operandStack).toBe(operandStackBefore);
+  expect(OperandStack.depth(ctx.operandStack)).toBe(depthBefore);
+  expect(OperandStack.depth(ctx.operandStack)).toBe(2);
+});
+
+test("エラー時 graphics state stack は差し替えられず textObject.active が true のまま", () => {
+  const ctx = buildActiveContext();
+  const stackBefore = ctx.graphicsStateStack;
+  const currentBefore = GraphicsStateStack.current(ctx.graphicsStateStack);
+
+  const result = btHandler(ctx);
+
+  assert(!result.ok);
+  // ハンドラは Err 経路で stack を replaceCurrent していない（入力 context が同一参照・同値のまま）
+  expect(ctx.graphicsStateStack).toBe(stackBefore);
+  const currentAfter = GraphicsStateStack.current(ctx.graphicsStateStack);
+  expect(currentAfter).toEqual(currentBefore);
+  expect(TextObject.isActive(currentAfter.textObject)).toBe(true);
+});

--- a/packages/core/src/content-stream/operators/text/bt/index.ts
+++ b/packages/core/src/content-stream/operators/text/bt/index.ts
@@ -1,0 +1,54 @@
+import type { PdfError } from "../../../../pdf/errors/index";
+import { err, ok } from "../../../../utils/result/index";
+import {
+  GraphicsState,
+  GraphicsStateStack,
+  TextObject,
+} from "../../../graphics-state/index";
+import type {
+  OperatorHandler,
+  OperatorHandlerContext,
+} from "../../../operator-registry/index";
+
+/** PDF 表記を保持した operator 名（"BT"）。 */
+const OPERATOR_NAME = "BT";
+
+/**
+ * PDF §9.4.1 `BT` operator (Begin Text Object) のハンドラ。
+ *
+ * text object を開始し、current text object を active へ遷移させて
+ * textMatrix / textLineMatrix を identity に初期化する (TextObject.begin 経由)。
+ * `BT` は引数を取らないため operand stack を pop / 検証 / clear せず
+ * 同一参照のまま返す。
+ *
+ * - operand 数: 0（operand stack を一切消費しない）
+ * - current text object が既に active の場合は二重ネスト（nested BT/ET）と
+ *   みなし `OPERATOR_ILLEGAL_STATE` を返す。このとき operand stack /
+ *   graphics state stack は変更しない。
+ * - textObject 以外の graphics state（ctm / textState 等）は変更しない
+ *
+ * @param context - 実行コンテキスト (operand stack / graphics state stack)
+ * @returns 更新後コンテキスト、または二重ネスト時の PdfError
+ */
+export const btHandler: OperatorHandler = (context: OperatorHandlerContext) => {
+  const current = GraphicsStateStack.current(context.graphicsStateStack);
+  if (TextObject.isActive(current.textObject)) {
+    const error: PdfError = {
+      code: "OPERATOR_ILLEGAL_STATE",
+      message: "BT: text object already active (nested BT/ET is not allowed)",
+      operatorName: OPERATOR_NAME,
+    };
+    return err(error);
+  }
+  const next = GraphicsState.update(current, {
+    textObject: TextObject.begin(),
+  });
+  const graphicsStateStack = GraphicsStateStack.replaceCurrent(
+    context.graphicsStateStack,
+    next,
+  );
+  return ok({
+    operandStack: context.operandStack,
+    graphicsStateStack,
+  });
+};

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -75,6 +75,7 @@ export type {
   PdfName,
   PdfNull,
   PdfObject,
+  PdfOperatorIllegalStateError,
   PdfOperatorOperandMissingError,
   PdfOperatorOperandTypeMismatchError,
   PdfOperatorOperandValueOutOfRangeError,

--- a/packages/core/src/pdf/errors/error/__tests__/error.type-export.test.ts
+++ b/packages/core/src/pdf/errors/error/__tests__/error.type-export.test.ts
@@ -4,6 +4,7 @@ import type {
   PdfCircularReferenceError,
   PdfError,
   PdfErrorCode,
+  PdfOperatorIllegalStateError,
   PdfOperatorOperandMissingError,
   PdfOperatorOperandTypeMismatchError,
   PdfOperatorOperandValueOutOfRangeError,
@@ -185,4 +186,22 @@ test("PdfOperatorPathNoCurrentPointError は PdfError union から narrow でき
   expect(narrowed).toBe(true);
   expect(error.code).toBe("OPERATOR_PATH_NO_CURRENT_POINT");
   expect(noCurrentPointError.operatorName).toBe("l");
+});
+
+test("PdfOperatorIllegalStateError は PdfError union から narrow できる", () => {
+  const illegalStateError: PdfOperatorIllegalStateError = {
+    code: "OPERATOR_ILLEGAL_STATE",
+    message: "BT: text object already active (nested BT/ET is not allowed)",
+    operatorName: "BT",
+  };
+  const error: PdfError = illegalStateError;
+
+  const narrowed: Exact<
+    Extract<PdfError, { code: "OPERATOR_ILLEGAL_STATE" }>,
+    PdfOperatorIllegalStateError
+  > = true;
+
+  expect(narrowed).toBe(true);
+  expect(error.code).toBe("OPERATOR_ILLEGAL_STATE");
+  expect(illegalStateError.operatorName).toBe("BT");
 });

--- a/packages/core/src/pdf/errors/error/index.ts
+++ b/packages/core/src/pdf/errors/error/index.ts
@@ -42,7 +42,8 @@ export type PdfParseErrorCode =
  * 全致命的PDFエラーコードの共用体型。
  * パースエラーコードに加え、循環参照・型不一致・operator registry エラー、
  * operator オペランド不足／型不一致／値域外エラー、
- * path operator の current point 未確立エラーのコードを含む。
+ * path operator の current point 未確立エラー、
+ * operator の不正なステート遷移エラー（OPERATOR_ILLEGAL_STATE）のコードを含む。
  *
  * @example
  * ```ts
@@ -284,7 +285,8 @@ export interface PdfOperatorIllegalStateError {
  * 全致命的PDFエラーの判別共用体型。
  * パースエラー、循環参照エラー、型不一致エラー、operator registry エラー、
  * operator オペランド不足／型不一致／値域外エラー、
- * path operator の current point 未確立エラーを包含する。
+ * path operator の current point 未確立エラー、
+ * operator の不正なステート遷移エラー（PdfOperatorIllegalStateError）を包含する。
  *
  * @example
  * ```ts

--- a/packages/core/src/pdf/errors/error/index.ts
+++ b/packages/core/src/pdf/errors/error/index.ts
@@ -57,7 +57,8 @@ export type PdfErrorCode =
   | "OPERATOR_OPERAND_MISSING"
   | "OPERATOR_OPERAND_TYPE_MISMATCH"
   | "OPERATOR_OPERAND_VALUE_OUT_OF_RANGE"
-  | "OPERATOR_PATH_NO_CURRENT_POINT";
+  | "OPERATOR_PATH_NO_CURRENT_POINT"
+  | "OPERATOR_ILLEGAL_STATE";
 
 /**
  * PDFパースエラーを表すインターフェース。
@@ -257,6 +258,29 @@ export interface PdfOperatorPathNoCurrentPointError {
 }
 
 /**
+ * Content stream operator の不正なステート遷移エラー。
+ * operator がその時点のグラフィックスステートでは実行できない場合に発生する。
+ * 例: text object が既に active な状態での `BT`（nested BT/ET。ISO 32000-1:2008 §9.4.1）。
+ *
+ * @example
+ * ```ts
+ * const error: PdfOperatorIllegalStateError = {
+ *   code: "OPERATOR_ILLEGAL_STATE",
+ *   message: "BT: text object already active (nested BT/ET is not allowed)",
+ *   operatorName: "BT",
+ * };
+ * ```
+ */
+export interface PdfOperatorIllegalStateError {
+  /** エラーコード（常に "OPERATOR_ILLEGAL_STATE"） */
+  readonly code: "OPERATOR_ILLEGAL_STATE";
+  /** 人間可読なエラーメッセージ */
+  readonly message: string;
+  /** 不正なステート遷移を検出した operator 名 */
+  readonly operatorName: string;
+}
+
+/**
  * 全致命的PDFエラーの判別共用体型。
  * パースエラー、循環参照エラー、型不一致エラー、operator registry エラー、
  * operator オペランド不足／型不一致／値域外エラー、
@@ -282,4 +306,5 @@ export type PdfError =
   | PdfOperatorOperandMissingError
   | PdfOperatorOperandTypeMismatchError
   | PdfOperatorOperandValueOutOfRangeError
-  | PdfOperatorPathNoCurrentPointError;
+  | PdfOperatorPathNoCurrentPointError
+  | PdfOperatorIllegalStateError;

--- a/packages/core/src/pdf/errors/index.ts
+++ b/packages/core/src/pdf/errors/index.ts
@@ -7,6 +7,7 @@ export type {
   PdfCircularReferenceError,
   PdfError,
   PdfErrorCode,
+  PdfOperatorIllegalStateError,
   PdfOperatorOperandMissingError,
   PdfOperatorOperandTypeMismatchError,
   PdfOperatorOperandValueOutOfRangeError,


### PR DESCRIPTION
## 概要

PDF §9.4.1 `BT` (Begin Text Object) オペレータのハンドラを新規実装しました（Epic #228 / Phase 4-D）。`BT` は operand を取らず、current text object が inactive のときのみ active へ遷移させ `textMatrix` / `textLineMatrix` を identity に初期化します。二重ネスト（既に active な状態での `BT`）は新規エラーコード `OPERATOR_ILLEGAL_STATE` で弾き、`throw` を一切行わず全経路を `Result` で返します。

## 変更内容

### 🎯 変更の種類

- [x] ✨ 新機能 (New feature)
- [x] 🚨 テスト追加/修正 (Tests)

### 📝 詳細な変更内容

#### 追加された機能・修正

- `btHandler`（`OperatorHandler`）を新規実装
  - operand を pop せず、operand stack を同一参照のまま返す（余剰要素があっても depth 不変）
  - inactive 起点で `active=true` へ遷移し、両 matrix を identity 初期化（`TextObject.begin` 経由）
  - active 起点（nested BT/ET）は `OPERATOR_ILLEGAL_STATE` を返し、operand / graphics state を変更しない
- 新規エラー型 `OPERATOR_ILLEGAL_STATE` / `PdfOperatorIllegalStateError` を追加し、`PdfErrorCode` / `PdfError` union を拡張、公開 API へ re-export
- registry 登録は本 issue スコープ外（別 issue）

#### 変更されたファイル

- `[NEW]` `packages/core/src/content-stream/operators/text/bt/index.ts`
- `[NEW]` `.../text/bt/__tests__/bt.basic.test.ts`（正常系 5）
- `[NEW]` `.../text/bt/__tests__/bt.error.test.ts`（異常系 3）
- `[MOD]` `packages/core/src/pdf/errors/error/index.ts`（union + interface）
- `[MOD]` `packages/core/src/pdf/errors/index.ts`（型 re-export）
- `[MOD]` `packages/core/src/index.ts`（公開 API re-export）
- `[MOD]` `.../pdf/errors/error/__tests__/error.type-export.test.ts`（narrow test 追記）

## 📊 システム図

### 状態マシン / フロー図

```mermaid
flowchart TD
    Start([BT 入力]) --> Check{isActive textObject?}
    Check -->|false（inactive）| Begin["TextObject.begin（active=true, TM/TLM=identity）"]:::new
    Check -->|true（active）| Err["err OPERATOR_ILLEGAL_STATE（operatorName=BT・operand/state 不変）"]:::new
    Begin --> Replace[GraphicsStateStack.replaceCurrent]
    Replace --> Ok(["ok（operandStack 同一参照・非 pop）"])
    Err --> Ret([Result 返却])
    Ok --> Ret
    classDef new fill:#ffe4b5,stroke:#d97706,stroke-width:2px
```

## 📋 関連 Issue

- Closes #240
- Refs #228 (Epic / Phase 4-D)

## 🧪 テスト

### テスト実行方法

```bash
pnpm --filter @pdfmod/core test
pnpm --filter @pdfmod/core typecheck
```

### テスト項目

- [x] 単体テスト (Unit tests)

### テスト結果

- `pnpm --filter @pdfmod/core test` → ✅ 172 files / 2335 tests green（`bt.basic` 5・`bt.error` 3 含む）
- `pnpm --filter @pdfmod/core typecheck`（`tsc --noEmit`）→ ✅ エラーなし
- Biome + oxlint → ✅ 0 warnings / 0 errors

## 🔍 レビューポイント

- `btHandler` が全経路 `Result`（`ok` / `err`）で `throw` を含まないこと
- operand 非 pop の同一参照素通し（`path/h` を写経）
- エラー時に operand stack / graphics state stack が不変であること（early return）
- `OPERATOR_ILLEGAL_STATE` の union 追加・re-export がアルファベット順を維持していること
- 公開 API（`packages/core/src/index.ts`）への re-export 追加は issue 変更リスト外だが、既存 `PdfOperator*Error` 群との一貫性のため意図的に追加（ユーザー確認済み）

## ⚠️ 破壊的変更

- [ ] この変更は既存の API に破壊的変更を含みます

union への追加のみで後方互換です（網羅 switch は `default` ありで影響なし）。

## ✅ チェックリスト

- [x] テストが正常に実行される
- [x] コミットメッセージが適切な形式で書かれている
- [x] PR 本文に `Closes #` で Issue が記載されている
- [x] セルフレビューを実施した（spec-based-code-review: CRITICAL/WARNING 0 件）