### PR TITLE
✨ [New Feature]: #266 IndirectRef 型と PdfObject::Reference を追加

### DIFF
--- a/rust/crates/core/src/object.rs
+++ b/rust/crates/core/src/object.rs
@@ -3,15 +3,16 @@
 //! ISO 32000 の PDF オブジェクト（null / boolean / numeric / string / name /
 //! array / dictionary / stream / indirect reference）を表す。現時点では
 //! `PdfObject`（null / boolean / integer / real / string / name / array /
-//! dictionary）と、補助の newtype（`PdfName` / `PdfDictionary` / `ObjectId` /
-//! `ObjectNumber` / `GenerationNumber`）を提供し、stream / indirect reference は
-//! 後続 Issue で追加する。
+//! dictionary / reference）と、補助の newtype（`PdfName` / `PdfDictionary` /
+//! `ObjectId` / `ObjectNumber` / `GenerationNumber` / `IndirectRef`）を提供し、
+//! stream は後続 Issue で追加する。
 
 pub mod dictionary;
 pub mod generation_number;
+pub mod indirect_ref;
 pub mod name;
 pub mod object_id;
 pub mod object_number;
 pub mod pdf_object;
 
-// stream / indirect reference は後続 Issue で対応する型・サブモジュールを追加する。
+// stream は後続 Issue で対応する型・サブモジュールを追加する。

--- a/rust/crates/core/src/object/indirect_ref.rs
+++ b/rust/crates/core/src/object/indirect_ref.rs
@@ -1,0 +1,178 @@
+//! PDF の間接参照（`N G R`）を表す `IndirectRef` を定義するモジュール。
+//!
+//! `ObjectId`（#258）で参照先の間接オブジェクトを指す値ラッパ。後続の
+//! オブジェクト解決（Epic R2）の入力となる土台を提供する。生成は無検証
+//! （infallible）で、任意の `ObjectId`（境界値含む）を無条件に受理する。
+//! 参照先の存在・世代の妥当性検証は xref レイヤ（R2）に委譲する。
+
+use crate::object::object_id::ObjectId;
+
+/// PDF の間接参照（`N G R`）。参照先を `ObjectId` で内包する値ラッパ。
+///
+/// `ObjectId` が `Copy` なので `IndirectRef` も `Copy`。等価・ハッシュは
+/// 内包する `ObjectId`（その両フィールド `u64`/`u16`）に依存する。
+/// 順序（`PartialOrd`/`Ord`）は付けない（`PdfObject` 自体が `Ord` 非実装で
+/// `Reference` 経由ソートは不可能・単体ソート用途も現状なし。必要時に非破壊で追加可能）。
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct IndirectRef {
+    target: ObjectId,
+}
+
+impl IndirectRef {
+    /// 参照先 `ObjectId` から `IndirectRef` を生成する。
+    ///
+    /// 無検証（infallible）。任意の `ObjectId` を受理する。
+    pub fn new(target: ObjectId) -> IndirectRef {
+        IndirectRef { target }
+    }
+
+    /// 参照先 `ObjectId` を `Copy` で取り出す。
+    pub fn target(&self) -> ObjectId {
+        self.target
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::object::generation_number::GenerationNumber;
+    use crate::object::object_number::ObjectNumber;
+    use std::collections::{HashMap, HashSet};
+
+    /// 代表ペアで `ObjectId` を `new` に包み `target()` で取り出すと入力と一致する（ラウンドトリップ・無損失）。
+    #[test]
+    fn new_then_target_roundtrips() {
+        for (n, g) in [(0u64, 0u16), (1, 1), (42, 42)] {
+            let target = ObjectId::new(ObjectNumber::new(n), GenerationNumber::new(g));
+            let ir = IndirectRef::new(target);
+            assert_eq!(ir.target(), target);
+        }
+    }
+
+    /// `target()` 経由で内包 `ObjectId` の object_number / generation_number に到達でき、入力と一致する。
+    #[test]
+    fn target_reaches_object_number_and_generation_number() {
+        let target = ObjectId::new(ObjectNumber::new(7), GenerationNumber::new(3));
+        let ir = IndirectRef::new(target);
+        assert_eq!(ir.target().object_number(), ObjectNumber::new(7));
+        assert_eq!(ir.target().generation_number(), GenerationNumber::new(3));
+    }
+
+    /// 同一 `ObjectId` から生成した 2 つの `IndirectRef` は == で等価（Eq が内包 ObjectId に委譲）。
+    #[test]
+    fn same_target_is_equal() {
+        let target = ObjectId::new(ObjectNumber::new(5), GenerationNumber::new(0));
+        let a = IndirectRef::new(target);
+        let b = IndirectRef::new(target);
+        assert_eq!(a, b);
+    }
+
+    /// `Copy` のため代入でコピーされ、元値も使用可能でコピーと等価。
+    #[test]
+    fn is_copy_so_original_stays_usable() {
+        let target = ObjectId::new(ObjectNumber::new(7), GenerationNumber::new(3));
+        let ir = IndirectRef::new(target);
+        let copied = ir;
+        assert_eq!(ir.target(), target);
+        assert_eq!(ir, copied);
+    }
+
+    /// `Debug` 出力に型名 `IndirectRef` を含む。
+    #[test]
+    fn debug_format_contains_type_name() {
+        let ir = IndirectRef::new(ObjectId::new(
+            ObjectNumber::new(1),
+            GenerationNumber::new(0),
+        ));
+        assert!(format!("{:?}", ir).contains("IndirectRef"));
+    }
+
+    /// `HashMap<IndirectRef, _>` のキーとして使え、同値キーで挿入値を取得できる（Hash + Eq）。
+    #[test]
+    fn works_as_hash_map_key() {
+        let target = ObjectId::new(ObjectNumber::new(10), GenerationNumber::new(0));
+        let mut map = HashMap::new();
+        map.insert(IndirectRef::new(target), "ref10");
+        assert_eq!(map.get(&IndirectRef::new(target)), Some(&"ref10"));
+    }
+
+    /// 同値 `IndirectRef` を `HashSet` に 2 回挿入すると 1 件に折りたたまれる。
+    #[test]
+    fn equal_keys_collapse_in_hash_set() {
+        let target = ObjectId::new(ObjectNumber::new(3), GenerationNumber::new(0));
+        let mut set = HashSet::new();
+        set.insert(IndirectRef::new(target));
+        set.insert(IndirectRef::new(target));
+        assert_eq!(set.len(), 1);
+    }
+
+    /// 内包 `ObjectId` が異なる 3 値は別キーとして `HashSet` に共存する
+    /// （generation 差異・object_number 差異の両軸で Eq により区別される）。
+    #[test]
+    fn distinct_keys_coexist_in_hash_set() {
+        let mut set = HashSet::new();
+        // object_number 同一・generation 差異
+        set.insert(IndirectRef::new(ObjectId::new(
+            ObjectNumber::new(7),
+            GenerationNumber::new(0),
+        )));
+        set.insert(IndirectRef::new(ObjectId::new(
+            ObjectNumber::new(7),
+            GenerationNumber::new(1),
+        )));
+        // generation 同一・object_number 差異
+        set.insert(IndirectRef::new(ObjectId::new(
+            ObjectNumber::new(8),
+            GenerationNumber::new(0),
+        )));
+        assert_eq!(set.len(), 3);
+    }
+
+    /// 最小境界 `(0, 0)` の `ObjectId` を無検証で受理し、ラウンドトリップが成立する。
+    #[test]
+    fn accepts_min_boundary_target() {
+        let target = ObjectId::new(ObjectNumber::new(0), GenerationNumber::new(0));
+        let ir = IndirectRef::new(target);
+        assert_eq!(ir.target(), target);
+        assert_eq!(ir.target().object_number().value(), 0);
+        assert_eq!(ir.target().generation_number().value(), 0);
+    }
+
+    /// 最大境界 `(u64::MAX, u16::MAX)` の `ObjectId` を無検証で受理し、ラウンドトリップが成立する。
+    #[test]
+    fn accepts_max_boundary_target() {
+        let target = ObjectId::new(ObjectNumber::new(u64::MAX), GenerationNumber::new(u16::MAX));
+        let ir = IndirectRef::new(target);
+        assert_eq!(ir.target(), target);
+        assert_eq!(ir.target().object_number().value(), u64::MAX);
+        assert_eq!(ir.target().generation_number().value(), u16::MAX);
+    }
+
+    /// 世代は同一・object_number のみ異なる 2 値は非等価（内包 ObjectId の差異が反映される）。
+    #[test]
+    fn not_equal_when_object_number_differs() {
+        let a = IndirectRef::new(ObjectId::new(
+            ObjectNumber::new(5),
+            GenerationNumber::new(0),
+        ));
+        let b = IndirectRef::new(ObjectId::new(
+            ObjectNumber::new(6),
+            GenerationNumber::new(0),
+        ));
+        assert_ne!(a, b);
+    }
+
+    /// object_number は同一・generation_number のみ異なる 2 値は非等価（内包 ObjectId の差異が反映される）。
+    #[test]
+    fn not_equal_when_generation_number_differs() {
+        let a = IndirectRef::new(ObjectId::new(
+            ObjectNumber::new(5),
+            GenerationNumber::new(0),
+        ));
+        let b = IndirectRef::new(ObjectId::new(
+            ObjectNumber::new(5),
+            GenerationNumber::new(1),
+        ));
+        assert_ne!(a, b);
+    }
+}

--- a/rust/crates/core/src/object/pdf_object.rs
+++ b/rust/crates/core/src/object/pdf_object.rs
@@ -3,14 +3,15 @@
 //! ISO 32000-1 §7.3 の PDF オブジェクトを 1 つの enum で表す。現時点では
 //! スカラ系 4 バリアント（Null / Boolean / Integer / Real）に加え、文字列
 //! （復号後の生バイト列）・名前（`PdfName`）・配列（`Vec<PdfObject>` の自己再帰）・
-//! 辞書（`PdfDictionary`）を定義する。参照・ストリームは後続 Issue で追加する。
+//! 辞書（`PdfDictionary`）・参照（`IndirectRef`）を定義する。ストリームは後続 Issue で追加する。
 //! 構築は無検証（infallible）で、テキスト解釈や妥当性検証・正規化は上位
 //! （lexer/parser）に委譲する。
 
 use crate::object::dictionary::PdfDictionary;
+use crate::object::indirect_ref::IndirectRef;
 use crate::object::name::PdfName;
 
-/// PDF 基本オブジェクト（スカラ系・文字列・名前・配列・辞書バリアントを表す enum）。
+/// PDF 基本オブジェクト（スカラ系・文字列・名前・配列・辞書・参照バリアントを表す enum）。
 ///
 /// 整数幅は `i64`、浮動小数点幅は `f64`（PDF パーサで最も一般的・桁あふれ耐性・
 /// 後続レクサーとの相性で確定）。`Real(f64)` を含むため `Eq`/`Hash`/`Ord` は
@@ -50,6 +51,11 @@ pub enum PdfObject {
     /// 値に `Real(NaN)` を含むと辞書同士は `==` で非等価になる（`Eq` 非実装の
     /// 根拠が再帰的に維持される）。
     Dictionary(PdfDictionary),
+    /// 間接参照オブジェクト（`N G R`）。`IndirectRef`（#073）をそのまま内包する。
+    ///
+    /// `IndirectRef` は `Copy` 値型（ヒープ確保なし）。参照先の存在・妥当性
+    /// 検証は行わず、無検証で忠実に保持する（解決は xref レイヤ R2 に委譲）。
+    Reference(IndirectRef),
 }
 
 impl PdfObject {
@@ -123,11 +129,32 @@ impl PdfObject {
             _ => None,
         }
     }
+
+    /// `Reference` のとき内部の `IndirectRef` を `Some` で取り出す（他は `None`）。
+    ///
+    /// `IndirectRef` は `Copy` なので値返し（`as_bool`/`as_integer` と同方針）。
+    pub fn as_reference(&self) -> Option<IndirectRef> {
+        match self {
+            Self::Reference(r) => Some(*r),
+            _ => None,
+        }
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::object::generation_number::GenerationNumber;
+    use crate::object::object_id::ObjectId;
+    use crate::object::object_number::ObjectNumber;
+
+    // テスト用に代表的な IndirectRef を構築するヘルパ（オブジェクト番号 n・世代 g）
+    fn make_ref(n: u64, g: u16) -> IndirectRef {
+        IndirectRef::new(ObjectId::new(
+            ObjectNumber::new(n),
+            GenerationNumber::new(g),
+        ))
+    }
 
     #[test]
     fn null_constructs_and_matches_null_arm() {
@@ -204,19 +231,25 @@ mod tests {
 
     #[test]
     fn as_bool_returns_none_for_non_boolean_variants() {
-        // Boolean 以外（Null/Integer/Real）では as_bool() が None を返すことを確認する
-        for obj in &[PdfObject::Null, PdfObject::Integer(0), PdfObject::Real(0.0)] {
+        // Boolean 以外（Null/Integer/Real/Reference）では as_bool() が None を返すことを確認する
+        for obj in &[
+            PdfObject::Null,
+            PdfObject::Integer(0),
+            PdfObject::Real(0.0),
+            PdfObject::Reference(make_ref(1, 0)),
+        ] {
             assert_eq!(obj.as_bool(), None);
         }
     }
 
     #[test]
     fn as_integer_returns_none_for_non_integer_variants() {
-        // Integer 以外（Null/Boolean/Real）では as_integer() が None を返すことを確認する
+        // Integer 以外（Null/Boolean/Real/Reference）では as_integer() が None を返すことを確認する
         for obj in &[
             PdfObject::Null,
             PdfObject::Boolean(true),
             PdfObject::Real(0.0),
+            PdfObject::Reference(make_ref(1, 0)),
         ] {
             assert_eq!(obj.as_integer(), None);
         }
@@ -224,11 +257,12 @@ mod tests {
 
     #[test]
     fn as_real_returns_none_for_non_real_variants() {
-        // Real 以外（Null/Boolean/Integer）では as_real() が None を返すことを確認する
+        // Real 以外（Null/Boolean/Integer/Reference）では as_real() が None を返すことを確認する
         for obj in &[
             PdfObject::Null,
             PdfObject::Boolean(true),
             PdfObject::Integer(0),
+            PdfObject::Reference(make_ref(1, 0)),
         ] {
             assert_eq!(obj.as_real(), None);
         }
@@ -251,13 +285,19 @@ mod tests {
 
     #[test]
     fn all_distinct_variants_are_mutually_not_equal() {
-        // 4 バリアントを総当たりで比較し、同一インデックスのみ等価・他は非等価であることを確認する
-        // （NaN は等価判定が崩れるため代表値には含めない）
+        // 全 9 バリアントを総当たりで比較し、同一インデックスのみ等価・他は非等価であることを確認する
+        // （NaN は等価判定が崩れるため代表値には含めない。String/Name/Array/Dictionary は有限値・
+        // Reference は Eq なので NaN 制約に抵触しない）
         let variants = [
             PdfObject::Null,
             PdfObject::Boolean(false),
             PdfObject::Integer(0),
             PdfObject::Real(0.0),
+            PdfObject::String(b"abc".to_vec()),
+            PdfObject::Name(PdfName::from("Type")),
+            PdfObject::Array(vec![PdfObject::Integer(1)]),
+            PdfObject::Dictionary(PdfDictionary::new()),
+            PdfObject::Reference(make_ref(1, 0)),
         ];
         for (i, a) in variants.iter().enumerate() {
             for (j, b) in variants.iter().enumerate() {
@@ -359,13 +399,14 @@ mod tests {
 
     #[test]
     fn as_string_returns_none_for_non_string_variants() {
-        // String 以外（Null/Boolean/Integer/Real/Name）では as_string() が None を返すことを確認する
+        // String 以外（Null/Boolean/Integer/Real/Name/Reference）では as_string() が None を返すことを確認する
         let variants = [
             PdfObject::Null,
             PdfObject::Boolean(true),
             PdfObject::Integer(0),
             PdfObject::Real(0.0),
             PdfObject::Name(PdfName::from("Type")),
+            PdfObject::Reference(make_ref(1, 0)),
         ];
         for obj in &variants {
             assert_eq!(obj.as_string(), None);
@@ -374,13 +415,14 @@ mod tests {
 
     #[test]
     fn as_name_returns_none_for_non_name_variants() {
-        // Name 以外（Null/Boolean/Integer/Real/String）では as_name() が None を返すことを確認する
+        // Name 以外（Null/Boolean/Integer/Real/String/Reference）では as_name() が None を返すことを確認する
         let variants = [
             PdfObject::Null,
             PdfObject::Boolean(true),
             PdfObject::Integer(0),
             PdfObject::Real(0.0),
             PdfObject::String(b"abc".to_vec()),
+            PdfObject::Reference(make_ref(1, 0)),
         ];
         for obj in &variants {
             assert_eq!(obj.as_name(), None);
@@ -545,7 +587,7 @@ mod tests {
 
     #[test]
     fn as_array_returns_none_for_non_array_variants() {
-        // Array 以外（Null/Boolean/Integer/Real/String/Name/Dictionary）では as_array() が None を返すことを確認する
+        // Array 以外（Null/Boolean/Integer/Real/String/Name/Dictionary/Reference）では as_array() が None を返すことを確認する
         let variants = [
             PdfObject::Null,
             PdfObject::Boolean(true),
@@ -554,6 +596,7 @@ mod tests {
             PdfObject::String(b"abc".to_vec()),
             PdfObject::Name(PdfName::from("Type")),
             PdfObject::Dictionary(PdfDictionary::new()),
+            PdfObject::Reference(make_ref(1, 0)),
         ];
         for obj in &variants {
             assert_eq!(obj.as_array(), None);
@@ -562,7 +605,7 @@ mod tests {
 
     #[test]
     fn as_dictionary_returns_none_for_non_dictionary_variants() {
-        // Dictionary 以外（Null/Boolean/Integer/Real/String/Name/Array）では as_dictionary() が None を返すことを確認する
+        // Dictionary 以外（Null/Boolean/Integer/Real/String/Name/Array/Reference）では as_dictionary() が None を返すことを確認する
         let variants = [
             PdfObject::Null,
             PdfObject::Boolean(true),
@@ -571,6 +614,7 @@ mod tests {
             PdfObject::String(b"abc".to_vec()),
             PdfObject::Name(PdfName::from("Type")),
             PdfObject::Array(vec![PdfObject::Integer(1)]),
+            PdfObject::Reference(make_ref(1, 0)),
         ];
         for obj in &variants {
             assert_eq!(obj.as_dictionary(), None);
@@ -749,5 +793,71 @@ mod tests {
         // Debug 出力が Array / Dictionary のバリアント名を含むことを確認する
         assert!(format!("{:?}", PdfObject::Array(vec![PdfObject::Integer(1)])).contains("Array"));
         assert!(format!("{:?}", PdfObject::Dictionary(PdfDictionary::new())).contains("Dictionary"));
+    }
+
+    #[test]
+    fn reference_constructs_and_matches_reference_arm() {
+        // Reference(IndirectRef) を構築し matches! で Reference 腕に入ることを確認する
+        let obj = PdfObject::Reference(make_ref(1, 0));
+        assert!(matches!(obj, PdfObject::Reference(_)));
+    }
+
+    #[test]
+    fn as_reference_returns_some_for_reference() {
+        // Reference(ir) に as_reference() を呼ぶと Some(ir) を返す（Copy 値返し）ことを代表値・境界値で確認する
+        let ir = make_ref(5, 0);
+        assert_eq!(PdfObject::Reference(ir).as_reference(), Some(ir));
+        let boundary = make_ref(u64::MAX, u16::MAX);
+        assert_eq!(
+            PdfObject::Reference(boundary).as_reference(),
+            Some(boundary)
+        );
+    }
+
+    #[test]
+    fn as_reference_returns_none_for_non_reference_variants() {
+        // Reference 以外（Null/Boolean/Integer/Real/String/Name/Array/Dictionary）では as_reference() が None を返すことを確認する
+        let variants = [
+            PdfObject::Null,
+            PdfObject::Boolean(true),
+            PdfObject::Integer(0),
+            PdfObject::Real(0.0),
+            PdfObject::String(b"abc".to_vec()),
+            PdfObject::Name(PdfName::from("Type")),
+            PdfObject::Array(vec![PdfObject::Integer(1)]),
+            PdfObject::Dictionary(PdfDictionary::new()),
+        ];
+        for obj in &variants {
+            assert_eq!(obj.as_reference(), None);
+        }
+    }
+
+    #[test]
+    fn same_inner_references_are_equal() {
+        // 同一 IndirectRef を内包する Reference 同士は == で等価になることを確認する
+        assert_eq!(
+            PdfObject::Reference(make_ref(7, 3)),
+            PdfObject::Reference(make_ref(7, 3))
+        );
+    }
+
+    #[test]
+    fn different_inner_references_are_not_equal() {
+        // 内包 IndirectRef が異なる Reference 同士は != で非等価になることを確認する
+        // generation 差異・object_number 差異の両軸で非等価になることを確認する（片フィールド依存でないことを保証）
+        assert_ne!(
+            PdfObject::Reference(make_ref(7, 3)),
+            PdfObject::Reference(make_ref(7, 4))
+        );
+        assert_ne!(
+            PdfObject::Reference(make_ref(7, 3)),
+            PdfObject::Reference(make_ref(8, 3))
+        );
+    }
+
+    #[test]
+    fn debug_format_contains_reference_variant_name() {
+        // Debug 出力が Reference のバリアント名を含むことを確認する
+        assert!(format!("{:?}", PdfObject::Reference(make_ref(1, 0))).contains("Reference"));
     }
 }

--- a/rust/crates/core/src/object/pdf_object.rs
+++ b/rust/crates/core/src/object/pdf_object.rs
@@ -51,7 +51,7 @@ pub enum PdfObject {
     /// 値に `Real(NaN)` を含むと辞書同士は `==` で非等価になる（`Eq` 非実装の
     /// 根拠が再帰的に維持される）。
     Dictionary(PdfDictionary),
-    /// 間接参照オブジェクト（`N G R`）。`IndirectRef`（#073）をそのまま内包する。
+    /// 間接参照オブジェクト（`N G R`）。`IndirectRef`（#266）をそのまま内包する。
     ///
     /// `IndirectRef` は `Copy` 値型（ヒープ確保なし）。参照先の存在・妥当性
     /// 検証は行わず、無検証で忠実に保持する（解決は xref レイヤ R2 に委譲）。


### PR DESCRIPTION
## 概要

PDF の間接参照（`N G R`）を表す `IndirectRef` 型を `pdfmod-core` に追加し、`PdfObject` に `Reference(IndirectRef)` バリアントとアクセサ `as_reference` を加えます。後続のオブジェクト解決（Epic R2）の入力となる土台を提供します。

## 変更内容

### 🎯 変更の種類

- [x] ✨ 新機能 (New feature)

### 📝 詳細な変更内容

#### 追加された機能・修正

- `IndirectRef` 型: 参照先を `ObjectId`（#258）で `Copy` 内包する newtype 風 struct。生成は無検証（infallible）・derive は最小（`Debug, Clone, Copy, PartialEq, Eq, Hash`。`PartialOrd`/`Ord` は付けない）。アクセサは `new(ObjectId)` と `target(&self) -> ObjectId` のみ（委譲アクセサは付けず `target().object_number()` 等で到達）
- `PdfObject::Reference(IndirectRef)` バリアントと `as_reference(&self) -> Option<IndirectRef>`（`Copy` 値返し・型一致時 `Some`・不一致時 `None`）
- 妥当性検証は行わず、参照先の存在・世代の検証は後続の xref レイヤ（R2）に委譲

#### 変更されたファイル

- `rust/crates/core/src/object/indirect_ref.rs` [NEW]: `IndirectRef` 型本体＋ colocated ユニットテスト
- `rust/crates/core/src/object.rs`: `pub mod indirect_ref;`（アルファベット順）追加・モジュール doc の予告を更新
- `rust/crates/core/src/object/pdf_object.rs`: `Reference` バリアント・`as_reference` 追加、既存網羅テストへの `Reference` 組み込み（`all_distinct_variants` を全 9 バリアントへ拡張）・`Reference` 専用テスト追加・enum/モジュール doc 更新

#### 削除されたファイル・機能

- なし

## 📊 システム図

### データフロー

```mermaid
flowchart TD
    ON["ObjectNumber::new(u64)"] --> OID
    GN["GenerationNumber::new(u16)"] --> OID
    OID["ObjectId::new (無検証)"] --> IR["IndirectRef::new(target) [NEW]"]
    IR --> REF["PdfObject::Reference(IndirectRef) [NEW]"]
    REF -->|"as_reference() [NEW]"| OPT["Option&lt;IndirectRef&gt; (Copy 値返し)"]
    OPT -->|Some| TGT["ir.target() -> ObjectId"]
    TGT --> NUM["object_number() / generation_number()"]

    classDef new fill:#ffe4b5,stroke:#d97706,stroke-width:2px
    class IR,REF new
```

すべて `Copy` 値型でヒープ確保ゼロ。`as_reference` は `Reference` のみ `Some(*r)`、他 8 バリアントは `_ => None` フォールバック。

## 📋 関連 Issue

- Closes #266
- Refs #251 (Epic: Rust Phase R0 基盤オブジェクトモデル)

## 🧪 テスト

### テスト実行方法

```bash
cd rust && cargo test -p pdfmod-core
```

### テスト項目

- [x] 単体テスト (Unit tests)

### テスト結果

- `cargo test -p pdfmod-core`: **186 passed; 0 failed**（`indirect_ref.rs` 12 件・`pdf_object.rs` の `Reference` 関連／既存網羅拡張を含む）
- `cargo clippy --all-targets -- -D warnings`: 警告ゼロ
- `cargo fmt --check`: 差分なし
- `cargo build`: 成功
- 外部 crate 依存ゼロ（`[dependencies]` 空・`std` のみ）を維持

検証観点: 構築/`target` ラウンドトリップ・値型挙動（Copy/Eq/Hash/Debug）・境界値 `(0,0)`/`(u64::MAX, u16::MAX)`・object_number/generation の両軸非等価・`HashSet`/`HashMap` キー・`as_reference` の Some/None・既存アクセサが `Reference` で `None`・全 9 バリアント総当たり非等価。

## 🔍 レビューポイント

- 設計判断（最小 derive・`PartialOrd`/`Ord` 非採用・委譲アクセサ非採用・無検証構築）は意図的選択です（exploration 後ヒアリングで確定）。隣接 `object_id.rs` の確立パターンを縮小適用しています
- `PdfObject` enum へのバリアント追加は理論上は破壊的ですが、`#[non_exhaustive]` なし・外部消費ゼロ・既存アクセサは `_ => None` フォールバックのため実質非破壊です

## ⚠️ 破壊的変更

- [ ] この変更は既存の API に破壊的変更を含みます

（実質非破壊。詳細はレビューポイント参照）

## ✅ チェックリスト

- [x] テストが正常に実行される（186 passed / clippy・fmt クリーン）
- [x] コミットメッセージが適切な形式で書かれている
- [x] セルフレビューを実施した（spec-based-code-review 4 エージェント＋ Codex レビュー実施・指摘対応済み）
- [x] 関連 Issue を本文に記載