### PR TITLE
✨ [New Feature]: #415 Tj operator handler (tjHandler) を実装

### DIFF
--- a/packages/core/src/content-stream/operators/text/tj/__tests__/tj.basic.test.ts
+++ b/packages/core/src/content-stream/operators/text/tj/__tests__/tj.basic.test.ts
@@ -1,0 +1,128 @@
+import { assert, expect, test } from "vitest";
+import type { PdfObject } from "../../../../../pdf/types/pdf-types/index";
+import {
+  GraphicsState,
+  GraphicsStateStack,
+  TextObject,
+} from "../../../../graphics-state/index";
+import { OperandStack } from "../../../../operand-stack/index";
+import type { OperatorHandlerContext } from "../../../../operator-registry/index";
+import { tjHandler } from "../index";
+
+// active な text object を持つ最小コンテキストを組むビルダ。
+// （default の GraphicsStateStack.create() は textObject 非 active のため
+//  TextObject.begin() を current に差し替える）
+const buildActiveContext = (operands: PdfObject[]): OperatorHandlerContext => {
+  const operandStack = OperandStack.create();
+  for (const operand of operands) {
+    OperandStack.push(operandStack, operand);
+  }
+  const activeState = GraphicsState.update(GraphicsState.create(), {
+    textObject: TextObject.begin(),
+  });
+  const graphicsStateStack = GraphicsStateStack.replaceCurrent(
+    GraphicsStateStack.create(),
+    activeState,
+  );
+  return { operandStack, graphicsStateStack };
+};
+
+const literalString = (bytes: number[]): PdfObject => ({
+  type: "string",
+  value: new Uint8Array(bytes),
+  encoding: "literal",
+});
+
+const hexString = (bytes: number[]): PdfObject => ({
+  type: "string",
+  value: new Uint8Array(bytes),
+  encoding: "hex",
+});
+
+test("ASCII literal string operand を受理し ok を返す", () => {
+  // "Hi" 相当のリテラル string を operand として与えると成功し、stack が 1 個減ること
+  const context = buildActiveContext([literalString([0x48, 0x69])]);
+
+  const result = tjHandler(context);
+
+  assert(result.ok);
+  expect(OperandStack.depth(result.value.operandStack)).toBe(0);
+});
+
+test('hex string operand（encoding: "hex"）も同型として受理する', () => {
+  // tokenizer/parser が literal / hex を単一 type: "string" として渡す前提を pin down
+  const context = buildActiveContext([hexString([0x48, 0x69])]);
+
+  const result = tjHandler(context);
+
+  assert(result.ok);
+  expect(OperandStack.depth(result.value.operandStack)).toBe(0);
+});
+
+test("空 string（0 バイト）operand でも成功する", () => {
+  // 値域検証を行わないため、長さ 0 の Uint8Array でも operand 整合性のみで成功すること
+  const context = buildActiveContext([literalString([])]);
+
+  const result = tjHandler(context);
+
+  assert(result.ok);
+  expect(OperandStack.depth(result.value.operandStack)).toBe(0);
+});
+
+test("非ASCII byte（0x80+）の string operand を素通しして成功する", () => {
+  // handler は byte 列の中身に解釈を加えず、型整合のみで受理すること
+  const context = buildActiveContext([literalString([0x82, 0xa0])]);
+
+  const result = tjHandler(context);
+
+  assert(result.ok);
+  expect(OperandStack.depth(result.value.operandStack)).toBe(0);
+});
+
+test("成功時に graphicsStateStack は入力と同一参照で返る", () => {
+  // 本フェーズでは graphics state を一切更新しないため replaceCurrent が呼ばれず
+  // 同一参照のまま戻ること
+  const context = buildActiveContext([literalString([0x48])]);
+
+  const result = tjHandler(context);
+
+  assert(result.ok);
+  expect(result.value.graphicsStateStack).toBe(context.graphicsStateStack);
+});
+
+test("成功時に operandStack は入力と同一参照で返る（in-place mutate）", () => {
+  // OperandStack.pop は in-place mutate のため、handler は新しい stack を作らず
+  // 入力の operand stack をそのまま（pop 済みで）返すこと
+  const context = buildActiveContext([literalString([0x48])]);
+
+  const result = tjHandler(context);
+
+  assert(result.ok);
+  expect(result.value.operandStack).toBe(context.operandStack);
+});
+
+test("成功時に current の textObject と textState は同一参照で維持される", () => {
+  // graphics state stack 同一参照に加え、current の内部フィールドも触られていないこと
+  const context = buildActiveContext([literalString([0x48])]);
+  const currentBefore = GraphicsStateStack.current(context.graphicsStateStack);
+
+  const result = tjHandler(context);
+
+  assert(result.ok);
+  const currentAfter = GraphicsStateStack.current(
+    result.value.graphicsStateStack,
+  );
+  expect(currentAfter.textObject).toBe(currentBefore.textObject);
+  expect(currentAfter.textState).toBe(currentBefore.textState);
+});
+
+test("成功時に text object は active のまま維持される", () => {
+  // Tj は active フラグに触れないため、後続 operator もそのまま BT/ET 内として処理可能であること
+  const context = buildActiveContext([literalString([0x48])]);
+
+  const result = tjHandler(context);
+
+  assert(result.ok);
+  const current = GraphicsStateStack.current(result.value.graphicsStateStack);
+  expect(TextObject.isActive(current.textObject)).toBe(true);
+});

--- a/packages/core/src/content-stream/operators/text/tj/__tests__/tj.error.test.ts
+++ b/packages/core/src/content-stream/operators/text/tj/__tests__/tj.error.test.ts
@@ -1,0 +1,188 @@
+import { assert, expect, test } from "vitest";
+import type { PdfObject } from "../../../../../pdf/types/pdf-types/index";
+import {
+  GraphicsState,
+  GraphicsStateStack,
+  TextObject,
+} from "../../../../graphics-state/index";
+import { OperandStack } from "../../../../operand-stack/index";
+import type { OperatorHandlerContext } from "../../../../operator-registry/index";
+import { tjHandler } from "../index";
+
+// text object が inactive なコンテキストを operand 付きで組むビルダ。
+// （default の GraphicsStateStack.create() は textObject 非 active）
+const buildInactiveContext = (
+  operands: PdfObject[] = [],
+): OperatorHandlerContext => {
+  const operandStack = OperandStack.create();
+  for (const operand of operands) {
+    OperandStack.push(operandStack, operand);
+  }
+  const graphicsStateStack = GraphicsStateStack.create();
+  return { operandStack, graphicsStateStack };
+};
+
+// active な text object を持つ最小コンテキストを組むビルダ（pop / 型検査用）。
+const buildActiveContext = (operands: PdfObject[]): OperatorHandlerContext => {
+  const operandStack = OperandStack.create();
+  for (const operand of operands) {
+    OperandStack.push(operandStack, operand);
+  }
+  const activeState = GraphicsState.update(GraphicsState.create(), {
+    textObject: TextObject.begin(),
+  });
+  const graphicsStateStack = GraphicsStateStack.replaceCurrent(
+    GraphicsStateStack.create(),
+    activeState,
+  );
+  return { operandStack, graphicsStateStack };
+};
+
+const literalString = (bytes: number[]): PdfObject => ({
+  type: "string",
+  value: new Uint8Array(bytes),
+  encoding: "literal",
+});
+
+test("inactive な state で Tj を実行すると OPERATOR_ILLEGAL_STATE を返す", () => {
+  // BT/ET の外（textObject 非 active）で Tj が出現したとき illegal state として失敗すること
+  const context = buildInactiveContext([literalString([0x48])]);
+
+  const result = tjHandler(context);
+
+  assert(!result.ok);
+  expect(result.error.code).toBe("OPERATOR_ILLEGAL_STATE");
+});
+
+test("illegal state エラーの operatorName が Tj である", () => {
+  // エラーに反映される operator 名が PDF 表記の "Tj" であること
+  const context = buildInactiveContext([literalString([0x48])]);
+
+  const result = tjHandler(context);
+
+  assert(!result.ok);
+  assert(result.error.code === "OPERATOR_ILLEGAL_STATE");
+  expect(result.error.operatorName).toBe("Tj");
+});
+
+test("illegal state エラーの message が BT/ET 外を示す", () => {
+  // ユーザー向けに BT/ET 外であることを説明する固定メッセージを返すこと
+  const context = buildInactiveContext([literalString([0x48])]);
+
+  const result = tjHandler(context);
+
+  assert(!result.ok);
+  expect(result.error.message).toBe(
+    "Tj: text object is not active (Tj must appear within BT/ET)",
+  );
+});
+
+test("illegal state 時、operand stack は pop されず内容が保持される", () => {
+  // active 検査は pop の前に置くため operand stack が一切触られないこと
+  // depth が元のまま、かつ top の operand 内容も変化していないこと（peek で内容確認）
+  const expected = literalString([0x48]);
+  const context = buildInactiveContext([expected]);
+
+  const result = tjHandler(context);
+
+  assert(!result.ok);
+  expect(OperandStack.depth(context.operandStack)).toBe(1);
+  const top = OperandStack.peek(context.operandStack);
+  assert(top.some);
+  expect(top.value).toEqual(expected);
+});
+
+test("illegal state 時、graphics state stack の current は変化しない", () => {
+  // ガード early-return により replaceCurrent が呼ばれず current 内部の textObject/textState が同一参照で残ること
+  const context = buildInactiveContext([literalString([0x48])]);
+  const currentBefore = GraphicsStateStack.current(context.graphicsStateStack);
+
+  const result = tjHandler(context);
+
+  assert(!result.ok);
+  const currentAfter = GraphicsStateStack.current(context.graphicsStateStack);
+  expect(currentAfter.textObject).toBe(currentBefore.textObject);
+  expect(currentAfter.textState).toBe(currentBefore.textState);
+});
+
+test("active state で operand が 0 個のとき OPERATOR_OPERAND_MISSING を返す", () => {
+  // active 検査を通過した後の pop で空が検出されエラーになること
+  const context = buildActiveContext([]);
+
+  const result = tjHandler(context);
+
+  assert(!result.ok);
+  assert(result.error.code === "OPERATOR_OPERAND_MISSING");
+  expect(result.error.operatorName).toBe("Tj");
+  expect(result.error.required).toBe(1);
+  expect(result.error.actual).toBe(0);
+  expect(result.error.message).toBe(
+    "Operator 'Tj' requires 1 operand(s), got 0",
+  );
+});
+
+test("OPERAND_MISSING 時、graphics state stack の current は変化しない", () => {
+  // pop 失敗で early-return するため replaceCurrent が呼ばれず current 内部参照が維持されること
+  const context = buildActiveContext([]);
+  const currentBefore = GraphicsStateStack.current(context.graphicsStateStack);
+
+  const result = tjHandler(context);
+
+  assert(!result.ok);
+  const currentAfter = GraphicsStateStack.current(context.graphicsStateStack);
+  expect(currentAfter.textObject).toBe(currentBefore.textObject);
+  expect(currentAfter.textState).toBe(currentBefore.textState);
+});
+
+test.each<[string, PdfObject]>([
+  ["integer", { type: "integer", value: 1 }],
+  ["real", { type: "real", value: 1.5 }],
+  ["name", { type: "name", value: "F1" }],
+  ["boolean", { type: "boolean", value: true }],
+  ["null", { type: "null" }],
+  ["array", { type: "array", elements: [] }],
+])("active state で operand が %s のとき OPERATOR_OPERAND_TYPE_MISMATCH を返す", (typeName, operand) => {
+  const context = buildActiveContext([operand]);
+
+  const result = tjHandler(context);
+
+  assert(!result.ok);
+  assert(result.error.code === "OPERATOR_OPERAND_TYPE_MISMATCH");
+  expect(result.error.operatorName).toBe("Tj");
+  expect(result.error.expected).toBe("string");
+  expect(result.error.actual).toBe(typeName);
+  expect(result.error.message).toBe(
+    `Operator 'Tj' expected string operand, got ${typeName}`,
+  );
+});
+
+test("OPERAND_TYPE_MISMATCH 時、graphics state stack の current は変化しない", () => {
+  // 型検査失敗で early-return するため replaceCurrent が呼ばれず current 内部参照が維持されること
+  const context = buildActiveContext([{ type: "integer", value: 1 }]);
+  const currentBefore = GraphicsStateStack.current(context.graphicsStateStack);
+
+  const result = tjHandler(context);
+
+  assert(!result.ok);
+  const currentAfter = GraphicsStateStack.current(context.graphicsStateStack);
+  expect(currentAfter.textObject).toBe(currentBefore.textObject);
+  expect(currentAfter.textState).toBe(currentBefore.textState);
+});
+
+test("type mismatch 後、pop 済み operand は復元しない（余剰 operand のみ残る）", () => {
+  // 既存ハンドラ規約: 部分消費した operand stack は復元しない。
+  // 余剰として積んだ integer は残り、検査対象として pop された name は失われる。
+  const context = buildActiveContext([
+    { type: "integer", value: 99 },
+    { type: "name", value: "F1" },
+  ]);
+
+  const result = tjHandler(context);
+
+  assert(!result.ok);
+  expect(result.error.code).toBe("OPERATOR_OPERAND_TYPE_MISMATCH");
+  expect(OperandStack.depth(context.operandStack)).toBe(1);
+  const top = OperandStack.peek(context.operandStack);
+  assert(top.some);
+  expect(top.value).toEqual({ type: "integer", value: 99 });
+});

--- a/packages/core/src/content-stream/operators/text/tj/index.ts
+++ b/packages/core/src/content-stream/operators/text/tj/index.ts
@@ -1,0 +1,75 @@
+import type { PdfError } from "../../../../pdf/errors/index";
+import { err, ok } from "../../../../utils/result/index";
+import { GraphicsStateStack, TextObject } from "../../../graphics-state/index";
+import { OperandStack } from "../../../operand-stack/index";
+import type {
+  OperatorHandler,
+  OperatorHandlerContext,
+} from "../../../operator-registry/index";
+
+/** PDF 表記を保持した operator 名（"Tj"）。 */
+const OPERATOR_NAME = "Tj";
+
+/**
+ * PDF §9.4.3 `Tj` operator (show a text string) のハンドラ。
+ * operand を 1 個 pop し、string であれば受理して operand を消費する。
+ *
+ * 検査順序（厳守）:
+ *   (1) active 検査（false なら `OPERATOR_ILLEGAL_STATE` を返す）
+ *   (2) operand pop（none なら `OPERATOR_OPERAND_MISSING`）
+ *   (3) 型検査（type !== "string" なら `OPERATOR_OPERAND_TYPE_MISMATCH`）
+ *
+ * - text object が active でない場合は `OPERATOR_ILLEGAL_STATE` を返す
+ *   （operand stack / graphics state stack は変更しない）
+ * - operand stack が空なら `OPERATOR_OPERAND_MISSING` を返す
+ * - 末尾が string 以外なら `OPERATOR_OPERAND_TYPE_MISMATCH` を返す
+ * - string 値の妥当性（バイト長・符号化）は本フェーズでは検証しない
+ * - 本フェーズでは textMatrix の平行移動（テキスト送り / advance）を行わない。
+ *   フォント幅辞書・文字間隔・単語間隔・水平スケール等が未実装のため、
+ *   graphics state stack は同一参照のまま返す。後続フォントフェーズで
+ *   本 handler にテキスト送りと描画イベント発火が追加される。
+ * - エラー時に部分消費した operand stack は復元しない（既存ハンドラ規約）
+ *
+ * @param context - 実行コンテキスト (operand stack / graphics state stack)
+ * @returns 成功なら更新後コンテキスト、失敗なら PdfError
+ */
+export const tjHandler: OperatorHandler = (context: OperatorHandlerContext) => {
+  const current = GraphicsStateStack.current(context.graphicsStateStack);
+  if (!TextObject.isActive(current.textObject)) {
+    const error: PdfError = {
+      code: "OPERATOR_ILLEGAL_STATE",
+      message: "Tj: text object is not active (Tj must appear within BT/ET)",
+      operatorName: OPERATOR_NAME,
+    };
+    return err(error);
+  }
+
+  const popped = OperandStack.pop(context.operandStack);
+  if (!popped.some) {
+    const error: PdfError = {
+      code: "OPERATOR_OPERAND_MISSING",
+      message: `Operator '${OPERATOR_NAME}' requires 1 operand(s), got 0`,
+      operatorName: OPERATOR_NAME,
+      required: 1,
+      actual: 0,
+    };
+    return err(error);
+  }
+
+  const operand = popped.value;
+  if (operand.type !== "string") {
+    const error: PdfError = {
+      code: "OPERATOR_OPERAND_TYPE_MISMATCH",
+      message: `Operator '${OPERATOR_NAME}' expected string operand, got ${operand.type}`,
+      operatorName: OPERATOR_NAME,
+      expected: "string",
+      actual: operand.type,
+    };
+    return err(error);
+  }
+
+  return ok({
+    operandStack: context.operandStack,
+    graphicsStateStack: context.graphicsStateStack,
+  });
+};


### PR DESCRIPTION
## 概要

PDF §9.4.3 `Tj` (show a text string) operator のハンドラ `tjHandler` を新規実装。active な text object 内で string operand を 1 個受け取って消費するパイプライン上の最小ノードを提供する。本フェーズは「operand の受理 + 検査」までを完了させる足場で、フォントメトリクスを使った textMatrix advance や描画イベント発火は後続フォントフェーズで本 handler に追加拡張される。

## 変更内容

### 🎯 変更の種類

- [x] ✨ 新機能 (New feature)
- [x] 🚨 テスト追加/修正 (Tests)

### 📝 詳細な変更内容

#### 追加された機能・修正

- `tjHandler` を新規実装（`OperatorHandler` 型を満たす矢印関数）
- 検査順序（厳守）: `(1) active 検査` → `(2) operand pop` → `(3) string 型判別`
- エラーは 3 種類:
  - `OPERATOR_ILLEGAL_STATE`: BT/ET 外で `Tj` が出現した場合（operand stack / graphics state stack は変更しない）
  - `OPERATOR_OPERAND_MISSING`: operand stack が空（`required: 1`, `actual: 0`）
  - `OPERATOR_OPERAND_TYPE_MISMATCH`: 末尾 operand が string 以外（`expected: "string"`, `actual: operand.type`）
- 成功時 `graphicsStateStack` は入力と同一参照のまま返す（本フェーズではフォントメトリクスが未実装のため textMatrix 更新を行わない）
- エラー時に部分消費した operand stack は復元しない（既存 `tc`/`t-star` ハンドラ規約を踏襲）
- 既存パターン踏襲: handler 骨格は `text/tc/index.ts`、active 検査早期 return は `text/t-star/index.ts` と一致

#### 変更されたファイル

- `packages/core/src/content-stream/operators/text/tj/index.ts` [NEW]
- `packages/core/src/content-stream/operators/text/tj/__tests__/tj.basic.test.ts` [NEW]
- `packages/core/src/content-stream/operators/text/tj/__tests__/tj.error.test.ts` [NEW]

#### 削除されたファイル・機能

なし

## 📊 システム図

### 状態マシン / フロー図

```mermaid
flowchart TD
    Start([Tj operator]) --> Active{TextObject.isActive?}
    Active -->|false| ErrIS[ERR: OPERATOR_ILLEGAL_STATE<br/>stack 両方同一参照]:::err
    Active -->|true| Pop[OperandStack.pop]
    Pop --> Some{some?}
    Some -->|none| ErrM[ERR: OPERATOR_OPERAND_MISSING<br/>required:1, actual:0]:::err
    Some -->|some| Type{operand.type === 'string'?}
    Type -->|no| ErrT[ERR: OPERATOR_OPERAND_TYPE_MISMATCH<br/>expected:'string']:::err
    Type -->|yes| Ok[ok: operandStack 同一参照<br/>graphicsStateStack 同一参照]:::ok

    classDef err fill:#fde2e1,stroke:#dc2626,stroke-width:2px
    classDef ok fill:#dcfce7,stroke:#16a34a,stroke-width:2px
```

### データフロー

```
OperatorHandlerContext (入力)
  ├─ operandStack        ── [..., string]
  └─ graphicsStateStack  ── current { textObject.active: true, textState, ... }
        │
        ▼  (1) active 検査 — false なら early-return（両 stack 同一参照）
        ▼  (2) operand pop — in-place mutate / none なら OPERAND_MISSING
        ▼  (3) type === "string" 判別 — no なら TYPE_MISMATCH（pop 済み operand は復元しない）
        ▼
ok({
  operandStack: context.operandStack,        ← pop 済み（in-place）
  graphicsStateStack: context.graphicsStateStack,  ← 同一参照（本フェーズでは触らない）
})
```

後続フェーズでは Step 3 の成功パスに `replaceCurrent(... { textObject: <translated> })` を 1 行追加するだけでテキスト送り (advance) と描画イベント発火を組み込める拡張点として残しています。

## 📋 関連 Issue

- Closes #415
- Refs #413 (Epic: text-showing operators ファミリー)

## 🧪 テスト

### テスト実行方法

```bash
pnpm --filter @pdfmod/core exec vitest run src/content-stream/operators/text/tj
pnpm --filter @pdfmod/core build
pnpm lint
```

### テスト項目

- [x] 単体テスト (Unit tests)

### テスト結果

- **`tj.basic.test.ts`: 8 件 pass**（成功系: ASCII literal / hex / 空 string / 非ASCII byte の素通し + 同一参照 pin down × 3（graphicsStateStack / operandStack / 内部 textObject・textState）+ active flag 維持）
- **`tj.error.test.ts`: 15 件 pass**（illegal-state 5 + missing 1 + 各エラー path での graphics state 不変 3 + `test.each` mismatch 6（integer/real/name/boolean/null/array）+ 非復元 pin down 1）
- **core 全テスト**: 2543 件 pass
- **build**: 成功
- **lint** (biome + oxlint): 363 files / 0 errors

## 🔍 レビューポイント

- 本フェーズで `graphicsStateStack` を同一参照のまま返す設計（実装計画 §3-3）— フォントメトリクス未実装のため正確な送り量が計算できず、誤った textMatrix を埋め込むより不変にしておく方が安全。テストで「同一参照」「内部 textObject/textState も同一参照」「active flag 維持」を pin down してリグレッション検出
- `operand.type === "string"` を `tj/index.ts` 内で直接判別（YAGNI、計画 §3-4）— `PdfString.is` companion object は後続 `TJ`/`'`/`"` 等で再利用が必要になった時点で抽出予定
- エラー時の operand stack 非復元規約（既存 `tc` と整合）— `tj.error.test.ts` 末尾の pin down テストで保護

## ✅ チェックリスト

- [x] コードレビューの準備ができている
- [x] テストが正常に実行される
- [x] コミットメッセージが適切な形式で書かれている
- [x] 関連する Issue が PR の「Development」に Linked されている（Closes #415）
- [x] セルフレビューを実施した（Codex + spec-based-code-review 5 観点で CRITICAL/WARNING 0、INFO 修正反映済み）
- [x] 破壊的変更なし