### PR TITLE
✨ [New Feature]: #241 ET オペレータハンドラ（end text object）を実装

### DIFF
--- a/packages/core/src/content-stream/operators/text/et/__tests__/et.basic.test.ts
+++ b/packages/core/src/content-stream/operators/text/et/__tests__/et.basic.test.ts
@@ -1,0 +1,80 @@
+import { assert, expect, test } from "vitest";
+import {
+  GraphicsState,
+  GraphicsStateStack,
+  Matrix,
+  TextObject,
+} from "../../../../graphics-state/index";
+import { OperandStack } from "../../../../operand-stack/index";
+import type { OperatorHandlerContext } from "../../../../operator-registry/index";
+import { etHandler } from "../index";
+
+// active な context を組むビルダ（btHandler ではなく TextObject.begin() で直接構築）
+const buildActiveContext = (): OperatorHandlerContext => {
+  const operandStack = OperandStack.create();
+  const activeState = GraphicsState.update(GraphicsState.create(), {
+    textObject: TextObject.begin(),
+  });
+  const graphicsStateStack = GraphicsStateStack.replaceCurrent(
+    GraphicsStateStack.create(),
+    activeState,
+  );
+  return { operandStack, graphicsStateStack };
+};
+
+test("active な state で ET を実行すると textObject.active が false へ遷移する", () => {
+  // BT 済み（active）の context に ET を適用すると text object が終了する
+  const ctx = buildActiveContext();
+
+  const result = etHandler(ctx);
+
+  assert(result.ok);
+  const current = GraphicsStateStack.current(result.value.graphicsStateStack);
+  expect(TextObject.isActive(current.textObject)).toBe(false);
+});
+
+test("ET 実行後 textMatrix が identity にリセットされる", () => {
+  // ET は TextObject.end 経由で textMatrix を identity に戻す
+  const ctx = buildActiveContext();
+
+  const result = etHandler(ctx);
+
+  assert(result.ok);
+  const current = GraphicsStateStack.current(result.value.graphicsStateStack);
+  expect(current.textObject.textMatrix).toEqual(Matrix.identity());
+});
+
+test("ET 実行後 textLineMatrix が identity にリセットされる", () => {
+  // ET は TextObject.end 経由で textLineMatrix を identity に戻す
+  const ctx = buildActiveContext();
+
+  const result = etHandler(ctx);
+
+  assert(result.ok);
+  const current = GraphicsStateStack.current(result.value.graphicsStateStack);
+  expect(current.textObject.textLineMatrix).toEqual(Matrix.identity());
+});
+
+test("ET は textObject 以外の graphics state（ctm / lineWidth）を変更しない", () => {
+  // ET が触れるのは textObject のみで、他の graphics state は不変
+  const ctx = buildActiveContext();
+  const before = GraphicsStateStack.current(ctx.graphicsStateStack);
+
+  const result = etHandler(ctx);
+
+  assert(result.ok);
+  const after = GraphicsStateStack.current(result.value.graphicsStateStack);
+  expect(after.ctm).toEqual(before.ctm);
+  expect(after.lineWidth).toBe(before.lineWidth);
+});
+
+test("ET は operand stack を消費せず同一参照のまま返す", () => {
+  // ET は引数を取らないため operand stack を pop / 差し替えしない
+  const ctx = buildActiveContext();
+
+  const result = etHandler(ctx);
+
+  assert(result.ok);
+  expect(OperandStack.depth(result.value.operandStack)).toBe(0);
+  expect(result.value.operandStack).toBe(ctx.operandStack);
+});

--- a/packages/core/src/content-stream/operators/text/et/__tests__/et.error.test.ts
+++ b/packages/core/src/content-stream/operators/text/et/__tests__/et.error.test.ts
@@ -1,0 +1,98 @@
+import { assert, expect, test } from "vitest";
+import {
+  GraphicsState,
+  GraphicsStateStack,
+  Matrix,
+  TextObject,
+} from "../../../../graphics-state/index";
+import { OperandStack } from "../../../../operand-stack/index";
+import type { OperatorHandlerContext } from "../../../../operator-registry/index";
+import { etHandler } from "../index";
+
+// inactive な初期 context を組むビルダ
+const buildContext = (): OperatorHandlerContext => {
+  const operandStack = OperandStack.create();
+  const graphicsStateStack = GraphicsStateStack.create();
+  return { operandStack, graphicsStateStack };
+};
+
+// inactive (active=false) かつ matrix が非 identity の textObject を持つ context。
+// ガードを通らず end() が誤って呼ばれた場合に matrix が identity へ潰れることを検出するための fixture。
+const NON_IDENTITY_MATRIX = Matrix.create(2, 0, 0, 2, 10, 20);
+const buildInactiveNonIdentityContext = (): OperatorHandlerContext => {
+  const operandStack = OperandStack.create();
+  const inactiveNonIdentity = {
+    active: false,
+    textMatrix: NON_IDENTITY_MATRIX,
+    textLineMatrix: NON_IDENTITY_MATRIX,
+  } as unknown as TextObject;
+  const state = GraphicsState.update(GraphicsState.create(), {
+    textObject: inactiveNonIdentity,
+  });
+  const graphicsStateStack = GraphicsStateStack.replaceCurrent(
+    GraphicsStateStack.create(),
+    state,
+  );
+  return { operandStack, graphicsStateStack };
+};
+
+test("inactive な state で ET を実行すると OPERATOR_ILLEGAL_STATE を返す", () => {
+  // BT 未実行（inactive 初期）の context に ET を適用すると ET without BT として失敗する
+  const ctx = buildContext();
+
+  const result = etHandler(ctx);
+
+  assert(!result.ok);
+  expect(result.error.code).toBe("OPERATOR_ILLEGAL_STATE");
+});
+
+test("inactive な state で ET を実行したときエラーの operatorName が ET である", () => {
+  // エラーに反映される operator 名が PDF 表記の "ET" であること
+  const ctx = buildContext();
+
+  const result = etHandler(ctx);
+
+  assert(!result.ok);
+  assert(result.error.code === "OPERATOR_ILLEGAL_STATE");
+  expect(result.error.operatorName).toBe("ET");
+});
+
+test("inactive な state で ET を実行したときエラーの message が ET without BT を示す", () => {
+  // ユーザー向けに BT 不在を説明する固定メッセージを返すこと
+  const ctx = buildContext();
+
+  const result = etHandler(ctx);
+
+  assert(!result.ok);
+  expect(result.error.message).toBe(
+    "ET: no active text object (ET without BT)",
+  );
+});
+
+test("エラー時 graphics state stack は差し替えられず current が変更されない", () => {
+  // ガードの early-return により stack を replaceCurrent しない（同一参照・同値のまま）
+  const ctx = buildContext();
+  const stackBefore = ctx.graphicsStateStack;
+  const currentBefore = GraphicsStateStack.current(ctx.graphicsStateStack);
+
+  const result = etHandler(ctx);
+
+  assert(!result.ok);
+  expect(ctx.graphicsStateStack).toBe(stackBefore);
+  const currentAfter = GraphicsStateStack.current(ctx.graphicsStateStack);
+  expect(currentAfter).toEqual(currentBefore);
+  expect(TextObject.isActive(currentAfter.textObject)).toBe(false);
+});
+
+test("inactive かつ非 identity の matrix を持つ state で ET → Err 時に textObject が変更されない", () => {
+  // ガードを通らず TextObject.end() が誤って呼ばれれば matrix が identity に潰れるため、
+  // 非 identity のまま保持されていることで end() 未実行（textObject 不変）を担保する
+  const ctx = buildInactiveNonIdentityContext();
+
+  const result = etHandler(ctx);
+
+  assert(!result.ok);
+  const current = GraphicsStateStack.current(ctx.graphicsStateStack);
+  expect(current.textObject.textMatrix).toEqual(NON_IDENTITY_MATRIX);
+  expect(current.textObject.textLineMatrix).toEqual(NON_IDENTITY_MATRIX);
+});

--- a/packages/core/src/content-stream/operators/text/et/__tests__/et.integration.test.ts
+++ b/packages/core/src/content-stream/operators/text/et/__tests__/et.integration.test.ts
@@ -1,0 +1,81 @@
+import { assert, expect, test } from "vitest";
+import {
+  GraphicsStateStack,
+  Matrix,
+  TextObject,
+} from "../../../../graphics-state/index";
+import { OperandStack } from "../../../../operand-stack/index";
+import type { OperatorHandlerContext } from "../../../../operator-registry/index";
+import { btHandler } from "../../bt/index";
+import { etHandler } from "../index";
+
+// inactive な初期 context を組むビルダ（registry/interpreter は使わずハンドラを直接連鎖適用する）
+const buildContext = (): OperatorHandlerContext => {
+  const operandStack = OperandStack.create();
+  const graphicsStateStack = GraphicsStateStack.create();
+  return { operandStack, graphicsStateStack };
+};
+
+test("BT → ET を連続適用すると textObject.active が false へ復帰する", () => {
+  // BT で active 化した text object を ET が終了させ、ライフサイクルが閉じる
+  const afterBt = btHandler(buildContext());
+  assert(afterBt.ok);
+
+  const afterEt = etHandler(afterBt.value);
+
+  assert(afterEt.ok);
+  const current = GraphicsStateStack.current(afterEt.value.graphicsStateStack);
+  expect(TextObject.isActive(current.textObject)).toBe(false);
+});
+
+test("BT → ET 後の textMatrix / textLineMatrix が identity である", () => {
+  // ET 終了後は両 matrix が identity に戻っている
+  const afterBt = btHandler(buildContext());
+  assert(afterBt.ok);
+
+  const afterEt = etHandler(afterBt.value);
+
+  assert(afterEt.ok);
+  const current = GraphicsStateStack.current(afterEt.value.graphicsStateStack);
+  expect(current.textObject.textMatrix).toEqual(Matrix.identity());
+  expect(current.textObject.textLineMatrix).toEqual(Matrix.identity());
+});
+
+test("BT を 2 回適用すると 2 回目が Err になる（BT BT）", () => {
+  // 1 回目の BT で active 化済みの状態に再び BT を適用すると二重ネストで失敗する
+  const afterBt = btHandler(buildContext());
+  assert(afterBt.ok);
+
+  const secondBt = btHandler(afterBt.value);
+
+  assert(!secondBt.ok);
+  assert(secondBt.error.code === "OPERATOR_ILLEGAL_STATE");
+  expect(secondBt.error.operatorName).toBe("BT");
+});
+
+test("inactive 初期状態で ET を単独適用すると Err になる", () => {
+  // 対応する BT が無い ET は ET without BT として失敗する
+  const result = etHandler(buildContext());
+
+  assert(!result.ok);
+  assert(result.error.code === "OPERATOR_ILLEGAL_STATE");
+  expect(result.error.operatorName).toBe("ET");
+});
+
+test("BT → ET 後に再度 BT → ET でライフサイクルを再開できる", () => {
+  // ET 後に inactive へ正しく戻るため、2 周目の BT → ET も成功する（再ガードが効く）
+  const afterFirstBt = btHandler(buildContext());
+  assert(afterFirstBt.ok);
+  const afterFirstEt = etHandler(afterFirstBt.value);
+  assert(afterFirstEt.ok);
+
+  const afterSecondBt = btHandler(afterFirstEt.value);
+  assert(afterSecondBt.ok);
+  const afterSecondEt = etHandler(afterSecondBt.value);
+
+  assert(afterSecondEt.ok);
+  const current = GraphicsStateStack.current(
+    afterSecondEt.value.graphicsStateStack,
+  );
+  expect(TextObject.isActive(current.textObject)).toBe(false);
+});

--- a/packages/core/src/content-stream/operators/text/et/index.ts
+++ b/packages/core/src/content-stream/operators/text/et/index.ts
@@ -1,0 +1,54 @@
+import type { PdfError } from "../../../../pdf/errors/index";
+import { err, ok } from "../../../../utils/result/index";
+import {
+  GraphicsState,
+  GraphicsStateStack,
+  TextObject,
+} from "../../../graphics-state/index";
+import type {
+  OperatorHandler,
+  OperatorHandlerContext,
+} from "../../../operator-registry/index";
+
+/** PDF 表記を保持した operator 名（"ET"）。 */
+const OPERATOR_NAME = "ET";
+
+/**
+ * PDF §9.4.1 `ET` operator (End Text Object) のハンドラ。
+ *
+ * 現在の text object を終了し、current text object を inactive へ戻して
+ * textMatrix / textLineMatrix を identity にリセットする (TextObject.end 経由)。
+ * `ET` は引数を取らないため operand stack を pop / 検証 / clear せず
+ * 同一参照のまま返す。
+ *
+ * - operand 数: 0（operand stack を一切消費しない）
+ * - current text object が active でない場合は対応する BT が無い
+ *   （ET without BT）とみなし `OPERATOR_ILLEGAL_STATE` を返す。このとき
+ *   operand stack / graphics state stack は変更しない。
+ * - textObject 以外の graphics state（ctm / textState 等）は変更しない
+ *
+ * @param context - 実行コンテキスト (operand stack / graphics state stack)
+ * @returns 更新後コンテキスト、または BT 不在時の PdfError
+ */
+export const etHandler: OperatorHandler = (context: OperatorHandlerContext) => {
+  const current = GraphicsStateStack.current(context.graphicsStateStack);
+  if (!TextObject.isActive(current.textObject)) {
+    const error: PdfError = {
+      code: "OPERATOR_ILLEGAL_STATE",
+      message: "ET: no active text object (ET without BT)",
+      operatorName: OPERATOR_NAME,
+    };
+    return err(error);
+  }
+  const next = GraphicsState.update(current, {
+    textObject: TextObject.end(current.textObject),
+  });
+  const graphicsStateStack = GraphicsStateStack.replaceCurrent(
+    context.graphicsStateStack,
+    next,
+  );
+  return ok({
+    operandStack: context.operandStack,
+    graphicsStateStack,
+  });
+};


### PR DESCRIPTION
## 概要

PDF §9.4.1 `ET` (End Text Object) オペレータのハンドラ `etHandler` を `btHandler` と完全対称な純関数として新規実装し、`BT` 〜 `ET` の text object ライフサイクル管理を完成させました。`ET` は現在の text object を終了し、`textObject.active` を `false` に戻して `textMatrix` / `textLineMatrix` を identity にリセットします（`TextObject.end()` 経由）。対応する `BT` が無い状態（inactive）で呼ばれた場合は `OPERATOR_ILLEGAL_STATE`（ET without BT）を `err` で返します。

**新規4ファイルの追加のみ**で、既存ファイルの変更はありません（破壊的変更なし）。

## 変更内容

### 🎯 変更の種類

- [x] ✨ 新機能 (New feature)
- [x] 🚨 テスト追加/修正 (Tests)

### 📝 詳細な変更内容

#### 追加された機能・修正

- `etHandler`: `OperatorHandlerContext` → `Result<OperatorHandlerContext, PdfError>` の純関数
  - `!TextObject.isActive(...)` ガード → `err(OPERATOR_ILLEGAL_STATE)`（early-return、stack 非差し替え）
  - active 時は `GraphicsState.update` で `textObject` のみ `TextObject.end()` に差し替え → `replaceCurrent` → `ok`
  - operand stack は消費せず**同一参照のまま透過**（arity 検証は registry/interpreter 層の責務）
  - エラーは `{ code: "OPERATOR_ILLEGAL_STATE", message: "ET: no active text object (ET without BT)", operatorName: "ET" }` の3フィールド（`position` 不使用）
- TDD（t-wada 式 Red-Green-Refactor）で basic / error / integration の3テストファイルを実装

#### 変更されたファイル（すべて新規 [NEW]）

- `packages/core/src/content-stream/operators/text/et/index.ts`
- `packages/core/src/content-stream/operators/text/et/__tests__/et.basic.test.ts`（正常系・不変性 5件）
- `packages/core/src/content-stream/operators/text/et/__tests__/et.error.test.ts`（異常系 5件）
- `packages/core/src/content-stream/operators/text/et/__tests__/et.integration.test.ts`（BT→ET composition 5件）

#### 削除されたファイル・機能

- なし

## 📊 システム図

### 状態マシン / フロー図（text object ライフサイクル）

```mermaid
flowchart TD
    Init([GraphicsStateStack.create]) --> Inactive["textObject.active = false<br/>(INACTIVE / 初期)<br/>matrices = identity"]
    Inactive -->|"BT (begin)"| Active["textObject.active = true<br/>(ACTIVE)<br/>matrices = identity"]
    Inactive -->|"ET (!isActive) → Err"| ErrET["OPERATOR_ILLEGAL_STATE<br/>(ET without BT)<br/>stack 非差し替え"]:::new
    Active -->|"ET (end)"| Inactive
    Active -->|"BT (isActive) → Err"| ErrBT["OPERATOR_ILLEGAL_STATE<br/>(nested BT/ET)"]

    classDef new fill:#ffe4b5,stroke:#d97706,stroke-width:2px
```

`ET (end)` 遷移と inactive での `ET → Err` ガード（[NEW] で強調）が本 PR の追加分です。`BT` 側の挙動は既存のままです。

### データフロー（etHandler 内部）

```
OperatorHandlerContext
  ├─ operandStack ─────────────────────────────┐ (消費せず同一参照で透過)
  └─ graphicsStateStack                         │
        ↓                                       │
  GraphicsStateStack.current() → current        │
        ↓                                       │
  TextObject.isActive(current.textObject)       │
   ├─ false (inactive) → err(OPERATOR_ILLEGAL_STATE)  ← stack 非差し替え
   └─ true  (active)                            │
         ↓                                      │
       TextObject.end() → GraphicsState.update({ textObject })
         ↓                                      │
       GraphicsStateStack.replaceCurrent()      │
         ↓                                      ▼
       ok({ operandStack, graphicsStateStack })
```

## 📋 関連 Issue

- Closes #241
- Refs #228 (親 Epic / Phase 4-D)

## 🧪 テスト

### テスト実行方法

```bash
pnpm --filter @pdfmod/core test   # 受け入れ基準
pnpm lint                          # biome + oxlint
pnpm typecheck                     # tsc --noEmit
```

### テスト項目

- [x] 単体テスト (Unit tests) — et.basic（5）/ et.error（5）
- [x] 統合テスト (Integration tests) — et.integration（5、BT→ET composition）

### テスト結果

- `pnpm --filter @pdfmod/core test`: **175 files / 2350 tests passed**（既存リグレッションなし）
- `pnpm lint`: 0 warnings / 0 errors
- `pnpm typecheck`: core / react とも Done
- spec-based code review（performance / design / spec-alignment 3エージェント並列）: **CRITICAL 0 / WARNING 0**、DoD 9/9 充足

## 🔍 レビューポイント

- `btHandler` との完全対称性（ガード条件を `isActive` → `!isActive` に反転、`begin()` → `end()` に置換）
- operand stack を同一参照で透過する設計（余剰 operand があっても pop しない）
- 単体テスト（basic/error）は `btHandler` に依存させず `TextObject.begin()` で直接 active state を構築。`btHandler→etHandler` の連鎖は integration テストに限定
- registry 登録は本 Issue のスコープ外（後続の text-operators 一括登録バレル新設時に委譲）

## ⚠️ 破壊的変更

- [ ] この変更は既存の API に破壊的変更を含みます

破壊的変更なし（新規ファイル追加のみ。ロールバックは新規ファイル削除で原状復帰可能）。

## ✅ チェックリスト

- [x] コードレビューの準備ができている
- [x] テストが正常に実行される
- [x] コミットメッセージが適切な形式で書かれている
- [x] PR 本文に Issue 連携キーワードを記載
- [x] セルフレビューを実施した（spec-based code review 含む）
- [x] 破壊的変更がある場合は明記されている（該当なし）