### PR TITLE
✨ [New Feature]: #258 ObjectId（ObjectNumber + GenerationNumber 複合キー型）を pdfmod-core に追加

### DIFF
--- a/rust/crates/core/src/byte_offset.rs
+++ b/rust/crates/core/src/byte_offset.rs
@@ -79,19 +79,11 @@ mod tests {
     #[test]
     fn sorts_in_ascending_order() {
         // 順不同の配列を sort() すると内部 u64 の昇順に並ぶことを確認する
-        let mut offsets = [
-            ByteOffset::new(3),
-            ByteOffset::new(1),
-            ByteOffset::new(2),
-        ];
+        let mut offsets = [ByteOffset::new(3), ByteOffset::new(1), ByteOffset::new(2)];
         offsets.sort();
         assert_eq!(
             offsets,
-            [
-                ByteOffset::new(1),
-                ByteOffset::new(2),
-                ByteOffset::new(3),
-            ]
+            [ByteOffset::new(1), ByteOffset::new(2), ByteOffset::new(3),]
         );
     }
 

--- a/rust/crates/core/src/lib.rs
+++ b/rust/crates/core/src/lib.rs
@@ -10,6 +10,6 @@
 //!
 //! 各モジュールの実装は後続 PR で追加する。
 
-pub mod object;
-pub mod error;
 pub mod byte_offset;
+pub mod error;
+pub mod object;

--- a/rust/crates/core/src/object.rs
+++ b/rust/crates/core/src/object.rs
@@ -6,6 +6,7 @@
 
 pub mod generation_number;
 pub mod name;
+pub mod object_id;
 pub mod object_number;
 pub mod pdf_object;
 

--- a/rust/crates/core/src/object/object_id.rs
+++ b/rust/crates/core/src/object/object_id.rs
@@ -1,0 +1,205 @@
+//! PDF の間接オブジェクトを一意に識別する複合キー `ObjectId` を定義するモジュール。
+//!
+//! オブジェクト番号 `ObjectNumber`（#255）と世代番号 `GenerationNumber`（#256）の組を
+//! 束ねた値ラッパ。xref エントリのキー・リゾルバのキャッシュキー
+//! （`HashMap<ObjectId, PdfObject>` 等）・循環参照検出の集合キー（`HashSet<ObjectId>`）の
+//! 構成要素として用いる。生成は無検証（infallible）で、任意の番号・世代の組を無条件に受理する。
+//! 世代不一致・番号の妥当性検証は xref レイヤ（R2）に委譲する。
+
+use crate::object::generation_number::GenerationNumber;
+use crate::object::object_number::ObjectNumber;
+
+/// PDF 間接オブジェクトの複合識別子。オブジェクト番号と世代番号の組で一意に識別する。
+///
+/// `object_number` を先に宣言することで、`PartialOrd`/`Ord` が
+/// 「object_number を第 1 キー、generation_number を第 2 キー」とする辞書順になる。
+/// 値ラッパであり `Copy`。等価・順序・ハッシュは両フィールド（内部の `u64`/`u16`）に依存する。
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct ObjectId {
+    object_number: ObjectNumber,
+    generation_number: GenerationNumber,
+}
+
+impl ObjectId {
+    /// オブジェクト番号と世代番号から `ObjectId` を生成する。
+    ///
+    /// 無検証（infallible）。任意の `(ObjectNumber, GenerationNumber)` の組を受理する。
+    pub fn new(object_number: ObjectNumber, generation_number: GenerationNumber) -> ObjectId {
+        ObjectId {
+            object_number,
+            generation_number,
+        }
+    }
+
+    /// オブジェクト番号を `Copy` で取り出す。
+    pub fn object_number(&self) -> ObjectNumber {
+        self.object_number
+    }
+
+    /// 世代番号を `Copy` で取り出す。
+    pub fn generation_number(&self) -> GenerationNumber {
+        self.generation_number
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::{HashMap, HashSet};
+
+    /// 代表ペアで `new` に包んだ値を 2 アクセサで取り出すと入力と一致する（ラウンドトリップ・無損失）。
+    #[test]
+    fn new_then_accessors_roundtrip() {
+        for (n, g) in [(0u64, 0u16), (1, 1), (42, 42), (u64::MAX, u16::MAX)] {
+            let id = ObjectId::new(ObjectNumber::new(n), GenerationNumber::new(g));
+            assert_eq!(id.object_number(), ObjectNumber::new(n));
+            assert_eq!(id.generation_number(), GenerationNumber::new(g));
+        }
+    }
+
+    /// object_number・generation_number がともに同一なら等価（Eq が両フィールドに委譲）。
+    #[test]
+    fn equal_when_both_fields_match() {
+        let a = ObjectId::new(ObjectNumber::new(5), GenerationNumber::new(0));
+        let b = ObjectId::new(ObjectNumber::new(5), GenerationNumber::new(0));
+        assert_eq!(a, b);
+    }
+
+    /// object_number 同一・generation_number のみ異なれば非等価（片フィールド依存でないことを保証）。
+    #[test]
+    fn not_equal_when_generation_differs() {
+        let a = ObjectId::new(ObjectNumber::new(5), GenerationNumber::new(0));
+        let b = ObjectId::new(ObjectNumber::new(5), GenerationNumber::new(1));
+        assert_ne!(a, b);
+    }
+
+    /// generation_number 同一・object_number のみ異なれば非等価（両フィールド依存の裏付け）。
+    #[test]
+    fn not_equal_when_object_number_differs() {
+        let a = ObjectId::new(ObjectNumber::new(5), GenerationNumber::new(0));
+        let b = ObjectId::new(ObjectNumber::new(6), GenerationNumber::new(0));
+        assert_ne!(a, b);
+    }
+
+    /// 辞書順は object_number を第 1 キーとする（generation_number に関わらず object_number が小さい方が小）。
+    #[test]
+    fn orders_by_object_number_first() {
+        let small = ObjectId::new(ObjectNumber::new(1), GenerationNumber::new(9));
+        let large = ObjectId::new(ObjectNumber::new(2), GenerationNumber::new(0));
+        assert!(small < large);
+        assert!(large > small);
+    }
+
+    /// object_number 同一時は第 2 キー generation_number で大小が決まる。
+    #[test]
+    fn orders_by_generation_when_object_number_equal() {
+        let small = ObjectId::new(ObjectNumber::new(5), GenerationNumber::new(1));
+        let large = ObjectId::new(ObjectNumber::new(5), GenerationNumber::new(2));
+        assert!(small < large);
+        assert!(large > small);
+    }
+
+    /// `sort()` すると Ord の 2 軸（object_number 優先 → generation_number）で辞書順に並ぶ。
+    #[test]
+    fn sorts_in_lexicographic_order() {
+        let mut ids = [
+            ObjectId::new(ObjectNumber::new(2), GenerationNumber::new(0)),
+            ObjectId::new(ObjectNumber::new(1), GenerationNumber::new(5)),
+            ObjectId::new(ObjectNumber::new(1), GenerationNumber::new(2)),
+        ];
+        ids.sort();
+        assert_eq!(
+            ids,
+            [
+                ObjectId::new(ObjectNumber::new(1), GenerationNumber::new(2)),
+                ObjectId::new(ObjectNumber::new(1), GenerationNumber::new(5)),
+                ObjectId::new(ObjectNumber::new(2), GenerationNumber::new(0)),
+            ]
+        );
+    }
+
+    /// `Copy` のため代入でコピーされ、元値も使用可能でコピーと等価。
+    #[test]
+    fn is_copy_so_original_stays_usable() {
+        let id = ObjectId::new(ObjectNumber::new(7), GenerationNumber::new(3));
+        let copied = id;
+        assert_eq!(id.object_number(), ObjectNumber::new(7));
+        assert_eq!(id.generation_number(), GenerationNumber::new(3));
+        assert_eq!(id, copied);
+    }
+
+    /// `HashMap<ObjectId, _>` のキーとして使え、同値キーで挿入値を取得できる（Hash + Eq）。
+    #[test]
+    fn works_as_hash_map_key() {
+        let mut map = HashMap::new();
+        map.insert(
+            ObjectId::new(ObjectNumber::new(10), GenerationNumber::new(0)),
+            "obj10",
+        );
+        assert_eq!(
+            map.get(&ObjectId::new(
+                ObjectNumber::new(10),
+                GenerationNumber::new(0)
+            )),
+            Some(&"obj10")
+        );
+    }
+
+    /// 同値 `ObjectId` を `HashSet` に 2 回挿入すると 1 件に折りたたまれる。
+    #[test]
+    fn equal_keys_collapse_in_hash_set() {
+        let mut set = HashSet::new();
+        set.insert(ObjectId::new(
+            ObjectNumber::new(3),
+            GenerationNumber::new(0),
+        ));
+        set.insert(ObjectId::new(
+            ObjectNumber::new(3),
+            GenerationNumber::new(0),
+        ));
+        assert_eq!(set.len(), 1);
+    }
+
+    /// object_number 同一・generation 違いの 2 値は別キーとして `HashSet` に共存する（両フィールド依存）。
+    #[test]
+    fn distinct_keys_coexist_in_hash_set() {
+        let mut set = HashSet::new();
+        set.insert(ObjectId::new(
+            ObjectNumber::new(7),
+            GenerationNumber::new(0),
+        ));
+        set.insert(ObjectId::new(
+            ObjectNumber::new(7),
+            GenerationNumber::new(1),
+        ));
+        assert_eq!(set.len(), 2);
+    }
+
+    /// 最小境界の組 `(0, 0)` を無検証で受理し、アクセサが `0`/`0` を返す。
+    #[test]
+    fn accepts_min_boundary_combo() {
+        let id = ObjectId::new(ObjectNumber::new(0), GenerationNumber::new(0));
+        assert_eq!(id.object_number().value(), 0);
+        assert_eq!(id.generation_number().value(), 0);
+    }
+
+    /// 最大境界の組 `(u64::MAX, u16::MAX)` を無検証で受理し、アクセサが各境界値を返す。
+    #[test]
+    fn accepts_max_boundary_combo() {
+        let id = ObjectId::new(ObjectNumber::new(u64::MAX), GenerationNumber::new(u16::MAX));
+        assert_eq!(id.object_number().value(), u64::MAX);
+        assert_eq!(id.generation_number().value(), u16::MAX);
+    }
+
+    /// 片フィールドのみ MAX の組（`(u64::MAX,0)` と `(0,u16::MAX)`）を受理し、双方は非等価。
+    #[test]
+    fn accepts_mixed_boundary_combo() {
+        let obj_max = ObjectId::new(ObjectNumber::new(u64::MAX), GenerationNumber::new(0));
+        let gen_max = ObjectId::new(ObjectNumber::new(0), GenerationNumber::new(u16::MAX));
+        assert_eq!(obj_max.object_number().value(), u64::MAX);
+        assert_eq!(obj_max.generation_number().value(), 0);
+        assert_eq!(gen_max.object_number().value(), 0);
+        assert_eq!(gen_max.generation_number().value(), u16::MAX);
+        assert_ne!(obj_max, gen_max);
+    }
+}


### PR DESCRIPTION
## 概要

PDF の間接オブジェクトを一意に識別する複合キー値型 `ObjectId`（オブジェクト番号 + 世代番号の組）を `pdfmod-core` に追加します。xref エントリのキー・リゾルバのキャッシュキー・循環参照検出の集合キーとして使える基盤型で、後続レイヤ（xref / resolver）の前提となります。破壊的変更はありません。

## 変更内容

### 🎯 変更の種類

- [x] ✨ 新機能 (New feature)
- [x] 🎨 既存ファイルの整形 (cargo fmt)

### 📝 詳細な変更内容

#### 追加された機能

- `ObjectId` 値型（named-field struct、`object_number` を先に宣言し辞書順を固定）
  - `new(ObjectNumber, GenerationNumber)` — infallible・無検証（妥当性検証は xref レイヤ R2 へ委譲）
  - アクセサ `object_number()` / `generation_number()` — 各 newtype を `Copy` で返却
  - `#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]`
- t-wada 式 TDD による 14 テスト（各 `#[test]` に日本語コメント付与）
  - ラウンドトリップ / 両フィールド依存の等価・非等価 / 辞書順 2 軸・ソート / Copy / HashMap・HashSet キー利用 / 境界値 `(0,0)`・`(u64::MAX,u16::MAX)`・片フィールドのみ MAX

#### 変更されたファイル

- `[NEW] rust/crates/core/src/object/object_id.rs`（205行・実装 + 14テスト）
- `[MODIFY] rust/crates/core/src/object.rs`（`pub mod object_id;` をアルファベット順で1行追加）
- `[STYLE] rust/crates/core/src/byte_offset.rs` / `rust/crates/core/src/lib.rs`（`cargo fmt` 整形・論理変更なし。`cargo fmt --check` の DoD を満たすための既存未整形の解消）

#### 削除されたファイル・機能

- なし

## 📊 システム図

### ObjectId 値のライフサイクル

```mermaid
flowchart TD
    ON["ObjectNumber::new(n) (u64)"] --> NEW
    GN["GenerationNumber::new(g) (u16)"] --> NEW
    NEW["ObjectId::new(obj, gen) [NEW]<br/>infallible / 無検証 / Copy"]:::new
    NEW --> ACC["object_number() / generation_number()<br/>（Copy で返却）"]
    NEW --> KEY{キーとして利用}
    KEY --> CMP["等価/順序<br/>PartialEq・Ord（object_number 優先 → generation_number）"]
    KEY --> HASH["Hash キー<br/>HashMap&lt;ObjectId,V&gt; / HashSet&lt;ObjectId&gt;"]

    classDef new fill:#ffe4b5,stroke:#d97706,stroke-width:2px
```

## 📋 関連 Issue

- Closes #258
- Relates to #251 (Epic R0), Refs #255 (ObjectNumber), #256 (GenerationNumber)

## 🧪 テスト

### テスト実行方法

```bash
cd rust && cargo test -p pdfmod-core object::object_id
cd rust && cargo test
```

### テスト項目

- [x] 単体テスト (Unit tests) — colocated `#[cfg(test)] mod tests`、14件

### テスト結果

- `cargo test`（パッケージ全体）: **108件パス**（新規 object_id 14件含む・リグレッションなし）
- `cargo build`: 成功
- `cargo fmt --check`: クリーン
- `cargo clippy -- -D warnings`: 警告ゼロ
- 外部 crate 依存ゼロ（`Cargo.toml` 無変更）
- 補足: Codex CLI および spec-based-code-review（performance / design / spec-alignment の3エージェント）でレビュー済み。CRITICAL 0 / DoD 全13項目充足。

## 🔍 レビューポイント

- `object_number` を先に宣言することで `PartialOrd`/`Ord` を「object_number 第1キー → generation_number 第2キー」の辞書順に固定しています（宣言順が確定仕様）。
- `new` は infallible・無検証（採番・世代インクリメント・retire は R2 #253 のスコープ）。`Display` / `From` も後続レイヤへ委譲しています。
- 整形コミット（`byte_offset.rs` / `lib.rs`）は実装と分離済みです（`🎨 [Structure]`）。

## ✅ チェックリスト

- [x] コードレビューの準備ができている
- [x] テストが正常に実行される
- [x] コミットメッセージが適切な形式で書かれている
- [x] PR 本文に Issue が記載されている（Closes #258）
- [x] セルフレビューを実施した
- [x] 破壊的変更なし