### PR TITLE
✨ [New Feature]: #267 PdfStream 型と PdfObject::Stream バリアントを追加

### DIFF
--- a/rust/crates/core/src/object.rs
+++ b/rust/crates/core/src/object.rs
@@ -1,11 +1,11 @@
 //! PDF オブジェクト型を定義するモジュール。
 //!
 //! ISO 32000 の PDF オブジェクト（null / boolean / numeric / string / name /
-//! array / dictionary / stream / indirect reference）を表す。現時点では
+//! array / dictionary / stream / indirect reference）を表す。
 //! `PdfObject`（null / boolean / integer / real / string / name / array /
-//! dictionary / reference）と、補助の newtype（`PdfName` / `PdfDictionary` /
-//! `ObjectId` / `ObjectNumber` / `GenerationNumber` / `IndirectRef`）を提供し、
-//! stream は後続 Issue で追加する。
+//! dictionary / stream / reference）と、補助の型（`PdfName` / `PdfDictionary` /
+//! `PdfStream` / `ObjectId` / `ObjectNumber` / `GenerationNumber` /
+//! `IndirectRef`）を提供する。
 
 pub mod dictionary;
 pub mod generation_number;
@@ -14,5 +14,4 @@ pub mod name;
 pub mod object_id;
 pub mod object_number;
 pub mod pdf_object;
-
-// stream は後続 Issue で対応する型・サブモジュールを追加する。
+pub mod stream;

--- a/rust/crates/core/src/object/dictionary.rs
+++ b/rust/crates/core/src/object/dictionary.rs
@@ -3,7 +3,7 @@
 //! キーは `PdfName`（#261）、値は `PdfObject`（#262）。内部表現は
 //! `BTreeMap<PdfName, PdfObject>` で、キーがソート順に並ぶため出力が決定的になり
 //! テストが安定する（`HashMap` の順序非決定・`Vec` の O(n) ルックアップは不採用）。
-//! 後続の `PdfObject` 辞書ケース（#265）や `PdfStream`（#267）の辞書部の基盤となる。
+//! `PdfObject` の辞書ケース（#265）や `PdfStream`（#267）の辞書部の基盤である。
 //!
 //! 生成・挿入は無検証（infallible）。null エントリの正規化や妥当性検証は
 //! 上位（lexer/parser）の責務であり、本型はストレージ + アクセサのみを担う。

--- a/rust/crates/core/src/object/pdf_object.rs
+++ b/rust/crates/core/src/object/pdf_object.rs
@@ -3,15 +3,16 @@
 //! ISO 32000-1 §7.3 の PDF オブジェクトを 1 つの enum で表す。現時点では
 //! スカラ系 4 バリアント（Null / Boolean / Integer / Real）に加え、文字列
 //! （復号後の生バイト列）・名前（`PdfName`）・配列（`Vec<PdfObject>` の自己再帰）・
-//! 辞書（`PdfDictionary`）・参照（`IndirectRef`）を定義する。ストリームは後続 Issue で追加する。
+//! 辞書（`PdfDictionary`）・ストリーム（`PdfStream`）・参照（`IndirectRef`）を定義する。
 //! 構築は無検証（infallible）で、テキスト解釈や妥当性検証・正規化は上位
 //! （lexer/parser）に委譲する。
 
 use crate::object::dictionary::PdfDictionary;
 use crate::object::indirect_ref::IndirectRef;
 use crate::object::name::PdfName;
+use crate::object::stream::PdfStream;
 
-/// PDF 基本オブジェクト（スカラ系・文字列・名前・配列・辞書・参照バリアントを表す enum）。
+/// PDF 基本オブジェクト（スカラ系・文字列・名前・配列・辞書・ストリーム・参照バリアントを表す enum）。
 ///
 /// 整数幅は `i64`、浮動小数点幅は `f64`（PDF パーサで最も一般的・桁あふれ耐性・
 /// 後続レクサーとの相性で確定）。`Real(f64)` を含むため `Eq`/`Hash`/`Ord` は
@@ -51,6 +52,14 @@ pub enum PdfObject {
     /// 値に `Real(NaN)` を含むと辞書同士は `==` で非等価になる（`Eq` 非実装の
     /// 根拠が再帰的に維持される）。
     Dictionary(PdfDictionary),
+    /// ストリームオブジェクト。`PdfStream`（#267）をそのまま内包する。
+    ///
+    /// 生バイトは無検証・無復号で忠実に保持し、フィルタ復号や `/Length` 整合性
+    /// 検証は後続フェーズ（lexer/parser 層）に委譲する。ISO 32000-1 §7.3.8 の
+    /// 「stream は間接オブジェクトでなければならない」という制約は本 enum では
+    /// 型表現せず、上位レイヤで担保する。辞書部の値に `Real(NaN)` を含むと
+    /// ストリーム同士は `==` で非等価になる（`Eq` 非実装の根拠が再帰的に維持される）。
+    Stream(PdfStream),
     /// 間接参照オブジェクト（`N G R`）。`IndirectRef`（#266）をそのまま内包する。
     ///
     /// `IndirectRef` は `Copy` 値型（ヒープ確保なし）。参照先の存在・妥当性
@@ -130,6 +139,16 @@ impl PdfObject {
         }
     }
 
+    /// `Stream` のとき内部の `PdfStream` を `&PdfStream` として `Some` で取り出す（他は `None`）。
+    ///
+    /// ヒープ保持のため参照返し（`as_dictionary` の `&PdfDictionary` 返しと同方針）。
+    pub fn as_stream(&self) -> Option<&PdfStream> {
+        match self {
+            Self::Stream(stream) => Some(stream),
+            _ => None,
+        }
+    }
+
     /// `Reference` のとき内部の `IndirectRef` を `Some` で取り出す（他は `None`）。
     ///
     /// `IndirectRef` は `Copy` なので値返し（`as_bool`/`as_integer` と同方針）。
@@ -154,6 +173,11 @@ mod tests {
             ObjectNumber::new(n),
             GenerationNumber::new(g),
         ))
+    }
+
+    // テスト用に空辞書 + 指定データの PdfStream を構築するヘルパ
+    fn make_stream(data: &[u8]) -> PdfStream {
+        PdfStream::new(PdfDictionary::new(), data)
     }
 
     #[test]
@@ -231,11 +255,12 @@ mod tests {
 
     #[test]
     fn as_bool_returns_none_for_non_boolean_variants() {
-        // Boolean 以外（Null/Integer/Real/Reference）では as_bool() が None を返すことを確認する
+        // Boolean 以外（Null/Integer/Real/Stream/Reference）では as_bool() が None を返すことを確認する
         for obj in &[
             PdfObject::Null,
             PdfObject::Integer(0),
             PdfObject::Real(0.0),
+            PdfObject::Stream(make_stream(b"data")),
             PdfObject::Reference(make_ref(1, 0)),
         ] {
             assert_eq!(obj.as_bool(), None);
@@ -244,11 +269,12 @@ mod tests {
 
     #[test]
     fn as_integer_returns_none_for_non_integer_variants() {
-        // Integer 以外（Null/Boolean/Real/Reference）では as_integer() が None を返すことを確認する
+        // Integer 以外（Null/Boolean/Real/Stream/Reference）では as_integer() が None を返すことを確認する
         for obj in &[
             PdfObject::Null,
             PdfObject::Boolean(true),
             PdfObject::Real(0.0),
+            PdfObject::Stream(make_stream(b"data")),
             PdfObject::Reference(make_ref(1, 0)),
         ] {
             assert_eq!(obj.as_integer(), None);
@@ -257,11 +283,12 @@ mod tests {
 
     #[test]
     fn as_real_returns_none_for_non_real_variants() {
-        // Real 以外（Null/Boolean/Integer/Reference）では as_real() が None を返すことを確認する
+        // Real 以外（Null/Boolean/Integer/Stream/Reference）では as_real() が None を返すことを確認する
         for obj in &[
             PdfObject::Null,
             PdfObject::Boolean(true),
             PdfObject::Integer(0),
+            PdfObject::Stream(make_stream(b"data")),
             PdfObject::Reference(make_ref(1, 0)),
         ] {
             assert_eq!(obj.as_real(), None);
@@ -285,8 +312,8 @@ mod tests {
 
     #[test]
     fn all_distinct_variants_are_mutually_not_equal() {
-        // 全 9 バリアントを総当たりで比較し、同一インデックスのみ等価・他は非等価であることを確認する
-        // （NaN は等価判定が崩れるため代表値には含めない。String/Name/Array/Dictionary は有限値・
+        // 全 10 バリアントを総当たりで比較し、同一インデックスのみ等価・他は非等価であることを確認する
+        // （NaN は等価判定が崩れるため代表値には含めない。String/Name/Array/Dictionary/Stream は有限値・
         // Reference は Eq なので NaN 制約に抵触しない）
         let variants = [
             PdfObject::Null,
@@ -297,6 +324,7 @@ mod tests {
             PdfObject::Name(PdfName::from("Type")),
             PdfObject::Array(vec![PdfObject::Integer(1)]),
             PdfObject::Dictionary(PdfDictionary::new()),
+            PdfObject::Stream(PdfStream::new(PdfDictionary::new(), b"data")),
             PdfObject::Reference(make_ref(1, 0)),
         ];
         for (i, a) in variants.iter().enumerate() {
@@ -399,13 +427,14 @@ mod tests {
 
     #[test]
     fn as_string_returns_none_for_non_string_variants() {
-        // String 以外（Null/Boolean/Integer/Real/Name/Reference）では as_string() が None を返すことを確認する
+        // String 以外（Null/Boolean/Integer/Real/Name/Stream/Reference）では as_string() が None を返すことを確認する
         let variants = [
             PdfObject::Null,
             PdfObject::Boolean(true),
             PdfObject::Integer(0),
             PdfObject::Real(0.0),
             PdfObject::Name(PdfName::from("Type")),
+            PdfObject::Stream(make_stream(b"data")),
             PdfObject::Reference(make_ref(1, 0)),
         ];
         for obj in &variants {
@@ -415,13 +444,14 @@ mod tests {
 
     #[test]
     fn as_name_returns_none_for_non_name_variants() {
-        // Name 以外（Null/Boolean/Integer/Real/String/Reference）では as_name() が None を返すことを確認する
+        // Name 以外（Null/Boolean/Integer/Real/String/Stream/Reference）では as_name() が None を返すことを確認する
         let variants = [
             PdfObject::Null,
             PdfObject::Boolean(true),
             PdfObject::Integer(0),
             PdfObject::Real(0.0),
             PdfObject::String(b"abc".to_vec()),
+            PdfObject::Stream(make_stream(b"data")),
             PdfObject::Reference(make_ref(1, 0)),
         ];
         for obj in &variants {
@@ -587,7 +617,7 @@ mod tests {
 
     #[test]
     fn as_array_returns_none_for_non_array_variants() {
-        // Array 以外（Null/Boolean/Integer/Real/String/Name/Dictionary/Reference）では as_array() が None を返すことを確認する
+        // Array 以外（Null/Boolean/Integer/Real/String/Name/Dictionary/Stream/Reference）では as_array() が None を返すことを確認する
         let variants = [
             PdfObject::Null,
             PdfObject::Boolean(true),
@@ -596,6 +626,7 @@ mod tests {
             PdfObject::String(b"abc".to_vec()),
             PdfObject::Name(PdfName::from("Type")),
             PdfObject::Dictionary(PdfDictionary::new()),
+            PdfObject::Stream(make_stream(b"data")),
             PdfObject::Reference(make_ref(1, 0)),
         ];
         for obj in &variants {
@@ -605,7 +636,7 @@ mod tests {
 
     #[test]
     fn as_dictionary_returns_none_for_non_dictionary_variants() {
-        // Dictionary 以外（Null/Boolean/Integer/Real/String/Name/Array/Reference）では as_dictionary() が None を返すことを確認する
+        // Dictionary 以外（Null/Boolean/Integer/Real/String/Name/Array/Stream/Reference）では as_dictionary() が None を返すことを確認する
         let variants = [
             PdfObject::Null,
             PdfObject::Boolean(true),
@@ -614,6 +645,7 @@ mod tests {
             PdfObject::String(b"abc".to_vec()),
             PdfObject::Name(PdfName::from("Type")),
             PdfObject::Array(vec![PdfObject::Integer(1)]),
+            PdfObject::Stream(make_stream(b"data")),
             PdfObject::Reference(make_ref(1, 0)),
         ];
         for obj in &variants {
@@ -816,7 +848,7 @@ mod tests {
 
     #[test]
     fn as_reference_returns_none_for_non_reference_variants() {
-        // Reference 以外（Null/Boolean/Integer/Real/String/Name/Array/Dictionary）では as_reference() が None を返すことを確認する
+        // Reference 以外（Null/Boolean/Integer/Real/String/Name/Array/Dictionary/Stream）では as_reference() が None を返すことを確認する
         let variants = [
             PdfObject::Null,
             PdfObject::Boolean(true),
@@ -826,6 +858,7 @@ mod tests {
             PdfObject::Name(PdfName::from("Type")),
             PdfObject::Array(vec![PdfObject::Integer(1)]),
             PdfObject::Dictionary(PdfDictionary::new()),
+            PdfObject::Stream(make_stream(b"data")),
         ];
         for obj in &variants {
             assert_eq!(obj.as_reference(), None);
@@ -859,5 +892,98 @@ mod tests {
     fn debug_format_contains_reference_variant_name() {
         // Debug 出力が Reference のバリアント名を含むことを確認する
         assert!(format!("{:?}", PdfObject::Reference(make_ref(1, 0))).contains("Reference"));
+    }
+
+    #[test]
+    fn stream_constructs_and_matches_stream_arm() {
+        // Stream(PdfStream::new(...)) を構築し matches! で Stream 腕に入ることを確認する
+        let obj = PdfObject::Stream(make_stream(b"data"));
+        assert!(matches!(obj, PdfObject::Stream(_)));
+    }
+
+    #[test]
+    fn as_stream_returns_some_for_stream() {
+        // Stream に as_stream() を呼ぶと Some(&PdfStream) を返し内容が一致する（参照返し）ことを確認する
+        let stream = make_stream(b"data");
+        let obj = PdfObject::Stream(stream.clone());
+        assert_eq!(obj.as_stream(), Some(&stream));
+    }
+
+    #[test]
+    fn as_stream_returns_none_for_non_stream_variants() {
+        // Stream 以外（Null/Boolean/Integer/Real/String/Name/Array/Dictionary/Reference）では as_stream() が None を返すことを確認する
+        let variants = [
+            PdfObject::Null,
+            PdfObject::Boolean(true),
+            PdfObject::Integer(0),
+            PdfObject::Real(0.0),
+            PdfObject::String(b"abc".to_vec()),
+            PdfObject::Name(PdfName::from("Type")),
+            PdfObject::Array(vec![PdfObject::Integer(1)]),
+            PdfObject::Dictionary(PdfDictionary::new()),
+            PdfObject::Reference(make_ref(1, 0)),
+        ];
+        for obj in &variants {
+            assert_eq!(obj.as_stream(), None);
+        }
+    }
+
+    #[test]
+    fn as_stream_then_accessors_roundtrip() {
+        // as_stream().unwrap().dictionary() / .data() で構築時の辞書・バイト列が返る（後段借用経路）ことを確認する
+        let mut dict = PdfDictionary::new();
+        dict.insert(PdfName::from("Length"), PdfObject::Integer(4));
+        let obj = PdfObject::Stream(PdfStream::new(dict.clone(), b"body"));
+        let stream = obj.as_stream().unwrap();
+        assert_eq!(stream.dictionary(), &dict);
+        assert_eq!(stream.data(), b"body");
+    }
+
+    #[test]
+    fn same_content_streams_wrapped_are_equal() {
+        // 同内容の PdfStream を内包する Stream 同士は == で等価になることを確認する
+        assert_eq!(
+            PdfObject::Stream(make_stream(b"data")),
+            PdfObject::Stream(make_stream(b"data"))
+        );
+    }
+
+    #[test]
+    fn stream_and_dictionary_with_same_dictionary_are_not_equal() {
+        // 同一辞書を持つ Stream（空データ）と Dictionary は異バリアントのため != で非等価になることを確認する
+        let mut dict = PdfDictionary::new();
+        dict.insert(PdfName::from("Type"), PdfObject::Integer(1));
+        assert_ne!(
+            PdfObject::Stream(PdfStream::new(dict.clone(), b"")),
+            PdfObject::Dictionary(dict)
+        );
+    }
+
+    #[test]
+    fn stream_containing_nan_is_not_equal_to_itself_content() {
+        // 辞書値に Real(NaN) を含む Stream 同士は NaN != NaN が enum まで伝播し != になることを確認する
+        let mut dict_a = PdfDictionary::new();
+        dict_a.insert(PdfName::from("N"), PdfObject::Real(f64::NAN));
+        let mut dict_b = PdfDictionary::new();
+        dict_b.insert(PdfName::from("N"), PdfObject::Real(f64::NAN));
+        assert_ne!(
+            PdfObject::Stream(PdfStream::new(dict_a, b"data")),
+            PdfObject::Stream(PdfStream::new(dict_b, b"data"))
+        );
+    }
+
+    #[test]
+    fn clone_preserves_stream_and_keeps_original_usable() {
+        // Stream バリアントを clone() すると複製が元と == かつ元も引き続き使用可能なことを確認する
+        let original = PdfObject::Stream(make_stream(b"data"));
+        let cloned = original.clone();
+        assert_eq!(cloned, original);
+        assert_eq!(original.as_stream().unwrap().data(), b"data");
+    }
+
+    #[test]
+    fn debug_format_contains_stream_variant_name() {
+        // Debug 出力が Stream のバリアント名を含むことを確認する
+        assert!(format!("{:?}", PdfObject::Stream(make_stream(b"data"))).contains("Stream"));
     }
 }

--- a/rust/crates/core/src/object/stream.rs
+++ b/rust/crates/core/src/object/stream.rs
@@ -1,0 +1,219 @@
+//! PDF のストリームオブジェクト（stream）を表す `PdfStream` を定義するモジュール。
+//!
+//! 辞書部 `PdfDictionary`（#264）と生バイト列 `Vec<u8>` の組。生成は無検証
+//! （infallible）で、空辞書・空バイト列・NUL/非UTF-8 を含む任意のバイト列を
+//! 無条件に受理する。`/Length` と実データ長の整合性検証やフィルタ
+//! （`/FlateDecode` 等）による復号は上位（lexer/parser 層・後続フェーズ）に委譲する。
+//!
+//! 本モジュールは Issue #267（Phase R0）で追加された PDF オブジェクト層の基盤型。
+
+use crate::object::dictionary::PdfDictionary;
+
+/// PDF ストリームオブジェクト。辞書部と生バイト列（**復号前**）を内包する。
+///
+/// `PdfDictionary`（`Real(f64)` の `NaN != NaN` により `Eq` 非実装）を内包する
+/// ため `Eq`/`Hash`/`Ord` は derive できない。ヒープ保持（`BTreeMap` + `Vec<u8>`）
+/// のため `Copy` も不可。「空辞書 + 空データ」をデフォルト値として量産する意味が
+/// 薄いため `Default` も付けない（複合 struct の前例 `ObjectId`/`IndirectRef` と
+/// 同方針）。よって derive は `Debug, Clone, PartialEq` のみ。
+#[derive(Debug, Clone, PartialEq)]
+pub struct PdfStream {
+    dictionary: PdfDictionary,
+    data: Vec<u8>,
+}
+
+impl PdfStream {
+    /// 辞書部と生バイト列から `PdfStream` を生成する。
+    ///
+    /// 無検証（infallible）。空辞書・空バイト列・NUL/非UTF-8/高位バイトを含む
+    /// 任意のバイト列を無条件に受理する。`/Length` 整合性検証やフィルタ復号は
+    /// 上位（lexer/parser 層）に委譲する。`data` は `impl Into<Vec<u8>>` 受け
+    /// （`PdfName::new` と同方針。`b"..."` を直接渡せる）。`Vec<u8>` 入力はムーブ格納で
+    /// コピーなし、スライス・配列参照入力は所有化のためのコピーが 1 回発生する。
+    pub fn new(dictionary: PdfDictionary, data: impl Into<Vec<u8>>) -> PdfStream {
+        PdfStream {
+            dictionary,
+            data: data.into(),
+        }
+    }
+
+    /// 辞書部への参照を取り出す。
+    ///
+    /// ヒープ保持のため参照返し（`PdfObject::as_dictionary` と同方針）。
+    pub fn dictionary(&self) -> &PdfDictionary {
+        &self.dictionary
+    }
+
+    /// 生バイト列（復号前）への参照を取り出す。
+    ///
+    /// ヒープ保持のため参照返し（`PdfName::as_bytes` と同方針）。
+    pub fn data(&self) -> &[u8] {
+        &self.data
+    }
+
+    /// `self` を消費して辞書部と生バイト列を所有権ごと分解する。
+    ///
+    /// 後続の復号フェーズで `Vec<u8>` をムーブで取り出してフィルタ復号の入力に
+    /// する用途を想定（格納済み `Vec<u8>` のムーブ返しで追加コピーなし）。
+    /// 参照取得で足りる場合は `dictionary()` /
+    /// `data()` を使う。本クレート初の所有権分解 API。
+    pub fn into_parts(self) -> (PdfDictionary, Vec<u8>) {
+        (self.dictionary, self.data)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::object::name::PdfName;
+    use crate::object::pdf_object::PdfObject;
+
+    /// 値入り辞書 + `b"stream data"` で構築し `dictionary()` / `data()` で入力と同内容が返る（ラウンドトリップ・無損失）。
+    #[test]
+    fn new_then_accessors_roundtrip() {
+        let mut dict = PdfDictionary::new();
+        dict.insert(PdfName::from("Length"), PdfObject::Integer(11));
+        let stream = PdfStream::new(dict.clone(), b"stream data");
+        assert_eq!(stream.dictionary(), &dict);
+        assert_eq!(stream.data(), b"stream data");
+    }
+
+    /// `b"..."`（`&[u8; N]`）・`Vec<u8>`・`&[u8]` の 3 形いずれも受理され `data()` が同一バイト列を返す（`impl Into<Vec<u8>>` の動作確認）。
+    #[test]
+    fn new_accepts_into_vec_u8_variants() {
+        let from_array_ref = PdfStream::new(PdfDictionary::new(), b"abc");
+        let from_vec = PdfStream::new(PdfDictionary::new(), b"abc".to_vec());
+        let from_slice = PdfStream::new(PdfDictionary::new(), b"abc".as_slice());
+        assert_eq!(from_array_ref.data(), b"abc");
+        assert_eq!(from_vec.data(), b"abc");
+        assert_eq!(from_slice.data(), b"abc");
+    }
+
+    /// `/Length` キーを入れた辞書で構築し `dictionary().get(&key)` で挿入した値に到達できる（後段借用経路）。
+    #[test]
+    fn dictionary_accessor_reaches_entries() {
+        let mut dict = PdfDictionary::new();
+        dict.insert(PdfName::from("Length"), PdfObject::Integer(3));
+        let stream = PdfStream::new(dict, b"xyz");
+        assert_eq!(
+            stream.dictionary().get(&PdfName::from("Length")),
+            Some(&PdfObject::Integer(3))
+        );
+    }
+
+    /// 空バイト列 `b""` を無検証で受理し `data()` が空スライスを返す。
+    #[test]
+    fn accepts_empty_data() {
+        let mut dict = PdfDictionary::new();
+        dict.insert(PdfName::from("Length"), PdfObject::Integer(0));
+        let stream = PdfStream::new(dict, b"");
+        assert_eq!(stream.data(), b"");
+    }
+
+    /// 空辞書 `PdfDictionary::new()` を無検証で受理し `dictionary().is_empty()` が真になる。
+    #[test]
+    fn accepts_empty_dictionary() {
+        let stream = PdfStream::new(PdfDictionary::new(), b"data");
+        assert!(stream.dictionary().is_empty());
+        assert_eq!(stream.data(), b"data");
+    }
+
+    /// 空辞書 + 空バイト列の両方空でも無検証で受理され両アクセサが空を返す。
+    #[test]
+    fn accepts_empty_dictionary_and_empty_data() {
+        let stream = PdfStream::new(PdfDictionary::new(), b"");
+        assert!(stream.dictionary().is_empty());
+        assert_eq!(stream.data(), b"");
+    }
+
+    /// `vec![0x00, 0x80, 0xFF]`（NUL/非UTF-8/高位バイト）がテキスト解釈されず生バイトのまま忠実に保持される（無検証保持）。
+    #[test]
+    fn data_preserves_nul_non_utf8_and_high_bytes() {
+        let stream = PdfStream::new(PdfDictionary::new(), vec![0x00, 0x80, 0xFF]);
+        assert_eq!(stream.data(), [0x00, 0x80, 0xFF].as_slice());
+    }
+
+    /// `into_parts()` で `(PdfDictionary, Vec<u8>)` に分解でき、分解結果が構築時の入力と同内容になる（所有権ムーブ）。
+    #[test]
+    fn into_parts_decomposes_ownership() {
+        let mut dict = PdfDictionary::new();
+        dict.insert(PdfName::from("Length"), PdfObject::Integer(4));
+        let stream = PdfStream::new(dict.clone(), b"body");
+        let (decomposed_dict, decomposed_data) = stream.into_parts();
+        assert_eq!(decomposed_dict, dict);
+        assert_eq!(decomposed_data, b"body".to_vec());
+    }
+
+    /// 空辞書 + 空データのストリームを `into_parts()` すると空辞書と空 `Vec` が返る。
+    #[test]
+    fn into_parts_on_empty_stream() {
+        let stream = PdfStream::new(PdfDictionary::new(), b"");
+        let (decomposed_dict, decomposed_data) = stream.into_parts();
+        assert!(decomposed_dict.is_empty());
+        assert!(decomposed_data.is_empty());
+    }
+
+    /// `clone()` の複製が元と `==` 等価かつ元も引き続き使用可能（深いコピー・独立性）。
+    #[test]
+    fn clone_preserves_content_and_keeps_original_usable() {
+        let mut dict = PdfDictionary::new();
+        dict.insert(PdfName::from("Length"), PdfObject::Integer(4));
+        let original = PdfStream::new(dict, b"body");
+        let cloned = original.clone();
+        assert_eq!(cloned, original);
+        assert_eq!(original.data(), b"body");
+    }
+
+    /// 同内容（同辞書 + 同データ）の 2 値は `==` で等価（`PartialEq` が両フィールドに委譲）。
+    #[test]
+    fn same_content_streams_are_equal() {
+        let mut dict_a = PdfDictionary::new();
+        dict_a.insert(PdfName::from("Length"), PdfObject::Integer(4));
+        let mut dict_b = PdfDictionary::new();
+        dict_b.insert(PdfName::from("Length"), PdfObject::Integer(4));
+        assert_eq!(
+            PdfStream::new(dict_a, b"body"),
+            PdfStream::new(dict_b, b"body")
+        );
+    }
+
+    /// dictionary は同一で data のみ異なる 2 値は `!=` 非等価（data 軸の差異が反映される）。
+    #[test]
+    fn not_equal_when_data_differs() {
+        assert_ne!(
+            PdfStream::new(PdfDictionary::new(), b"abc"),
+            PdfStream::new(PdfDictionary::new(), b"abd")
+        );
+    }
+
+    /// data は同一で dictionary のみ異なる 2 値は `!=` 非等価（dictionary 軸の差異が反映される）。
+    #[test]
+    fn not_equal_when_dictionary_differs() {
+        let mut dict = PdfDictionary::new();
+        dict.insert(PdfName::from("Length"), PdfObject::Integer(3));
+        assert_ne!(
+            PdfStream::new(dict, b"abc"),
+            PdfStream::new(PdfDictionary::new(), b"abc")
+        );
+    }
+
+    /// 辞書値に `Real(NaN)` を含む同内容ストリーム同士は `!=` 非等価（`NaN != NaN` の再帰伝播。`Eq` 非実装の根拠）。
+    #[test]
+    fn nan_in_dictionary_propagates_to_inequality() {
+        let mut dict_a = PdfDictionary::new();
+        dict_a.insert(PdfName::from("N"), PdfObject::Real(f64::NAN));
+        let mut dict_b = PdfDictionary::new();
+        dict_b.insert(PdfName::from("N"), PdfObject::Real(f64::NAN));
+        assert_ne!(
+            PdfStream::new(dict_a, b"data"),
+            PdfStream::new(dict_b, b"data")
+        );
+    }
+
+    /// `Debug` 出力に型名 `PdfStream` を含む。
+    #[test]
+    fn debug_format_contains_type_name() {
+        let stream = PdfStream::new(PdfDictionary::new(), b"data");
+        assert!(format!("{:?}", stream).contains("PdfStream"));
+    }
+}


### PR DESCRIPTION
## 概要

PDF ストリームオブジェクト（辞書 + 生バイト列）を表す `PdfStream` 型を pdfmod-core に追加し、`PdfObject` enum に `Stream` バリアントと `as_stream()` アクセサを追加します（Epic #251 Phase R0）。

生バイトは無検証・無復号で忠実に保持し、フィルタ復号（`/FlateDecode` 等）・`/Length` 整合性検証は後続フェーズ（lexer/parser 層・Epic R1/R2）に委譲します。

## 変更内容

### 🎯 変更の種類

- [x] ✨ 新機能 (New feature)
- [x] 🚨 テスト追加/修正 (Tests)
- [x] 📖 ドキュメント更新 (Documentation)

### 📝 詳細な変更内容

#### 追加された機能・修正

- `PdfStream` 型（`rust/crates/core/src/object/stream.rs` 新規）
  - private フィールド `dictionary: PdfDictionary` / `data: Vec<u8>`
  - `new(PdfDictionary, impl Into<Vec<u8>>)` — 無検証（infallible）構築。`b"..."` / `Vec<u8>` / `&[u8]` を受理
  - `dictionary()` / `data()` — 参照アクセサ
  - `into_parts()` — 本クレート初の所有権分解 API（後続復号フェーズで `Vec<u8>` をムーブで取り出すゼロコピー経路）
  - derive は `Debug, Clone, PartialEq` のみ（`Real(f64)` の NaN により `Eq` 不可。根拠を doc に明記）
- `PdfObject::Stream(PdfStream)` バリアント（`Dictionary` 直後・ISO 32000 §7.3 登場順）と `as_stream() -> Option<&PdfStream>`（参照返し）
  - §7.3.8「stream は間接オブジェクトでなければならない」は型表現せず上位レイヤで担保する方針をバリアント doc に明記
- テスト24件追加（stream.rs 15件 + pdf_object.rs 9件）+ 既存列挙テスト9個（総当たり 9→10 バリアント化・`as_xxx_returns_none` 系×8）へ Stream を追記

#### 変更されたファイル

- `rust/crates/core/src/object/stream.rs` [NEW]
- `rust/crates/core/src/object.rs` [MODIFY] — `pub mod stream;` 宣言・モジュール doc 現在形化
- `rust/crates/core/src/object/pdf_object.rs` [MODIFY] — バリアント・アクセサ・テスト
- `rust/crates/core/src/object/dictionary.rs` [MODIFY] — doc 文言のみ（コード変更なし）

#### 削除されたファイル・機能

- なし（破壊的変更なし: クレート外利用者なし・クレート内に非網羅 match なし）

## 📋 関連 Issue

- Closes #267
- Refs #251（親 Epic Phase R0）

## 🧪 テスト

### テスト実行方法

```bash
cd rust && cargo test -p pdfmod-core
```

### テスト項目

- [x] 単体テスト (Unit tests)
- [ ] 統合テスト (Integration tests) — 外部依存・非同期なしのクレート内完結のため対象外
- [ ] E2E テスト (End-to-end tests) — 同上
- [x] 手動テスト (Manual testing) — build / fmt / clippy / grep による追記漏れ確認

### テスト結果

- `cargo test -p pdfmod-core`: **210 passed / 0 failed**（既存186 + 新規24、リグレッションなし）
- `cargo build -p pdfmod-core` 成功 / `cargo fmt --check` クリーン / `cargo clippy --all-targets` 警告0
- TDD（Red-Green-Refactor）で実装。検証内容は各テストに日本語コメントで記載

## 🔍 レビューポイント

- `into_parts()` はコードベース初の所有権分解 API です。後続復号フェーズでの用途を doc に明記していますが、doc の説明が十分か確認をお願いします
- `PdfObject` のサイズは約 32→48 バイトに増加します。既存バリアントとの一貫性（全バリアント非 Box）を優先して Box 化していません（implementation-plan で確定済みのトレードオフ。将来肥大化した場合の Box 化判断の材料として記録）
- 列挙テストへの Stream 追記はコンパイルエラーにならない人力網羅のため、総当たり1個 + `as_xxx_returns_none` 系8個の追記漏れがないかご確認ください

## ⚠️ 破壊的変更

- [ ] この変更は既存の API に破壊的変更を含みます

なし。

## 📚 追加情報

### 参考資料

- ISO 32000-1:2008 §7.3.8（ストリームオブジェクト）
- 仕様・計画: `.plugin-workspace/.specs/archive/073-pdf-stream-object/`

### 注意事項

- 外部依存ゼロ制約を維持（`Cargo.toml` 変更なし）
- `/Length` と実データ長の整合性は本型では検証しません（上位委譲を doc に明記）

## ✅ チェックリスト

- [x] コードレビューの準備ができている
- [x] テストが正常に実行される
- [x] ドキュメントが更新されている（必要に応じて）
- [x] コミットメッセージが適切な形式で書かれている
- [ ] 関連する Issue が PR の「Development」に Linked されている（Closes キーワードで自動 Link）
- [x] PR 本文に `Closes #` / `Fixes #` / `Refs #` などで Issue が記載されている
- [x] セルフレビューを実施した（AIレビュー: Codex「問題なし」+ spec-based-code-review CRITICAL 0 / DoD 12項目充足）
- [x] 破壊的変更がある場合は明記されている（なし）

🤖 Generated with [Claude Code](https://claude.com/claude-code)