### PR TITLE
✨ [New Feature]: #292 PDF Tm operator (tmHandler) を実装

### DIFF
--- a/packages/core/src/content-stream/operators/text/tm/__tests__/tm.basic.test.ts
+++ b/packages/core/src/content-stream/operators/text/tm/__tests__/tm.basic.test.ts
@@ -1,0 +1,238 @@
+import { assert, expect, test } from "vitest";
+import type { PdfObject } from "../../../../../pdf/types/pdf-types/index";
+import {
+  GraphicsState,
+  GraphicsStateStack,
+  Matrix,
+  TextObject,
+} from "../../../../graphics-state/index";
+import { OperandStack } from "../../../../operand-stack/index";
+import type { OperatorHandlerContext } from "../../../../operator-registry/index";
+import { tmHandler } from "../index";
+
+// active な text object を持つ context を operand 付きで組む。
+// operand は PDF 表記 `a b c d e f Tm` の並び（配列を [a, b, c, d, e, f] 順）で渡す。
+const buildActiveContext = (
+  operands: PdfObject[],
+  textObject: TextObject = TextObject.begin(),
+): OperatorHandlerContext => {
+  const operandStack = OperandStack.create();
+  for (const operand of operands) {
+    OperandStack.push(operandStack, operand);
+  }
+  const activeState = GraphicsState.update(GraphicsState.create(), {
+    textObject,
+  });
+  const graphicsStateStack = GraphicsStateStack.replaceCurrent(
+    GraphicsStateStack.create(),
+    activeState,
+  );
+  return { operandStack, graphicsStateStack };
+};
+
+const int = (value: number): PdfObject => ({ type: "integer", value });
+const real = (value: number): PdfObject => ({ type: "real", value });
+
+test("'1 0 0 1 72 720 Tm' で textMatrix / textLineMatrix がともに [1,0,0,1,72,720] になる", () => {
+  const context = buildActiveContext([
+    int(1),
+    int(0),
+    int(0),
+    int(1),
+    int(72),
+    int(720),
+  ]);
+  const result = tmHandler(context);
+
+  assert(result.ok);
+  const current = GraphicsStateStack.current(result.value.graphicsStateStack);
+  expect(current.textObject.textMatrix).toEqual(
+    Matrix.create(1, 0, 0, 1, 72, 720),
+  );
+  expect(current.textObject.textLineMatrix).toEqual(
+    Matrix.create(1, 0, 0, 1, 72, 720),
+  );
+});
+
+test("'2 3 5 7 11 13 Tm'（a..f すべて相異）で両 matrix が [2,3,5,7,11,13] になり f→a pop + reverse の順序が保たれる", () => {
+  // a..f を相異な素数にすることで、b/c 取り違えや reverse 漏れを検出する。
+  const context = buildActiveContext([
+    int(2),
+    int(3),
+    int(5),
+    int(7),
+    int(11),
+    int(13),
+  ]);
+  const result = tmHandler(context);
+
+  assert(result.ok);
+  const current = GraphicsStateStack.current(result.value.graphicsStateStack);
+  expect(current.textObject.textMatrix).toEqual(
+    Matrix.create(2, 3, 5, 7, 11, 13),
+  );
+  expect(current.textObject.textLineMatrix).toEqual(
+    Matrix.create(2, 3, 5, 7, 11, 13),
+  );
+});
+
+test("既存 textMatrix=[1,0,0,1,100,100] を無視して '2 0 0 2 10 20 Tm' で [2,0,0,2,10,20] に絶対上書きする", () => {
+  // Td の相対移動と異なり、Tm は現在の行列に依存せず matrix で置換する。
+  const existing = TextObject.setMatrix(
+    TextObject.begin(),
+    Matrix.create(1, 0, 0, 1, 100, 100),
+  );
+  const context = buildActiveContext(
+    [int(2), int(0), int(0), int(2), int(10), int(20)],
+    existing,
+  );
+  const result = tmHandler(context);
+
+  assert(result.ok);
+  const current = GraphicsStateStack.current(result.value.graphicsStateStack);
+  expect(current.textObject.textMatrix).toEqual(
+    Matrix.create(2, 0, 0, 2, 10, 20),
+  );
+  expect(current.textObject.textLineMatrix).toEqual(
+    Matrix.create(2, 0, 0, 2, 10, 20),
+  );
+});
+
+test("integer / real 混在 operand でも両 matrix に各 value がそのまま格納される", () => {
+  // real 位置に整数で表せない小数 72.5 を置き、real 経路が値を丸めず保持することを実証する
+  // （72.0 だと int(72) と同値になり real 経路の検証にならない）。
+  const context = buildActiveContext([
+    int(1),
+    int(0),
+    int(0),
+    int(1),
+    real(72.5),
+    int(720),
+  ]);
+  const result = tmHandler(context);
+
+  assert(result.ok);
+  const current = GraphicsStateStack.current(result.value.graphicsStateStack);
+  expect(current.textObject.textMatrix).toEqual(
+    Matrix.create(1, 0, 0, 1, 72.5, 720),
+  );
+  expect(current.textObject.textLineMatrix).toEqual(
+    Matrix.create(1, 0, 0, 1, 72.5, 720),
+  );
+});
+
+test("小数・負値（'1.5 0 0 -2.25 -10.5 0 Tm'）を値域検証せず matrix にそのまま格納する", () => {
+  const context = buildActiveContext([
+    real(1.5),
+    int(0),
+    int(0),
+    real(-2.25),
+    real(-10.5),
+    int(0),
+  ]);
+  const result = tmHandler(context);
+
+  assert(result.ok);
+  const current = GraphicsStateStack.current(result.value.graphicsStateStack);
+  expect(current.textObject.textMatrix).toEqual(
+    Matrix.create(1.5, 0, 0, -2.25, -10.5, 0),
+  );
+  expect(current.textObject.textLineMatrix).toEqual(
+    Matrix.create(1.5, 0, 0, -2.25, -10.5, 0),
+  );
+});
+
+test.each<[string, PdfObject, number]>([
+  ["+Infinity", real(Number.POSITIVE_INFINITY), Number.POSITIVE_INFINITY],
+  ["-Infinity", real(Number.NEGATIVE_INFINITY), Number.NEGATIVE_INFINITY],
+])("境界値 '%s' を a に渡しても値域検証せず matrix[0] にそのまま格納し result.ok", (_label, operand, expected) => {
+  const context = buildActiveContext([
+    operand,
+    int(0),
+    int(0),
+    int(1),
+    int(0),
+    int(0),
+  ]);
+  const result = tmHandler(context);
+
+  assert(result.ok);
+  const current = GraphicsStateStack.current(result.value.graphicsStateStack);
+  expect(current.textObject.textMatrix[0]).toBe(expected);
+});
+
+test("境界値 NaN を a に渡しても値域検証せず matrix[0] に NaN を格納し result.ok", () => {
+  // NaN は toEqual / toBe の NaN 比較仕様に頼らず Number.isNaN で明示判定する。
+  const context = buildActiveContext([
+    real(Number.NaN),
+    int(0),
+    int(0),
+    int(1),
+    int(0),
+    int(0),
+  ]);
+  const result = tmHandler(context);
+
+  assert(result.ok);
+  const current = GraphicsStateStack.current(result.value.graphicsStateStack);
+  expect(Number.isNaN(current.textObject.textMatrix[0])).toBe(true);
+});
+
+test("余剰 operand（非数値）があっても頂上 6 個（f→a）のみ pop し、7 個目は型検査せず残して depth=1 になる", () => {
+  // push 順 [余剰(非数値 name), a=1, b=0, c=0, d=1, e=72, f=720]。頂上は f=720。
+  // 余剰を非数値にすることで、ループが OPERAND_COUNT=6 で確実に打ち切り 7 個目を
+  // 型検査しないこと（もし 7 個 pop していれば name で TYPE_MISMATCH になり成功しない）を証明する。
+  const surplus: PdfObject = { type: "name", value: "X" };
+  const context = buildActiveContext([
+    surplus,
+    int(1),
+    int(0),
+    int(0),
+    int(1),
+    int(72),
+    int(720),
+  ]);
+  const result = tmHandler(context);
+
+  assert(result.ok);
+  const current = GraphicsStateStack.current(result.value.graphicsStateStack);
+  expect(current.textObject.textMatrix).toEqual(
+    Matrix.create(1, 0, 0, 1, 72, 720),
+  );
+  expect(OperandStack.depth(result.value.operandStack)).toBe(1);
+  const top = OperandStack.peek(result.value.operandStack);
+  assert(top.some);
+  expect(top.value).toEqual(surplus);
+});
+
+test("成功時 operandStack は context.operandStack と同一参照で返る（in-place pop）", () => {
+  const context = buildActiveContext([
+    int(1),
+    int(0),
+    int(0),
+    int(1),
+    int(72),
+    int(720),
+  ]);
+  const result = tmHandler(context);
+
+  assert(result.ok);
+  expect(result.value.operandStack).toBe(context.operandStack);
+  expect(OperandStack.depth(result.value.operandStack)).toBe(0);
+});
+
+test("成功時に text object は active のまま維持される", () => {
+  const context = buildActiveContext([
+    int(1),
+    int(0),
+    int(0),
+    int(1),
+    int(72),
+    int(720),
+  ]);
+  const result = tmHandler(context);
+
+  assert(result.ok);
+  const current = GraphicsStateStack.current(result.value.graphicsStateStack);
+  expect(TextObject.isActive(current.textObject)).toBe(true);
+});

--- a/packages/core/src/content-stream/operators/text/tm/__tests__/tm.error.test.ts
+++ b/packages/core/src/content-stream/operators/text/tm/__tests__/tm.error.test.ts
@@ -1,0 +1,197 @@
+import { assert, expect, test } from "vitest";
+import type { PdfObject } from "../../../../../pdf/types/pdf-types/index";
+import {
+  GraphicsState,
+  GraphicsStateStack,
+  TextObject,
+} from "../../../../graphics-state/index";
+import { OperandStack } from "../../../../operand-stack/index";
+import type { OperatorHandlerContext } from "../../../../operator-registry/index";
+import { tmHandler } from "../index";
+
+// active=true の context（operand 不足・型不一致テスト用）。
+// operand は PDF 表記 `a b c d e f Tm` の並び（配列を [a, b, c, d, e, f] 順）で渡す。
+const buildActiveContext = (operands: PdfObject[]): OperatorHandlerContext => {
+  const operandStack = OperandStack.create();
+  for (const operand of operands) {
+    OperandStack.push(operandStack, operand);
+  }
+  const activeState = GraphicsState.update(GraphicsState.create(), {
+    textObject: TextObject.begin(),
+  });
+  const graphicsStateStack = GraphicsStateStack.replaceCurrent(
+    GraphicsStateStack.create(),
+    activeState,
+  );
+  return { operandStack, graphicsStateStack };
+};
+
+// inactive な context（active=false ガードテスト用。GraphicsStateStack.create() 既定）。
+const buildInactiveContext = (
+  operands: PdfObject[],
+): OperatorHandlerContext => {
+  const operandStack = OperandStack.create();
+  for (const operand of operands) {
+    OperandStack.push(operandStack, operand);
+  }
+  return { operandStack, graphicsStateStack: GraphicsStateStack.create() };
+};
+
+const int = (value: number): PdfObject => ({ type: "integer", value });
+
+// 全非数値型網羅（td.error.test.ts より流用）。
+const nonNumericOperands: [string, PdfObject][] = [
+  ["name", { type: "name", value: "F1" }],
+  ["boolean", { type: "boolean", value: true }],
+  ["null", { type: "null" }],
+  [
+    "string",
+    { type: "string", value: new Uint8Array([0x61]), encoding: "literal" },
+  ],
+  ["array", { type: "array", elements: [] }],
+  ["dictionary", { type: "dictionary", entries: new Map() }],
+  [
+    "indirect-ref",
+    { type: "indirect-ref", objectNumber: 1, generationNumber: 0 },
+  ],
+];
+
+const name = (value: string): PdfObject => ({ type: "name", value });
+
+test("active=false で Tm を呼ぶと OPERATOR_ILLEGAL_STATE を返し operand stack は不変", () => {
+  const context = buildInactiveContext([
+    int(1),
+    int(0),
+    int(0),
+    int(1),
+    int(72),
+    int(720),
+  ]);
+  const result = tmHandler(context);
+
+  assert(!result.ok);
+  assert(result.error.code === "OPERATOR_ILLEGAL_STATE");
+  expect(result.error.operatorName).toBe("Tm");
+  expect(result.error.message).toBe(
+    "Tm: text object is not active (Tm must appear within BT/ET)",
+  );
+  expect(OperandStack.depth(context.operandStack)).toBe(6);
+});
+
+test.each([
+  { label: "0 個", count: 0 },
+  { label: "1 個", count: 1 },
+  { label: "2 個", count: 2 },
+  { label: "3 個", count: 3 },
+  { label: "4 個", count: 4 },
+  { label: "5 個", count: 5 },
+])("operand $label のとき OPERATOR_OPERAND_MISSING（actual=push 個数）を返し、push 分は全消費で depth=0", ({
+  count,
+}) => {
+  const operands: PdfObject[] = Array.from({ length: count }, () => int(1));
+  const context = buildActiveContext(operands);
+  const result = tmHandler(context);
+
+  assert(!result.ok);
+  assert(result.error.code === "OPERATOR_OPERAND_MISSING");
+  expect(result.error.operatorName).toBe("Tm");
+  expect(result.error.required).toBe(6);
+  expect(result.error.actual).toBe(count);
+  expect(result.error.message).toBe(
+    `Operator 'Tm' requires 6 operand(s), got ${count}`,
+  );
+  expect(OperandStack.depth(context.operandStack)).toBe(0);
+});
+
+test.each(
+  nonNumericOperands,
+)("頂上 f が %s のとき OPERATOR_OPERAND_TYPE_MISMATCH を返し depth は 5（top のみ pop 済み）", (typeName, operand) => {
+  // push 順 [a, b, c, d, e, f] の f（頂上）を非数値にする。最初の pop で停止する。
+  const context = buildActiveContext([
+    int(1),
+    int(0),
+    int(0),
+    int(1),
+    int(72),
+    operand,
+  ]);
+  const result = tmHandler(context);
+
+  assert(!result.ok);
+  assert(result.error.code === "OPERATOR_OPERAND_TYPE_MISMATCH");
+  expect(result.error.operatorName).toBe("Tm");
+  expect(result.error.expected).toBe("number");
+  expect(result.error.actual).toBe(typeName);
+  expect(result.error.message).toBe(
+    `Operator 'Tm' expected number operand, got ${typeName}`,
+  );
+  expect(OperandStack.depth(context.operandStack)).toBe(5);
+});
+
+test.each<{ label: string; operands: PdfObject[]; depth: number }>([
+  {
+    label: "a（最下層）",
+    operands: [name("F1"), int(0), int(0), int(1), int(72), int(720)],
+    depth: 0,
+  },
+  {
+    label: "b",
+    operands: [int(1), name("F1"), int(0), int(1), int(72), int(720)],
+    depth: 1,
+  },
+  {
+    label: "c",
+    operands: [int(1), int(0), name("F1"), int(1), int(72), int(720)],
+    depth: 2,
+  },
+  {
+    label: "d",
+    operands: [int(1), int(0), int(0), name("F1"), int(72), int(720)],
+    depth: 3,
+  },
+  {
+    label: "e",
+    operands: [int(1), int(0), int(0), int(1), name("F1"), int(720)],
+    depth: 4,
+  },
+  {
+    label: "f（頂上）",
+    operands: [int(1), int(0), int(0), int(1), int(72), name("F1")],
+    depth: 5,
+  },
+])("PDF 位置 $label が非数値のとき TYPE_MISMATCH を返し、f→a の検査順序に応じて残 depth=$depth になる", ({
+  operands,
+  depth,
+}) => {
+  const context = buildActiveContext(operands);
+  const result = tmHandler(context);
+
+  assert(!result.ok);
+  assert(result.error.code === "OPERATOR_OPERAND_TYPE_MISMATCH");
+  expect(result.error.actual).toBe("name");
+  // f→a の順に pop し、非数値の位置で停止する。残 depth は混入位置の index に一致する。
+  expect(OperandStack.depth(context.operandStack)).toBe(depth);
+});
+
+test("TYPE_MISMATCH 後も部分消費した operand は復元せず、最下層の余剰 operand のみ残る", () => {
+  const surplus = int(99);
+  // push 順（bottom→top）= [surplus, a=name, b, c, d, e, f]。
+  // f→b の 5 個の数値を pop して通過し、a=name で MISMATCH。pop 済みは戻さない。
+  const context = buildActiveContext([
+    surplus,
+    name("F1"),
+    int(0),
+    int(0),
+    int(1),
+    int(72),
+    int(720),
+  ]);
+  const result = tmHandler(context);
+
+  assert(!result.ok);
+  assert(result.error.code === "OPERATOR_OPERAND_TYPE_MISMATCH");
+  expect(OperandStack.depth(context.operandStack)).toBe(1);
+  const top = OperandStack.peek(context.operandStack);
+  assert(top.some);
+  expect(top.value).toEqual(surplus);
+});

--- a/packages/core/src/content-stream/operators/text/tm/index.ts
+++ b/packages/core/src/content-stream/operators/text/tm/index.ts
@@ -1,0 +1,106 @@
+import type { PdfError } from "../../../../pdf/errors/index";
+import { err, ok } from "../../../../utils/result/index";
+import {
+  GraphicsState,
+  GraphicsStateStack,
+  Matrix,
+  TextObject,
+} from "../../../graphics-state/index";
+import { OperandStack } from "../../../operand-stack/index";
+import type {
+  OperatorHandler,
+  OperatorHandlerContext,
+} from "../../../operator-registry/index";
+import { NumericPdfObject } from "../../graphics-state/numeric-pdf-object/index";
+
+/** PDF 表記を保持した operator 名（"Tm"）。 */
+const OPERATOR_NAME = "Tm";
+
+/** Tm が要求する operand 数（a b c d e f）。 */
+const OPERAND_COUNT = 6;
+
+/**
+ * PDF §9.4.2 `Tm` operator (Set the text matrix and text line matrix) のハンドラ。
+ *
+ * operand stack から `a b c d e f` の 6 個の数値を pop し、
+ * `Matrix.create(a, b, c, d, e, f)` で `textMatrix` / `textLineMatrix` を
+ * **絶対上書き**する。`Td` / `TD` の相対移動と異なり、現在の行列を無視して
+ * 置換する (`Tm' = Tlm' = matrix`)。`Tm` は BT 〜 ET の内側でのみ有効。
+ *
+ * 検査順序（厳守）:
+ *   (1) active 検査（false なら operand stack を一切消費せず Err）
+ *   (2) f → e → d → c → b → a の順に 6 回 pop し、各 pop 後に型検査
+ *
+ * - text object が active でない場合は `OPERATOR_ILLEGAL_STATE` を返す
+ *   （operand stack / graphics state stack は変更しない）
+ * - operand 不足 (< 6) のとき `OPERATOR_OPERAND_MISSING` を返す。
+ *   `actual` には pop に成功した個数を入れる
+ * - operand に integer / real 以外が混在したとき `OPERATOR_OPERAND_TYPE_MISMATCH` を返す
+ * - 値域（`NaN` / `Infinity` / 負値 / 小数）は本 handler では検証せずそのまま格納する
+ * - エラー時に operand stack の部分消費は復元しない（既存ハンドラ規約）
+ * - 成功時 operandStack は同一参照のまま返す（in-place pop 済み）
+ *
+ * operand 順序: PDF 表記 `a b c d e f Tm` のスタック頂上は f。
+ * したがって f → a の順に pop し、reverse して PDF 順 [a, b, c, d, e, f] に戻す。
+ *
+ * @param context - 実行コンテキスト (operand stack / graphics state stack)
+ * @returns 成功なら更新後コンテキスト、失敗なら PdfError
+ */
+export const tmHandler: OperatorHandler = (context: OperatorHandlerContext) => {
+  const current = GraphicsStateStack.current(context.graphicsStateStack);
+  if (!TextObject.isActive(current.textObject)) {
+    const error: PdfError = {
+      code: "OPERATOR_ILLEGAL_STATE",
+      message: "Tm: text object is not active (Tm must appear within BT/ET)",
+      operatorName: OPERATOR_NAME,
+    };
+    return err(error);
+  }
+
+  const popped: NumericPdfObject[] = [];
+  for (let i = 0; i < OPERAND_COUNT; i++) {
+    const result = OperandStack.pop(context.operandStack);
+    if (!result.some) {
+      const error: PdfError = {
+        code: "OPERATOR_OPERAND_MISSING",
+        message: `Operator '${OPERATOR_NAME}' requires ${OPERAND_COUNT} operand(s), got ${i}`,
+        operatorName: OPERATOR_NAME,
+        required: OPERAND_COUNT,
+        actual: i,
+      };
+      return err(error);
+    }
+    const operand = result.value;
+    if (!NumericPdfObject.is(operand)) {
+      const error: PdfError = {
+        code: "OPERATOR_OPERAND_TYPE_MISMATCH",
+        message: `Operator '${OPERATOR_NAME}' expected number operand, got ${operand.type}`,
+        operatorName: OPERATOR_NAME,
+        expected: "number",
+        actual: operand.type,
+      };
+      return err(error);
+    }
+    popped.push(operand);
+  }
+
+  // popped は LIFO 順で [f, e, d, c, b, a]。reverse して PDF 順 [a, b, c, d, e, f] に戻す
+  const [a, b, c, d, e, f] = popped
+    .slice()
+    .reverse()
+    .map((operand) => operand.value);
+
+  const operandMatrix = Matrix.create(a, b, c, d, e, f);
+  const next = GraphicsState.update(current, {
+    textObject: TextObject.setMatrix(current.textObject, operandMatrix),
+  });
+  const graphicsStateStack = GraphicsStateStack.replaceCurrent(
+    context.graphicsStateStack,
+    next,
+  );
+
+  return ok({
+    operandStack: context.operandStack,
+    graphicsStateStack,
+  });
+};


### PR DESCRIPTION
## 概要

PDF §9.4.2 `Tm` operator（`a b c d e f Tm`）の handler `tmHandler` を新規実装します。`Td`/`TD` の相対移動と異なり、現在の行列を無視して `textMatrix` / `textLineMatrix` を `Matrix.create(a,b,c,d,e,f)` で**絶対上書き**します。handler 本体と TDD ベースのテスト2ファイルを追加します（既存 API・operator 登録テーブルは無変更）。

## 変更の種類

- ✨ 新機能（`tmHandler` の追加）
- 🚨 テスト（正常系/異常系の網羅テスト追加）

## 詳細な変更内容

**追加（[NEW]）**
- `packages/core/src/content-stream/operators/text/tm/index.ts` — `tmHandler` 本体（106行）
- `packages/core/src/content-stream/operators/text/tm/__tests__/tm.basic.test.ts` — 正常系11ケース
- `packages/core/src/content-stream/operators/text/tm/__tests__/tm.error.test.ts` — 異常系21ケース

**設計のポイント**
- 検査順序を厳守: ① active 検査（false なら operand 不消費で即 `Err`）→ ② `f→a` の6回 pop & 各 number 型検査 → ③ `reverse` で PDF 順 `[a..f]` 復元 → `setMatrix` → `update` → `replaceCurrent`
- `throw` 禁止。全エラーを `Result` の `err(...)` で返却
- `Td`/`cm` の既存規約を踏襲: 部分消費した operand stack を復元しない／operand 値域（NaN・Infinity・負値・小数）は非検証（number 型のみ検査）／成功時 operandStack は同一参照で返す

## システム図

```mermaid
flowchart TD
    A["tmHandler(context)"] --> B{"textObject<br/>active?"}
    B -- "No" --> E1["Err: OPERATOR_ILLEGAL_STATE<br/>(operand 不消費)"]
    B -- "Yes" --> C["f→a を 6 回 pop<br/>& 各 number 型検査"]
    C -- "pop 不足" --> E2["Err: OPERATOR_OPERAND_MISSING<br/>actual = pop 成功数"]
    C -- "非数値" --> E3["Err: OPERATOR_OPERAND_TYPE_MISMATCH<br/>actual = operand.type"]
    C -- "6 個 OK" --> D["reverse → [a..f]<br/>Matrix.create(a,b,c,d,e,f)"]
    D --> F["TextObject.setMatrix<br/>textMatrix = textLineMatrix = matrix<br/>(絶対上書き)"]
    F --> G["GraphicsState.update<br/>→ replaceCurrent"]
    G --> H["Ok({ operandStack(同一参照),<br/>graphicsStateStack(更新) })"]
    style A fill:#dff,stroke:#066
    style H fill:#dfd,stroke:#060
```

（本 PR の追加分は上図フロー全体が新規）

## 関連Issue

Closes #292
Refs #288（親 Epic: Phase 4-E）

## テスト

- ✅ `pnpm --filter @pdfmod/core test` — **185 files / 2487 tests green**（`tm.basic` 11 / `tm.error` 21、リグレッションなし）
- ✅ `pnpm --filter @pdfmod/core typecheck` — エラーなし
- ✅ `pnpm --filter @pdfmod/core build` — 成功
- ✅ lint（oxlint / biome）— warning・error なし
- ✅ Codex レビュー — 問題なし
- ✅ spec-based code review（performance/design/spec-alignment/test-quality 4観点）— CRITICAL 0 / WARNING 0（1件は対応済み）、DoD 11/11 充足

## レビューポイント

- **絶対上書きの正当性**: `Td` の相対移動（`translateLine`）でなく `setMatrix` で置換していること（既存 `textMatrix` に非依存）
- **pop 順序**: スタック頂上 = f のため `f→a` で pop し `reverse` で PDF 順を復元（テストで相異素数 `[2,3,5,7,11,13]` を用い取り違えを検出）
- **スコープ**: 本 Issue では operator 登録テーブルへ**登録しない**（`Td`/`TD` 同様、Epic #288 の後続フェーズで配線予定）。そのため実装済みだがディスパッチ未配線の状態