### PR TITLE
✨ [New Feature]: #294 text positioning operators の barrel と registerTextPositioningOperators ヘルパを実装

### DIFF
--- a/packages/core/src/content-stream/operators/text/text-positioning-operators/__tests__/text-positioning-operators.basic.test.ts
+++ b/packages/core/src/content-stream/operators/text/text-positioning-operators/__tests__/text-positioning-operators.basic.test.ts
@@ -1,0 +1,37 @@
+import { assert, expect, test } from "vitest";
+import {
+  type OperatorHandler,
+  OperatorRegistry,
+} from "../../../../operator-registry/index";
+import {
+  registerTextPositioningOperators,
+  tdHandler,
+  tdLeadingHandler,
+  tmHandler,
+  tStarHandler,
+} from "../index";
+
+// 空 registry に一括登録すると各 operator 名で同一参照の handler が lookup できる
+test.each<readonly [string, OperatorHandler]>([
+  ["Td", tdHandler],
+  ["TD", tdLeadingHandler],
+  ["Tm", tmHandler],
+  ["T*", tStarHandler],
+])("registerTextPositioningOperators は %s に対応する handler を登録する", (name, expectedHandler) => {
+  const result = registerTextPositioningOperators(OperatorRegistry.create());
+  assert(result.ok);
+
+  const looked = OperatorRegistry.lookup(result.value, name);
+  assert(looked.some);
+  expect(looked.value).toBe(expectedHandler);
+});
+
+test("registerTextPositioningOperators の戻り値は ok で 4 operator すべてを保持する registry を返す", () => {
+  const result = registerTextPositioningOperators(OperatorRegistry.create());
+  assert(result.ok);
+
+  expect(OperatorRegistry.has(result.value, "Td")).toBe(true);
+  expect(OperatorRegistry.has(result.value, "TD")).toBe(true);
+  expect(OperatorRegistry.has(result.value, "Tm")).toBe(true);
+  expect(OperatorRegistry.has(result.value, "T*")).toBe(true);
+});

--- a/packages/core/src/content-stream/operators/text/text-positioning-operators/__tests__/text-positioning-operators.basic.test.ts
+++ b/packages/core/src/content-stream/operators/text/text-positioning-operators/__tests__/text-positioning-operators.basic.test.ts
@@ -26,6 +26,7 @@ test.each<readonly [string, OperatorHandler]>([
   expect(looked.value).toBe(expectedHandler);
 });
 
+// 一括登録後の registry を OperatorRegistry.has で全件確認する
 test("registerTextPositioningOperators の戻り値は ok で 4 operator すべてを保持する registry を返す", () => {
   const result = registerTextPositioningOperators(OperatorRegistry.create());
   assert(result.ok);

--- a/packages/core/src/content-stream/operators/text/text-positioning-operators/__tests__/text-positioning-operators.error.test.ts
+++ b/packages/core/src/content-stream/operators/text/text-positioning-operators/__tests__/text-positioning-operators.error.test.ts
@@ -1,0 +1,41 @@
+import { afterEach, assert, expect, test, vi } from "vitest";
+import {
+  type OperatorHandler,
+  OperatorRegistry,
+} from "../../../../operator-registry/index";
+import {
+  registerTextPositioningOperators,
+  tdHandler,
+  tdLeadingHandler,
+  tmHandler,
+  tStarHandler,
+} from "../index";
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+// [重複させる operator 名, その handler, 短絡までに register が呼ばれる名列（登録順の prefix）]
+test.each<readonly [string, OperatorHandler, readonly string[]]>([
+  ["Td", tdHandler, ["Td"]],
+  ["TD", tdLeadingHandler, ["Td", "TD"]],
+  ["Tm", tmHandler, ["Td", "TD", "Tm"]],
+  ["T*", tStarHandler, ["Td", "TD", "Tm", "T*"]],
+])("%s が登録済みのとき registerTextPositioningOperators は Err を返し reduce が登録順 prefix で短絡する", (name, handler, expectedCalledNames) => {
+  const seed = OperatorRegistry.register(
+    OperatorRegistry.create(),
+    name,
+    handler,
+  );
+  assert(seed.ok);
+
+  const registerSpy = vi.spyOn(OperatorRegistry, "register");
+  const result = registerTextPositioningOperators(seed.value);
+
+  assert(!result.ok);
+  assert(result.error.code === "OPERATOR_ALREADY_REGISTERED");
+  expect(result.error.operatorName).toBe(name);
+  expect(registerSpy.mock.calls.map((call) => call[1])).toEqual(
+    expectedCalledNames,
+  );
+});

--- a/packages/core/src/content-stream/operators/text/text-positioning-operators/__tests__/text-positioning-operators.integration.test.ts
+++ b/packages/core/src/content-stream/operators/text/text-positioning-operators/__tests__/text-positioning-operators.integration.test.ts
@@ -1,0 +1,96 @@
+import { assert, expect, test } from "vitest";
+import { flatMap } from "../../../../../utils/result/index";
+import {
+  GraphicsStateStack,
+  Matrix,
+  TextObject,
+} from "../../../../graphics-state/index";
+import type { ContentStreamInterpreterResult } from "../../../../interpreter/index";
+import { ContentStreamInterpreter } from "../../../../interpreter/index";
+import { OperatorRegistry } from "../../../../operator-registry/index";
+import { registerTextStateOperators } from "../../text-state-operators/index";
+import { registerTextPositioningOperators } from "../index";
+
+const encode = (s: string): Uint8Array => new TextEncoder().encode(s);
+
+// text-state（BT/ET/TL 等）と text-positioning の両 barrel を併用登録した registry を
+// 作るテストヘルパ。登録失敗は assert で即座に検出する。
+const createRegistry = (): OperatorRegistry => {
+  const registered = flatMap(
+    registerTextStateOperators(OperatorRegistry.create()),
+    registerTextPositioningOperators,
+  );
+  assert(registered.ok);
+  return registered.value;
+};
+
+// 正常系用: content stream を実行し、成功結果を返すヘルパ（失敗時は assert で即座に検出）。
+// 異常系（BT なし Td → Err）はこのヘルパを使わず execute を直接呼んで Err を検証する。
+const execute = (stream: string): ContentStreamInterpreterResult => {
+  const result = ContentStreamInterpreter.execute({
+    data: encode(stream),
+    registry: createRegistry(),
+  });
+  assert(result.ok);
+  return result.value;
+};
+
+test("4 operator 全部入り stream（ET なし）で textMatrix / textLineMatrix と leading が dispatch 経由で更新される", () => {
+  // Tm で (72,720) に絶対配置 → TD で (+10,-14) 移動 + leading=14
+  // → T* で leading 分改行 (0,-14) → Td で (+5,+5) 移動 = (87,697)。
+  // 演算仕様の再検証ではなく 4 operator 全部の影響が dispatch 経由で反映されたことの確認。
+  const executed = execute("BT 1 0 0 1 72 720 Tm 10 -14 TD T* 5 5 Td");
+  expect(executed.warnings).toEqual([]);
+
+  const current = GraphicsStateStack.current(
+    executed.context.graphicsStateStack,
+  );
+  expect(current.textObject.textMatrix).toEqual(
+    Matrix.create(1, 0, 0, 1, 87, 697),
+  );
+  expect(current.textObject.textLineMatrix).toEqual(
+    Matrix.create(1, 0, 0, 1, 87, 697),
+  );
+  expect(current.textState.leading).toBe(14);
+});
+
+test("TL（text-state barrel 側）で設定した leading を T* が参照する（両 barrel 併用の実証）", () => {
+  // BT のまま終了し active な textObject の matrix を観測する（ET は matrix を
+  // identity にリセットするため含めない）。
+  const executed = execute("BT 14 TL T*");
+  expect(executed.warnings).toEqual([]);
+
+  const current = GraphicsStateStack.current(
+    executed.context.graphicsStateStack,
+  );
+  expect(current.textObject.textMatrix).toEqual(
+    Matrix.create(1, 0, 0, 1, 0, -14),
+  );
+  expect(current.textObject.textLineMatrix).toEqual(
+    Matrix.create(1, 0, 0, 1, 0, -14),
+  );
+});
+
+test("BT なしで Td を実行すると execute が OPERATOR_ILLEGAL_STATE の Err を返す", () => {
+  // text object が active でない状態の positioning operator は handler が Err を返し、
+  // interpreter はそれをそのまま伝播する（dispatch 経路の代表として Td のみ検証）。
+  const result = ContentStreamInterpreter.execute({
+    data: encode("10 20 Td"),
+    registry: createRegistry(),
+  });
+
+  assert(!result.ok);
+  expect(result.error.code).toBe("OPERATOR_ILLEGAL_STATE");
+});
+
+test("全部入り stream に ET を加えると warnings は空のまま textObject が非 active になる", () => {
+  // 補助テスト: BT/ET 併用時に UNKNOWN_OPERATOR warning が出ない（= 登録漏れなし）
+  // ことと、ET 後に text object が終了状態になることを確認する。
+  const executed = execute("BT 1 0 0 1 72 720 Tm 10 -14 TD T* 5 5 Td ET");
+  expect(executed.warnings).toEqual([]);
+
+  const current = GraphicsStateStack.current(
+    executed.context.graphicsStateStack,
+  );
+  expect(TextObject.isActive(current.textObject)).toBe(false);
+});

--- a/packages/core/src/content-stream/operators/text/text-positioning-operators/index.ts
+++ b/packages/core/src/content-stream/operators/text/text-positioning-operators/index.ts
@@ -1,0 +1,44 @@
+import type { PdfError } from "../../../../pdf/errors/index";
+import type { Result } from "../../../../utils/result/index";
+import { flatMap, ok } from "../../../../utils/result/index";
+import type { OperatorHandler } from "../../../operator-registry/index";
+import { OperatorRegistry } from "../../../operator-registry/index";
+import { tStarHandler } from "../t-star/index";
+import { tdHandler } from "../td/index";
+import { tdLeadingHandler } from "../td-leading/index";
+import { tmHandler } from "../tm/index";
+
+export { tStarHandler } from "../t-star/index";
+export { tdHandler } from "../td/index";
+export { tdLeadingHandler } from "../td-leading/index";
+export { tmHandler } from "../tm/index";
+
+// 登録順は Issue 指定順（Td, TD, Tm, T*）。
+// この順序は error テストの fail-fast 呼び出し順検証に直結する。
+const TEXT_POSITIONING_OPERATORS: ReadonlyArray<
+  readonly [string, OperatorHandler]
+> = [
+  ["Td", tdHandler],
+  ["TD", tdLeadingHandler],
+  ["Tm", tmHandler],
+  ["T*", tStarHandler],
+];
+
+/**
+ * Text positioning operator (Td / TD / Tm / T*) を
+ * OperatorRegistry に一括登録するヘルパ。
+ *
+ * fail-fast: いずれかの register が Err を返した時点で reduce 内 flatMap が
+ * 短絡し、後続 operator の register は呼ばれない。
+ *
+ * @param registry - 登録元 registry
+ * @returns 全 operator が登録された新しい registry、または重複登録時の PdfError
+ */
+export const registerTextPositioningOperators = (
+  registry: OperatorRegistry,
+): Result<OperatorRegistry, PdfError> =>
+  TEXT_POSITIONING_OPERATORS.reduce<Result<OperatorRegistry, PdfError>>(
+    (acc, [name, handler]) =>
+      flatMap(acc, (r) => OperatorRegistry.register(r, name, handler)),
+    ok(registry),
+  );


### PR DESCRIPTION
## 概要

Phase 4-E の 4 つの text positioning operator handler（`Td` / `TD` / `Tm` / `T*`）を 1 ファイルから re-export する barrel を作成し、`OperatorRegistry` へ一括登録するヘルパ `registerTextPositioningOperators(registry): Result<OperatorRegistry, PdfError>` を提供します。既存の `text-state-operators`（#242）/ `color-operators` / `path-operators` / `graphics-state-operators` の 4 barrel と完全同形パターンです。

## 変更内容

### 🎯 変更の種類

- [x] ✨ 新機能 (New feature)
- [x] 🚨 テスト追加/修正 (Tests)

### 📝 詳細な変更内容

#### 追加された機能・修正

- `registerTextPositioningOperators`: `TEXT_POSITIONING_OPERATORS`（非 export、`["Td", "TD", "Tm", "T*"]` 順固定）を `reduce` + `flatMap` で畳み込む fail-fast 一括登録ヘルパ。重複時は `OPERATOR_ALREADY_REGISTERED` の Err を返し、後続の register は呼ばれない
- 4 handler（`tdHandler` / `tdLeadingHandler` / `tmHandler` / `tStarHandler`）の re-export
- 提供範囲は既存 4 barrel と同じ deep import API（`src/index.ts` への export 追加なし）

#### 変更されたファイル

- `packages/core/src/content-stream/operators/text/text-positioning-operators/index.ts` [NEW]
- 同 `__tests__/text-positioning-operators.basic.test.ts` [NEW]（lookup 参照同一 ×4 + has 全件）
- 同 `__tests__/text-positioning-operators.error.test.ts` [NEW]（重複 4 位置の fail-fast 呼び出し順 prefix 検証）
- 同 `__tests__/text-positioning-operators.integration.test.ts` [NEW]（interpreter 経由 dispatch・text-state barrel 併用・BT なし異常系・ET 終了）

#### 削除されたファイル・機能

- なし（**既存ファイルの変更ゼロ**、追加 4 ファイル 219 行のみ）

## 📊 システム図

### データフロー

```mermaid
flowchart TD
    td["td/index.ts<br/>tdHandler"] --> barrel
    tdl["td-leading/index.ts<br/>tdLeadingHandler"] --> barrel
    tm["tm/index.ts<br/>tmHandler"] --> barrel
    tstar["t-star/index.ts<br/>tStarHandler"] --> barrel
    barrel["text-positioning-operators/index.ts<br/>re-export + TEXT_POSITIONING_OPERATORS（非 export）"]:::new
    barrel --> reg["registerTextPositioningOperators(registry)<br/>reduce + flatMap（fail-fast）"]:::new
    reg -->|"Ok: 新 registry（immutable）"| ok["Result&lt;OperatorRegistry, PdfError&gt;"]
    reg -->|"Err: OPERATOR_ALREADY_REGISTERED<br/>（短絡・後続 register 呼び出しなし）"| ok
    ok --> exec["ContentStreamInterpreter.execute<br/>（integration テストで registerTextStateOperators と併用）"]

    classDef new fill:#ffe4b5,stroke:#d97706,stroke-width:2px
```

## 📋 関連 Issue

- Closes #294（親 Epic #288、依存: #290 Td / #291 TD / #292 Tm / #293 T*）

## 🧪 テスト

### テスト実行方法

```bash
pnpm --filter @pdfmod/core test
```

### テスト項目

- [x] 単体テスト (Unit tests) — basic 5 件 / error 4 件
- [x] 統合テスト (Integration tests) — interpreter 経由 4 件
- [x] 手動テスト (Manual testing) — build / lint / typecheck

### テスト結果

- `pnpm --filter @pdfmod/core test`: **2516 テスト全件パス**（190 ファイル、リグレッションなし）
- `pnpm --filter @pdfmod/core build` / `pnpm lint` / `pnpm typecheck`: すべて成功
- AIレビュー: codex「問題なし」、spec-based-code-review 5 エージェント並列で **CRITICAL 0 / WARNING 0**（INFO 9 件はすべて spec が意図的に選択したパターンの記録。うちテストコメント欠落 1 件は対応済み）

## 🔍 レビューポイント

- `TEXT_POSITIONING_OPERATORS` の登録順 `["Td", "TD", "Tm", "T*"]` は error テストの fail-fast 呼び出し順検証に直結するため固定です
- integration テストの matrix 観測 stream は ET を含めません（`TextObject.end` が matrix を identity にリセットするため。コード内コメントに理由を記載）
- error テストの `vi.spyOn(OperatorRegistry, "register")` は既存 4 barrel と同形の踏襲パターンです（exploration-report で保守一貫性優先と判断済み）

## ⚠️ 破壊的変更

- [ ] この変更は既存の API に破壊的変更を含みます

なし。新規ディレクトリの追加のみで、ロールバックはディレクトリ削除のみで完了します。

## ✅ チェックリスト

- [x] コードレビューの準備ができている
- [x] テストが正常に実行される
- [x] コミットメッセージが適切な形式で書かれている
- [x] PR 本文に `Closes #` で Issue が記載されている
- [x] セルフレビューを実施した（codex + spec-based-code-review 5 エージェント）
- [x] 破壊的変更がある場合は明記されている（破壊的変更なし）

🤖 Generated with [Claude Code](https://claude.com/claude-code)