### PR TITLE
✨ [New Feature]: #242 text state operators の barrel と registerTextStateOperators ヘルパを実装

### DIFF
--- a/packages/core/src/content-stream/operators/text/text-state-operators/__tests__/text-state-operators.basic.test.ts
+++ b/packages/core/src/content-stream/operators/text/text-state-operators/__tests__/text-state-operators.basic.test.ts
@@ -1,0 +1,49 @@
+import { assert, expect, test } from "vitest";
+import type { OperatorHandler } from "../../../../operator-registry/index";
+import { OperatorRegistry } from "../../../../operator-registry/index";
+import {
+  btHandler,
+  etHandler,
+  registerTextStateOperators,
+  tcHandler,
+  tfHandler,
+  tlHandler,
+  trHandler,
+  tsHandler,
+  twHandler,
+  tzHandler,
+} from "../index";
+
+test.each<readonly [string, OperatorHandler]>([
+  ["BT", btHandler],
+  ["ET", etHandler],
+  ["Tf", tfHandler],
+  ["Tc", tcHandler],
+  ["Tw", twHandler],
+  ["Tz", tzHandler],
+  ["TL", tlHandler],
+  ["Tr", trHandler],
+  ["Ts", tsHandler],
+])("registerTextStateOperators は %s に対応する handler を登録する", (name, expectedHandler) => {
+  const result = registerTextStateOperators(OperatorRegistry.create());
+  assert(result.ok);
+
+  const looked = OperatorRegistry.lookup(result.value, name);
+  assert(looked.some);
+  expect(looked.value).toBe(expectedHandler);
+});
+
+test("registerTextStateOperators の戻り値は ok で 9 operator すべてを保持する registry を返す", () => {
+  const result = registerTextStateOperators(OperatorRegistry.create());
+  assert(result.ok);
+
+  expect(OperatorRegistry.has(result.value, "BT")).toBe(true);
+  expect(OperatorRegistry.has(result.value, "ET")).toBe(true);
+  expect(OperatorRegistry.has(result.value, "Tf")).toBe(true);
+  expect(OperatorRegistry.has(result.value, "Tc")).toBe(true);
+  expect(OperatorRegistry.has(result.value, "Tw")).toBe(true);
+  expect(OperatorRegistry.has(result.value, "Tz")).toBe(true);
+  expect(OperatorRegistry.has(result.value, "TL")).toBe(true);
+  expect(OperatorRegistry.has(result.value, "Tr")).toBe(true);
+  expect(OperatorRegistry.has(result.value, "Ts")).toBe(true);
+});

--- a/packages/core/src/content-stream/operators/text/text-state-operators/__tests__/text-state-operators.basic.test.ts
+++ b/packages/core/src/content-stream/operators/text/text-state-operators/__tests__/text-state-operators.basic.test.ts
@@ -1,6 +1,8 @@
 import { assert, expect, test } from "vitest";
-import type { OperatorHandler } from "../../../../operator-registry/index";
-import { OperatorRegistry } from "../../../../operator-registry/index";
+import {
+  type OperatorHandler,
+  OperatorRegistry,
+} from "../../../../operator-registry/index";
 import {
   btHandler,
   etHandler,

--- a/packages/core/src/content-stream/operators/text/text-state-operators/__tests__/text-state-operators.error.test.ts
+++ b/packages/core/src/content-stream/operators/text/text-state-operators/__tests__/text-state-operators.error.test.ts
@@ -1,0 +1,49 @@
+import { afterEach, assert, expect, test, vi } from "vitest";
+import type { OperatorHandler } from "../../../../operator-registry/index";
+import { OperatorRegistry } from "../../../../operator-registry/index";
+import {
+  btHandler,
+  etHandler,
+  registerTextStateOperators,
+  tcHandler,
+  tfHandler,
+  tlHandler,
+  trHandler,
+  tsHandler,
+  twHandler,
+  tzHandler,
+} from "../index";
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+// [重複させる operator 名, その handler, 短絡までに register が呼ばれる名列（登録順の prefix）]
+test.each<readonly [string, OperatorHandler, readonly string[]]>([
+  ["BT", btHandler, ["BT"]],
+  ["ET", etHandler, ["BT", "ET"]],
+  ["Tf", tfHandler, ["BT", "ET", "Tf"]],
+  ["Tc", tcHandler, ["BT", "ET", "Tf", "Tc"]],
+  ["Tw", twHandler, ["BT", "ET", "Tf", "Tc", "Tw"]],
+  ["Tz", tzHandler, ["BT", "ET", "Tf", "Tc", "Tw", "Tz"]],
+  ["TL", tlHandler, ["BT", "ET", "Tf", "Tc", "Tw", "Tz", "TL"]],
+  ["Tr", trHandler, ["BT", "ET", "Tf", "Tc", "Tw", "Tz", "TL", "Tr"]],
+  ["Ts", tsHandler, ["BT", "ET", "Tf", "Tc", "Tw", "Tz", "TL", "Tr", "Ts"]],
+])("%s が登録済みのとき registerTextStateOperators は Err を返し reduce は %s で短絡する", (name, handler, expectedCalledNames) => {
+  const seed = OperatorRegistry.register(
+    OperatorRegistry.create(),
+    name,
+    handler,
+  );
+  assert(seed.ok);
+
+  const registerSpy = vi.spyOn(OperatorRegistry, "register");
+  const result = registerTextStateOperators(seed.value);
+
+  assert(!result.ok);
+  assert(result.error.code === "OPERATOR_ALREADY_REGISTERED");
+  expect(result.error.operatorName).toBe(name);
+  expect(registerSpy.mock.calls.map((call) => call[1])).toEqual(
+    expectedCalledNames,
+  );
+});

--- a/packages/core/src/content-stream/operators/text/text-state-operators/__tests__/text-state-operators.error.test.ts
+++ b/packages/core/src/content-stream/operators/text/text-state-operators/__tests__/text-state-operators.error.test.ts
@@ -1,6 +1,8 @@
 import { afterEach, assert, expect, test, vi } from "vitest";
-import type { OperatorHandler } from "../../../../operator-registry/index";
-import { OperatorRegistry } from "../../../../operator-registry/index";
+import {
+  type OperatorHandler,
+  OperatorRegistry,
+} from "../../../../operator-registry/index";
 import {
   btHandler,
   etHandler,
@@ -29,7 +31,7 @@ test.each<readonly [string, OperatorHandler, readonly string[]]>([
   ["TL", tlHandler, ["BT", "ET", "Tf", "Tc", "Tw", "Tz", "TL"]],
   ["Tr", trHandler, ["BT", "ET", "Tf", "Tc", "Tw", "Tz", "TL", "Tr"]],
   ["Ts", tsHandler, ["BT", "ET", "Tf", "Tc", "Tw", "Tz", "TL", "Tr", "Ts"]],
-])("%s が登録済みのとき registerTextStateOperators は Err を返し reduce は %s で短絡する", (name, handler, expectedCalledNames) => {
+])("%s が登録済みのとき registerTextStateOperators は Err を返し reduce が登録順 prefix で短絡する", (name, handler, expectedCalledNames) => {
   const seed = OperatorRegistry.register(
     OperatorRegistry.create(),
     name,

--- a/packages/core/src/content-stream/operators/text/text-state-operators/__tests__/text-state-operators.integration.test.ts
+++ b/packages/core/src/content-stream/operators/text/text-state-operators/__tests__/text-state-operators.integration.test.ts
@@ -1,0 +1,128 @@
+import { assert, expect, test } from "vitest";
+import {
+  GraphicsStateStack,
+  TextObject,
+  TextRenderingMode,
+} from "../../../../graphics-state/index";
+import type { ContentStreamInterpreterResult } from "../../../../interpreter/index";
+import { ContentStreamInterpreter } from "../../../../interpreter/index";
+import { OperatorRegistry } from "../../../../operator-registry/index";
+import { registerTextStateOperators } from "../index";
+
+const encode = (s: string): Uint8Array => new TextEncoder().encode(s);
+
+// registerTextStateOperators で全 operator を登録した registry で content stream を
+// 実行し、成功結果を返すテストヘルパ。失敗時は assert で即座に検出する。
+const execute = (stream: string): ContentStreamInterpreterResult => {
+  const registered = registerTextStateOperators(OperatorRegistry.create());
+  assert(registered.ok);
+
+  const result = ContentStreamInterpreter.execute({
+    data: encode(stream),
+    registry: registered.value,
+  });
+  assert(result.ok);
+  return result.value;
+};
+
+test("全 9 operator を含む content stream を実行すると textState と textObject が遷移する", () => {
+  const executed = execute("BT /F1 12 Tf 2 Tc 3 Tw 200 Tz 14 TL 1 Tr 5 Ts ET");
+  expect(executed.warnings).toEqual([]);
+
+  const current = GraphicsStateStack.current(
+    executed.context.graphicsStateStack,
+  );
+
+  // Tf: フォント名（Option）とサイズ
+  assert(current.textState.fontName.some);
+  expect(current.textState.fontName.value).toBe("F1");
+  expect(current.textState.fontSize).toBe(12);
+
+  // Tc / Tw: 文字間隔・単語間隔
+  expect(current.textState.charSpace).toBe(2);
+  expect(current.textState.wordSpace).toBe(3);
+
+  // Tz: 水平スケール（デフォルト 100 と異なる 200 で変化を観測）
+  expect(current.textState.horizontalScaling).toBe(200);
+
+  // TL / Ts: 行送り・テキスト上昇
+  expect(current.textState.leading).toBe(14);
+  expect(current.textState.rise).toBe(5);
+
+  // Tr: レンダリングモード（STROKE=1、デフォルト FILL=0 と差を観測）
+  expect(current.textState.renderingMode).toBe(
+    TextRenderingMode.create(TextRenderingMode.STROKE),
+  );
+
+  // ET 後: textObject は非 active
+  expect(TextObject.isActive(current.textObject)).toBe(false);
+});
+
+// 個別 operator の content stream で対応する textState 数値フィールドのみが
+// 更新されることを検証する。全部入り stream（上記）が登録漏れ・実行漏れを担保し、
+// こちらは失敗時に原因 operator を特定できる粒度を担保する。
+test.each<
+  readonly [
+    string,
+    "charSpace" | "wordSpace" | "horizontalScaling" | "leading" | "rise",
+    number,
+  ]
+>([
+  ["2 Tc", "charSpace", 2],
+  ["3 Tw", "wordSpace", 3],
+  ["200 Tz", "horizontalScaling", 200],
+  ["14 TL", "leading", 14],
+  ["5 Ts", "rise", 5],
+])("単体 content stream '%s' を実行すると textState.%s が更新される", (stream, field, expected) => {
+  const executed = execute(stream);
+  expect(executed.warnings).toEqual([]);
+
+  const current = GraphicsStateStack.current(
+    executed.context.graphicsStateStack,
+  );
+  expect(current.textState[field]).toBe(expected);
+});
+
+test("単体 content stream '/F1 12 Tf' を実行すると fontName と fontSize が更新される", () => {
+  const executed = execute("/F1 12 Tf");
+  expect(executed.warnings).toEqual([]);
+
+  const current = GraphicsStateStack.current(
+    executed.context.graphicsStateStack,
+  );
+  assert(current.textState.fontName.some);
+  expect(current.textState.fontName.value).toBe("F1");
+  expect(current.textState.fontSize).toBe(12);
+});
+
+test("単体 content stream '1 Tr' を実行すると renderingMode が STROKE になる", () => {
+  const executed = execute("1 Tr");
+  expect(executed.warnings).toEqual([]);
+
+  const current = GraphicsStateStack.current(
+    executed.context.graphicsStateStack,
+  );
+  expect(current.textState.renderingMode).toBe(
+    TextRenderingMode.create(TextRenderingMode.STROKE),
+  );
+});
+
+test("単体 content stream 'BT' を実行すると textObject が active になる", () => {
+  const executed = execute("BT");
+  expect(executed.warnings).toEqual([]);
+
+  const current = GraphicsStateStack.current(
+    executed.context.graphicsStateStack,
+  );
+  expect(TextObject.isActive(current.textObject)).toBe(true);
+});
+
+test("content stream 'BT ET' を実行すると textObject が非 active になる", () => {
+  const executed = execute("BT ET");
+  expect(executed.warnings).toEqual([]);
+
+  const current = GraphicsStateStack.current(
+    executed.context.graphicsStateStack,
+  );
+  expect(TextObject.isActive(current.textObject)).toBe(false);
+});

--- a/packages/core/src/content-stream/operators/text/text-state-operators/index.ts
+++ b/packages/core/src/content-stream/operators/text/text-state-operators/index.ts
@@ -1,0 +1,58 @@
+import type { PdfError } from "../../../../pdf/errors/index";
+import type { Result } from "../../../../utils/result/index";
+import { flatMap, ok } from "../../../../utils/result/index";
+import type { OperatorHandler } from "../../../operator-registry/index";
+import { OperatorRegistry } from "../../../operator-registry/index";
+import { btHandler } from "../bt/index";
+import { etHandler } from "../et/index";
+import { tcHandler } from "../tc/index";
+import { tfHandler } from "../tf/index";
+import { tlHandler } from "../tl/index";
+import { trHandler } from "../tr/index";
+import { tsHandler } from "../ts/index";
+import { twHandler } from "../tw/index";
+import { tzHandler } from "../tz/index";
+
+export { btHandler } from "../bt/index";
+export { etHandler } from "../et/index";
+export { tcHandler } from "../tc/index";
+export { tfHandler } from "../tf/index";
+export { tlHandler } from "../tl/index";
+export { trHandler } from "../tr/index";
+export { tsHandler } from "../ts/index";
+export { twHandler } from "../tw/index";
+export { tzHandler } from "../tz/index";
+
+// 登録順は Issue 指定順（BT, ET, Tf, Tc, Tw, Tz, TL, Tr, Ts）。
+// この順序は error テストの fail-fast 呼び出し順検証に直結する。
+const TEXT_STATE_OPERATORS: ReadonlyArray<readonly [string, OperatorHandler]> =
+  [
+    ["BT", btHandler],
+    ["ET", etHandler],
+    ["Tf", tfHandler],
+    ["Tc", tcHandler],
+    ["Tw", twHandler],
+    ["Tz", tzHandler],
+    ["TL", tlHandler],
+    ["Tr", trHandler],
+    ["Ts", tsHandler],
+  ];
+
+/**
+ * Text state operator (BT / ET / Tf / Tc / Tw / Tz / TL / Tr / Ts) を
+ * OperatorRegistry に一括登録するヘルパ。
+ *
+ * fail-fast: いずれかの register が Err を返した時点で reduce 内 flatMap が
+ * 短絡し、後続 operator の register は呼ばれない。
+ *
+ * @param registry - 登録元 registry
+ * @returns 全 operator が登録された新しい registry、または重複登録時の PdfError
+ */
+export const registerTextStateOperators = (
+  registry: OperatorRegistry,
+): Result<OperatorRegistry, PdfError> =>
+  TEXT_STATE_OPERATORS.reduce<Result<OperatorRegistry, PdfError>>(
+    (acc, [name, handler]) =>
+      flatMap(acc, (r) => OperatorRegistry.register(r, name, handler)),
+    ok(registry),
+  );


### PR DESCRIPTION
## 概要

Phase 4-D で個別実装済みの 9 つの text state handler（BT / ET / Tf / Tc / Tw / Tz / TL / Tr / Ts）を `OperatorRegistry` へ一括登録する barrel `index.ts` と ヘルパ `registerTextStateOperators` を新規追加します。content stream 実行側が 9 operator を 1 関数呼び出しで登録できるようにし、既存の `registerColorOperators`（Phase 4-C）/ `registerPathOperators`（Phase 4-B）と同一パターン（`reduce` + `flatMap` による fail-fast）に揃えます。

純粋な新規追加であり、既存 9 handler は再 export のみで実装変更はありません（破壊的変更なし）。

## 変更内容

### 🎯 変更の種類

- [x] ✨ 新機能 (New feature)
- [x] 🚨 テスト追加/修正 (Tests)

### 📝 詳細な変更内容

#### 追加された機能・修正

- `registerTextStateOperators(registry): Result<OperatorRegistry, PdfError>` — 9 operator を Issue 指定順（`BT, ET, Tf, Tc, Tw, Tz, TL, Tr, Ts`）で一括登録。`reduce` + `flatMap` により重複登録時は fail-fast で短絡し、後続 `register` を呼ばない
- barrel として 9 handler を camelCase（`btHandler`〜`tsHandler`）で再 export

#### 変更されたファイル（すべて新規追加）

- `packages/core/src/content-stream/operators/text/text-state-operators/index.ts`
- `packages/core/src/content-stream/operators/text/text-state-operators/__tests__/text-state-operators.basic.test.ts`
- `packages/core/src/content-stream/operators/text/text-state-operators/__tests__/text-state-operators.error.test.ts`
- `packages/core/src/content-stream/operators/text/text-state-operators/__tests__/text-state-operators.integration.test.ts`

#### 削除されたファイル・機能

- なし

## 📊 システム図

### 状態マシン / フロー図

`registerTextStateOperators` の reduce + flatMap による登録ループと fail-fast 短絡（ファイル全体が [NEW]）。

```mermaid
flowchart TD
    Start([registerTextStateOperators]) --> Acc["acc = ok(registry)"]
    Acc --> Step{"次の operator<br/>BT→ET→Tf→Tc→Tw→Tz→TL→Tr→Ts"}
    Step -->|"acc が Ok"| Reg["OperatorRegistry.register"]
    Step -->|"acc が Err (fail-fast)"| Skip["register を呼ばず Err を伝播"]
    Reg -->|"成功"| NextOk["acc = Ok 新 registry"]
    Reg -->|"重複 OPERATOR_ALREADY_REGISTERED"| NextErr["acc = Err PdfError"]
    NextOk --> Step
    NextErr --> Step
    Skip --> Step
    Step -->|"全 9 要素を消費"| Done(["Result&lt;OperatorRegistry, PdfError&gt;"])
```

## 📋 関連 Issue

- Closes #242
- Refs #228

## 🧪 テスト

### テスト実行方法

```bash
pnpm --filter @pdfmod/core test
pnpm --filter @pdfmod/core build
pnpm -w run lint
```

### テスト項目

- [x] 単体テスト (Unit tests) — basic / error
- [x] 統合テスト (Integration tests) — integration

### テスト結果

- `pnpm --filter @pdfmod/core test`: ✅ 178 ファイル / 2379 tests passed（新規 29 ケース）
  - basic: 9 operator の登録網羅（lookup）+ 返り値 registry の 9 operator 同時保持（has）
  - error: 全 9 operator の重複時 fail-fast 短絡を spy 呼び出し名列で登録順 prefix 検証
  - integration: 全部入り content stream `BT /F1 12 Tf 2 Tc 3 Tw 200 Tz 14 TL 1 Tr 5 Ts ET` の state 遷移 + operator 個別の遷移検証
- `pnpm --filter @pdfmod/core build`: ✅ 成功（vite build + tsc 宣言生成）
- `pnpm -w run lint`（biome + oxlint）: ✅ 0 warnings / 0 errors

## 🔍 レビューポイント

- `TEXT_STATE_OPERATORS` の登録順が Issue 指定順（`BT, ET, Tf, Tc, Tw, Tz, TL, Tr, Ts`）であること。この順序は error テストの fail-fast 呼び出し順検証に直結します
- `color-operators/index.ts` と同一の barrel 二重宣言（import は配列構築用、export は公開用）パターンであること
- integration の全部入り stream（登録漏れ・実行漏れの不在を担保）に加え、operator 個別テスト（失敗箇所の特定性向上）を追加しています

## ⚠️ 破壊的変更

- [ ] この変更は既存の API に破壊的変更を含みます

なし（既存 9 handler は再 export のみで実装変更なし）。

## ✅ チェックリスト

- [x] コードレビューの準備ができている
- [x] テストが正常に実行される
- [x] コミットメッセージが適切な形式で書かれている（実装とテストを分割）
- [x] PR 本文に `Closes #242` / `Refs #228` で Issue を記載
- [x] セルフレビューを実施した（spec-based code review: CRITICAL/WARNING 0）
- [x] 破壊的変更なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)