### PR TITLE
✨ [New Feature]: #073 TextObject 位置決め行列更新メソッド (translateLine / setMatrix) を実装

### DIFF
--- a/packages/core/src/content-stream/graphics-state/text-object/__tests__/text-object.positioning.test.ts
+++ b/packages/core/src/content-stream/graphics-state/text-object/__tests__/text-object.positioning.test.ts
@@ -4,8 +4,8 @@ import { TextObject } from "../../text-object";
 
 // active=true の任意 TextObject を生で組むヘルパ（dirty state 構築用）
 const buildActive = (
-  textMatrix: readonly number[],
-  textLineMatrix: readonly number[],
+  textMatrix: readonly [number, number, number, number, number, number],
+  textLineMatrix: readonly [number, number, number, number, number, number],
 ): TextObject =>
   ({
     active: true,

--- a/packages/core/src/content-stream/graphics-state/text-object/__tests__/text-object.positioning.test.ts
+++ b/packages/core/src/content-stream/graphics-state/text-object/__tests__/text-object.positioning.test.ts
@@ -1,0 +1,110 @@
+import { expect, test } from "vitest";
+import { Matrix } from "../../matrix";
+import { TextObject } from "../../text-object";
+
+// active=true の任意 TextObject を生で組むヘルパ（dirty state 構築用）
+const buildActive = (
+  textMatrix: readonly number[],
+  textLineMatrix: readonly number[],
+): TextObject =>
+  ({
+    active: true,
+    textMatrix,
+    textLineMatrix,
+  }) as TextObject;
+
+// --- translateLine: 正常系（絶対配置） ---
+test("translateLine(begin, 72, 720) は両 matrix を [1,0,0,1,72,720] にする", () => {
+  const next = TextObject.translateLine(TextObject.begin(), 72, 720);
+  expect(next.textMatrix).toEqual([1, 0, 0, 1, 72, 720]);
+  expect(next.textLineMatrix).toEqual([1, 0, 0, 1, 72, 720]);
+});
+
+// --- translateLine: 正常系（相対累積 / 三角測量で一般化） ---
+test("translateLine は現 textLineMatrix を基準に累積する（[..72,720]+(0,-14)=[..72,706]）", () => {
+  const state = buildActive([1, 0, 0, 1, 72, 720], [1, 0, 0, 1, 72, 720]);
+  const next = TextObject.translateLine(state, 0, -14);
+  expect(next.textMatrix).toEqual([1, 0, 0, 1, 72, 706]);
+  expect(next.textLineMatrix).toEqual([1, 0, 0, 1, 72, 706]);
+});
+
+// --- translateLine: 乗算順検証（非可換ケース） ---
+// 平行移動同士だと左右を入れ替えても同結果になり向き誤りを検出できない。
+// スケールを含む Tlm を使い multiply(translation, Tlm) の向きを固定する。
+// translate(5,7) × [2,0,0,2,10,20] = [2,0,0,2,20,34]（逆順なら [2,0,0,2,15,27]）
+test("translateLine は multiply(translation, Tlm) の向きで計算する（非可換で検証）", () => {
+  const state = buildActive([9, 0, 0, 9, 99, 99], [2, 0, 0, 2, 10, 20]);
+  const next = TextObject.translateLine(state, 5, 7);
+  expect(next.textMatrix).toEqual([2, 0, 0, 2, 20, 34]);
+  expect(next.textLineMatrix).toEqual([2, 0, 0, 2, 20, 34]);
+});
+
+// --- translateLine: 境界値（ゼロ移動） ---
+// translate(0,0) は identity。Tlm' = Tlm（不変）、Tm' = Tlm（元 Tm が異なれば Tlm にリセット）。
+test("translateLine(state, 0, 0) は Tlm を保ち Tm を Tlm に揃え、新インスタンスを返す", () => {
+  const state = buildActive([5, 0, 0, 5, 1, 2], [1, 0, 0, 1, 72, 720]);
+  const next = TextObject.translateLine(state, 0, 0);
+  expect(next.textLineMatrix).toEqual([1, 0, 0, 1, 72, 720]); // Tlm は不変
+  expect(next.textMatrix).toEqual([1, 0, 0, 1, 72, 720]); // Tm は Tlm に設定（元 [5,..] からリセット）
+  expect(next).not.toBe(state); // 新インスタンス（別参照）
+});
+
+// --- translateLine: エッジケース（負値） ---
+test("translateLine は負値の平行移動を正しく累積する（[..72,720]+(-14,-14)=[..58,706]）", () => {
+  const state = buildActive([1, 0, 0, 1, 72, 720], [1, 0, 0, 1, 72, 720]);
+  const next = TextObject.translateLine(state, -14, -14);
+  expect(next.textMatrix).toEqual([1, 0, 0, 1, 58, 706]);
+  expect(next.textLineMatrix).toEqual([1, 0, 0, 1, 58, 706]);
+});
+
+// --- translateLine: 不変性 ---
+test("translateLine は元 state を mutate しない", () => {
+  const state = buildActive([1, 0, 0, 1, 72, 720], [1, 0, 0, 1, 72, 720]);
+  TextObject.translateLine(state, 0, -14);
+  expect(state.textMatrix).toEqual([1, 0, 0, 1, 72, 720]);
+  expect(state.textLineMatrix).toEqual([1, 0, 0, 1, 72, 720]);
+});
+
+// --- translateLine: active 保持（active=true / false 双方） ---
+test("translateLine は active を引き継ぐ（true のまま）", () => {
+  const next = TextObject.translateLine(TextObject.begin(), 1, 1);
+  expect(next.active).toBe(true);
+});
+test("translateLine は active を引き継ぐ（inactive は false のまま）", () => {
+  const next = TextObject.translateLine(TextObject.inactive(), 1, 1);
+  expect(next.active).toBe(false);
+});
+
+// --- setMatrix: 正常系（上書き） ---
+test("setMatrix(state, [2,0,0,2,10,20]) は両 matrix を [2,0,0,2,10,20] にする", () => {
+  const m = Matrix.create(2, 0, 0, 2, 10, 20);
+  const next = TextObject.setMatrix(TextObject.begin(), m);
+  expect(next.textMatrix).toEqual([2, 0, 0, 2, 10, 20]);
+  expect(next.textLineMatrix).toEqual([2, 0, 0, 2, 10, 20]);
+});
+
+// --- setMatrix: べき等性 ---
+test("setMatrix は同一 matrix の再適用で同値（決定的上書き）", () => {
+  const m = Matrix.create(2, 0, 0, 2, 10, 20);
+  const once = TextObject.setMatrix(TextObject.begin(), m);
+  const twice = TextObject.setMatrix(once, m);
+  expect(twice.textMatrix).toEqual(once.textMatrix);
+  expect(twice.textLineMatrix).toEqual(once.textLineMatrix);
+});
+
+// --- setMatrix: 不変性 / active 保持 ---
+test("setMatrix は元 state を mutate せず active を引き継ぐ", () => {
+  const state = buildActive([1, 0, 0, 1, 0, 0], [1, 0, 0, 1, 0, 0]);
+  const next = TextObject.setMatrix(state, Matrix.create(2, 0, 0, 2, 10, 20));
+  expect(state.textMatrix).toEqual([1, 0, 0, 1, 0, 0]); // 元 state は不変
+  expect(state.textLineMatrix).toEqual([1, 0, 0, 1, 0, 0]);
+  expect(next).not.toBe(state); // 新インスタンス
+  expect(next.active).toBe(true); // active 引き継ぎ
+});
+test("setMatrix は active を引き継ぐ（inactive は false のまま）", () => {
+  const next = TextObject.setMatrix(
+    TextObject.inactive(),
+    Matrix.create(2, 0, 0, 2, 10, 20),
+  );
+  expect(next.active).toBe(false);
+});

--- a/packages/core/src/content-stream/graphics-state/text-object/index.ts
+++ b/packages/core/src/content-stream/graphics-state/text-object/index.ts
@@ -73,4 +73,46 @@ export const TextObject = {
   isActive(state: TextObject): boolean {
     return state.active;
   },
+  /**
+   * `Td` / `TD` / `T*` operator (ISO 32000-1:2008 §9.4.2) の行送りに相当する
+   * テキスト行行列の更新。`Tlm' = translate(tx, ty) × Tlm` を計算し、
+   * `Tm'` も同値に設定する (`Tm' = Tlm'`)。
+   *
+   * `translate(tx, ty)` は `Matrix.create(1, 0, 0, 1, tx, ty)`。
+   * 引数の向きは「左 = 適用する変換」(`cm` ハンドラと同一規約)。
+   * `active` は引数 state から引き継ぐ。元 state は変更しない (純粋関数)。
+   *
+   * @param state - 更新対象の TextObject
+   * @param tx - x 方向の平行移動量
+   * @param ty - y 方向の平行移動量 (行送りは通常負値)
+   * @returns `textMatrix` / `textLineMatrix` を更新した新しい TextObject
+   */
+  translateLine(state: TextObject, tx: number, ty: number): TextObject {
+    const translation = Matrix.create(1, 0, 0, 1, tx, ty);
+    const next = Matrix.multiply(translation, state.textLineMatrix);
+    return {
+      active: state.active,
+      textMatrix: next,
+      textLineMatrix: next,
+    } as TextObject;
+  },
+  /**
+   * `Tm` operator (ISO 32000-1:2008 §9.4.2) のテキスト行列上書き。
+   * `Tm' = Tlm' = matrix` に設定する (引数 matrix を両フィールドへ代入)。
+   *
+   * `active` は引数 state から引き継ぐ。元 state は変更しない (純粋関数)。
+   * `Matrix` は readonly tuple かつ常に新規生成されるため、引数 matrix を
+   * 両フィールドへ同一参照で代入しても不変性は保たれる。
+   *
+   * @param state - 更新対象の TextObject
+   * @param matrix - 新しい textMatrix / textLineMatrix
+   * @returns `textMatrix` / `textLineMatrix` を matrix に置き換えた新しい TextObject
+   */
+  setMatrix(state: TextObject, matrix: Matrix): TextObject {
+    return {
+      active: state.active,
+      textMatrix: matrix,
+      textLineMatrix: matrix,
+    } as TextObject;
+  },
 } as const;

--- a/packages/core/src/content-stream/graphics-state/text-object/index.ts
+++ b/packages/core/src/content-stream/graphics-state/text-object/index.ts
@@ -101,7 +101,7 @@ export const TextObject = {
    * `Tm' = Tlm' = matrix` に設定する (引数 matrix を両フィールドへ代入)。
    *
    * `active` は引数 state から引き継ぐ。元 state は変更しない (純粋関数)。
-   * `Matrix` は readonly tuple かつ常に新規生成されるため、引数 matrix を
+   * `Matrix` は readonly tuple のため要素を破壊的変更できず、引数 matrix を
    * 両フィールドへ同一参照で代入しても不変性は保たれる。
    *
    * @param state - 更新対象の TextObject

--- a/packages/core/src/content-stream/graphics-state/text-object/index.ts
+++ b/packages/core/src/content-stream/graphics-state/text-object/index.ts
@@ -98,11 +98,12 @@ export const TextObject = {
   },
   /**
    * `Tm` operator (ISO 32000-1:2008 §9.4.2) のテキスト行列上書き。
-   * `Tm' = Tlm' = matrix` に設定する (引数 matrix を両フィールドへ代入)。
+   * `Tm' = Tlm' = matrix` に設定する (両フィールドを引数 matrix と同値にする)。
    *
    * `active` は引数 state から引き継ぐ。元 state は変更しない (純粋関数)。
-   * `Matrix` は readonly tuple のため要素を破壊的変更できず、引数 matrix を
-   * 両フィールドへ同一参照で代入しても不変性は保たれる。
+   * `Matrix` は readonly tuple として不変に扱う値であり、本コードベースでは
+   * 生成後に破壊的変更しない運用のため、引数 matrix をそのまま両フィールドへ
+   * 代入してよい (防御コピー不要)。
    *
    * @param state - 更新対象の TextObject
    * @param matrix - 新しい textMatrix / textLineMatrix


### PR DESCRIPTION
## 概要

Phase 4-E の位置決めオペレータ (`Td` / `TD` / `Tm` / `T*`) が共通利用する行列計算ロジックを `TextObject` コンパニオンに集約する。`translateLine`（行送り累積）と `setMatrix`（行列上書き）の2メソッドをイミュータブルな純粋関数として追加し、handler 層が operand の pop / 型検査 / active 検査に専念できるよう責務を分離する。

## 変更の種類

- ✨ 新機能 (New feature)
- 🚨 テスト追加 (Tests)

## 詳細な変更内容

### 追加された機能

- `TextObject.translateLine(state, tx, ty)`: `Tlm' = translate(tx, ty) × Tlm`（`Matrix.multiply(translation, state.textLineMatrix)`、左=変換の `cm` ハンドラと同一規約）を計算し `Tm' = Tlm' = next` を設定。
- `TextObject.setMatrix(state, matrix)`: 引数 `matrix` を両フィールドへ同一参照で代入（`Tm' = Tlm' = matrix`）。
- いずれも `active` を引数 state から引き継ぐ純粋関数で、`throw` せず・元 state を mutate せず、単段 `as TextObject` キャストで新インスタンスを返す。

### 変更されたファイル

- `packages/core/src/content-stream/graphics-state/text-object/index.ts` — companion に2メソッドを追加（JSDoc 付き）
- `packages/core/src/content-stream/graphics-state/text-object/__tests__/text-object.positioning.test.ts` — 新規ユニットテスト12件（フラット構造）

### コミット一覧

| コミット | 種別 | 内容 |
|:-|:-|:-|
| `77b736d` | ✨ New Feature | `translateLine` / `setMatrix` 実装 |
| `27ff379` | 🧪 Tests | ユニットテスト12件 |
| `a904b0e` | 📝 Doc | setMatrix の不変性根拠を「readonly tuple のため要素を破壊的変更できない」に明確化（Copilot レビュー対応） |
| `77766c9` | 🏷️ Types | テストヘルパ `buildActive` の引数を `readonly [number×6]` タプル型に厳密化し arity 不一致をコンパイル時検出（Copilot レビュー対応） |

## 📊 システム図

```mermaid
flowchart TD
    Begin([BT / begin]) --> Active["ACTIVE<br/>Tm = Tlm = identity<br/>active = true"]
    Active -->|"translateLine(tx,ty)"| Tr["TRANSLATED [NEW]<br/>next = translate(tx,ty) × Tlm<br/>Tm = Tlm = next<br/>active = state.active"]
    Active -->|"setMatrix(matrix)"| Ov["OVERWRITTEN [NEW]<br/>Tm = Tlm = matrix<br/>active = state.active"]
    Tr -->|"translateLine (累積)"| Tr
    Ov -->|"translateLine (上書き後も累積可)"| Tr

    classDef new fill:#ffe4b5,stroke:#d97706,stroke-width:2px
    class Tr,Ov new
```

## 📋 関連 Issue

- Closes #073
- 親 Epic: #288 / blocked by #228

## 🧪 テスト

### テスト実行方法

```bash
pnpm --filter @pdfmod/core test
pnpm --filter @pdfmod/core build
pnpm typecheck
pnpm lint
```

### テスト項目

- [x] 単体テスト (Unit tests) — 新規12件（絶対配置・相対累積・乗算順(非可換)・ゼロ移動・負値・上書き・べき等性・不変性・active 保持 true/false）

### テスト結果

- `pnpm --filter @pdfmod/core test`: **179 files / 2391 tests passed**（リグレッションなし）
- `pnpm --filter @pdfmod/core build`: 成功
- `pnpm typecheck` / `pnpm lint`（biome + oxlint）: エラーなし
- **CI**: ✅ PASSED

## 👀 レビュー対応

- **codex レビュー（実装時）**: `setMatrix` の active=false テスト欠如を指摘 → テスト追加で解消
- **Copilot レビュー（PR）**: 2件の指摘（JSDoc の不変性根拠 / テストヘルパの型安全性）に対応コミット（`a904b0e` / `77766c9`）を投入し、両スレッドとも **resolved**

## 🔍 レビューポイント

- `translateLine` の乗算順 `Matrix.multiply(translation, state.textLineMatrix)`（向きを逆にすると累積が誤る。非可換テストで固定）
- `active` を固定値ではなく `state.active` で引き継ぐ点（既存 `begin`/`end` と異なる唯一の挙動）
- 新2メソッドのみ単段 `as TextObject` キャスト（ブランド型はベース型に assignable）。既存メソッドの二段キャストは本PR範囲外

## ⚠️ 破壊的変更

- [ ] なし（既存 `begin` / `end` / `inactive` / `isActive` および BT/ET ハンドラへの影響なし。companion への純粋追加のみ）