### PR TITLE
✨ [New Feature]: #293 T* operator handler (tStarHandler) を実装

### DIFF
--- a/packages/core/src/content-stream/operators/text/t-star/__tests__/t-star.basic.test.ts
+++ b/packages/core/src/content-stream/operators/text/t-star/__tests__/t-star.basic.test.ts
@@ -1,0 +1,225 @@
+import { assert, expect, test } from "vitest";
+import type { PdfObject } from "../../../../../pdf/types/pdf-types/index";
+import {
+  GraphicsState,
+  GraphicsStateStack,
+  Matrix,
+  TextObject,
+  TextState,
+} from "../../../../graphics-state/index";
+import { OperandStack } from "../../../../operand-stack/index";
+import type { OperatorHandlerContext } from "../../../../operator-registry/index";
+import { tStarHandler } from "../index";
+
+// leading / textObject を仕込んだ active コンテキストを組むビルダ。
+// （td-leading.basic.test.ts の buildActiveContext を leading 注入可能に拡張）
+const buildActiveContext = (
+  operands: PdfObject[],
+  leading: number,
+  textObject: TextObject = TextObject.begin(),
+): OperatorHandlerContext => {
+  const operandStack = OperandStack.create();
+  for (const operand of operands) {
+    OperandStack.push(operandStack, operand);
+  }
+  const activeState = GraphicsState.update(GraphicsState.create(), {
+    textObject,
+    textState: TextState.update(TextState.create(), { leading }),
+  });
+  const graphicsStateStack = GraphicsStateStack.replaceCurrent(
+    GraphicsStateStack.create(),
+    activeState,
+  );
+  return { operandStack, graphicsStateStack };
+};
+
+// active かつ任意の Tm / Tlm を持つ TextObject を生で組むヘルパ（dirty state 構築用）。
+// text-object.positioning.test.ts の buildActive と同一の確立パターン。
+const buildDirtyTextObject = (
+  textMatrix: Matrix,
+  textLineMatrix: Matrix,
+): TextObject =>
+  ({
+    active: true,
+    textMatrix,
+    textLineMatrix,
+  }) as unknown as TextObject;
+
+const int = (value: number): PdfObject => ({ type: "integer", value });
+
+test("leading=14 で T* を実行すると両 matrix が translate(0, -14) になる", () => {
+  // BT 直後（Tm=Tlm=identity）に TL 14 相当の leading が設定された状態で
+  // T* が 0 -TL Td 相当の行送り（0, -14）を適用すること
+  const context = buildActiveContext([], 14);
+
+  const result = tStarHandler(context);
+
+  assert(result.ok);
+  const current = GraphicsStateStack.current(result.value.graphicsStateStack);
+  expect(current.textObject.textMatrix).toEqual(
+    Matrix.create(1, 0, 0, 1, 0, -14),
+  );
+  expect(current.textObject.textLineMatrix).toEqual(
+    Matrix.create(1, 0, 0, 1, 0, -14),
+  );
+});
+
+test("leading=14 のまま T* を 2 回連続実行すると f 成分が -28 に累積する", () => {
+  // 連続 T* は Tlm への translate 乗算が累積する（三角測量 — 固定値実装の排除）
+  const first = tStarHandler(buildActiveContext([], 14));
+  assert(first.ok);
+
+  const firstObject = GraphicsStateStack.current(
+    first.value.graphicsStateStack,
+  ).textObject;
+  const second = tStarHandler(buildActiveContext([], 14, firstObject));
+
+  assert(second.ok);
+  const current = GraphicsStateStack.current(second.value.graphicsStateStack);
+  expect(current.textObject.textMatrix).toEqual(
+    Matrix.create(1, 0, 0, 1, 0, -28),
+  );
+  expect(current.textObject.textLineMatrix).toEqual(
+    Matrix.create(1, 0, 0, 1, 0, -28),
+  );
+});
+
+test("負の leading=-10 で T* を実行すると上方向 translate(0, 10) に移動する", () => {
+  // leading の符号反転（-leading）により負の leading は上方向移動になること
+  const context = buildActiveContext([], -10);
+
+  const result = tStarHandler(context);
+
+  assert(result.ok);
+  const current = GraphicsStateStack.current(result.value.graphicsStateStack);
+  expect(current.textObject.textMatrix).toEqual(
+    Matrix.create(1, 0, 0, 1, 0, 10),
+  );
+  expect(current.textObject.textLineMatrix).toEqual(
+    Matrix.create(1, 0, 0, 1, 0, 10),
+  );
+});
+
+test("Tm=Tlm=[1,0,0,1,72,720] の起点から leading=14 の T* で f 成分が 706 になる", () => {
+  // Tlm 非 identity 起点でも translate(0, -TL) × Tlm の乗算方向で累積すること（回帰検出）
+  const origin = Matrix.create(1, 0, 0, 1, 72, 720);
+  const context = buildActiveContext(
+    [],
+    14,
+    buildDirtyTextObject(origin, origin),
+  );
+
+  const result = tStarHandler(context);
+
+  assert(result.ok);
+  const current = GraphicsStateStack.current(result.value.graphicsStateStack);
+  expect(current.textObject.textMatrix).toEqual(
+    Matrix.create(1, 0, 0, 1, 72, 706),
+  );
+  expect(current.textObject.textLineMatrix).toEqual(
+    Matrix.create(1, 0, 0, 1, 72, 706),
+  );
+});
+
+test("成功時に operandStack は同一参照で返る", () => {
+  // T* は operand を取らないため operand stack に一切触れず同一参照のまま返すこと
+  const context = buildActiveContext([], 14);
+
+  const result = tStarHandler(context);
+
+  assert(result.ok);
+  expect(result.value.operandStack).toBe(context.operandStack);
+});
+
+test("成功時に text object は active のまま維持される", () => {
+  // translateLine が active を引き継ぐため T* 後も text object が閉じないこと
+  const context = buildActiveContext([], 14);
+
+  const result = tStarHandler(context);
+
+  assert(result.ok);
+  const current = GraphicsStateStack.current(result.value.graphicsStateStack);
+  expect(TextObject.isActive(current.textObject)).toBe(true);
+});
+
+test("成功時に textState の leading は更新されず実行前と同値のまま", () => {
+  // TD と異なり T* は leading を参照するのみで textState を更新しないこと（差分仕様の pin down）
+  const context = buildActiveContext([], 14);
+
+  const result = tStarHandler(context);
+
+  assert(result.ok);
+  const current = GraphicsStateStack.current(result.value.graphicsStateStack);
+  expect(current.textState.leading).toBe(14);
+});
+
+test("成功時、渡した context 側の graphics state は変更されない（不変更新）", () => {
+  // mutate ではなく新インスタンス生成で更新するため、実行前の current は不変であり、
+  // 入力スタック自体も差し替えられず新スタックのみが更新されること
+  const context = buildActiveContext([], 14);
+  const currentBefore = GraphicsStateStack.current(context.graphicsStateStack);
+
+  const result = tStarHandler(context);
+
+  assert(result.ok);
+  expect(currentBefore.textObject.textMatrix).toEqual(Matrix.identity());
+  expect(currentBefore.textObject.textLineMatrix).toEqual(Matrix.identity());
+  // 実行後も入力スタックの current は実行前のインスタンスのまま（スタック自体が mutate されていない）
+  expect(GraphicsStateStack.current(context.graphicsStateStack)).toBe(
+    currentBefore,
+  );
+  // 返却されたスタックは入力スタックとは別の新インスタンスであること
+  expect(result.value.graphicsStateStack).not.toBe(context.graphicsStateStack);
+});
+
+test("leading=0（default）・begin 直後で T* を実行しても両 matrix は identity のまま", () => {
+  // TextState.create() の default leading=0 では translate(0, 0) の no-op 相当になること
+  const context = buildActiveContext([], 0);
+
+  const result = tStarHandler(context);
+
+  assert(result.ok);
+  const current = GraphicsStateStack.current(result.value.graphicsStateStack);
+  expect(current.textObject.textMatrix).toEqual(Matrix.identity());
+  expect(current.textObject.textLineMatrix).toEqual(Matrix.identity());
+});
+
+test("leading=0・dirty state（Tm≠Tlm）で T* を実行すると Tlm は不変・Tm が Tlm にリセットされる", () => {
+  // translateLine(0, 0) は Tlm 不変だが Tm を Tlm に揃える。「matrix 不変」は
+  // begin 直後の文脈でのみ正確であり、dirty state ではリセットが起きることを T* レベルで pin down する
+  const dirtyTm = Matrix.create(5, 0, 0, 5, 1, 2);
+  const lineTlm = Matrix.create(1, 0, 0, 1, 72, 720);
+  const context = buildActiveContext(
+    [],
+    0,
+    buildDirtyTextObject(dirtyTm, lineTlm),
+  );
+
+  const result = tStarHandler(context);
+
+  assert(result.ok);
+  const current = GraphicsStateStack.current(result.value.graphicsStateStack);
+  // Tlm は不変であること
+  expect(current.textObject.textLineMatrix).toEqual(lineTlm);
+  // Tm は Tlm と同値にリセットされること
+  expect(current.textObject.textMatrix).toEqual(lineTlm);
+});
+
+test("operand stack に余剰要素があっても pop せず行送りは通常どおり成功する", () => {
+  // T* は operand を取らないため、余剰要素は depth 不変・スタック先頭もそのままで
+  // graphics state の更新だけが行われること
+  const context = buildActiveContext([int(99), int(7)], 14);
+
+  const result = tStarHandler(context);
+
+  assert(result.ok);
+  expect(result.value.operandStack).toBe(context.operandStack);
+  expect(OperandStack.depth(result.value.operandStack)).toBe(2);
+  const top = OperandStack.peek(result.value.operandStack);
+  assert(top.some);
+  expect(top.value).toEqual(int(7));
+  const current = GraphicsStateStack.current(result.value.graphicsStateStack);
+  expect(current.textObject.textMatrix).toEqual(
+    Matrix.create(1, 0, 0, 1, 0, -14),
+  );
+});

--- a/packages/core/src/content-stream/operators/text/t-star/__tests__/t-star.error.test.ts
+++ b/packages/core/src/content-stream/operators/text/t-star/__tests__/t-star.error.test.ts
@@ -1,0 +1,113 @@
+import { assert, expect, test } from "vitest";
+import type { PdfObject } from "../../../../../pdf/types/pdf-types/index";
+import {
+  GraphicsState,
+  GraphicsStateStack,
+  Matrix,
+  TextObject,
+  TextState,
+} from "../../../../graphics-state/index";
+import { OperandStack } from "../../../../operand-stack/index";
+import type { OperatorHandlerContext } from "../../../../operator-registry/index";
+import { tStarHandler } from "../index";
+
+// text object が inactive なコンテキストを operand 付きで組むビルダ。
+// （default の GraphicsStateStack.create() は textObject 非 active）
+const buildInactiveContext = (
+  operands: PdfObject[] = [],
+): OperatorHandlerContext => {
+  const operandStack = OperandStack.create();
+  for (const operand of operands) {
+    OperandStack.push(operandStack, operand);
+  }
+  const graphicsStateStack = GraphicsStateStack.create();
+  return { operandStack, graphicsStateStack };
+};
+
+const int = (value: number): PdfObject => ({ type: "integer", value });
+
+// inactive (active=false) かつ matrix が非 identity・leading が非 default の context。
+// et.error.test.ts の buildInactiveNonIdentityContext と同一の生リテラル構築パターン。
+// ガードを通らず translateLine が誤って呼ばれた場合に matrix が変化することを検出するための fixture。
+const NON_IDENTITY_MATRIX = Matrix.create(2, 0, 0, 2, 10, 20);
+const buildInactiveNonIdentityContext = (): OperatorHandlerContext => {
+  const operandStack = OperandStack.create();
+  const inactiveNonIdentity = {
+    active: false,
+    textMatrix: NON_IDENTITY_MATRIX,
+    textLineMatrix: NON_IDENTITY_MATRIX,
+  } as unknown as TextObject;
+  const state = GraphicsState.update(GraphicsState.create(), {
+    textObject: inactiveNonIdentity,
+    textState: TextState.update(TextState.create(), { leading: 14 }),
+  });
+  const graphicsStateStack = GraphicsStateStack.replaceCurrent(
+    GraphicsStateStack.create(),
+    state,
+  );
+  return { operandStack, graphicsStateStack };
+};
+
+test("inactive な state で T* を実行すると OPERATOR_ILLEGAL_STATE を返す", () => {
+  // BT/ET の外（textObject 非 active）で T* が出現したとき illegal state として失敗すること
+  const context = buildInactiveContext();
+
+  const result = tStarHandler(context);
+
+  assert(!result.ok);
+  expect(result.error.code).toBe("OPERATOR_ILLEGAL_STATE");
+});
+
+test("inactive な state で T* を実行したときエラーの operatorName が T* である", () => {
+  // エラーに反映される operator 名が PDF 表記の "T*" であること
+  const context = buildInactiveContext();
+
+  const result = tStarHandler(context);
+
+  assert(!result.ok);
+  assert(result.error.code === "OPERATOR_ILLEGAL_STATE");
+  expect(result.error.operatorName).toBe("T*");
+});
+
+test("inactive な state で T* を実行したときエラーの message が BT/ET 外を示す", () => {
+  // ユーザー向けに BT/ET 外であることを説明する固定メッセージを返すこと
+  const context = buildInactiveContext();
+
+  const result = tStarHandler(context);
+
+  assert(!result.ok);
+  expect(result.error.message).toBe(
+    "T*: text object is not active (T* must appear within BT/ET)",
+  );
+});
+
+test("エラー時 operand stack は変更されない（depth・内容とも実行前と同値）", () => {
+  // エラー時は新 context が返らないため、渡した context.operandStack を直接検証する。
+  // T* は operand を取らないため illegal state でも pop が一切起きないこと
+  const context = buildInactiveContext([int(99), int(7)]);
+
+  const result = tStarHandler(context);
+
+  assert(!result.ok);
+  expect(OperandStack.depth(context.operandStack)).toBe(2);
+  const top = OperandStack.peek(context.operandStack);
+  assert(top.some);
+  expect(top.value).toEqual(int(7));
+});
+
+test("エラー時 graphics state stack は差し替えられず current が変更されない", () => {
+  // ガードの early-return により replaceCurrent が呼ばれず、非 identity の matrix と
+  // 非 default の textState（leading=14）がそのまま保持されること（et.error.test.ts パターン）
+  const context = buildInactiveNonIdentityContext();
+  const stackBefore = context.graphicsStateStack;
+
+  const result = tStarHandler(context);
+
+  assert(!result.ok);
+  expect(context.graphicsStateStack).toBe(stackBefore);
+  const current = GraphicsStateStack.current(context.graphicsStateStack);
+  expect(current.textObject.textMatrix).toEqual(NON_IDENTITY_MATRIX);
+  expect(current.textObject.textLineMatrix).toEqual(NON_IDENTITY_MATRIX);
+  expect(current.textState.leading).toBe(14);
+  expect(TextObject.isActive(current.textObject)).toBe(false);
+});

--- a/packages/core/src/content-stream/operators/text/t-star/index.ts
+++ b/packages/core/src/content-stream/operators/text/t-star/index.ts
@@ -1,0 +1,63 @@
+import type { PdfError } from "../../../../pdf/errors/index";
+import { err, ok } from "../../../../utils/result/index";
+import {
+  GraphicsState,
+  GraphicsStateStack,
+  TextObject,
+} from "../../../graphics-state/index";
+import type {
+  OperatorHandler,
+  OperatorHandlerContext,
+} from "../../../operator-registry/index";
+
+/** PDF 表記を保持した operator 名（"T*"）。 */
+const OPERATOR_NAME = "T*";
+
+/**
+ * PDF §9.4.2 `T*` operator (Move to start of next line) のハンドラ。
+ *
+ * `0 -TL Td` と等価。current の `textState.leading` を参照し、
+ * `TextObject.translateLine(textObject, 0, -leading)` でテキスト行列を
+ * 次行頭へ移動する（`Tlm' = translate(0, -TL) × Tlm`、`Tm' = Tlm'`）。
+ * `T*` は BT 〜 ET の内側でのみ有効。引数を取らないため operand stack を
+ * pop / 検証 / clear せず同一参照のまま返す。
+ *
+ * 検査順序（厳守）:
+ *   (1) active 検査（false なら `OPERATOR_ILLEGAL_STATE` を返す）
+ *
+ * - operand 数: 0（operand stack を一切消費しない）
+ * - text object が active でない場合は `OPERATOR_ILLEGAL_STATE` を返す
+ *   （operand stack / graphics state stack は変更しない）
+ * - エラー時に operand stack は変更されない（pop を行わないため復元も不要）
+ * - `leading` は参照のみで textState は更新しない（`TD` との差分）
+ * - `leading` の値域（`NaN` / `Infinity`）は本 handler では検証しない
+ *   （`TD` が設定した値をそのまま使う）
+ *
+ * @param context - 実行コンテキスト (operand stack / graphics state stack)
+ * @returns 成功なら更新後コンテキスト、失敗なら PdfError
+ */
+export const tStarHandler: OperatorHandler = (
+  context: OperatorHandlerContext,
+) => {
+  const current = GraphicsStateStack.current(context.graphicsStateStack);
+  if (!TextObject.isActive(current.textObject)) {
+    const error: PdfError = {
+      code: "OPERATOR_ILLEGAL_STATE",
+      message: "T*: text object is not active (T* must appear within BT/ET)",
+      operatorName: OPERATOR_NAME,
+    };
+    return err(error);
+  }
+
+  const leading = current.textState.leading;
+  const textObject = TextObject.translateLine(current.textObject, 0, -leading);
+  const next = GraphicsState.update(current, { textObject });
+  const graphicsStateStack = GraphicsStateStack.replaceCurrent(
+    context.graphicsStateStack,
+    next,
+  );
+  return ok({
+    operandStack: context.operandStack,
+    graphicsStateStack,
+  });
+};


### PR DESCRIPTION
## 概要

PDF §9.4.2 `T*`（move to start of next line）オペレータのハンドラ `tStarHandler` を `@pdfmod/core` に追加します。`T*` は operand を 0 個取り `0 -TL Td` と等価で、`textState.leading` を参照して `TextObject.translateLine(0, -leading)` によりテキスト行列を次行頭へ移動します（Phase 4-E テキスト位置決め系オペレータの一部）。

## 変更内容

### 🎯 変更の種類

- [x] ✨ 新機能 (New feature)
- [x] 🚨 テスト追加/修正 (Tests)

### 📝 詳細な変更内容

#### 追加された機能・修正

- `tStarHandler`: active 検査 → `leading` 参照 → `translateLine(0, -leading)` → `GraphicsState.update` → `replaceCurrent` → `ok` の 0-operand ハンドラ
- inactive な text object では `OPERATOR_ILLEGAL_STATE`（`operatorName: "T*"`）を `err` で返却（throw 不使用・`Result` 規約準拠）
- operand stack は pop / 検証 / clear せず同一参照のまま返却（bt/et と同一の 0-operand 規約）
- `TD` と異なり `textState` は更新しない（`leading` は参照のみ）
- `"T*"` のレジストリ登録は含まない（#294 `registerTextPositioningOperators` に委譲 — 既存ファイルへの変更ゼロ）

#### 変更されたファイル

- `packages/core/src/content-stream/operators/text/t-star/index.ts` [NEW]
- `packages/core/src/content-stream/operators/text/t-star/__tests__/t-star.basic.test.ts` [NEW]（正常系・境界値 11 テスト）
- `packages/core/src/content-stream/operators/text/t-star/__tests__/t-star.error.test.ts` [NEW]（異常系 5 テスト）

#### 削除されたファイル・機能

- なし

## 📊 システム図

### 状態マシン / フロー図

```mermaid
flowchart TD
    Start([T* 実行 — operand 0 個]) --> ReadCurrent[GraphicsStateStack.current]:::new
    ReadCurrent --> CheckActive{TextObject.isActive?}:::new
    CheckActive -->|false| Error["err(OPERATOR_ILLEGAL_STATE)<br/>operand / graphics state stack 不変"]:::new
    CheckActive -->|true| ReadLeading["leading = textState.leading<br/>（参照のみ・textState 非更新）"]:::new
    ReadLeading --> Translate["TextObject.translateLine(0, -leading)<br/>Tlm' = translate(0,-TL) × Tlm、Tm' = Tlm'"]:::new
    Translate --> Update["GraphicsState.update({ textObject })"]:::new
    Update --> Replace[GraphicsStateStack.replaceCurrent]:::new
    Replace --> Ok(["ok({ operandStack: 同一参照, graphicsStateStack: 新スタック })"]):::new

    classDef new fill:#ffe4b5,stroke:#d97706,stroke-width:2px
```

※ `leading=0` でも `translateLine(0, 0)` を無条件適用します（Tlm 不変・Tm が Tlm にリセットされる仕様を dirty state まで pin down 済み — early return は誤最適化）。

## 📋 関連 Issue

- Closes #293
- Relates to #288（親 Epic）/ #294（レジストリ登録の後続 Issue）

## 🧪 テスト

### テスト実行方法

```bash
pnpm --filter @pdfmod/core test
```

### テスト項目

- [x] 単体テスト (Unit tests)
- [ ] 統合テスト (Integration tests)
- [ ] E2E テスト (End-to-end tests)
- [x] 手動テスト (Manual testing) — git status による変更スコープ確認・レジストリ未登録確認

### テスト結果

- t-wada 式 TDD（Red-Green-Refactor 8 サイクル）で実装。t-star 16 テストを含む全 2503 テスト green
- `pnpm --filter @pdfmod/core build` 成功、`pnpm lint` / `pnpm typecheck` エラーなし
- AIレビュー: codex（指摘なし）+ spec-based-code-review 4 エージェント（最終: CRITICAL 0 / WARNING 0）

## 🔍 レビューポイント

- `leading=0` の仕様 pin down: begin 直後は matrix 不変、Tm≠Tlm の dirty state では Tm が Tlm にリセットされる（`translateLine(0,0)` 仕様の T* レベル固定）
- 成功パスの不変更新検証: 入力スタックの current 参照同一性（`toBe`）と返却スタックの非同一性（`not.toBe`）で「mutate なし・新スタックのみ更新」を固定
- `"T*"` がレジストリ未登録のままであること（#294 スコープの不侵食）

## ⚠️ 破壊的変更

- [ ] この変更は既存の API に破壊的変更を含みます

純粋な追加のみ（既存 export / 型シグネチャの変更なし）。ロールバックは新規ファイル削除のみ。

## ✅ チェックリスト

- [x] コードレビューの準備ができている
- [x] テストが正常に実行される
- [x] ドキュメントが更新されている（必要に応じて — JSDoc 完備）
- [x] コミットメッセージが適切な形式で書かれている
- [ ] 関連する Issue が PR の「Development」に Linked されている
- [x] PR 本文に `Closes #` / `Refs #` で Issue が記載されている
- [x] セルフレビューを実施した
- [x] 破壊的変更がある場合は明記されている

🤖 Generated with [Claude Code](https://claude.com/claude-code)