### PR TITLE
✨ [New Feature]: #401 lexer に read_integer (PDF 整数トークン解析) を追加

### DIFF
--- a/rust/crates/core/src/lexer.rs
+++ b/rust/crates/core/src/lexer.rs
@@ -146,6 +146,86 @@ impl<'a> Lexer<'a> {
             break;
         }
     }
+
+    /// 現在位置から PDF 整数トークン（ISO 32000-1 §7.3.3）を読み出す。
+    ///
+    /// 先頭の `+` / `-` 符号（任意）と ASCII 数字 1 文字以上から成る字句を整数として
+    /// 解釈し、`i64` で返す。読み終了の条件は「whitespace / delimiter / EOF に到達」
+    /// する地点。`.` または非数字 regular byte（例: `123abc`）に到達した場合は整数として
+    /// 完結できないため `None` を返し、`pos` を呼び出し前の位置に巻き戻す。整数として
+    /// 完結できる場合は `Some(i64)` を返し `pos` を末尾まで進める。
+    ///
+    /// 以下の場合は `None` を返し、`pos` は呼び出し前の位置に戻す（巻き戻し）:
+    /// - 先頭バイトが `+` / `-` / ASCII 数字 のいずれでもない（pos は元々動かないため
+    ///   実質的に不変）
+    /// - 先頭 `+` / `-` のみで直後に ASCII 数字 が続かない（例: `+x`, `-`, `-(`）
+    /// - 数字読み中に `.` を検出（実数候補。上位で `read_real` を試せるよう pos を戻す）
+    /// - 数字読み中に数字でも `.` でもない regular byte を検出（PDF トークン境界違反。
+    ///   例: `123abc`）
+    /// - `i64` のオーバーフロー（`checked_mul` / `checked_add` / `checked_sub` が None）
+    ///
+    /// `i64::MIN` の絶対値は `i64::MAX + 1` で正数として表現不可のため、累積は
+    /// **符号付き**で行う（正なら `checked_add`、負なら `checked_sub`）。これにより
+    /// `-9223372036854775808` を `Some(i64::MIN)` として正しく扱える。
+    pub fn read_integer(&mut self) -> Option<i64> {
+        let start = self.pos;
+
+        let sign: i64 = match self.peek() {
+            Some(b'+') => {
+                self.pos = self.pos.checked_add(1)?;
+                1
+            }
+            Some(b'-') => {
+                self.pos = self.pos.checked_add(1)?;
+                -1
+            }
+            Some(b) if b.is_ascii_digit() => 1,
+            _ => return None,
+        };
+
+        match self.peek() {
+            Some(b) if b.is_ascii_digit() => {}
+            _ => {
+                self.pos = start;
+                return None;
+            }
+        }
+
+        let mut acc: i64 = 0;
+        // 停止条件が EOF だけでなく「境界 break / 巻き戻し return / オーバーフロー return」と
+        // 多岐にわたるため、while let ではなく loop + let-else で表現する。
+        #[allow(clippy::while_let_loop)]
+        loop {
+            let Some(b) = self.peek() else { break };
+
+            if ByteKind::is_whitespace(b) || ByteKind::is_delimiter(b) {
+                break;
+            }
+            if !b.is_ascii_digit() {
+                self.pos = start;
+                return None;
+            }
+
+            let d = (b - b'0') as i64;
+            let next_acc = acc.checked_mul(10).and_then(|v| match sign {
+                1 => v.checked_add(d),
+                _ => v.checked_sub(d),
+            });
+            let Some(v) = next_acc else {
+                self.pos = start;
+                return None;
+            };
+            acc = v;
+
+            let Some(next) = self.pos.checked_add(1) else {
+                self.pos = start;
+                return None;
+            };
+            self.pos = next;
+        }
+
+        Some(acc)
+    }
 }
 
 #[cfg(test)]
@@ -550,6 +630,7 @@ mod tests {
         lexer.skip_whitespace();
         let _ = lexer.skip_comment();
         lexer.skip_whitespace_and_comments();
+        let _ = lexer.read_integer();
         assert_eq!(lexer.position(), len);
         assert!(lexer.is_eof());
     }
@@ -565,6 +646,7 @@ mod tests {
         lexer.skip_whitespace();
         let _ = lexer.skip_comment();
         lexer.skip_whitespace_and_comments();
+        let _ = lexer.read_integer();
         assert_eq!(lexer.position(), 0);
     }
 
@@ -589,5 +671,444 @@ mod tests {
         let mut lexer = Lexer::new(b"\n%PDF-1.7\nbody");
         lexer.skip_whitespace_and_comments();
         assert_eq!(lexer.peek(), Some(b'b'));
+    }
+
+    // ---------- Phase 8: read_integer ----------
+
+    // Phase 8-A: 早期 None（先頭バイトが該当せず pos 不変）
+
+    #[test]
+    fn read_integer_returns_none_for_empty_input() {
+        // 空入力に対する read_integer が None を返し pos が 0 のままであることを確認する
+        let mut lexer = Lexer::new(&[]);
+        assert_eq!(lexer.read_integer(), None);
+        assert_eq!(lexer.position(), 0);
+    }
+
+    #[test]
+    fn read_integer_returns_none_at_eof() {
+        // EOF 状態の read_integer が None を返し pos が EOF 位置のままであることを確認する
+        let mut lexer = Lexer::new(b"a");
+        lexer.advance();
+        assert_eq!(lexer.read_integer(), None);
+        assert_eq!(lexer.position(), 1);
+    }
+
+    #[test]
+    fn read_integer_returns_none_for_leading_whitespace() {
+        // 先頭が whitespace の入力で read_integer が None・pos が 0 のままであることを確認する
+        let mut lexer = Lexer::new(b" 123");
+        assert_eq!(lexer.read_integer(), None);
+        assert_eq!(lexer.position(), 0);
+    }
+
+    #[test]
+    fn read_integer_returns_none_for_leading_delimiter() {
+        // 先頭が delimiter '(' の入力で read_integer が None・pos が 0 のままであることを確認する
+        let mut lexer = Lexer::new(b"(123");
+        assert_eq!(lexer.read_integer(), None);
+        assert_eq!(lexer.position(), 0);
+    }
+
+    #[test]
+    fn read_integer_returns_none_for_every_leading_delimiter_byte() {
+        // 仕様 §2.2 の delimiter 10 バイト全てを先頭に置いた場合、各々 None・pos 0 で停止することを確認する
+        let delimiter_bytes = [0x28, 0x29, 0x3C, 0x3E, 0x5B, 0x5D, 0x7B, 0x7D, 0x2F, 0x25];
+        for d in delimiter_bytes {
+            let input = [d, b'1', b'2', b'3'];
+            let mut lexer = Lexer::new(&input);
+            assert_eq!(
+                lexer.read_integer(),
+                None,
+                "delimiter 0x{d:02X} should yield None"
+            );
+            assert_eq!(lexer.position(), 0, "delimiter 0x{d:02X} should keep pos 0");
+        }
+    }
+
+    #[test]
+    fn read_integer_returns_none_for_every_leading_whitespace_byte() {
+        // 仕様 §2.1 の whitespace 6 バイト全てを先頭に置いた場合、各々 None・pos 0 で停止することを確認する
+        let whitespace_bytes = [0x00, 0x09, 0x0A, 0x0C, 0x0D, 0x20];
+        for w in whitespace_bytes {
+            let input = [w, b'1', b'2', b'3'];
+            let mut lexer = Lexer::new(&input);
+            assert_eq!(
+                lexer.read_integer(),
+                None,
+                "whitespace 0x{w:02X} should yield None"
+            );
+            assert_eq!(
+                lexer.position(),
+                0,
+                "whitespace 0x{w:02X} should keep pos 0"
+            );
+        }
+    }
+
+    #[test]
+    fn read_integer_returns_none_for_leading_non_digit_regular_byte() {
+        // 先頭が非数字 regular の入力で read_integer が None・pos が 0 のままであることを確認する
+        let mut lexer = Lexer::new(b"abc");
+        assert_eq!(lexer.read_integer(), None);
+        assert_eq!(lexer.position(), 0);
+    }
+
+    #[test]
+    fn read_integer_returns_none_for_lone_plus_at_eof() {
+        // 符号 '+' のみで EOF の入力が None を返し pos が 0 に巻き戻されることを確認する
+        let mut lexer = Lexer::new(b"+");
+        assert_eq!(lexer.read_integer(), None);
+        assert_eq!(lexer.position(), 0);
+    }
+
+    #[test]
+    fn read_integer_returns_none_for_lone_minus_at_eof() {
+        // 符号 '-' のみで EOF の入力が None を返し pos が 0 に巻き戻されることを確認する
+        let mut lexer = Lexer::new(b"-");
+        assert_eq!(lexer.read_integer(), None);
+        assert_eq!(lexer.position(), 0);
+    }
+
+    #[test]
+    fn read_integer_returns_none_for_plus_then_non_digit_regular() {
+        // '+' の直後が非数字 regular のとき None を返し pos が 0 に巻き戻されることを確認する
+        let mut lexer = Lexer::new(b"+x");
+        assert_eq!(lexer.read_integer(), None);
+        assert_eq!(lexer.position(), 0);
+    }
+
+    #[test]
+    fn read_integer_returns_none_for_minus_then_delimiter() {
+        // '-' の直後が delimiter のとき None を返し pos が 0 に巻き戻されることを確認する
+        let mut lexer = Lexer::new(b"-(");
+        assert_eq!(lexer.read_integer(), None);
+        assert_eq!(lexer.position(), 0);
+    }
+
+    #[test]
+    fn read_integer_returns_none_for_plus_then_whitespace() {
+        // '+' の直後が whitespace のとき None を返し pos が 0 に巻き戻されることを確認する
+        let mut lexer = Lexer::new(b"+ ");
+        assert_eq!(lexer.read_integer(), None);
+        assert_eq!(lexer.position(), 0);
+    }
+
+    #[test]
+    fn read_integer_returns_none_for_sign_then_every_delimiter_byte() {
+        // 符号 ∈ {+, -} × delimiter 10 種の全 20 組で None・pos 0 に巻き戻されることを確認する
+        let signs = [b'+', b'-'];
+        let delimiter_bytes = [0x28, 0x29, 0x3C, 0x3E, 0x5B, 0x5D, 0x7B, 0x7D, 0x2F, 0x25];
+        for s in signs {
+            for d in delimiter_bytes {
+                let input = [s, d];
+                let mut lexer = Lexer::new(&input);
+                assert_eq!(
+                    lexer.read_integer(),
+                    None,
+                    "sign 0x{s:02X} + delimiter 0x{d:02X} should yield None"
+                );
+                assert_eq!(
+                    lexer.position(),
+                    0,
+                    "sign 0x{s:02X} + delimiter 0x{d:02X} should rollback to 0"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn read_integer_returns_none_for_sign_then_every_whitespace_byte() {
+        // 符号 ∈ {+, -} × whitespace 6 種の全 12 組で None・pos 0 に巻き戻されることを確認する
+        let signs = [b'+', b'-'];
+        let whitespace_bytes = [0x00, 0x09, 0x0A, 0x0C, 0x0D, 0x20];
+        for s in signs {
+            for w in whitespace_bytes {
+                let input = [s, w];
+                let mut lexer = Lexer::new(&input);
+                assert_eq!(
+                    lexer.read_integer(),
+                    None,
+                    "sign 0x{s:02X} + whitespace 0x{w:02X} should yield None"
+                );
+                assert_eq!(
+                    lexer.position(),
+                    0,
+                    "sign 0x{s:02X} + whitespace 0x{w:02X} should rollback to 0"
+                );
+            }
+        }
+    }
+
+    // Phase 8-B: 単一/複数桁の正数（符号なし）
+
+    #[test]
+    fn read_integer_reads_single_digit_zero() {
+        // 単一桁 '0' を Some(0) として読み pos を 1 進めることを確認する
+        let mut lexer = Lexer::new(b"0");
+        assert_eq!(lexer.read_integer(), Some(0));
+        assert_eq!(lexer.position(), 1);
+    }
+
+    #[test]
+    fn read_integer_reads_single_digit_seven() {
+        // 値の三角測量: 単一桁 '7' を Some(7) として読むことを確認する
+        let mut lexer = Lexer::new(b"7");
+        assert_eq!(lexer.read_integer(), Some(7));
+        assert_eq!(lexer.position(), 1);
+    }
+
+    #[test]
+    fn read_integer_reads_multi_digit_123() {
+        // 桁数の三角測量: 複数桁 '123' を Some(123) として読み pos を 3 進めることを確認する
+        let mut lexer = Lexer::new(b"123");
+        assert_eq!(lexer.read_integer(), Some(123));
+        assert_eq!(lexer.position(), 3);
+    }
+
+    #[test]
+    fn read_integer_reads_leading_zero_padded_00042() {
+        // 先頭ゼロ '00042' を Some(42) として読み pos を 5 進めることを確認する（先頭ゼロ許容）
+        let mut lexer = Lexer::new(b"00042");
+        assert_eq!(lexer.read_integer(), Some(42));
+        assert_eq!(lexer.position(), 5);
+    }
+
+    // Phase 8-C: + 付き正数
+
+    #[test]
+    fn read_integer_reads_plus_zero() {
+        // '+0' を Some(0) として読み pos を 2 進めることを確認する
+        let mut lexer = Lexer::new(b"+0");
+        assert_eq!(lexer.read_integer(), Some(0));
+        assert_eq!(lexer.position(), 2);
+    }
+
+    #[test]
+    fn read_integer_reads_plus_17() {
+        // 値の三角測量: '+17' を Some(17) として読み pos を 3 進めることを確認する
+        let mut lexer = Lexer::new(b"+17");
+        assert_eq!(lexer.read_integer(), Some(17));
+        assert_eq!(lexer.position(), 3);
+    }
+
+    // Phase 8-D: - 付き負数
+
+    #[test]
+    fn read_integer_reads_minus_one() {
+        // '-1' を Some(-1) として読み pos を 2 進めることを確認する
+        let mut lexer = Lexer::new(b"-1");
+        assert_eq!(lexer.read_integer(), Some(-1));
+        assert_eq!(lexer.position(), 2);
+    }
+
+    #[test]
+    fn read_integer_reads_minus_45() {
+        // 値の三角測量: '-45' を Some(-45) として読み pos を 3 進めることを確認する
+        let mut lexer = Lexer::new(b"-45");
+        assert_eq!(lexer.read_integer(), Some(-45));
+        assert_eq!(lexer.position(), 3);
+    }
+
+    #[test]
+    fn read_integer_reads_minus_leading_zero_007() {
+        // 負数の先頭ゼロ '-007' を Some(-7) として読み pos を 4 進めることを確認する
+        let mut lexer = Lexer::new(b"-007");
+        assert_eq!(lexer.read_integer(), Some(-7));
+        assert_eq!(lexer.position(), 4);
+    }
+
+    // Phase 8-E: トークン境界
+
+    #[test]
+    fn read_integer_stops_at_whitespace() {
+        // 後続が空白の '42 rest' を Some(42) として読み peek が ' ' を指すことを確認する
+        let mut lexer = Lexer::new(b"42 rest");
+        assert_eq!(lexer.read_integer(), Some(42));
+        assert_eq!(lexer.position(), 2);
+        assert_eq!(lexer.peek(), Some(b' '));
+    }
+
+    #[test]
+    fn read_integer_stops_at_delimiter() {
+        // 後続が delimiter の '42]rest' を Some(42) として読み peek が ']' を指すことを確認する
+        let mut lexer = Lexer::new(b"42]rest");
+        assert_eq!(lexer.read_integer(), Some(42));
+        assert_eq!(lexer.position(), 2);
+        assert_eq!(lexer.peek(), Some(b']'));
+    }
+
+    #[test]
+    fn read_integer_stops_at_every_delimiter_byte() {
+        // '42' + delimiter 10 種の全組で Some(42)・pos 2・peek が当該 delimiter を指すことを確認する
+        let delimiter_bytes = [0x28, 0x29, 0x3C, 0x3E, 0x5B, 0x5D, 0x7B, 0x7D, 0x2F, 0x25];
+        for d in delimiter_bytes {
+            let input = [b'4', b'2', d];
+            let mut lexer = Lexer::new(&input);
+            assert_eq!(
+                lexer.read_integer(),
+                Some(42),
+                "delimiter 0x{d:02X} should still yield Some(42)"
+            );
+            assert_eq!(lexer.position(), 2, "delimiter 0x{d:02X} should stop at 2");
+            assert_eq!(
+                lexer.peek(),
+                Some(d),
+                "delimiter 0x{d:02X} should be the next peek byte"
+            );
+        }
+    }
+
+    #[test]
+    fn read_integer_stops_at_every_whitespace_byte() {
+        // '42' + whitespace 6 種の全組で Some(42)・pos 2・peek が当該 whitespace を指すことを確認する
+        let whitespace_bytes = [0x00, 0x09, 0x0A, 0x0C, 0x0D, 0x20];
+        for w in whitespace_bytes {
+            let input = [b'4', b'2', w];
+            let mut lexer = Lexer::new(&input);
+            assert_eq!(
+                lexer.read_integer(),
+                Some(42),
+                "whitespace 0x{w:02X} should still yield Some(42)"
+            );
+            assert_eq!(lexer.position(), 2, "whitespace 0x{w:02X} should stop at 2");
+            assert_eq!(
+                lexer.peek(),
+                Some(w),
+                "whitespace 0x{w:02X} should be the next peek byte"
+            );
+        }
+    }
+
+    #[test]
+    fn read_integer_stops_at_eof() {
+        // EOF 直前の '42' を Some(42) として読み EOF に達することを確認する
+        let mut lexer = Lexer::new(b"42");
+        assert_eq!(lexer.read_integer(), Some(42));
+        assert_eq!(lexer.position(), 2);
+        assert!(lexer.is_eof());
+    }
+
+    #[test]
+    fn read_integer_stops_at_lf() {
+        // 後続が LF の '42\n' を Some(42) として読み peek が LF を指すことを確認する
+        let mut lexer = Lexer::new(b"42\n");
+        assert_eq!(lexer.read_integer(), Some(42));
+        assert_eq!(lexer.position(), 2);
+        assert_eq!(lexer.peek(), Some(b'\n'));
+    }
+
+    #[test]
+    fn read_integer_returns_none_for_digits_then_non_digit_regular() {
+        // 数字途中で非数字 regular '123abc' を検出した場合 None・pos が 0 に巻き戻されることを確認する
+        let mut lexer = Lexer::new(b"123abc");
+        assert_eq!(lexer.read_integer(), None);
+        assert_eq!(lexer.position(), 0);
+    }
+
+    #[test]
+    fn read_integer_returns_none_for_signed_digits_then_non_digit_regular() {
+        // 符号付き数字途中で非数字 regular '-12x' を検出した場合 None・pos が 0 に巻き戻されることを確認する
+        let mut lexer = Lexer::new(b"-12x");
+        assert_eq!(lexer.read_integer(), None);
+        assert_eq!(lexer.position(), 0);
+    }
+
+    // Phase 8-F: . 遭遇（実数候補 — 次タスクの read_real に渡すため巻き戻し）
+
+    #[test]
+    fn read_integer_returns_none_when_dot_after_digits() {
+        // 数字後に '.' が続く '12.3' を None として返し pos が 0 に巻き戻されることを確認する
+        let mut lexer = Lexer::new(b"12.3");
+        assert_eq!(lexer.read_integer(), None);
+        assert_eq!(lexer.position(), 0);
+    }
+
+    #[test]
+    fn read_integer_returns_none_when_dot_at_trailing() {
+        // 末尾が '.' の '4.' を None として返し pos が 0 に巻き戻されることを確認する
+        let mut lexer = Lexer::new(b"4.");
+        assert_eq!(lexer.read_integer(), None);
+        assert_eq!(lexer.position(), 0);
+    }
+
+    #[test]
+    fn read_integer_returns_none_when_leading_dot() {
+        // 先頭が '.' の '.002' を None として返し pos が 0 のままであることを確認する（先頭バイト早期 None 経路）
+        let mut lexer = Lexer::new(b".002");
+        assert_eq!(lexer.read_integer(), None);
+        assert_eq!(lexer.position(), 0);
+    }
+
+    #[test]
+    fn read_integer_returns_none_when_dot_after_sign_and_digits() {
+        // 符号付き数字後に '.' が続く '-3.14' を None として返し pos が 0 に巻き戻されることを確認する
+        let mut lexer = Lexer::new(b"-3.14");
+        assert_eq!(lexer.read_integer(), None);
+        assert_eq!(lexer.position(), 0);
+    }
+
+    // Phase 8-G: i64 境界（オーバーフロー検知）
+
+    #[test]
+    fn read_integer_reads_i64_max() {
+        // i64::MAX (9223372036854775807) を Some(i64::MAX) として読み pos を 19 進めることを確認する
+        let mut lexer = Lexer::new(b"9223372036854775807");
+        assert_eq!(lexer.read_integer(), Some(i64::MAX));
+        assert_eq!(lexer.position(), 19);
+    }
+
+    #[test]
+    fn read_integer_returns_none_for_i64_max_plus_one() {
+        // i64::MAX + 1 (9223372036854775808) は checked_add でオーバーフローし None・pos 巻き戻しになることを確認する
+        let mut lexer = Lexer::new(b"9223372036854775808");
+        assert_eq!(lexer.read_integer(), None);
+        assert_eq!(lexer.position(), 0);
+    }
+
+    #[test]
+    fn read_integer_reads_i64_min() {
+        // 符号付き累積により i64::MIN (-9223372036854775808) を Some(i64::MIN) として読めることを確認する
+        let mut lexer = Lexer::new(b"-9223372036854775808");
+        assert_eq!(lexer.read_integer(), Some(i64::MIN));
+        assert_eq!(lexer.position(), 20);
+    }
+
+    #[test]
+    fn read_integer_returns_none_for_i64_min_minus_one() {
+        // i64::MIN - 1 (-9223372036854775809) は checked_sub でオーバーフローし None・pos 巻き戻しになることを確認する
+        let mut lexer = Lexer::new(b"-9223372036854775809");
+        assert_eq!(lexer.read_integer(), None);
+        assert_eq!(lexer.position(), 0);
+    }
+
+    #[test]
+    fn read_integer_returns_none_for_very_long_digits_overflow() {
+        // i64 桁数を大幅に超える数字列は途中で checked_mul が None を返し巻き戻されることを確認する
+        let mut lexer = Lexer::new(b"99999999999999999999999");
+        assert_eq!(lexer.read_integer(), None);
+        assert_eq!(lexer.position(), 0);
+    }
+
+    // Phase 8-H: pos 巻き戻し（中間位置 / 副作用検証）
+
+    #[test]
+    fn read_integer_at_mid_buffer_advances_correctly() {
+        // 'x123 ' で先頭 'x' を advance 後 read_integer を呼び Some(123)・pos == 4・peek が ' ' を指すことを確認する
+        let mut lexer = Lexer::new(b"x123 ");
+        lexer.advance();
+        assert_eq!(lexer.read_integer(), Some(123));
+        assert_eq!(lexer.position(), 4);
+        assert_eq!(lexer.peek(), Some(b' '));
+    }
+
+    #[test]
+    fn read_integer_failure_at_mid_buffer_rolls_back_to_call_site() {
+        // 'x12.3' で先頭 'x' を advance 後（pos == 1）に read_integer を呼ぶと None かつ pos が 1（呼び出し前位置）に巻き戻ることを確認する
+        let mut lexer = Lexer::new(b"x12.3");
+        lexer.advance();
+        assert_eq!(lexer.position(), 1);
+        assert_eq!(lexer.read_integer(), None);
+        assert_eq!(lexer.position(), 1);
     }
 }


### PR DESCRIPTION
## 概要

PDF 整数トークン（ISO 32000-1 §7.3.3）の字句解析 API として `Lexer::read_integer(&mut self) -> Option<i64>` を `rust/crates/core/src/lexer.rs` に追加する。Issue #401 のサブタスク 1（整数のトークン化）のみを対象とし、Real / `next_token` ディスパッチ / `Primitive::Integer` ラップ / `Result` 化はスコープ外。

## 変更内容

### 🎯 変更の種類

- [x] ✨ 新機能 (New feature)

### 📝 詳細な変更内容

#### 追加された機能

- `Lexer<'a>::read_integer(&mut self) -> Option<i64>` を追加
  - 先頭の `+` / `-` 符号（任意）と ASCII 数字 1 文字以上を i64 に解釈
  - 失敗時は `pos` を呼び出し前の位置に**巻き戻し**（rollback パターンを初導入）
  - 累積は **符号付き**（正: `checked_add` / 負: `checked_sub`）で `-9223372036854775808` を `Some(i64::MIN)` として表現可能
  - `.` または非数字 regular byte に遭遇すると整数として完結できないため `None` + 巻き戻し（後続タスクの `read_real` が同 pos から拾える）

#### 変更されたファイル

- `rust/crates/core/src/lexer.rs`
  - `Lexer<'a>` impl に `read_integer` を追加（+78 行 / 単一関数完結）
  - Phase 7 既存テスト `all_apis_do_not_panic_at_eof` / `all_apis_do_not_panic_for_empty_input` の 2 件に `let _ = lexer.read_integer();` を追記（panic 不在契約の横断スイープ）
  - Phase 8 として read_integer 専用テスト群 32 関数（うち網羅スイープを 4 つ含むため実際の検証ケース数は 100+）を追加

## 📊 システム図

### `read_integer` 状態遷移（簡略版）

```mermaid
flowchart TD
    Entry([呼び出し<br/>start = pos]) --> Peek1{先頭バイト?}
    Peek1 -->|+ or -| Sign[符号確定<br/>pos += 1]
    Peek1 -->|ASCII digit| Loop
    Peek1 -->|EOF / ws / delim /<br/>非数字 regular| EarlyNone([None<br/>pos 不変])

    Sign --> Peek2{次のバイト?}
    Peek2 -->|ASCII digit| Loop
    Peek2 -->|非 digit| Rollback1

    Loop[累積ループ<br/>符号付き checked_*] --> Decide{次のバイト?}
    Decide -->|ASCII digit| Loop
    Decide -->|ws / delim / EOF| Success([Some i64<br/>pos = 末尾])
    Decide -->|. or 非数字 regular| Rollback2
    Loop -->|checked_mul/add/sub<br/>が None| Rollback3

    Rollback1[pos = start]:::rb
    Rollback2[pos = start]:::rb
    Rollback3[pos = start]:::rb
    Rollback1 --> Fail([None])
    Rollback2 --> Fail
    Rollback3 --> Fail

    classDef rb fill:#ffe4b5,stroke:#d97706,stroke-width:2px
```

## 🔗 関連 Issue

Refs #401（タスク 1: 整数のトークン化のみ。残タスク 2/3/4 は別 PR で対応）
親 Epic: #252
依存: #400（Lexer 骨格、`52d3849` でマージ済み）

## 🧪 テスト

| 項目 | コマンド | 結果 |
|:---|:---|:---|
| ビルド | `cargo build` | 成功（warning 0） |
| 単体テスト | `cargo test -p pdfmod-core lexer` | **206 / 206 pass**（うち read_integer 42 件 + Phase 7 panic 不在 2 件） |
| Clippy | `cargo clippy --all-targets -- -D warnings` | 警告 0 |
| Format | `cargo fmt --check` | 差分 0 |
| Doc | `cargo doc --no-deps` | 生成成功 |

### テスト網羅性

- 早期 None: 空入力 / EOF / 先頭 whitespace 6 種・delimiter 10 種・非数字 regular / 符号単独・符号 + ws 6 種・delim 10 種（巻き戻し経路）
- 正常系: 単一桁 / 複数桁 / 先頭ゼロ許容 / `+` 付き / `-` 付き / `-007`
- トークン境界: whitespace 6 種・delimiter 10 種スイープ / LF / EOF
- `.` 遭遇: `12.3` / `4.` / `.002` / `-3.14`（全て巻き戻し）
- i64 境界: MAX / MAX+1 / MIN / MIN-1 / 極端な長さ
- pos 副作用: 中間位置からの成功・失敗時の呼び出し前位置への巻き戻し
- Phase 7 横断 panic 不在テストへの統合

## 🔍 レビューポイント

1. **符号付き累積の採用根拠**: 正数累積後の `checked_neg` では `-i64::MIN` を表現不可。正なら `checked_add` / 負なら `checked_sub` の符号付き累積で `Some(i64::MIN)` を返せる（implementation-plan §3.1.1）
2. **`loop` + `let-else` の採用**: clippy `while_let_loop` を `#[allow]` で抑止。停止条件が「境界 break / 巻き戻し return / オーバーフロー return」と多岐にわたるため、`while let` よりも `loop` のフラット構造が妥当（memory `rust-loop-vs-while-let.md` / plan §3.1.1）
3. **巻き戻しパターンの初導入**: `let start = self.pos;` + 失敗パスでの `self.pos = start;` が既存 lexer API には無いパターン。`read_real` 等の後続タスクが同パターンを踏襲できる設計
4. **`read_integer` docstring**: ISO 32000-1 §7.3.3 への参照を含み、Issue 番号は記載しない（プロジェクト規約 `no-issue-detail-in-code-comments.md` 準拠）

## ⚠️ 破壊的変更

- [ ] この変更は既存の API に破壊的変更を含みます

純粋な追加 API のため破壊的変更なし。既存テストへの影響は Phase 7 横断スイープ 2 件への `let _ = lexer.read_integer();` 追記のみ。

## 📚 追加情報

### 参考資料

- ISO 32000-1:2008 §7.3.3 Numeric Objects
- `.plugin-workspace/.specs/archive/073-lexer-integer-token/implementation-plan.md`
- `docs/specs/01_lexical_conventions.md` §3.3

### Spec-Based Code Review 結果

5 並列レビュー（performance / design / spec-alignment / test-quality / comment-quality）実施済み:
- CRITICAL: 0 / WARNING: 3 / INFO: 11
- WARNING のうち 1 件（docstring 不整合）は本 PR の修正で解消済み
- 残 2 件は implementation-plan §3.1.1 と一致する設計判断のため現状維持

## ✅ チェックリスト

- [x] コードレビューの準備ができている
- [x] テストが正常に実行される（cargo test 206 / 206 pass）
- [x] ドキュメントが更新されている（read_integer の docstring を追加）
- [x] コミットメッセージが適切な形式で書かれている
- [x] 関連する Issue が PR の「Development」に Linked されている
- [x] PR 本文に `Refs #401` で Issue が記載されている
- [x] セルフレビューを実施した
- [x] 破壊的変更なし