### PR TITLE
✨ [New Feature]: #414 TextObject.translateText を追加 (textMatrix のみ平行移動)

### DIFF
--- a/packages/core/src/content-stream/graphics-state/text-object/__tests__/text-object.translate-text.test.ts
+++ b/packages/core/src/content-stream/graphics-state/text-object/__tests__/text-object.translate-text.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from "vitest";
-import { TextObject } from "../index";
+import { TextObject } from "../../text-object";
 
 // active=true の任意 TextObject を生で組むヘルパ（dirty state 構築用）
 const buildActive = (

--- a/packages/core/src/content-stream/graphics-state/text-object/__tests__/text-object.translate-text.test.ts
+++ b/packages/core/src/content-stream/graphics-state/text-object/__tests__/text-object.translate-text.test.ts
@@ -1,0 +1,90 @@
+import { expect, test } from "vitest";
+import { TextObject } from "../index";
+
+// active=true の任意 TextObject を生で組むヘルパ（dirty state 構築用）
+const buildActive = (
+  textMatrix: readonly [number, number, number, number, number, number],
+  textLineMatrix: readonly [number, number, number, number, number, number],
+): TextObject =>
+  ({
+    active: true,
+    textMatrix,
+    textLineMatrix,
+  }) as TextObject;
+
+// active=false の任意 TextObject を生で組むヘルパ（inactive dirty state 構築用）
+const buildInactive = (
+  textMatrix: readonly [number, number, number, number, number, number],
+  textLineMatrix: readonly [number, number, number, number, number, number],
+): TextObject =>
+  ({
+    active: false,
+    textMatrix,
+    textLineMatrix,
+  }) as TextObject;
+
+// 1. 水平移動: textMatrix が動き textLineMatrix は不変
+test("translateText(state, 10, 0) は textMatrix を水平移動し textLineMatrix を変更しない", () => {
+  const state = buildActive([1, 0, 0, 1, 72, 720], [1, 0, 0, 1, 72, 720]);
+  const next = TextObject.translateText(state, 10, 0);
+  expect(next.textMatrix).toEqual([1, 0, 0, 1, 82, 720]);
+  expect(next.textLineMatrix).toEqual([1, 0, 0, 1, 72, 720]);
+});
+
+// 2. 非可換性 / 一般化: translate(5,-3) × Tm (scale を含む Tm で向きを固定)
+// 平行移動同士だと左右を入れ替えても同結果になり向き誤りを検出できない。
+// scale を含む Tm を使い multiply(translation, Tm) の向きを固定する。
+// translate(5,-3) × [2,0,0,2,10,20] = [2,0,0,2,20,14]（逆順なら [2,0,0,2,15,17]）
+test("translateText(state, 5, -3) は textMatrix を translate(5,-3) × Tm にする", () => {
+  const state = buildActive([2, 0, 0, 2, 10, 20], [9, 0, 0, 9, 99, 99]);
+  const next = TextObject.translateText(state, 5, -3);
+  expect(next.textMatrix).toEqual([2, 0, 0, 2, 20, 14]);
+  expect(next.textLineMatrix).toEqual([9, 0, 0, 9, 99, 99]);
+});
+
+// 3. no-op 相当: tx=ty=0 で textMatrix 不変 (Tm != Tlm の dirty state で
+//    translateLine が Tm を Tlm にリセットするのに対し translateText は Tm を保持する差分を固定)
+test("translateText(state, 0, 0) は textMatrix を変更しない (no-op 相当, Tm は Tlm にリセットされない)", () => {
+  const state = buildActive([5, 0, 0, 5, 1, 2], [1, 0, 0, 1, 72, 720]);
+  const next = TextObject.translateText(state, 0, 0);
+  expect(next.textMatrix).toEqual([5, 0, 0, 5, 1, 2]);
+  expect(next.textLineMatrix).toEqual([1, 0, 0, 1, 72, 720]);
+  expect(next).not.toBe(state);
+});
+
+// 4. active フラグ保持 (active=true / inactive 双方, active のみ検証)
+test("translateText は active フラグを保持する (active=true)", () => {
+  const next = TextObject.translateText(TextObject.begin(), 1, 1);
+  expect(next.active).toBe(true);
+});
+test("translateText は active フラグを保持する (inactive は false のまま)", () => {
+  const next = TextObject.translateText(TextObject.inactive(), 1, 1);
+  expect(next.active).toBe(false);
+});
+
+// 5. 元 state の不変性
+test("translateText は引数 state の textMatrix / textLineMatrix を変更しない", () => {
+  const state = buildActive([1, 0, 0, 1, 72, 720], [1, 0, 0, 1, 72, 720]);
+  const next = TextObject.translateText(state, 5, -3);
+  expect(state.textMatrix).toEqual([1, 0, 0, 1, 72, 720]);
+  expect(state.textLineMatrix).toEqual([1, 0, 0, 1, 72, 720]);
+  expect(next).not.toBe(state);
+});
+
+// 6. inactive state (active=false) で textMatrix のみ移動・active=false 維持
+test("translateText は inactive state でも textMatrix のみ移動し active=false を維持する", () => {
+  const state = buildInactive([3, 0, 0, 3, 4, 5], [6, 0, 0, 6, 7, 8]);
+  const next = TextObject.translateText(state, 7, 9);
+  expect(next.textMatrix).toEqual([3, 0, 0, 3, 25, 32]);
+  expect(next.textLineMatrix).toEqual([6, 0, 0, 6, 7, 8]);
+  expect(next.active).toBe(false);
+});
+
+// 7. textLineMatrix 据え置き明示検証 (参照据え置き: toBe(state.textLineMatrix))
+// (1)(2) の toEqual 値比較と役割を分け、防御コピーせず参照を引き継ぐ実装方針を固定
+// (translateLine との差分を明示)
+test("translateText の戻り値の textLineMatrix は引数と同一参照で据え置かれる", () => {
+  const state = buildActive([2, 0, 0, 2, 10, 20], [9, 0, 0, 9, 99, 99]);
+  const next = TextObject.translateText(state, 5, -3);
+  expect(next.textLineMatrix).toBe(state.textLineMatrix);
+});

--- a/packages/core/src/content-stream/graphics-state/text-object/index.ts
+++ b/packages/core/src/content-stream/graphics-state/text-object/index.ts
@@ -116,4 +116,31 @@ export const TextObject = {
       textLineMatrix: matrix,
     } as TextObject;
   },
+  /**
+   * `TJ` の数値要素による位置調整 (ISO 32000-1:2008 §9.4.3 / Issue §6.5)
+   * や将来のグリフ送り (advance) の基盤となる、テキスト行列のみの平行移動。
+   * `Tm' = translate(tx, ty) × Tm` を計算する (ISO 32000-1:2008 §9.4.2 の
+   * テキスト行列更新)。`textLineMatrix` (行頭) は据え置く点が `translateLine`
+   * との差分。
+   *
+   * `translate(tx, ty)` は `Matrix.create(1, 0, 0, 1, tx, ty)`。
+   * 引数の向きは「左 = 適用する変換」(`cm` / `translateLine` ハンドラと同一規約)。
+   * `active` は引数 state から引き継ぐ。元 state は変更しない (純粋関数)。
+   * `Matrix` は readonly tuple であり、本コードベースでは生成後に破壊的変更しない
+   * 運用のため `state.textLineMatrix` をそのまま据え置いてよい (防御コピー不要)。
+   *
+   * @param state - 更新対象の TextObject
+   * @param tx - x 方向の平行移動量
+   * @param ty - y 方向の平行移動量
+   * @returns `textMatrix` のみを更新し `textLineMatrix` を据え置いた新しい TextObject
+   */
+  translateText(state: TextObject, tx: number, ty: number): TextObject {
+    const translation = Matrix.create(1, 0, 0, 1, tx, ty);
+    const next = Matrix.multiply(translation, state.textMatrix);
+    return {
+      active: state.active,
+      textMatrix: next,
+      textLineMatrix: state.textLineMatrix,
+    } as TextObject;
+  },
 } as const;

--- a/packages/core/src/content-stream/graphics-state/text-object/index.ts
+++ b/packages/core/src/content-stream/graphics-state/text-object/index.ts
@@ -117,7 +117,7 @@ export const TextObject = {
     } as TextObject;
   },
   /**
-   * `TJ` の数値要素による位置調整 (ISO 32000-1:2008 §9.4.3 / Issue #414 §6.5)
+   * `TJ` の数値要素による位置調整 (ISO 32000-1:2008 §9.4.3)
    * や将来のグリフ送り (advance) の基盤となる、テキスト行列のみの平行移動。
    * `Tm' = translate(tx, ty) × Tm` を計算する (ISO 32000-1:2008 §9.4.2 の
    * テキスト行列更新)。`textLineMatrix` (行頭) は据え置く点が `translateLine`

--- a/packages/core/src/content-stream/graphics-state/text-object/index.ts
+++ b/packages/core/src/content-stream/graphics-state/text-object/index.ts
@@ -117,7 +117,7 @@ export const TextObject = {
     } as TextObject;
   },
   /**
-   * `TJ` の数値要素による位置調整 (ISO 32000-1:2008 §9.4.3 / Issue §6.5)
+   * `TJ` の数値要素による位置調整 (ISO 32000-1:2008 §9.4.3 / Issue #414 §6.5)
    * や将来のグリフ送り (advance) の基盤となる、テキスト行列のみの平行移動。
    * `Tm' = translate(tx, ty) × Tm` を計算する (ISO 32000-1:2008 §9.4.2 の
    * テキスト行列更新)。`textLineMatrix` (行頭) は据え置く点が `translateLine`


### PR DESCRIPTION
## 概要

`TextObject` に **`translateText(state, tx, ty)`** メソッドを追加。
`Tm' = translate(tx, ty) × Tm` を計算し、`textLineMatrix`（行頭）を据え置く純粋関数。

`TJ` の数値要素による位置調整（ISO 32000-1:2008 §9.4.3）や将来のグリフ送り（advance）の基盤となる。
本 PR では純粋関数 1 メソッド追加とテストのみ。handler 配線・`TJ` operator 統合は Epic #413 配下の別 Issue 対応。

## 変更内容

### 🎯 変更の種類

- [x] ✨ 新機能 (New feature)

### 📝 詳細な変更内容

#### 追加された機能

- `TextObject.translateText(state, tx, ty): TextObject`
  - 純粋関数。元 state 不破壊、`throw` しない
  - `Matrix.multiply(translation, state.textMatrix)` で `textMatrix` のみ更新
  - `textLineMatrix` は `state.textLineMatrix` を**参照据え置き**（防御コピー不要）
  - `active` は引数 state から引き継ぐ

#### 兄弟メソッドとの差分

| メソッド | 掛け先 | textMatrix | textLineMatrix |
|---------|-------|-----------|---------------|
| `translateLine` (既存) | `Tlm` | `next` に更新 | `next` に更新 |
| `setMatrix` (既存) | — | `matrix` に置換 | `matrix` に置換 |
| **`translateText` (本PR)** | `Tm` | `next` に更新 | **据え置き** |

#### 変更されたファイル

- `packages/core/src/content-stream/graphics-state/text-object/index.ts` (+27 行) — `setMatrix` 直後に `translateText` メソッドを additive 追加
- `packages/core/src/content-stream/graphics-state/text-object/__tests__/text-object.translate-text.test.ts` (新規 +90 行) — 8 テスト

#### 削除されたファイル・機能

なし

#### 変更しなかったファイル（スコープ確認）

- barrel (`graphics-state/index.ts`) — 既存エクスポートに additive method を足すのみのため無変更
- `Matrix` モジュール — `Matrix.create` / `Matrix.multiply` のみ再利用（新ヘルパなし）

## 📊 システム図

### データフロー

```mermaid
flowchart TD
    Input["translateText(state, tx, ty)"]
    Create["translation = Matrix.create(1, 0, 0, 1, tx, ty)"]
    Mul["next = Matrix.multiply(translation, state.textMatrix)"]
    Return["{ active: state.active,<br/>  textMatrix: next, [NEW: 更新]<br/>  textLineMatrix: state.textLineMatrix [据え置き] }"]
    Input --> Create
    Create --> Mul
    Mul --> Return

    style Return fill:#ffe4b5,stroke:#d97706,stroke-width:2px
```

### `translateLine` との対比

```
                       TextObject { active, textMatrix (Tm), textLineMatrix (Tlm) }
                                                 |
              +----------------------------------+----------------------------------+
              |                                                                     |
        translateLine(state, tx, ty)                              translateText(state, tx, ty)
                  (既存)                                                   (本PR)
              |                                                                     |
   next = multiply(translation, Tlm)                       next = multiply(translation, Tm)
              |                                                                     |
              v                                                                     v
   { textMatrix: next,                                     { textMatrix: next,         [NEW: 更新]
     textLineMatrix: next }                                  textLineMatrix: state.textLineMatrix }
                                                                                     ↑ 据え置き
```

## 関連Issue

- Closes #414 (`[Phase 4-F] TextObject に textMatrix を平行移動する translateText を追加する`)
- 親 Epic: Refs #413
- 関連: Refs #289 (translateLine)

## テスト

`pnpm --filter @pdfmod/core test` で全 **2524 テスト green**（新規 8 テスト含む）。
`pnpm --filter @pdfmod/core build` 成功、`pnpm lint` 0 warnings / 0 errors。

### 新規追加テスト（8 ケース、`describe` 不使用のフラット構造）

| # | カテゴリ | テスト名（要約） | 検証ポイント |
|---|---------|----------------|------------|
| 1 | 正常系 | 水平移動 `(10, 0)` | `textMatrix = [1,0,0,1,82,720]` / `textLineMatrix` 不変 |
| 2 | 正常系 | 非可換性 `(5, -3)` (scale 含む Tm) | `translate(5,-3) × [2,0,0,2,10,20] = [2,0,0,2,20,14]`（逆順なら `[2,0,0,2,15,17]` → 乗算順を固定） |
| 3 | 境界値 | no-op `(0, 0)` (Tm ≠ Tlm dirty state) | `Tm` は `Tlm` にリセットされない（`translateLine` との API 契約差分を固定） |
| 4a | 正常系 | active 保持 (active=true) | `next.active === true` |
| 4b | 正常系 | active 保持 (inactive は false のまま) | `next.active === false` |
| 5 | エッジ | 元 state 不変性 | 引数 state の `textMatrix` / `textLineMatrix` が呼び出し前と同値 / `next !== state` |
| 6 | エッジ | inactive dirty state | `textMatrix = [3,0,0,3,25,32]` / `textLineMatrix` 据え置き / `active=false` 維持 |
| 7 | 正常系 | `textLineMatrix` 参照据え置き | `next.textLineMatrix === state.textLineMatrix` (防御コピーなし) |

### 品質チェック

- [x] `pnpm --filter @pdfmod/core test` 全 green（2524 / 2524）
- [x] `pnpm --filter @pdfmod/core build` 成功（vite build + tsc 宣言出力）
- [x] `pnpm lint` (biome + oxlint) エラー・警告なし
- [x] 既存 handler（td / td-leading / t-star / tm）のテストにリグレッションなし

## レビューポイント

- **乗算順**: `Matrix.multiply(translation, state.textMatrix)` の順序が `cm` / `translateLine` と同じ「左 = 適用する変換」規約に揃っているか
- **参照据え置き**: `textLineMatrix: state.textLineMatrix` で防御コピーを省略している点（既存 `setMatrix` と同方針、`Matrix` は readonly tuple 運用）
- **責務境界**: 引数 `tx` / `ty` は既に PDF text-space 用の移動量に換算済み。`TJ` 固有の換算（符号反転 / `1/1000` スケール / font size / horizontal scaling / text rise / writing mode）は呼び出し側 handler の責務。値域検証（NaN / Infinity / 負値）も呼び出し側に委譲（本メソッドは throw しない）
- **テストヘルパ**: `buildActive` / `buildInactive` で active / inactive 両方の dirty state 構築を統一（spec-based-code-review の INFO 指摘 I-001 反映）

## 関連ドキュメント

- spec: `.plugin-workspace/.specs/073-text-object-translate-text/`
  - `implementation-plan.md`（実装計画）
  - `tasks.md`（全タスク ■）
  - `spec-based-code-review/review-001.md`（CRITICAL 0 / WARNING 0 / INFO 6 → I-001 修正済み）