### PR TITLE
✨ [New Feature]: #265 PdfObject に Array/Dictionary バリアントとアクセサを追加

### DIFF
--- a/rust/crates/core/src/object.rs
+++ b/rust/crates/core/src/object.rs
@@ -1,7 +1,10 @@
 //! PDF オブジェクト型を定義するモジュール。
 //!
-//! ISO 32000 の PDF オブジェクト（boolean / numeric / string / name /
-//! array / dictionary / stream / null / indirect reference）を表す型を
+//! ISO 32000 の PDF オブジェクト（null / boolean / numeric / string / name /
+//! array / dictionary / stream / indirect reference）を表す。現時点では
+//! `PdfObject`（null / boolean / integer / real / string / name / array /
+//! dictionary）と、補助の newtype（`PdfName` / `PdfDictionary` / `ObjectId` /
+//! `ObjectNumber` / `GenerationNumber`）を提供し、stream / indirect reference は
 //! 後続 Issue で追加する。
 
 pub mod dictionary;
@@ -11,7 +14,4 @@ pub mod object_id;
 pub mod object_number;
 pub mod pdf_object;
 
-// 後続 Issue で各オブジェクト型をサブモジュールとして追加する（以下は例の一部）:
-// pub mod boolean;
-// pub mod numeric;
-// pub mod string;
+// stream / indirect reference は後続 Issue で対応する型・サブモジュールを追加する。

--- a/rust/crates/core/src/object/pdf_object.rs
+++ b/rust/crates/core/src/object/pdf_object.rs
@@ -2,13 +2,15 @@
 //!
 //! ISO 32000-1 §7.3 の PDF オブジェクトを 1 つの enum で表す。現時点では
 //! スカラ系 4 バリアント（Null / Boolean / Integer / Real）に加え、文字列
-//! （復号後の生バイト列）と名前（`PdfName`）を定義し、配列・辞書・参照・
-//! ストリームは後続 Issue で追加する。構築は無検証（infallible）で、文字列の
-//! テキスト解釈や妥当性検証は上位（lexer/parser）に委譲する。
+//! （復号後の生バイト列）・名前（`PdfName`）・配列（`Vec<PdfObject>` の自己再帰）・
+//! 辞書（`PdfDictionary`）を定義する。参照・ストリームは後続 Issue で追加する。
+//! 構築は無検証（infallible）で、テキスト解釈や妥当性検証・正規化は上位
+//! （lexer/parser）に委譲する。
 
+use crate::object::dictionary::PdfDictionary;
 use crate::object::name::PdfName;
 
-/// PDF 基本オブジェクト（スカラ系・文字列・名前バリアントを表す enum）。
+/// PDF 基本オブジェクト（スカラ系・文字列・名前・配列・辞書バリアントを表す enum）。
 ///
 /// 整数幅は `i64`、浮動小数点幅は `f64`（PDF パーサで最も一般的・桁あふれ耐性・
 /// 後続レクサーとの相性で確定）。`Real(f64)` を含むため `Eq`/`Hash`/`Ord` は
@@ -35,6 +37,19 @@ pub enum PdfObject {
     String(Vec<u8>),
     /// 名前オブジェクト（`/Name` 本体）。`PdfName`（#261）をそのまま内包する。
     Name(PdfName),
+    /// 配列オブジェクト（順序付きオブジェクトリスト）。
+    ///
+    /// 専用ラッパ型を設けず `Vec<PdfObject>` を直接保持し、`PdfObject` の
+    /// 自己再帰によりネスト（配列内に配列・辞書など）を表現する。妥当性検証や
+    /// 正規化は行わず、空配列も無検証で忠実に保持する。要素に `Real(NaN)` を
+    /// 含むと `NaN != NaN` が配列全体に伝播し、配列同士は `==` で非等価になる。
+    Array(Vec<PdfObject>),
+    /// 辞書オブジェクト。`PdfDictionary`（#264）をそのまま内包する。
+    ///
+    /// 値型 `PdfObject` を介して配列・辞書を値に持つ多段ネストを表現する。
+    /// 値に `Real(NaN)` を含むと辞書同士は `==` で非等価になる（`Eq` 非実装の
+    /// 根拠が再帰的に維持される）。
+    Dictionary(PdfDictionary),
 }
 
 impl PdfObject {
@@ -85,6 +100,26 @@ impl PdfObject {
     pub fn as_name(&self) -> Option<&PdfName> {
         match self {
             Self::Name(name) => Some(name),
+            _ => None,
+        }
+    }
+
+    /// `Array` のとき内部の要素列を `&[PdfObject]` として `Some` で取り出す（他は `None`）。
+    ///
+    /// ヒープ保持のため参照返し（`as_string` の `as_slice()` と同方針）。
+    pub fn as_array(&self) -> Option<&[PdfObject]> {
+        match self {
+            Self::Array(items) => Some(items.as_slice()),
+            _ => None,
+        }
+    }
+
+    /// `Dictionary` のとき内部の `PdfDictionary` を `&PdfDictionary` として `Some` で取り出す（他は `None`）。
+    ///
+    /// ヒープ保持のため参照返し（`as_name` の `&PdfName` 返しと同方針）。
+    pub fn as_dictionary(&self) -> Option<&PdfDictionary> {
+        match self {
+            Self::Dictionary(dict) => Some(dict),
             _ => None,
         }
     }
@@ -452,5 +487,267 @@ mod tests {
         // Debug 出力が String / Name のバリアント名を含むことを確認する（任意・優先度低）
         assert!(format!("{:?}", PdfObject::String(b"x".to_vec())).contains("String"));
         assert!(format!("{:?}", PdfObject::Name(PdfName::from("A"))).contains("Name"));
+    }
+
+    #[test]
+    fn array_constructs_and_matches_array_arm() {
+        // Array(vec![Integer(1)]) を構築し matches! で Array 腕に入ることを確認する
+        let obj = PdfObject::Array(vec![PdfObject::Integer(1)]);
+        assert!(matches!(obj, PdfObject::Array(_)));
+    }
+
+    #[test]
+    fn dictionary_constructs_and_matches_dictionary_arm() {
+        // Dictionary(PdfDictionary::new()) を構築し matches! で Dictionary 腕に入ることを確認する
+        let obj = PdfObject::Dictionary(PdfDictionary::new());
+        assert!(matches!(obj, PdfObject::Dictionary(_)));
+    }
+
+    #[test]
+    fn as_array_returns_some_for_array() {
+        // 要素入り Array に as_array() を呼ぶと Some(&[...]) を返し要素が一致することを確認する
+        let obj = PdfObject::Array(vec![PdfObject::Integer(1), PdfObject::Boolean(true)]);
+        assert_eq!(
+            obj.as_array(),
+            Some([PdfObject::Integer(1), PdfObject::Boolean(true)].as_slice())
+        );
+    }
+
+    #[test]
+    fn as_dictionary_returns_some_for_dictionary() {
+        // 値入り Dictionary に as_dictionary() を呼ぶと Some(&PdfDictionary) を返し内容が一致することを確認する
+        let mut dict = PdfDictionary::new();
+        dict.insert(PdfName::from("Type"), PdfObject::Integer(42));
+        let obj = PdfObject::Dictionary(dict.clone());
+        assert_eq!(obj.as_dictionary(), Some(&dict));
+    }
+
+    #[test]
+    fn as_array_then_index_roundtrips() {
+        // as_array().unwrap()[i] で各要素にアクセスでき元の要素が返る（後段借用経路）ことを確認する
+        let obj = PdfObject::Array(vec![PdfObject::Integer(10), PdfObject::Integer(20)]);
+        let items = obj.as_array().unwrap();
+        assert_eq!(items[0], PdfObject::Integer(10));
+        assert_eq!(items[1], PdfObject::Integer(20));
+    }
+
+    #[test]
+    fn as_dictionary_then_get_roundtrips() {
+        // as_dictionary().unwrap().get(&key) で挿入した値が返る（後段借用経路）ことを確認する
+        let mut dict = PdfDictionary::new();
+        dict.insert(PdfName::from("Key"), PdfObject::Integer(7));
+        let obj = PdfObject::Dictionary(dict);
+        assert_eq!(
+            obj.as_dictionary().unwrap().get(&PdfName::from("Key")),
+            Some(&PdfObject::Integer(7))
+        );
+    }
+
+    #[test]
+    fn as_array_returns_none_for_non_array_variants() {
+        // Array 以外（Null/Boolean/Integer/Real/String/Name/Dictionary）では as_array() が None を返すことを確認する
+        let variants = [
+            PdfObject::Null,
+            PdfObject::Boolean(true),
+            PdfObject::Integer(0),
+            PdfObject::Real(0.0),
+            PdfObject::String(b"abc".to_vec()),
+            PdfObject::Name(PdfName::from("Type")),
+            PdfObject::Dictionary(PdfDictionary::new()),
+        ];
+        for obj in &variants {
+            assert_eq!(obj.as_array(), None);
+        }
+    }
+
+    #[test]
+    fn as_dictionary_returns_none_for_non_dictionary_variants() {
+        // Dictionary 以外（Null/Boolean/Integer/Real/String/Name/Array）では as_dictionary() が None を返すことを確認する
+        let variants = [
+            PdfObject::Null,
+            PdfObject::Boolean(true),
+            PdfObject::Integer(0),
+            PdfObject::Real(0.0),
+            PdfObject::String(b"abc".to_vec()),
+            PdfObject::Name(PdfName::from("Type")),
+            PdfObject::Array(vec![PdfObject::Integer(1)]),
+        ];
+        for obj in &variants {
+            assert_eq!(obj.as_dictionary(), None);
+        }
+    }
+
+    #[test]
+    fn as_array_returns_empty_slice_for_empty_array() {
+        // 空配列 Array(vec![]) は as_array() で Some(空スライス) を返すことを確認する
+        let obj = PdfObject::Array(vec![]);
+        let empty: &[PdfObject] = &[];
+        assert_eq!(obj.as_array(), Some(empty));
+    }
+
+    #[test]
+    fn as_dictionary_returns_empty_for_empty_dictionary() {
+        // 空辞書 Dictionary(PdfDictionary::new()) は as_dictionary() で Some かつ is_empty() が真になることを確認する
+        let obj = PdfObject::Dictionary(PdfDictionary::new());
+        let dict = obj.as_dictionary();
+        assert!(dict.is_some());
+        assert!(dict.unwrap().is_empty());
+    }
+
+    #[test]
+    fn same_content_arrays_are_equal() {
+        // 同内容（有限値のみ）の Array 同士は == で等価になることを確認する
+        assert_eq!(
+            PdfObject::Array(vec![PdfObject::Integer(1), PdfObject::Boolean(true)]),
+            PdfObject::Array(vec![PdfObject::Integer(1), PdfObject::Boolean(true)])
+        );
+    }
+
+    #[test]
+    fn same_content_dictionaries_are_equal() {
+        // 同内容（有限値のみ）の Dictionary 同士は == で等価になることを確認する
+        let mut a = PdfDictionary::new();
+        a.insert(PdfName::from("A"), PdfObject::Integer(1));
+        let mut b = PdfDictionary::new();
+        b.insert(PdfName::from("A"), PdfObject::Integer(1));
+        assert_eq!(PdfObject::Dictionary(a), PdfObject::Dictionary(b));
+    }
+
+    #[test]
+    fn different_content_arrays_are_not_equal() {
+        // 要素が異なる Array 同士・長さ違いの Array 同士は != で非等価になることを確認する
+        assert_ne!(
+            PdfObject::Array(vec![PdfObject::Integer(1)]),
+            PdfObject::Array(vec![PdfObject::Integer(2)])
+        );
+        assert_ne!(
+            PdfObject::Array(vec![PdfObject::Integer(1)]),
+            PdfObject::Array(vec![PdfObject::Integer(1), PdfObject::Integer(1)])
+        );
+    }
+
+    #[test]
+    fn empty_array_and_empty_dictionary_are_not_equal() {
+        // 空配列 Array(vec![]) と空辞書 Dictionary(PdfDictionary::new()) は異バリアントのため != になることを確認する
+        assert_ne!(
+            PdfObject::Array(vec![]),
+            PdfObject::Dictionary(PdfDictionary::new())
+        );
+    }
+
+    #[test]
+    fn array_and_dictionary_are_not_equal() {
+        // 非空 Array と非空 Dictionary は異バリアントのため != になることを確認する
+        let mut dict = PdfDictionary::new();
+        dict.insert(PdfName::from("A"), PdfObject::Integer(1));
+        assert_ne!(
+            PdfObject::Array(vec![PdfObject::Integer(1)]),
+            PdfObject::Dictionary(dict)
+        );
+    }
+
+    #[test]
+    fn array_containing_nan_is_not_equal_to_itself_content() {
+        // 要素に Real(NaN) を含む Array 同士は NaN != NaN が配列に伝播し != になることを確認する
+        assert_ne!(
+            PdfObject::Array(vec![PdfObject::Real(f64::NAN)]),
+            PdfObject::Array(vec![PdfObject::Real(f64::NAN)])
+        );
+    }
+
+    #[test]
+    fn dictionary_containing_nan_value_is_not_equal_to_itself_content() {
+        // 値に Real(NaN) を持つ Dictionary 同士は NaN が辞書に伝播し != になることを確認する
+        let mut a = PdfDictionary::new();
+        a.insert(PdfName::from("N"), PdfObject::Real(f64::NAN));
+        let mut b = PdfDictionary::new();
+        b.insert(PdfName::from("N"), PdfObject::Real(f64::NAN));
+        assert_ne!(PdfObject::Dictionary(a), PdfObject::Dictionary(b));
+    }
+
+    #[test]
+    fn array_can_nest_dictionary_and_array() {
+        // 配列内に辞書・配列を入れた多段 Array を構築し as_array で取り出すとネスト構造が忠実に保持され同内容なら == になることを確認する
+        let mut inner_dict = PdfDictionary::new();
+        inner_dict.insert(PdfName::from("K"), PdfObject::Integer(1));
+        let nested = PdfObject::Array(vec![
+            PdfObject::Dictionary(inner_dict.clone()),
+            PdfObject::Array(vec![PdfObject::Integer(2)]),
+        ]);
+        let items = nested.as_array().unwrap();
+        assert_eq!(items[0], PdfObject::Dictionary(inner_dict));
+        assert_eq!(items[1], PdfObject::Array(vec![PdfObject::Integer(2)]));
+
+        let mut inner_dict2 = PdfDictionary::new();
+        inner_dict2.insert(PdfName::from("K"), PdfObject::Integer(1));
+        let nested2 = PdfObject::Array(vec![
+            PdfObject::Dictionary(inner_dict2),
+            PdfObject::Array(vec![PdfObject::Integer(2)]),
+        ]);
+        assert_eq!(nested, nested2);
+    }
+
+    #[test]
+    fn dictionary_value_can_be_array_and_dictionary() {
+        // 辞書値に配列・辞書を入れた多段 Dictionary を構築し as_dictionary().get() で取り出すとネスト構造が忠実に保持され、同内容なら == になることを確認する
+        let mut inner = PdfDictionary::new();
+        inner.insert(PdfName::from("Inner"), PdfObject::Integer(9));
+        let mut outer = PdfDictionary::new();
+        outer.insert(
+            PdfName::from("Arr"),
+            PdfObject::Array(vec![PdfObject::Integer(1)]),
+        );
+        outer.insert(PdfName::from("Dict"), PdfObject::Dictionary(inner.clone()));
+        let obj = PdfObject::Dictionary(outer);
+        let d = obj.as_dictionary().unwrap();
+        assert_eq!(
+            d.get(&PdfName::from("Arr")),
+            Some(&PdfObject::Array(vec![PdfObject::Integer(1)]))
+        );
+        assert_eq!(
+            d.get(&PdfName::from("Dict")),
+            Some(&PdfObject::Dictionary(inner))
+        );
+
+        // 配列版（array_can_nest_dictionary_and_array）と対称に、辞書全体の == 比較でも同内容なら等価になることを確認する
+        let mut inner2 = PdfDictionary::new();
+        inner2.insert(PdfName::from("Inner"), PdfObject::Integer(9));
+        let mut outer2 = PdfDictionary::new();
+        outer2.insert(
+            PdfName::from("Arr"),
+            PdfObject::Array(vec![PdfObject::Integer(1)]),
+        );
+        outer2.insert(PdfName::from("Dict"), PdfObject::Dictionary(inner2));
+        assert_eq!(obj, PdfObject::Dictionary(outer2));
+    }
+
+    #[test]
+    fn clone_preserves_array_and_dictionary_and_keeps_original_usable() {
+        // 有限値のみの Array/Dictionary を clone() すると複製が元と == かつ元も引き続き使用可能なことを確認する
+        let original_array =
+            PdfObject::Array(vec![PdfObject::Integer(1), PdfObject::Boolean(true)]);
+        let cloned_array = original_array.clone();
+        assert_eq!(cloned_array, original_array);
+        assert_eq!(original_array.as_array().unwrap().len(), 2);
+
+        let mut dict = PdfDictionary::new();
+        dict.insert(PdfName::from("Type"), PdfObject::Integer(42));
+        let original_dict = PdfObject::Dictionary(dict);
+        let cloned_dict = original_dict.clone();
+        assert_eq!(cloned_dict, original_dict);
+        assert_eq!(
+            original_dict
+                .as_dictionary()
+                .unwrap()
+                .get(&PdfName::from("Type")),
+            Some(&PdfObject::Integer(42))
+        );
+    }
+
+    #[test]
+    fn debug_format_contains_array_and_dictionary_variant_names() {
+        // Debug 出力が Array / Dictionary のバリアント名を含むことを確認する
+        assert!(format!("{:?}", PdfObject::Array(vec![PdfObject::Integer(1)])).contains("Array"));
+        assert!(format!("{:?}", PdfObject::Dictionary(PdfDictionary::new())).contains("Dictionary"));
     }
 }


### PR DESCRIPTION
## 概要

`PdfObject`（#262/#263）に配列バリアント `Array(Vec<PdfObject>)` と辞書バリアント `Dictionary(PdfDictionary)`（#264）を追加し、PDF 複合オブジェクトの再帰的ネスト構造（配列内に辞書・辞書値に配列など）を単一 enum で表現可能にします。後続の lexer/parser・`PdfStream`(#267) の基盤を整える変更です。対象は単一ファイル `rust/crates/core/src/object/pdf_object.rs` のみ。

## 変更内容

### 🎯 変更の種類

- [x] ✨ 新機能 (New feature)
- [x] 🚨 テスト追加/修正 (Tests)

### 📝 詳細な変更内容

#### 追加された機能・修正

- enum `PdfObject` の末尾（`Name` の後）に 2 バリアントを追加
  - `Array(Vec<PdfObject>)` — 専用ラッパ型を設けず `Vec<PdfObject>` を直接保持し、自己再帰でネストを表現
  - `Dictionary(PdfDictionary)` — #264 の `PdfDictionary` をそのまま内包
- 参照返しアクセサ 2 メソッドを追加（O(1)・コピーなし。既存 `as_string`/`as_name` と同方針）
  - `as_array(&self) -> Option<&[PdfObject]>`（`Array` 一致時 `Some(&[..])` / 他は `None`）
  - `as_dictionary(&self) -> Option<&PdfDictionary>`（`Dictionary` 一致時 `Some(&..)` / 他は `None`）
- モジュール `//!` doc・型 doc を Array/Dictionary 追加後の現状に更新（「後続 Issue で追加する」の旧記述を解消）
- `use crate::object::dictionary::PdfDictionary;` を追加（`pdf_object ⇄ dictionary` の相互 use。Rust では循環依存にならず問題なし）
- 設計方針: `derive` は `#[derive(Debug, Clone, PartialEq)]` のまま（`Eq`/`Hash`/`Copy`/`#[non_exhaustive]` は付与せず）。外部 crate 依存ゼロ（std のみ）。

#### 追加されたテスト（colocated・フラット構造・各テストに日本語コメント）

- 構築/`matches!`・`as_array`/`as_dictionary` の Some/None 分岐・後段借用経路（`get()`/index）
- 境界値: 空配列（空スライス）・空辞書（`is_empty()`）
- 非等価: 異内容/長さ違い・異バリアント（空配列 vs 空辞書・Array vs Dictionary）
- エッジ: `Real(NaN)` 伝播（配列・辞書とも `==` で非等価）・多段ネスト（配列内辞書/配列・辞書値配列/辞書）
- `Clone` 保持（元も使用可能）・`Debug` 出力にバリアント名

#### 削除されたファイル・機能

- なし（バリアント・アクセサの追加のみ。既存 API は不変）

## 📋 関連 Issue

- Closes #265
- Refs #262, #263, #264

## 🧪 テスト

### テスト実行方法

```bash
cd rust && cargo test -p pdfmod-core
```

### テスト項目

- [x] 単体テスト (Unit tests)

### テスト結果

- `cargo test -p pdfmod-core`: **168 件全パス**（新規 Array/Dictionary テスト + 既存テスト。リグレッションなし）
- `cargo check --all-targets`: 成功（相互 use もコンパイルエラーなし・警告ゼロ）
- `cargo fmt --check`: 差分なし
- `cargo clippy -- -D warnings`: 警告なし

## 🔍 レビューポイント

- enum バリアントの追加位置（`Name` の後・末尾）と derive 不変（`Eq`/`Hash`/`Copy`/`#[non_exhaustive]` 非付与）の妥当性
- アクセサが参照返しのみ（可変アクセサ・ムーブ取り出しは本 Issue ではスコープ外）である点
- `Real(NaN)` を含む配列・辞書が `PartialEq` で非等価になる挙動（IEEE 754 準拠の意図された挙動。`Eq` 非実装方針が再帰的に維持される）
- spec-based code review 済み（CRITICAL/WARNING 0・DoD 13/13 充足）。指摘 I-002（辞書版ネストテストの全体 `==` 比較欠如）は対応済み

## ⚠️ 破壊的変更

- [ ] この変更は既存の API に破壊的変更を含みます

破壊的変更なし。バリアント・アクセサの追加のみで、既存 API（`as_bool`/`as_integer`/`as_real`/`as_string`/`as_name`/`is_null`）は不変。

## ✅ チェックリスト

- [x] コードレビューの準備ができている
- [x] テストが正常に実行される
- [x] ドキュメントが更新されている（モジュール/型 doc）
- [x] コミットメッセージが適切な形式で書かれている
- [x] PR 本文に `Closes #265` で Issue が記載されている
- [x] セルフレビューを実施した
- [x] 破壊的変更なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)