### PR TITLE
✨ [New Feature]: #291 PDF TD operator の tdLeadingHandler を実装

### DIFF
--- a/packages/core/src/content-stream/operators/text/td-leading/__tests__/td-leading.basic.test.ts
+++ b/packages/core/src/content-stream/operators/text/td-leading/__tests__/td-leading.basic.test.ts
@@ -1,0 +1,189 @@
+import { assert, expect, test } from "vitest";
+import type { PdfObject } from "../../../../../pdf/types/pdf-types/index";
+import {
+  GraphicsState,
+  GraphicsStateStack,
+  Matrix,
+  TextObject,
+} from "../../../../graphics-state/index";
+import { OperandStack } from "../../../../operand-stack/index";
+import type { OperatorHandlerContext } from "../../../../operator-registry/index";
+import { tdLeadingHandler } from "../index";
+
+// active な text object を持つ context を operand 付きで組む。
+// operand は PDF 表記 `tx ty TD` の並び（配列を [tx, ty] 順）で渡す。
+const buildActiveContext = (
+  operands: PdfObject[],
+  textObject: TextObject = TextObject.begin(),
+): OperatorHandlerContext => {
+  const operandStack = OperandStack.create();
+  for (const operand of operands) {
+    OperandStack.push(operandStack, operand);
+  }
+  const activeState = GraphicsState.update(GraphicsState.create(), {
+    textObject,
+  });
+  const graphicsStateStack = GraphicsStateStack.replaceCurrent(
+    GraphicsStateStack.create(),
+    activeState,
+  );
+  return { operandStack, graphicsStateStack };
+};
+
+const int = (value: number): PdfObject => ({ type: "integer", value });
+const real = (value: number): PdfObject => ({ type: "real", value });
+
+test("'72 720 TD' で両 matrix=[1,0,0,1,72,720] かつ leading=-720 になる", () => {
+  const context = buildActiveContext([int(72), int(720)]);
+  const result = tdLeadingHandler(context);
+
+  assert(result.ok);
+  const current = GraphicsStateStack.current(result.value.graphicsStateStack);
+  expect(current.textObject.textMatrix).toEqual(
+    Matrix.create(1, 0, 0, 1, 72, 720),
+  );
+  expect(current.textObject.textLineMatrix).toEqual(
+    Matrix.create(1, 0, 0, 1, 72, 720),
+  );
+  expect(current.textState.leading).toBe(-720);
+});
+
+test("'0 -14 TD' で leading=14（符号反転）かつ matrix が [1,0,0,1,0,-14] に相対移動する", () => {
+  const context = buildActiveContext([int(0), int(-14)]);
+  const result = tdLeadingHandler(context);
+
+  assert(result.ok);
+  const current = GraphicsStateStack.current(result.value.graphicsStateStack);
+  expect(current.textState.leading).toBe(14);
+  expect(current.textObject.textMatrix).toEqual(
+    Matrix.create(1, 0, 0, 1, 0, -14),
+  );
+  expect(current.textObject.textLineMatrix).toEqual(
+    Matrix.create(1, 0, 0, 1, 0, -14),
+  );
+});
+
+test("'-30 -14 TD' で tx は反転せず matrix に -30 が入り、leading は ty のみ反転して 14 になる", () => {
+  const context = buildActiveContext([int(-30), int(-14)]);
+  const result = tdLeadingHandler(context);
+
+  assert(result.ok);
+  const current = GraphicsStateStack.current(result.value.graphicsStateStack);
+  // tx=-30 は反転されず matrix[4]（e）にそのまま、ty=-14 も matrix[5]（f）にそのまま。
+  expect(current.textObject.textMatrix).toEqual(
+    Matrix.create(1, 0, 0, 1, -30, -14),
+  );
+  expect(current.textObject.textLineMatrix).toEqual(
+    Matrix.create(1, 0, 0, 1, -30, -14),
+  );
+  // leading は ty のみ反転（-ty = 14）。tx(-30) には一切依存しない。
+  expect(current.textState.leading).toBe(14);
+});
+
+test("'72 720 TD' の後 '0 -14 TD' で両 matrix が [1,0,0,1,72,706] に累積し leading が 14 に更新される", () => {
+  const first = tdLeadingHandler(buildActiveContext([int(72), int(720)]));
+  assert(first.ok);
+
+  const firstObject = GraphicsStateStack.current(
+    first.value.graphicsStateStack,
+  ).textObject;
+  const second = tdLeadingHandler(
+    buildActiveContext([int(0), int(-14)], firstObject),
+  );
+
+  assert(second.ok);
+  const current = GraphicsStateStack.current(second.value.graphicsStateStack);
+  expect(current.textObject.textMatrix).toEqual(
+    Matrix.create(1, 0, 0, 1, 72, 706),
+  );
+  expect(current.textObject.textLineMatrix).toEqual(
+    Matrix.create(1, 0, 0, 1, 72, 706),
+  );
+  expect(current.textState.leading).toBe(14);
+});
+
+test("integer / real 混在 operand で matrix に 720.5 が入り leading=-720.5 になる", () => {
+  const context = buildActiveContext([int(72), real(720.5)]);
+  const result = tdLeadingHandler(context);
+
+  assert(result.ok);
+  const current = GraphicsStateStack.current(result.value.graphicsStateStack);
+  expect(current.textObject.textMatrix).toEqual(
+    Matrix.create(1, 0, 0, 1, 72, 720.5),
+  );
+  expect(current.textState.leading).toBe(-720.5);
+});
+
+test("integer / real 混在の逆方向（tx=real / ty=integer）でも matrix に 72.5 が入り leading=-720 になる", () => {
+  // tx 位置に real / ty 位置に integer を渡し、型ガードが tx・ty どちらの位置でも
+  // integer/real を等価に受理することを pin down する（順方向との対称性の固定）。
+  const context = buildActiveContext([real(72.5), int(720)]);
+  const result = tdLeadingHandler(context);
+
+  assert(result.ok);
+  const current = GraphicsStateStack.current(result.value.graphicsStateStack);
+  expect(current.textObject.textMatrix).toEqual(
+    Matrix.create(1, 0, 0, 1, 72.5, 720),
+  );
+  expect(current.textState.leading).toBe(-720);
+});
+
+test("成功時に text object は active のまま維持される", () => {
+  const context = buildActiveContext([int(72), int(720)]);
+  const result = tdLeadingHandler(context);
+
+  assert(result.ok);
+  const current = GraphicsStateStack.current(result.value.graphicsStateStack);
+  expect(TextObject.isActive(current.textObject)).toBe(true);
+});
+
+test("成功時に operandStack は同一参照で返り depth が 0 になる", () => {
+  const context = buildActiveContext([int(72), int(720)]);
+  const result = tdLeadingHandler(context);
+
+  assert(result.ok);
+  expect(result.value.operandStack).toBe(context.operandStack);
+  expect(OperandStack.depth(result.value.operandStack)).toBe(0);
+});
+
+test("余剰 operand があっても末尾 2 個のみ pop し残り 1 個を保持する", () => {
+  const context = buildActiveContext([int(99), int(5), int(7)]);
+  const result = tdLeadingHandler(context);
+
+  assert(result.ok);
+  const current = GraphicsStateStack.current(result.value.graphicsStateStack);
+  expect(current.textObject.textMatrix).toEqual(
+    Matrix.create(1, 0, 0, 1, 5, 7),
+  );
+  expect(current.textState.leading).toBe(-7);
+  expect(OperandStack.depth(result.value.operandStack)).toBe(1);
+});
+
+test.each<[string, PdfObject, number]>([
+  ["+Infinity", real(Number.POSITIVE_INFINITY), Number.POSITIVE_INFINITY],
+  ["-Infinity", real(Number.NEGATIVE_INFINITY), Number.NEGATIVE_INFINITY],
+  ["負値", real(-3.5), -3.5],
+  ["小数", real(1.25), 1.25],
+  ["0", int(0), 0],
+])("境界値 '%s' を ty に渡しても値域検証せず matrix にそのまま格納し leading は反転値になる", (_label, operand, expected) => {
+  const context = buildActiveContext([int(10), operand]);
+  const result = tdLeadingHandler(context);
+
+  assert(result.ok);
+  const current = GraphicsStateStack.current(result.value.graphicsStateStack);
+  // matrix[5]（f）には反転前の生 ty がそのまま入る。
+  expect(current.textObject.textMatrix[5]).toBe(expected);
+  // leading は ty のみ反転した値（-ty）。値域検証で弾かれない。
+  expect(current.textState.leading).toBe(-expected);
+});
+
+test("境界値 NaN を ty に渡しても値域検証せず matrix・leading に NaN を格納する", () => {
+  // NaN は toEqual / toBe の NaN 比較仕様に頼らず Number.isNaN で明示判定する。
+  const context = buildActiveContext([int(10), real(Number.NaN)]);
+  const result = tdLeadingHandler(context);
+
+  assert(result.ok);
+  const current = GraphicsStateStack.current(result.value.graphicsStateStack);
+  expect(Number.isNaN(current.textObject.textMatrix[5])).toBe(true);
+  expect(Number.isNaN(current.textState.leading)).toBe(true);
+});

--- a/packages/core/src/content-stream/operators/text/td-leading/__tests__/td-leading.error.test.ts
+++ b/packages/core/src/content-stream/operators/text/td-leading/__tests__/td-leading.error.test.ts
@@ -1,0 +1,153 @@
+import { assert, expect, test } from "vitest";
+import type { PdfObject } from "../../../../../pdf/types/pdf-types/index";
+import {
+  GraphicsState,
+  GraphicsStateStack,
+  TextObject,
+} from "../../../../graphics-state/index";
+import { OperandStack } from "../../../../operand-stack/index";
+import type { OperatorHandlerContext } from "../../../../operator-registry/index";
+import { tdLeadingHandler } from "../index";
+
+// active=true の context（operand 不足・型不一致テスト用）。
+// operand は PDF 表記 `tx ty TD` の並び（配列を [tx, ty] 順）で渡す。
+const buildActiveContext = (operands: PdfObject[]): OperatorHandlerContext => {
+  const operandStack = OperandStack.create();
+  for (const operand of operands) {
+    OperandStack.push(operandStack, operand);
+  }
+  const activeState = GraphicsState.update(GraphicsState.create(), {
+    textObject: TextObject.begin(),
+  });
+  const graphicsStateStack = GraphicsStateStack.replaceCurrent(
+    GraphicsStateStack.create(),
+    activeState,
+  );
+  return { operandStack, graphicsStateStack };
+};
+
+// inactive な context（active=false ガードテスト用。GraphicsStateStack.create() 既定）。
+const buildInactiveContext = (
+  operands: PdfObject[],
+): OperatorHandlerContext => {
+  const operandStack = OperandStack.create();
+  for (const operand of operands) {
+    OperandStack.push(operandStack, operand);
+  }
+  return { operandStack, graphicsStateStack: GraphicsStateStack.create() };
+};
+
+const int = (value: number): PdfObject => ({ type: "integer", value });
+
+// 全非数値型網羅（td.error.test.ts より流用）。
+const nonNumericOperands: [string, PdfObject][] = [
+  ["name", { type: "name", value: "F1" }],
+  ["boolean", { type: "boolean", value: true }],
+  ["null", { type: "null" }],
+  [
+    "string",
+    { type: "string", value: new Uint8Array([0x61]), encoding: "literal" },
+  ],
+  ["array", { type: "array", elements: [] }],
+  ["dictionary", { type: "dictionary", entries: new Map() }],
+  [
+    "indirect-ref",
+    { type: "indirect-ref", objectNumber: 1, generationNumber: 0 },
+  ],
+];
+
+test("active=false で TD を呼ぶと OPERATOR_ILLEGAL_STATE を返し operand stack は不変", () => {
+  const context = buildInactiveContext([int(72), int(720)]);
+  const result = tdLeadingHandler(context);
+
+  assert(!result.ok);
+  assert(result.error.code === "OPERATOR_ILLEGAL_STATE");
+  expect(result.error.operatorName).toBe("TD");
+  expect(result.error.message).toBe(
+    "TD: text object is not active (TD must appear within BT/ET)",
+  );
+  expect(OperandStack.depth(context.operandStack)).toBe(2);
+});
+
+test("operand 0 個のとき OPERATOR_OPERAND_MISSING（actual=0）を返す", () => {
+  const context = buildActiveContext([]);
+  const result = tdLeadingHandler(context);
+
+  assert(!result.ok);
+  assert(result.error.code === "OPERATOR_OPERAND_MISSING");
+  expect(result.error.operatorName).toBe("TD");
+  expect(result.error.required).toBe(2);
+  expect(result.error.actual).toBe(0);
+  expect(result.error.message).toBe(
+    "Operator 'TD' requires 2 operand(s), got 0",
+  );
+});
+
+test("operand 1 個（ty のみ）のとき OPERATOR_OPERAND_MISSING（actual=1）を返し ty は pop 済みで depth=0", () => {
+  const context = buildActiveContext([int(720)]);
+  const result = tdLeadingHandler(context);
+
+  assert(!result.ok);
+  assert(result.error.code === "OPERATOR_OPERAND_MISSING");
+  expect(result.error.required).toBe(2);
+  expect(result.error.actual).toBe(1);
+  expect(result.error.message).toBe(
+    "Operator 'TD' requires 2 operand(s), got 1",
+  );
+  expect(OperandStack.depth(context.operandStack)).toBe(0);
+});
+
+test.each(
+  nonNumericOperands,
+)("ty が %s のとき OPERATOR_OPERAND_TYPE_MISMATCH を返す", (typeName, operand) => {
+  // buildActiveContext は配列を [tx, ty] 順で受け取る（top=ty を先に pop）。
+  // ここでは tx=数値 / ty=非数値 なので、先に pop される ty で MISMATCH になる。
+  const context = buildActiveContext([int(72), operand]);
+  const result = tdLeadingHandler(context);
+
+  assert(!result.ok);
+  assert(result.error.code === "OPERATOR_OPERAND_TYPE_MISMATCH");
+  expect(result.error.operatorName).toBe("TD");
+  expect(result.error.expected).toBe("number");
+  expect(result.error.actual).toBe(typeName);
+  expect(result.error.message).toBe(
+    `Operator 'TD' expected number operand, got ${typeName}`,
+  );
+});
+
+test.each(
+  nonNumericOperands,
+)("tx が %s のとき（ty は数値）OPERATOR_OPERAND_TYPE_MISMATCH を返す", (typeName, operand) => {
+  // buildActiveContext は配列を [tx, ty] 順で受け取る（top=ty を先に pop）。
+  // ここでは tx=非数値 / ty=数値 なので、ty を pop して通過した後 tx で MISMATCH になる。
+  const context = buildActiveContext([operand, int(720)]);
+  const result = tdLeadingHandler(context);
+
+  assert(!result.ok);
+  assert(result.error.code === "OPERATOR_OPERAND_TYPE_MISMATCH");
+  expect(result.error.operatorName).toBe("TD");
+  expect(result.error.expected).toBe("number");
+  expect(result.error.actual).toBe(typeName);
+  expect(result.error.message).toBe(
+    `Operator 'TD' expected number operand, got ${typeName}`,
+  );
+});
+
+test("TYPE_MISMATCH 後も部分消費した operand は復元せず、余剰 operand のみ残る", () => {
+  const surplus: PdfObject = int(99);
+  // bottom→top = [surplus, tx(非数値), ty(数値)]。
+  // ty=数値 は pop して通過、tx=非数値 で MISMATCH。pop 済みは戻さない。
+  const context = buildActiveContext([
+    surplus,
+    { type: "name", value: "F1" },
+    int(7),
+  ]);
+  const result = tdLeadingHandler(context);
+
+  assert(!result.ok);
+  assert(result.error.code === "OPERATOR_OPERAND_TYPE_MISMATCH");
+  expect(OperandStack.depth(context.operandStack)).toBe(1);
+  const top = OperandStack.peek(context.operandStack);
+  assert(top.some);
+  expect(top.value).toEqual(surplus);
+});

--- a/packages/core/src/content-stream/operators/text/td-leading/index.ts
+++ b/packages/core/src/content-stream/operators/text/td-leading/index.ts
@@ -1,0 +1,128 @@
+import type { PdfError } from "../../../../pdf/errors/index";
+import { err, ok } from "../../../../utils/result/index";
+import {
+  GraphicsState,
+  GraphicsStateStack,
+  TextObject,
+  TextState,
+} from "../../../graphics-state/index";
+import { OperandStack } from "../../../operand-stack/index";
+import type {
+  OperatorHandler,
+  OperatorHandlerContext,
+} from "../../../operator-registry/index";
+import { NumericPdfObject } from "../../graphics-state/numeric-pdf-object/index";
+
+/** PDF 表記を保持した operator 名（"TD"）。 */
+const OPERATOR_NAME = "TD";
+
+/**
+ * PDF §9.4.2 `TD` operator (Move to start of next line and set leading) のハンドラ。
+ *
+ * operand stack から `tx ty` を pop し、`Td` 相当の行列更新
+ * （`Tlm' = translate(tx, ty) × Tlm`、`Tm' = Tlm'`）に加えて
+ * `textState.leading = -ty`（PDF 仕様上 `-ty TL` 相当）を設定する。
+ * 行列更新（textObject）と leading 設定（textState）は 1 回の
+ * `GraphicsState.update` で同時反映する。`TD` は BT 〜 ET の内側でのみ有効。
+ *
+ * 検査順序（厳守。`Td` と同一規約）:
+ *   (1) active 検査（false なら operand stack を一切消費せず Err）
+ *   (2) ty pop  → (3) ty 型検査
+ *   (4) tx pop  → (5) tx 型検査
+ *
+ * - text object が active でない場合は `OPERATOR_ILLEGAL_STATE` を返す
+ *   （operand stack / graphics state stack は変更しない）
+ * - operand 不足のとき `OPERATOR_OPERAND_MISSING` を返す。
+ *   `actual` には pop に成功した個数（ty 不足なら 0 / tx 不足なら 1）を入れる
+ * - operand が integer / real 以外のとき `OPERATOR_OPERAND_TYPE_MISMATCH` を返す
+ * - 値域（`NaN` / `Infinity` / 負値 / `0` / 小数）は本 handler では検証しない
+ *   （`-ty` 反転後の値をそのまま格納する）
+ * - エラー時に operand stack の部分消費は復元しない（既存ハンドラ規約）
+ *
+ * operand 順序: PDF 表記 `tx ty TD` のスタック頂上は ty。
+ * したがって ty を先に pop、tx を後に pop する。
+ * leading にのみ `-ty`（符号反転）を入れ、translateLine には反転前の生 ty を渡す。
+ *
+ * @param context - 実行コンテキスト (operand stack / graphics state stack)
+ * @returns 成功なら更新後コンテキスト、失敗なら PdfError
+ */
+export const tdLeadingHandler: OperatorHandler = (
+  context: OperatorHandlerContext,
+) => {
+  const current = GraphicsStateStack.current(context.graphicsStateStack);
+  if (!TextObject.isActive(current.textObject)) {
+    const error: PdfError = {
+      code: "OPERATOR_ILLEGAL_STATE",
+      message: "TD: text object is not active (TD must appear within BT/ET)",
+      operatorName: OPERATOR_NAME,
+    };
+    return err(error);
+  }
+
+  const poppedTy = OperandStack.pop(context.operandStack);
+  if (!poppedTy.some) {
+    const error: PdfError = {
+      code: "OPERATOR_OPERAND_MISSING",
+      message: `Operator '${OPERATOR_NAME}' requires 2 operand(s), got 0`,
+      operatorName: OPERATOR_NAME,
+      required: 2,
+      actual: 0,
+    };
+    return err(error);
+  }
+  const tyOperand = poppedTy.value;
+  if (!NumericPdfObject.is(tyOperand)) {
+    const error: PdfError = {
+      code: "OPERATOR_OPERAND_TYPE_MISMATCH",
+      message: `Operator '${OPERATOR_NAME}' expected number operand, got ${tyOperand.type}`,
+      operatorName: OPERATOR_NAME,
+      expected: "number",
+      actual: tyOperand.type,
+    };
+    return err(error);
+  }
+
+  const poppedTx = OperandStack.pop(context.operandStack);
+  if (!poppedTx.some) {
+    const error: PdfError = {
+      code: "OPERATOR_OPERAND_MISSING",
+      message: `Operator '${OPERATOR_NAME}' requires 2 operand(s), got 1`,
+      operatorName: OPERATOR_NAME,
+      required: 2,
+      actual: 1,
+    };
+    return err(error);
+  }
+  const txOperand = poppedTx.value;
+  if (!NumericPdfObject.is(txOperand)) {
+    const error: PdfError = {
+      code: "OPERATOR_OPERAND_TYPE_MISMATCH",
+      message: `Operator '${OPERATOR_NAME}' expected number operand, got ${txOperand.type}`,
+      operatorName: OPERATOR_NAME,
+      expected: "number",
+      actual: txOperand.type,
+    };
+    return err(error);
+  }
+
+  // TD 固有: leading=-ty（符号反転は leading のみ）と matrix を 1 回の
+  // GraphicsState.update で同時反映する。translateLine には反転前の生 ty を渡す。
+  const textState = TextState.update(current.textState, {
+    leading: -tyOperand.value,
+  });
+  const textObject = TextObject.translateLine(
+    current.textObject,
+    txOperand.value,
+    tyOperand.value,
+  );
+  const next = GraphicsState.update(current, { textState, textObject });
+  const graphicsStateStack = GraphicsStateStack.replaceCurrent(
+    context.graphicsStateStack,
+    next,
+  );
+
+  return ok({
+    operandStack: context.operandStack,
+    graphicsStateStack,
+  });
+};


### PR DESCRIPTION
## 概要

PDF §9.4.2 `TD` operator（`tx ty` — 次行の先頭へ移動し、あわせて leading を設定する）のハンドラ `tdLeadingHandler` を新規追加します。`Td`（#290）相当の行列更新に加え `textState.leading = -ty`（PDF 仕様上 `-ty TL` 相当）を **1 回の `GraphicsState.update`** で同時反映するのが本機能の核心です。

## 変更内容

### 🎯 変更の種類

- [x] ✨ 新機能 (New feature)
- [x] 🚨 テスト追加/修正 (Tests)

### 📝 詳細な変更内容

#### 追加された機能・修正

- `tdLeadingHandler`（`OPERATOR_NAME="TD"`）: active 検査 → ty pop/型検査 → tx pop/型検査 → 成功時に `TextState.update({ leading: -ty })` と `TextObject.translateLine(tx, ty)` を **1 回の `GraphicsState.update`** で合成反映
- **leading のみ `-ty`（符号反転）**、`translateLine` には反転前の生 ty を渡す非対称な値の流れ（`72 720 TD → leading=-720`、`0 -14 TD → leading=14`）
- エラー仕様は `Td` と同形（`OPERATOR_ILLEGAL_STATE` / `OPERATOR_OPERAND_MISSING` required=2 actual=0\|1 / `OPERATOR_OPERAND_TYPE_MISMATCH`）。throw 不使用・すべて `Result` 返却
- 値域（NaN/Infinity/負値/0/小数）は非検証（`Td`/`TL` と同一規約）

#### 変更されたファイル

- `[NEW]` `packages/core/src/content-stream/operators/text/td-leading/index.ts`（handler 本体）
- `[NEW]` `packages/core/src/content-stream/operators/text/td-leading/__tests__/td-leading.basic.test.ts`（正常系 15 tests）
- `[NEW]` `packages/core/src/content-stream/operators/text/td-leading/__tests__/td-leading.error.test.ts`（異常系 18 tests）

#### 削除されたファイル・機能

- なし

> **スコープ外（意図的）**: registry 登録・バレル配線は本 Issue の範囲外（`Td` も未登録で整合）。`td/index.ts` のロジックは共有せず自己完結で複製（既存ハンドラの独立スタイルに準拠）。既存ファイルへの変更はゼロ。

## 📊 システム図

### 状態マシン / フロー図

\`\`\`mermaid
flowchart TD
    Start([context]) --> Active{TextObject.isActive?}
    Active -->|false| ErrState[Err: OPERATOR_ILLEGAL_STATE<br/>operand 不変]:::new
    Active -->|true| PopTy[OperandStack.pop → ty]
    PopTy -->|None| ErrMiss0[Err: OPERAND_MISSING<br/>actual=0]:::new
    PopTy -->|Some| TyType{NumericPdfObject.is ty?}
    TyType -->|非number| ErrTy[Err: TYPE_MISMATCH]:::new
    TyType -->|number| PopTx[OperandStack.pop → tx]
    PopTx -->|None| ErrMiss1[Err: OPERAND_MISSING<br/>actual=1]:::new
    PopTx -->|Some| TxType{NumericPdfObject.is tx?}
    TxType -->|非number| ErrTx[Err: TYPE_MISMATCH]:::new
    TxType -->|number| Update[GraphicsState.update を 1 回<br/>leading=-ty / matrix=translateLine tx,ty]:::new
    Update --> Ok([ok: graphicsStateStack 更新<br/>operandStack 同一参照]):::new

    classDef new fill:#ffe4b5,stroke:#d97706,stroke-width:2px
\`\`\`

### データフロー

\`\`\`
OperandStack (頂上: ty, その下: tx)
    │
    ├─ pop → ty ─┬─ (符号反転) -ty ──▶ TextState.update({ leading: -ty })  [NEW]
    │            │                                  │
    │            └─ (生 ty) ─┐                      ▼
    ├─ pop → tx ───────────┐ │                textState (next)
    │                      ▼ ▼                      │
    │        TextObject.translateLine(tx, ty)  [NEW]│
    │            = Matrix.multiply(translate(tx,ty), Tlm)
    │                      │                        │
    │                      ▼                        │
    │                textObject (next: Tlm'=Tm')    │
    │                      └───────────┬────────────┘
    │                                  ▼
    └──────────▶ GraphicsState.update(current, { textState, textObject })  [NEW: 1 回のみ]
                                       ▼
                 ok({ operandStack(同一参照), graphicsStateStack })
\`\`\`

## 📋 関連 Issue

- Refs #291（[Phase 4-E] TD operator handler）
- 親 Epic: #288 / blocked by #289 / related #290

## 🧪 テスト

### テスト実行方法

\`\`\`bash
pnpm --filter @pdfmod/core test td-leading
\`\`\`

### テスト項目

- [x] 単体テスト (Unit tests) — **33 passed**（basic 15 / error 18）
- [ ] 統合テスト（registry 未配線のため不要）
- [ ] E2E テスト（同上）
- [x] 全体テスト green（`pnpm --filter @pdfmod/core test`: 183 files / 2454 tests passed）
- [x] `pnpm --filter @pdfmod/core build` 成功
- [x] biome / oxlint クリーン（0 errors）

## レビューポイント

- **leading の符号反転 `-ty` と matrix の生 ty 渡しの非対称性**（`td-leading/index.ts` 末尾の update ブロック）— `-30 -14 TD` テストで tx 非反転・tx/ty 取り違え・leading の tx 非依存を pin down
- **`GraphicsState.update` を 1 回だけ呼ぶ合成**（textState + textObject を 1 partial に）— テストは spy 回数でなく結果状態で担保
- spec-based-code-review（4 エージェント）実施済み: CRITICAL/WARNING 0 件・DoD 13/13 充足

🤖 Generated with [Claude Code](https://claude.com/claude-code)