### PR TITLE
✨ [New Feature]: #073 PdfObject enum 骨格（Null/Boolean/Integer/Real）を pdfmod-core に追加

### DIFF
--- a/rust/crates/core/src/object.rs
+++ b/rust/crates/core/src/object.rs
@@ -7,6 +7,7 @@
 pub mod generation_number;
 pub mod name;
 pub mod object_number;
+pub mod pdf_object;
 
 // 後続 Issue で各オブジェクト型をサブモジュールとして追加する（以下は例の一部）:
 // pub mod boolean;

--- a/rust/crates/core/src/object/pdf_object.rs
+++ b/rust/crates/core/src/object/pdf_object.rs
@@ -1,0 +1,260 @@
+//! PDF 基本オブジェクトの中核 `PdfObject` を定義するモジュール。
+//!
+//! ISO 32000-1 §7.3 の PDF オブジェクトを 1 つの enum で表す。本 Issue では
+//! スカラ系 4 バリアント（Null / Boolean / Integer / Real）のみを定義し、
+//! 文字列・名前・配列・辞書・参照・ストリームは後続 Issue で追加する。
+//! 構築は無検証（infallible）で、妥当性検証は上位（lexer/parser）に委譲する。
+
+/// PDF 基本オブジェクト（スカラ系 4 バリアントの起点）。
+///
+/// 整数幅は `i64`、浮動小数点幅は `f64`（PDF パーサで最も一般的・桁あふれ耐性・
+/// 後続レクサーとの相性で確定）。`Real(f64)` を含むため `Eq`/`Hash`/`Ord` は
+/// derive できない（IEEE 754: `NaN != NaN`）。`Copy` も付けない（後続のヒープ
+/// 保持バリアント追加で必ず外れ、撤回が破壊的変更になるため最初から付けず API を
+/// 安定させる）。`PartialOrd` も付けない（PDF オブジェクト間に意味ある全順序は
+/// なく、`PdfErrorCode` 同様に用途上不要）。よって derive は `Debug, Clone,
+/// PartialEq` のみ。
+#[derive(Debug, Clone, PartialEq)]
+pub enum PdfObject {
+    /// null オブジェクト（値の不在）。
+    Null,
+    /// 真偽値オブジェクト（`true` / `false`）。
+    Boolean(bool),
+    /// 整数オブジェクト（`i64`、`i64::MIN..=i64::MAX` を無検証で保持）。
+    Integer(i64),
+    /// 実数オブジェクト（`f64`、`NaN`/`±0.0`/`Inf` を無検証で保持）。
+    Real(f64),
+}
+
+impl PdfObject {
+    /// `Null` バリアントかどうかを返す述語。
+    ///
+    /// `Null` のとき `true`、他バリアントでは `false`。
+    pub fn is_null(&self) -> bool {
+        matches!(self, Self::Null)
+    }
+
+    /// `Boolean` のとき内部の `bool` を `Some` で取り出す（他は `None`）。
+    pub fn as_bool(&self) -> Option<bool> {
+        match self {
+            Self::Boolean(b) => Some(*b),
+            _ => None,
+        }
+    }
+
+    /// `Integer` のとき内部の `i64` を `Some` で取り出す（他は `None`）。
+    pub fn as_integer(&self) -> Option<i64> {
+        match self {
+            Self::Integer(n) => Some(*n),
+            _ => None,
+        }
+    }
+
+    /// `Real` のとき内部の `f64` を `Some` で取り出す（他は `None`）。
+    pub fn as_real(&self) -> Option<f64> {
+        match self {
+            Self::Real(r) => Some(*r),
+            _ => None,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn null_constructs_and_matches_null_arm() {
+        // Null を構築し match で Null 腕に入ることを確認する
+        let obj = PdfObject::Null;
+        assert!(matches!(obj, PdfObject::Null));
+    }
+
+    #[test]
+    fn boolean_constructs_and_matches_with_inner_value() {
+        // Boolean(true) を構築し match の Boolean(b) 腕で b == true になることを確認する
+        let obj = PdfObject::Boolean(true);
+        match obj {
+            PdfObject::Boolean(b) => assert!(b),
+            _ => panic!("Boolean 腕に入らなかった"),
+        }
+    }
+
+    #[test]
+    fn integer_constructs_and_matches_with_inner_value() {
+        // Integer(42) を構築し match の Integer(n) 腕で n == 42 になることを確認する
+        let obj = PdfObject::Integer(42);
+        match obj {
+            PdfObject::Integer(n) => assert_eq!(n, 42),
+            _ => panic!("Integer 腕に入らなかった"),
+        }
+    }
+
+    #[test]
+    fn real_constructs_and_matches_with_inner_value() {
+        // Real(1.5) を構築し match の Real(r) 腕で r == 1.5 になることを確認する
+        let obj = PdfObject::Real(1.5);
+        match obj {
+            PdfObject::Real(r) => assert_eq!(r, 1.5),
+            _ => panic!("Real 腕に入らなかった"),
+        }
+    }
+
+    #[test]
+    fn is_null_returns_true_for_null() {
+        // Null に is_null() を呼ぶと true を返すことを確認する
+        assert!(PdfObject::Null.is_null());
+    }
+
+    #[test]
+    fn as_bool_returns_some_for_boolean() {
+        // Boolean(true) に as_bool() を呼ぶと Some(true) を返すことを確認する
+        assert_eq!(PdfObject::Boolean(true).as_bool(), Some(true));
+    }
+
+    #[test]
+    fn as_integer_returns_some_for_integer() {
+        // Integer(7) に as_integer() を呼ぶと Some(7) を返すことを確認する
+        assert_eq!(PdfObject::Integer(7).as_integer(), Some(7));
+    }
+
+    #[test]
+    fn as_real_returns_some_for_real() {
+        // Real(2.5) に as_real() を呼ぶと Some(2.5) を返すことを確認する
+        assert_eq!(PdfObject::Real(2.5).as_real(), Some(2.5));
+    }
+
+    #[test]
+    fn is_null_returns_false_for_non_null_variants() {
+        // Null 以外（Boolean/Integer/Real）では is_null() が false を返すことを確認する
+        for obj in &[
+            PdfObject::Boolean(true),
+            PdfObject::Integer(0),
+            PdfObject::Real(0.0),
+        ] {
+            assert!(!obj.is_null());
+        }
+    }
+
+    #[test]
+    fn as_bool_returns_none_for_non_boolean_variants() {
+        // Boolean 以外（Null/Integer/Real）では as_bool() が None を返すことを確認する
+        for obj in &[PdfObject::Null, PdfObject::Integer(0), PdfObject::Real(0.0)] {
+            assert_eq!(obj.as_bool(), None);
+        }
+    }
+
+    #[test]
+    fn as_integer_returns_none_for_non_integer_variants() {
+        // Integer 以外（Null/Boolean/Real）では as_integer() が None を返すことを確認する
+        for obj in &[
+            PdfObject::Null,
+            PdfObject::Boolean(true),
+            PdfObject::Real(0.0),
+        ] {
+            assert_eq!(obj.as_integer(), None);
+        }
+    }
+
+    #[test]
+    fn as_real_returns_none_for_non_real_variants() {
+        // Real 以外（Null/Boolean/Integer）では as_real() が None を返すことを確認する
+        for obj in &[
+            PdfObject::Null,
+            PdfObject::Boolean(true),
+            PdfObject::Integer(0),
+        ] {
+            assert_eq!(obj.as_real(), None);
+        }
+    }
+
+    #[test]
+    fn same_variant_same_value_is_equal() {
+        // 同一バリアント・同値は == で等価になることを確認する
+        assert_eq!(PdfObject::Integer(1), PdfObject::Integer(1));
+        assert_eq!(PdfObject::Boolean(false), PdfObject::Boolean(false));
+        assert_eq!(PdfObject::Null, PdfObject::Null);
+    }
+
+    #[test]
+    fn different_variants_are_not_equal() {
+        // 異なるバリアント間は数値的同値でも != で非等価になることを確認する
+        assert_ne!(PdfObject::Integer(1), PdfObject::Real(1.0));
+        assert_ne!(PdfObject::Boolean(false), PdfObject::Null);
+    }
+
+    #[test]
+    fn all_distinct_variants_are_mutually_not_equal() {
+        // 4 バリアントを総当たりで比較し、同一インデックスのみ等価・他は非等価であることを確認する
+        // （NaN は等価判定が崩れるため代表値には含めない）
+        let variants = [
+            PdfObject::Null,
+            PdfObject::Boolean(false),
+            PdfObject::Integer(0),
+            PdfObject::Real(0.0),
+        ];
+        for (i, a) in variants.iter().enumerate() {
+            for (j, b) in variants.iter().enumerate() {
+                if i == j {
+                    assert_eq!(a, b);
+                } else {
+                    assert_ne!(a, b);
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn integer_preserves_i64_boundaries() {
+        // Integer(i64::MIN) / Integer(i64::MAX) を as_integer() でそのまま取り出せることを確認する
+        for n in [i64::MIN, i64::MAX] {
+            assert_eq!(PdfObject::Integer(n).as_integer(), Some(n));
+        }
+    }
+
+    #[test]
+    fn positive_and_negative_zero_are_equal() {
+        // Real(0.0) と Real(-0.0) は IEEE 754 準拠で == 等価になることを確認する
+        assert_eq!(PdfObject::Real(0.0), PdfObject::Real(-0.0));
+    }
+
+    #[test]
+    fn nan_is_not_equal_to_itself() {
+        // Real(NaN) 同士は IEEE 754 準拠で != 非等価（NaN != NaN）になることを確認する
+        assert_ne!(PdfObject::Real(f64::NAN), PdfObject::Real(f64::NAN));
+    }
+
+    #[test]
+    fn real_preserves_infinities() {
+        // Real(±INFINITY) を as_real() でそのまま取り出せること（doc の「Inf 可」を裏付け）を確認する
+        for r in [f64::INFINITY, f64::NEG_INFINITY] {
+            assert_eq!(PdfObject::Real(r).as_real(), Some(r));
+        }
+    }
+
+    #[test]
+    fn clone_preserves_value_and_keeps_original_usable() {
+        // NaN 以外（Integer(7)）は Clone で複製でき、複製が元と == かつ元も使用可能なことを確認する
+        let original = PdfObject::Integer(7);
+        let cloned = original.clone();
+        assert_eq!(cloned, original);
+        assert_eq!(original.as_integer(), Some(7));
+    }
+
+    #[test]
+    fn clone_preserves_nan_real() {
+        // Real(NaN) の clone 保持は == では検証できないため as_real().is_some_and(is_nan) で確認する
+        let original = PdfObject::Real(f64::NAN);
+        let cloned = original.clone();
+        assert!(cloned.as_real().is_some_and(f64::is_nan));
+    }
+
+    #[test]
+    fn debug_format_contains_variant_name() {
+        // Debug 出力が各バリアント名を含むことを確認する
+        assert!(format!("{:?}", PdfObject::Null).contains("Null"));
+        assert!(format!("{:?}", PdfObject::Boolean(true)).contains("Boolean"));
+        assert!(format!("{:?}", PdfObject::Integer(0)).contains("Integer"));
+        assert!(format!("{:?}", PdfObject::Real(0.0)).contains("Real"));
+    }
+}


### PR DESCRIPTION
## 概要

ISO 32000-1 §7.3 の PDF 基本オブジェクトを表す中核 enum `PdfObject` の骨格を `@pdfmod/core`（Rust クレート `pdfmod-core`）に新規追加します。本 Issue ではスカラ系 4 バリアント（Null / Boolean(bool) / Integer(i64) / Real(f64)）と最小アクセサのみを実装し、文字列・名前・配列・辞書・参照・ストリームは後続 Issue に委ねます。

完全な新規追加（既存コードに `PdfObject` 参照ゼロ）で、破壊的変更はありません。

## 変更内容

### 🎯 変更の種類

- [x] ✨ 新機能 (New feature)
- [x] 🚨 テスト追加/修正 (Tests)

### 📝 詳細な変更内容

#### 追加された機能

- `PdfObject` enum（4 バリアント）: `Null` / `Boolean(bool)` / `Integer(i64)` / `Real(f64)`
- アクセサ 4 種（検索的セマンティクス）:
  - `is_null(&self) -> bool`
  - `as_bool(&self) -> Option<bool>` / `as_integer(&self) -> Option<i64>` / `as_real(&self) -> Option<f64>`
  - バリアント一致時のみ `Some(値)` / `true`、不一致は `None` / `false`
- derive は `#[derive(Debug, Clone, PartialEq)]` のみに限定
  - `Copy` 不付与: 後続のヒープ保持バリアント（String/Array/Dictionary）追加で必ず外れ、撤回が破壊的変更になるため
  - `Eq`/`Hash`/`Ord` 不付与: `Real(f64)` を含むため（IEEE 754: `NaN != NaN`）
  - `PartialOrd` 不付与: PDF オブジェクト間に意味ある全順序がないため（`PdfErrorCode` 前例に準拠）
- colocated ユニットテスト 22 件（フラット構造・各テストに日本語コメント）

#### 変更されたファイル

- `rust/crates/core/src/object/pdf_object.rs`（新規）— enum 本体・アクセサ・テスト
- `rust/crates/core/src/object.rs`（変更）— `pub mod pdf_object;` を `object_number` の直後（アルファベット順末尾）に追加

> `lib.rs` は未変更（`pub mod object;` 既存のため `pdfmod_core::object::pdf_object::PdfObject` として公開）。外部依存の追加なし（std のみ）。

## 📊 システム図

### 状態 / アクセサ フロー図

```mermaid
flowchart TD
    Build([構築 / 無検証 infallible]) --> PO{PdfObject}
    PO --> N["Null"]:::new
    PO --> B["Boolean(bool)"]:::new
    PO --> I["Integer(i64)"]:::new
    PO --> R["Real(f64)"]:::new
    N -->|is_null| T1["true"]
    B -->|as_bool| O1["Some(b)"]
    I -->|as_integer| O2["Some(n)"]
    R -->|as_real| O3["Some(r)"]
    PO -.->|不一致アクセサ| NONE["None / false"]
    classDef new fill:#ffe4b5,stroke:#d97706,stroke-width:2px
```

## 📋 関連 Issue

- Closes #073
- Refs #251 (Epic)

## 🧪 テスト

### テスト実行方法

```bash
cd rust
cargo test -p pdfmod-core
```

### テスト項目

- [x] 単体テスト (Unit tests) — colocated `#[cfg(test)] mod tests` 22 件

### テスト結果

- `cargo test -p pdfmod-core`: **94 件全パス**（pdf_object 22 件 + 既存 72 件、リグレッションなし）
- `cargo clippy -p pdfmod-core --all-targets -- -D warnings`: **0 警告**
- `cargo fmt --check`: 変更対象 2 ファイル（pdf_object.rs / object.rs）に差分なし

主な網羅シナリオ: 4 バリアントの構築・match 分岐、各アクセサの一致 `Some`/不一致 `None`、同値 `==`・異バリアント `!=`（総当たり）、`i64::MIN`/`MAX` 保持、`Real(0.0) == Real(-0.0)`、`Real(NaN) != Real(NaN)`、`Real(±Inf)` 保持、`Clone` 複製、Debug 出力。

## 🔍 レビューポイント

- derive を `Debug, Clone, PartialEq` のみに限定した設計判断（型 doc に理由を明記）
- `Integer(1) != Real(1.0)`（数値的同値でも異バリアントは非等価）が意図どおりであること
- `Real(NaN)` の clone 保持は `==` ではなく `as_real().is_some_and(f64::is_nan)` で検証している点

## ⚠️ 破壊的変更

- [ ] この変更は既存の API に破壊的変更を含みます

破壊的変更なし（完全な新規追加）。

## ✅ チェックリスト

- [x] コードレビューの準備ができている
- [x] テストが正常に実行される
- [x] コミットメッセージが適切な形式で書かれている
- [x] PR 本文に Issue 連携キーワードを記載した
- [x] セルフレビューを実施した（spec-based-code-review 実施済み: CRITICAL/WARNING 0 件）
- [x] 破壊的変更がある場合は明記されている（該当なし）

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)