### PR TITLE
🔧 [Config]: Claude Code のプラグイン設定とローカルファイルの gitignore を追加

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -5,5 +5,76 @@
   },
   "env": {
     "CLAUDE_CODE_NO_FLICKER": "1"
+  },
+  "enabledPlugins": {
+    "typescript-rules-plugin@d-market-typescript": true,
+    "react-rules-plugin@d-market-react": true,
+    "spec-plugin@d-market-spec": true,
+    "spec-review-plugin@d-market-spec": true,
+    "git-workflow-plugin@d-market-git": true,
+    "spec-to-issues-plugin@d-market-git": true,
+    "workflow-automation-plugin@d-market-git": true,
+    "doc-gen-plugin@d-market-doc-gen": true,
+    "statusline-plugin@d-market-statusline": true,
+    "skill-creator@d-market-skill": true,
+    "marketplace-template@d-market-skill": true,
+    "skill-grower@d-market-skill": true,
+    "rust-workflow-plugin@d-market-rust": true,
+    "typescript-lsp@claude-plugins-official": true
+  },
+  "extraKnownMarketplaces": {
+    "d-market-typescript": {
+      "source": {
+        "source": "git",
+        "url": "https://github.com/DIO0550/d-market-typescript.git"
+      },
+      "autoUpdate": true
+    },
+    "d-market-react": {
+      "source": {
+        "source": "git",
+        "url": "https://github.com/DIO0550/d-market-react.git"
+      }
+    },
+    "d-market-spec": {
+      "source": {
+        "source": "git",
+        "url": "https://github.com/DIO0550/d-market-spec.git"
+      },
+      "autoUpdate": true
+    },
+    "d-market-git": {
+      "source": {
+        "source": "git",
+        "url": "https://github.com/DIO0550/d-market-git.git"
+      },
+      "autoUpdate": true
+    },
+    "d-market-doc-gen": {
+      "source": {
+        "source": "git",
+        "url": "https://github.com/DIO0550/d-market-doc-gen.git"
+      }
+    },
+    "d-market-statusline": {
+      "source": {
+        "source": "git",
+        "url": "https://github.com/DIO0550/d-market-statusline.git"
+      },
+      "autoUpdate": true
+    },
+    "d-market-skill": {
+      "source": {
+        "source": "github",
+        "repo": "DIO0550/d-market-skill"
+      },
+      "autoUpdate": true
+    },
+    "d-market-rust": {
+      "source": {
+        "source": "github",
+        "repo": "DIO0550/d-market-rust"
+      }
+    }
   }
 }

--- a/.gitignore
+++ b/.gitignore
@@ -153,3 +153,9 @@ vite.config.ts.timestamp-*
 
 .test-rules.yml
 .worktreeinclude
+
+# Claude Code / Codex 作業ファイル・ローカル設定
+.claude/settings.local.json
+.claude/plugin-workspace/
+/plugin-workspace/
+.codex/


### PR DESCRIPTION
## 概要

Claude Code の開発ワークフロー用プラグインとマーケットプレースを `.claude/settings.json` に登録し、各開発者のローカル環境固有ファイルを `.gitignore` に追加する。チーム共通のスキル（コミット規約・PR作成・spec駆動開発など）を利用可能にしつつ、ローカル設定の誤コミットを防ぐ。

## 変更内容

### 🎯 変更の種類

- [x] 🔧 設定変更 (Configuration)

### 📝 詳細な変更内容

#### 追加された設定

- `.claude/settings.json`
  - `enabledPlugins`: d-market 系プラグイン（typescript-rules / react-rules / spec / git-workflow / spec-to-issues / workflow-automation / doc-gen / statusline / skill-creator / rust-workflow など）と `typescript-lsp` を有効化
  - `extraKnownMarketplaces`: 上記プラグインの取得元マーケットプレース（git / github ソース）を登録
- `.gitignore`
  - `.claude/settings.local.json`、`.claude/plugin-workspace/`、`/plugin-workspace/`、`.codex/` を追跡対象から除外

#### 変更されたファイル

- `.claude/settings.json`
- `.gitignore`

## 📋 関連 Issue

- なし（リポジトリ全体の開発環境設定の追加のため）

## 🧪 テスト

設定ファイルのみの変更であり、アプリケーションコードへの影響はない。

### テスト項目

- [x] 手動テスト (Manual testing) — JSON の構文・プラグイン有効化が反映されることを確認

## 🔍 レビューポイント

- `enabledPlugins` と `extraKnownMarketplaces` の対応関係（各プラグインの marketplace 名）に齟齬がないか
- `.gitignore` のパターンが意図したローカルファイルのみを除外しているか

## ⚠️ 破壊的変更

- [ ] この変更は既存の API に破壊的変更を含みます

なし。

## ✅ チェックリスト

- [x] コードレビューの準備ができている
- [x] テストが正常に実行される（設定変更のみ）
- [x] コミットメッセージが適切な形式で書かれている
- [x] セルフレビューを実施した

🤖 Generated with [Claude Code](https://claude.com/claude-code)