### PR TITLE
✨ [New Feature]: #421 ' (apostrophe) operator handler を実装

### DIFF
--- a/packages/core/src/content-stream/operators/text/apostrophe/__tests__/apostrophe.basic.test.ts
+++ b/packages/core/src/content-stream/operators/text/apostrophe/__tests__/apostrophe.basic.test.ts
@@ -1,0 +1,239 @@
+import { assert, expect, test } from "vitest";
+import type { PdfObject } from "../../../../../pdf/types/pdf-types/index";
+import {
+  GraphicsState,
+  GraphicsStateStack,
+  Matrix,
+  TextObject,
+  TextState,
+} from "../../../../graphics-state/index";
+import { OperandStack } from "../../../../operand-stack/index";
+import type { OperatorHandlerContext } from "../../../../operator-registry/index";
+import { apostropheHandler } from "../index";
+
+// leading / textObject を仕込んだ active コンテキストを組むビルダ。
+// テストヘルパは共通化せず各テストファイル内にローカル定義する規約（本 issue では
+// 抽出をスコープ外とする方針）に従い、basic / error 間でも個別に定義する。
+const buildActiveContext = (
+  operands: PdfObject[],
+  leading: number = 0,
+  textObject: TextObject = TextObject.begin(),
+): OperatorHandlerContext => {
+  const operandStack = OperandStack.create();
+  for (const operand of operands) {
+    OperandStack.push(operandStack, operand);
+  }
+  const activeState = GraphicsState.update(GraphicsState.create(), {
+    textObject,
+    textState: TextState.update(TextState.create(), { leading }),
+  });
+  const graphicsStateStack = GraphicsStateStack.replaceCurrent(
+    GraphicsStateStack.create(),
+    activeState,
+  );
+  return { operandStack, graphicsStateStack };
+};
+
+// active かつ任意の Tm / Tlm を持つ TextObject を生で組むヘルパ（dirty state 構築用）。
+// translateLine(0, 0) が「Tlm 不変・Tm を Tlm にリセット」する挙動を pin down するため、
+// TextObject.begin() ではなく Tm ≠ Tlm な fixture を構築する必要がある。
+const buildDirtyTextObject = (
+  textMatrix: Matrix,
+  textLineMatrix: Matrix,
+): TextObject =>
+  ({
+    active: true,
+    textMatrix,
+    textLineMatrix,
+  }) as unknown as TextObject;
+
+const literalString = (bytes: number[]): PdfObject => ({
+  type: "string",
+  value: new Uint8Array(bytes),
+  encoding: "literal",
+});
+
+const hexString = (bytes: number[]): PdfObject => ({
+  type: "string",
+  value: new Uint8Array(bytes),
+  encoding: "hex",
+});
+
+test("leading=14 の active context で string operand を受理し両 matrix が translate(0, -14) になる", () => {
+  // `string '` ≡ `T* string Tj` の T* 部に相当する平行移動 (0, -leading) が適用されること
+  const context = buildActiveContext([literalString([0x48, 0x69])], 14);
+
+  const result = apostropheHandler(context);
+
+  assert(result.ok);
+  const current = GraphicsStateStack.current(result.value.graphicsStateStack);
+  expect(current.textObject.textMatrix).toEqual(
+    Matrix.create(1, 0, 0, 1, 0, -14),
+  );
+  expect(current.textObject.textLineMatrix).toEqual(
+    Matrix.create(1, 0, 0, 1, 0, -14),
+  );
+  // operand は pop されて stack は空であること
+  expect(OperandStack.depth(result.value.operandStack)).toBe(0);
+});
+
+test('hex string operand（encoding: "hex"）も string として受理し同じ平行移動になる', () => {
+  // tokenizer/parser が literal / hex を単一 type: "string" として渡す前提を pin down
+  const context = buildActiveContext([hexString([0x48, 0x69])], 14);
+
+  const result = apostropheHandler(context);
+
+  assert(result.ok);
+  const current = GraphicsStateStack.current(result.value.graphicsStateStack);
+  expect(current.textObject.textMatrix).toEqual(
+    Matrix.create(1, 0, 0, 1, 0, -14),
+  );
+  expect(current.textObject.textLineMatrix).toEqual(
+    Matrix.create(1, 0, 0, 1, 0, -14),
+  );
+  expect(OperandStack.depth(result.value.operandStack)).toBe(0);
+});
+
+test("leading=14 のまま ' を 2 回連続実行すると f 成分が -28 に累積する", () => {
+  // 連続 ' は Tlm への translate 乗算が累積する（三角測量 — 固定値実装の排除）
+  const first = apostropheHandler(
+    buildActiveContext([literalString([0x48])], 14),
+  );
+  assert(first.ok);
+
+  const firstObject = GraphicsStateStack.current(
+    first.value.graphicsStateStack,
+  ).textObject;
+  const second = apostropheHandler(
+    buildActiveContext([literalString([0x69])], 14, firstObject),
+  );
+
+  assert(second.ok);
+  const current = GraphicsStateStack.current(second.value.graphicsStateStack);
+  expect(current.textObject.textMatrix).toEqual(
+    Matrix.create(1, 0, 0, 1, 0, -28),
+  );
+  expect(current.textObject.textLineMatrix).toEqual(
+    Matrix.create(1, 0, 0, 1, 0, -28),
+  );
+});
+
+test("operand stack に 2 つあるとき先頭 1 つだけ消費される", () => {
+  // 余剰 operand が積まれていても、' は末尾 1 つだけ pop して残りは保持されること
+  const remaining = literalString([0x41]);
+  const consumed = literalString([0x42]);
+  const context = buildActiveContext([remaining, consumed], 14);
+
+  const result = apostropheHandler(context);
+
+  assert(result.ok);
+  expect(OperandStack.depth(result.value.operandStack)).toBe(1);
+  const top = OperandStack.peek(result.value.operandStack);
+  assert(top.some);
+  expect(top.value).toEqual(remaining);
+  const current = GraphicsStateStack.current(result.value.graphicsStateStack);
+  expect(current.textObject.textMatrix).toEqual(
+    Matrix.create(1, 0, 0, 1, 0, -14),
+  );
+});
+
+test("leading=0（default）で ' を実行しても両 matrix は identity のまま（no-op 相当）", () => {
+  // TextState.create() の default leading=0 では translate(0, 0) の no-op 相当になること
+  const context = buildActiveContext([literalString([0x48])], 0);
+
+  const result = apostropheHandler(context);
+
+  assert(result.ok);
+  const current = GraphicsStateStack.current(result.value.graphicsStateStack);
+  expect(current.textObject.textMatrix).toEqual(Matrix.identity());
+  expect(current.textObject.textLineMatrix).toEqual(Matrix.identity());
+  // operand は pop 済みであること
+  expect(OperandStack.depth(result.value.operandStack)).toBe(0);
+});
+
+test("leading=0・dirty state（Tm≠Tlm）で ' を実行すると Tlm は不変・Tm が Tlm にリセットされる", () => {
+  // translateLine(0, 0) は Tlm 不変だが Tm を Tlm に揃える。「matrix 不変」は
+  // begin 直後の文脈でのみ正確であり、dirty state ではリセットが起きることを pin down する
+  const dirtyTm = Matrix.create(5, 0, 0, 5, 1, 2);
+  const lineTlm = Matrix.create(1, 0, 0, 1, 72, 720);
+  const context = buildActiveContext(
+    [literalString([0x48])],
+    0,
+    buildDirtyTextObject(dirtyTm, lineTlm),
+  );
+
+  const result = apostropheHandler(context);
+
+  assert(result.ok);
+  const current = GraphicsStateStack.current(result.value.graphicsStateStack);
+  // Tlm は不変であること
+  expect(current.textObject.textLineMatrix).toEqual(lineTlm);
+  // Tm は Tlm と同値にリセットされること
+  expect(current.textObject.textMatrix).toEqual(lineTlm);
+});
+
+test("負の leading=-5 で ' を実行すると上方向 translate(0, 5) に移動する", () => {
+  // leading の符号反転（-leading）により負の leading は上方向移動になること
+  // handler 側で値域検証しない規約を pin down
+  const context = buildActiveContext([literalString([0x48])], -5);
+
+  const result = apostropheHandler(context);
+
+  assert(result.ok);
+  const current = GraphicsStateStack.current(result.value.graphicsStateStack);
+  expect(current.textObject.textMatrix).toEqual(
+    Matrix.create(1, 0, 0, 1, 0, 5),
+  );
+  expect(current.textObject.textLineMatrix).toEqual(
+    Matrix.create(1, 0, 0, 1, 0, 5),
+  );
+});
+
+test("leading=NaN を素通しで受け取り matrix の f 成分が NaN になる", () => {
+  // 値域検証なし規約に従い、translateLine が NaN を素通しすること
+  const context = buildActiveContext([literalString([0x48])], Number.NaN);
+
+  const result = apostropheHandler(context);
+
+  assert(result.ok);
+  const current = GraphicsStateStack.current(result.value.graphicsStateStack);
+  expect(Number.isNaN(current.textObject.textMatrix[5])).toBe(true);
+  expect(Number.isNaN(current.textObject.textLineMatrix[5])).toBe(true);
+});
+
+test("leading=Infinity を素通しで受け取り matrix の f 成分が -Infinity になる", () => {
+  // 値域検証なし規約に従い、-leading の符号反転だけが行われること
+  const context = buildActiveContext(
+    [literalString([0x48])],
+    Number.POSITIVE_INFINITY,
+  );
+
+  const result = apostropheHandler(context);
+
+  assert(result.ok);
+  const current = GraphicsStateStack.current(result.value.graphicsStateStack);
+  expect(current.textObject.textMatrix[5]).toBe(Number.NEGATIVE_INFINITY);
+  expect(current.textObject.textLineMatrix[5]).toBe(Number.NEGATIVE_INFINITY);
+});
+
+test("成功時に operandStack は入力と同一参照で返る（in-place mutate）", () => {
+  // OperandStack.pop は in-place mutate のため、handler は新しい stack を作らず
+  // 入力の operand stack をそのまま（pop 済みで）返すこと
+  const context = buildActiveContext([literalString([0x48])], 14);
+
+  const result = apostropheHandler(context);
+
+  assert(result.ok);
+  expect(result.value.operandStack).toBe(context.operandStack);
+});
+
+test("leading=0 でも成功時に graphicsStateStack は入力と異なる新規参照で返る", () => {
+  // translate が no-op 相当でも replaceCurrent は必ず呼ばれるため、
+  // stack 自体は新インスタンスになること（同一参照ではない）
+  const context = buildActiveContext([literalString([0x48])], 0);
+
+  const result = apostropheHandler(context);
+
+  assert(result.ok);
+  expect(result.value.graphicsStateStack).not.toBe(context.graphicsStateStack);
+});

--- a/packages/core/src/content-stream/operators/text/apostrophe/__tests__/apostrophe.error.test.ts
+++ b/packages/core/src/content-stream/operators/text/apostrophe/__tests__/apostrophe.error.test.ts
@@ -1,0 +1,233 @@
+import { assert, expect, test } from "vitest";
+import type { PdfObject } from "../../../../../pdf/types/pdf-types/index";
+import {
+  GraphicsState,
+  GraphicsStateStack,
+  Matrix,
+  TextObject,
+  TextState,
+} from "../../../../graphics-state/index";
+import { OperandStack } from "../../../../operand-stack/index";
+import type { OperatorHandlerContext } from "../../../../operator-registry/index";
+import { apostropheHandler } from "../index";
+
+// active=true / leading 任意 の context を組み立てる。
+const buildActiveContext = (
+  operands: PdfObject[],
+  leading: number = 0,
+): OperatorHandlerContext => {
+  const operandStack = OperandStack.create();
+  for (const operand of operands) {
+    OperandStack.push(operandStack, operand);
+  }
+  const activeState = GraphicsState.update(GraphicsState.create(), {
+    textObject: TextObject.begin(),
+    textState: TextState.update(TextState.create(), { leading }),
+  });
+  const graphicsStateStack = GraphicsStateStack.replaceCurrent(
+    GraphicsStateStack.create(),
+    activeState,
+  );
+  return { operandStack, graphicsStateStack };
+};
+
+// active=false (BT 未発行) の context を組み立てる。
+const buildInactiveContext = (
+  operands: PdfObject[] = [],
+): OperatorHandlerContext => {
+  const operandStack = OperandStack.create();
+  for (const operand of operands) {
+    OperandStack.push(operandStack, operand);
+  }
+  const graphicsStateStack = GraphicsStateStack.create();
+  return { operandStack, graphicsStateStack };
+};
+
+// inactive かつ非 identity の matrix / 非 default の leading を持つ context。
+// ガードを通らず translateLine が誤って呼ばれた場合に matrix が変化することを検出するための fixture。
+const NON_IDENTITY_MATRIX = Matrix.create(2, 0, 0, 2, 10, 20);
+const buildInactiveNonIdentityContext = (): OperatorHandlerContext => {
+  const operandStack = OperandStack.create();
+  const inactiveNonIdentity = {
+    active: false,
+    textMatrix: NON_IDENTITY_MATRIX,
+    textLineMatrix: NON_IDENTITY_MATRIX,
+  } as unknown as TextObject;
+  const state = GraphicsState.update(GraphicsState.create(), {
+    textObject: inactiveNonIdentity,
+    textState: TextState.update(TextState.create(), { leading: 14 }),
+  });
+  const graphicsStateStack = GraphicsStateStack.replaceCurrent(
+    GraphicsStateStack.create(),
+    state,
+  );
+  return { operandStack, graphicsStateStack };
+};
+
+const literalString = (bytes: number[]): PdfObject => ({
+  type: "string",
+  value: new Uint8Array(bytes),
+  encoding: "literal",
+});
+
+test("inactive な state で ' を実行すると OPERATOR_ILLEGAL_STATE を返す", () => {
+  // BT/ET の外（textObject 非 active）で ' が出現したとき illegal state として失敗すること
+  const context = buildInactiveContext([literalString([0x48])]);
+
+  const result = apostropheHandler(context);
+
+  assert(!result.ok);
+  expect(result.error.code).toBe("OPERATOR_ILLEGAL_STATE");
+});
+
+test("inactive で ' を実行したときエラーの operatorName が ' である", () => {
+  // エラーに反映される operator 名が PDF 表記の "'" であること
+  const context = buildInactiveContext([literalString([0x48])]);
+
+  const result = apostropheHandler(context);
+
+  assert(!result.ok);
+  assert(result.error.code === "OPERATOR_ILLEGAL_STATE");
+  expect(result.error.operatorName).toBe("'");
+});
+
+test("inactive で ' を実行したときエラーの message が BT/ET 外を示す", () => {
+  // ユーザー向けに BT/ET 外であることを説明する固定メッセージを返すこと
+  const context = buildInactiveContext([literalString([0x48])]);
+
+  const result = apostropheHandler(context);
+
+  assert(!result.ok);
+  expect(result.error.message).toBe(
+    "': text object is not active (' must appear within BT/ET)",
+  );
+});
+
+test("illegal state 時、operand stack は pop されず内容が保持される", () => {
+  // active 検査は pop の前に置くため operand stack が一切触られないこと
+  const expected = literalString([0x48]);
+  const context = buildInactiveContext([expected]);
+
+  const result = apostropheHandler(context);
+
+  assert(!result.ok);
+  expect(OperandStack.depth(context.operandStack)).toBe(1);
+  const top = OperandStack.peek(context.operandStack);
+  assert(top.some);
+  expect(top.value).toEqual(expected);
+});
+
+test("illegal state 時、graphics state stack は差し替えられず current が変更されない", () => {
+  // ガードの early-return により replaceCurrent が呼ばれず、非 identity の matrix と
+  // 非 default の textState（leading=14）がそのまま保持されること
+  const context = buildInactiveNonIdentityContext();
+  const stackBefore = context.graphicsStateStack;
+
+  const result = apostropheHandler(context);
+
+  assert(!result.ok);
+  expect(context.graphicsStateStack).toBe(stackBefore);
+  const current = GraphicsStateStack.current(context.graphicsStateStack);
+  expect(current.textObject.textMatrix).toEqual(NON_IDENTITY_MATRIX);
+  expect(current.textObject.textLineMatrix).toEqual(NON_IDENTITY_MATRIX);
+  expect(current.textState.leading).toBe(14);
+  expect(TextObject.isActive(current.textObject)).toBe(false);
+});
+
+test("active かつ operand が 0 個のとき OPERATOR_OPERAND_MISSING を返す", () => {
+  // active 検査を通過した後の pop で空が検出されエラーになること
+  const context = buildActiveContext([], 14);
+
+  const result = apostropheHandler(context);
+
+  assert(!result.ok);
+  assert(result.error.code === "OPERATOR_OPERAND_MISSING");
+  expect(result.error.operatorName).toBe("'");
+  expect(result.error.required).toBe(1);
+  expect(result.error.actual).toBe(0);
+  expect(result.error.message).toBe(
+    "Operator ''' requires 1 operand(s), got 0",
+  );
+});
+
+test("OPERAND_MISSING 時、graphics state stack の current は変化しない", () => {
+  // pop 失敗で early-return するため replaceCurrent が呼ばれず current 内部参照が維持されること
+  const context = buildActiveContext([], 14);
+  const currentBefore = GraphicsStateStack.current(context.graphicsStateStack);
+
+  const result = apostropheHandler(context);
+
+  assert(!result.ok);
+  const currentAfter = GraphicsStateStack.current(context.graphicsStateStack);
+  expect(currentAfter.textObject).toBe(currentBefore.textObject);
+  expect(currentAfter.textState).toBe(currentBefore.textState);
+});
+
+test.each<[string, PdfObject]>([
+  ["integer", { type: "integer", value: 1 }],
+  ["real", { type: "real", value: 1.5 }],
+  ["name", { type: "name", value: "F1" }],
+  ["boolean", { type: "boolean", value: true }],
+  ["null", { type: "null" }],
+  ["array", { type: "array", elements: [] }],
+  ["dictionary", { type: "dictionary", entries: new Map() }],
+  [
+    "indirect-ref",
+    { type: "indirect-ref", objectNumber: 1, generationNumber: 0 },
+  ],
+  [
+    "stream",
+    {
+      type: "stream",
+      dictionary: { type: "dictionary", entries: new Map() },
+      data: new Uint8Array(),
+    },
+  ],
+])("active state で operand が %s のとき OPERATOR_OPERAND_TYPE_MISMATCH を返す", (typeName, operand) => {
+  const context = buildActiveContext([operand], 14);
+
+  const result = apostropheHandler(context);
+
+  assert(!result.ok);
+  assert(result.error.code === "OPERATOR_OPERAND_TYPE_MISMATCH");
+  expect(result.error.operatorName).toBe("'");
+  expect(result.error.expected).toBe("string");
+  expect(result.error.actual).toBe(typeName);
+  expect(result.error.message).toBe(
+    `Operator ''' expected string operand, got ${typeName}`,
+  );
+});
+
+test("型不一致時、pop 済み operand は復元されない（余剰 operand のみ残る）", () => {
+  // 既存ハンドラ規約: 部分消費した operand stack は復元しない。
+  // 余剰として積んだ integer は残り、検査対象として pop された name は失われる。
+  const context = buildActiveContext(
+    [
+      { type: "integer", value: 99 },
+      { type: "name", value: "F1" },
+    ],
+    14,
+  );
+
+  const result = apostropheHandler(context);
+
+  assert(!result.ok);
+  expect(result.error.code).toBe("OPERATOR_OPERAND_TYPE_MISMATCH");
+  expect(OperandStack.depth(context.operandStack)).toBe(1);
+  const top = OperandStack.peek(context.operandStack);
+  assert(top.some);
+  expect(top.value).toEqual({ type: "integer", value: 99 });
+});
+
+test("OPERAND_TYPE_MISMATCH 時、graphics state stack の current は変化しない", () => {
+  // 型検査失敗で early-return するため replaceCurrent が呼ばれず current 内部参照が維持されること
+  const context = buildActiveContext([{ type: "integer", value: 1 }], 14);
+  const currentBefore = GraphicsStateStack.current(context.graphicsStateStack);
+
+  const result = apostropheHandler(context);
+
+  assert(!result.ok);
+  const currentAfter = GraphicsStateStack.current(context.graphicsStateStack);
+  expect(currentAfter.textObject).toBe(currentBefore.textObject);
+  expect(currentAfter.textState).toBe(currentBefore.textState);
+});

--- a/packages/core/src/content-stream/operators/text/apostrophe/index.ts
+++ b/packages/core/src/content-stream/operators/text/apostrophe/index.ts
@@ -1,0 +1,91 @@
+import type { PdfError } from "../../../../pdf/errors/index";
+import { err, ok } from "../../../../utils/result/index";
+import {
+  GraphicsState,
+  GraphicsStateStack,
+  TextObject,
+} from "../../../graphics-state/index";
+import { OperandStack } from "../../../operand-stack/index";
+import type {
+  OperatorHandler,
+  OperatorHandlerContext,
+} from "../../../operator-registry/index";
+
+/** PDF 表記を保持した operator 名（"'"）。 */
+const OPERATOR_NAME = "'";
+
+/**
+ * PDF §9.4.3 `'` (apostrophe / move to next line and show text) operator のハンドラ。
+ *
+ * `string '` は `T* string Tj` と等価。current の `textState.leading` を参照し、
+ * `TextObject.translateLine(textObject, 0, -leading)` でテキスト行列を次行頭へ
+ * 移動した上で、string operand を受理する（`'` 自体は 1 個の string operand を消費）。
+ *
+ * 検査順序（厳守）:
+ *   (1) active 検査（false なら `OPERATOR_ILLEGAL_STATE` を返す）
+ *   (2) operand pop（none なら `OPERATOR_OPERAND_MISSING`）
+ *   (3) 型検査（type !== "string" なら `OPERATOR_OPERAND_TYPE_MISMATCH`）
+ *
+ * - text object が active でない場合は `OPERATOR_ILLEGAL_STATE` を返す
+ *   （operand stack / graphics state stack は変更しない）
+ * - operand stack が空なら `OPERATOR_OPERAND_MISSING` を返す
+ *   （graphics state stack は変更しない）
+ * - 末尾が string 以外なら `OPERATOR_OPERAND_TYPE_MISMATCH` を返す
+ *   （エラー時に部分消費した operand stack は復元しない — 既存ハンドラ規約）
+ * - `leading` の値域（負値 / `NaN` / `Infinity`）は本 handler では検証しない
+ *   （`tStarHandler` と同一規約。`translateLine` に素通しさせる）
+ * - フォント幅辞書が未実装のため、本フェーズでは描画後の advance 計算と
+ *   描画イベント発火は行わない（`tjHandler` と同一規約）。
+ *
+ * @param context - 実行コンテキスト (operand stack / graphics state stack)
+ * @returns 成功なら更新後コンテキスト、失敗なら PdfError
+ */
+export const apostropheHandler: OperatorHandler = (
+  context: OperatorHandlerContext,
+) => {
+  const current = GraphicsStateStack.current(context.graphicsStateStack);
+  if (!TextObject.isActive(current.textObject)) {
+    const error: PdfError = {
+      code: "OPERATOR_ILLEGAL_STATE",
+      message: "': text object is not active (' must appear within BT/ET)",
+      operatorName: OPERATOR_NAME,
+    };
+    return err(error);
+  }
+
+  const popped = OperandStack.pop(context.operandStack);
+  if (!popped.some) {
+    const error: PdfError = {
+      code: "OPERATOR_OPERAND_MISSING",
+      message: `Operator '${OPERATOR_NAME}' requires 1 operand(s), got 0`,
+      operatorName: OPERATOR_NAME,
+      required: 1,
+      actual: 0,
+    };
+    return err(error);
+  }
+
+  const operand = popped.value;
+  if (operand.type !== "string") {
+    const error: PdfError = {
+      code: "OPERATOR_OPERAND_TYPE_MISMATCH",
+      message: `Operator '${OPERATOR_NAME}' expected string operand, got ${operand.type}`,
+      operatorName: OPERATOR_NAME,
+      expected: "string",
+      actual: operand.type,
+    };
+    return err(error);
+  }
+
+  const leading = current.textState.leading;
+  const textObject = TextObject.translateLine(current.textObject, 0, -leading);
+  const next = GraphicsState.update(current, { textObject });
+  const graphicsStateStack = GraphicsStateStack.replaceCurrent(
+    context.graphicsStateStack,
+    next,
+  );
+  return ok({
+    operandStack: context.operandStack,
+    graphicsStateStack,
+  });
+};


### PR DESCRIPTION
## 概要

PDF §9.4.3 の `'` (apostrophe / move to next line and show text) operator のハンドラを新規実装する。`string '` は `T* string Tj` と等価で、`(0, -leading)` の平行移動を行った後に string operand を 1 個受理する。`tjHandler` (#415) と `tStarHandler` (#293) の合成形で、新規発明は不要。

## 変更内容

### 🎯 変更の種類

- [x] ✨ 新機能 (New feature)

### 📝 詳細な変更内容

#### 追加された機能

- `apostropheHandler: OperatorHandler` を新規実装
  - 検査順序: **active → pop → string 型** の早期 return（兄弟ハンドラ規約踏襲）
  - 成功時: `TextObject.translateLine(textObject, 0, -leading)` → `GraphicsState.update` → `GraphicsStateStack.replaceCurrent` の 3-step pipeline
  - エラー: `OPERATOR_ILLEGAL_STATE` / `OPERATOR_OPERAND_MISSING` / `OPERATOR_OPERAND_TYPE_MISMATCH`
  - `throw` 不使用、`Result<T, PdfError>` で返却
  - エラー時 operand stack は復元しない（既存規約）
  - `leading` の値域（負値 / `NaN` / `Infinity`）は handler 側で検証しない（`tStarHandler` と同一規約）

#### 追加されたファイル（3 ファイル）

- `packages/core/src/content-stream/operators/text/apostrophe/index.ts` — ハンドラ本体
- `packages/core/src/content-stream/operators/text/apostrophe/__tests__/apostrophe.basic.test.ts` — 正常系 11 tests
- `packages/core/src/content-stream/operators/text/apostrophe/__tests__/apostrophe.error.test.ts` — 異常系 18 tests（`test.each` で PdfObject 全 9 型網羅）

#### 既存ファイル変更

なし。barrel / registry 登録は Epic #413 配下の別 issue でスコープ外。

## 📊 システム図

### 状態マシン / フロー図

```mermaid
flowchart TD
    Start([apostropheHandler context]) --> GetCurrent[current = GraphicsStateStack.current]
    GetCurrent --> CheckActive{TextObject.isActive?}
    CheckActive -- false --> ErrIllegal[err: OPERATOR_ILLEGAL_STATE<br/>stack 不変]:::err
    CheckActive -- true --> Pop[OperandStack.pop]
    Pop --> CheckSome{popped.some?}
    CheckSome -- false --> ErrMissing[err: OPERATOR_OPERAND_MISSING<br/>state stack 不変]:::err
    CheckSome -- true --> CheckType{operand.type === string?}
    CheckType -- false --> ErrType[err: OPERATOR_OPERAND_TYPE_MISMATCH<br/>operand pop 済み 復元なし]:::err
    CheckType -- true --> Translate[textObject' = TextObject.translateLine 0, -leading]:::new
    Translate --> Update[next = GraphicsState.update]:::new
    Update --> Replace[graphicsStateStack' = GraphicsStateStack.replaceCurrent]:::new
    Replace --> Ok([ok: operandStack 同一参照 / graphicsStateStack 新規参照]):::ok

    classDef err fill:#ffe4e1,stroke:#d97706,stroke-width:2px
    classDef new fill:#ffe4b5,stroke:#d97706,stroke-width:2px
    classDef ok fill:#d4f8d4,stroke:#16a34a,stroke-width:2px
```

## 📋 関連 Issue

- Closes #421

## 🧪 テスト

### テスト実行コマンド

```bash
pnpm --filter @pdfmod/core test src/content-stream/operators/text/apostrophe
```

### テスト項目

- [x] 単体テスト (Unit tests)

### テスト結果

- **apostrophe**: 29 tests passed（basic 11 + error 18）
- **core 全体**: 2625 tests passed（リグレッションなし）
- `pnpm --filter @pdfmod/core typecheck`: エラーゼロ
- `pnpm --filter @pdfmod/core build`: 成功
- `grep -n "throw "` (handler): 0 件
- `grep -rn "describe("` (テスト): 0 件（フラット構造）

#### 網羅性

| カテゴリ | カバレッジ |
| --- | --- |
| 検査順序 | active 両分岐 / pop 両分岐 / 型 両分岐 |
| leading 境界値 | 0（default） / -5（負値） / NaN / Infinity / dirty state (Tm≠Tlm) |
| operand 累積 | 連続 2 回呼び出しで f 成分が -28 に累積（三角測量） |
| 型網羅 | integer / real / name / boolean / null / array / dictionary / indirect-ref / stream の 9 型 |
| 参照同一性 | operandStack 同一・graphicsStateStack 新規（leading=0 でも新規） |
| stack 不変性 | 3 エラー × graphics state stack 不変、illegal state 時 operand 不変 |

## 🔍 レビューポイント

- 兄弟 `tjHandler` + `tStarHandler` の**忠実な合成形**であり、新規パターンは導入していない（implementation-plan.md Step 3 で個別実装を許容）
- `test.each` の型網羅は `PdfObject` ユニオン全 9 型を網羅（spec-based-code-review の指摘反映）
- `dirty state` テストで `translateLine(0, 0)` が「Tlm 不変・Tm を Tlm にリセット」する挙動を pin down
- レビュー (spec-based-code-review) で CRITICAL/WARNING は 0 件で完了

## ⚠️ 破壊的変更

- [ ] 破壊的変更なし（新規ファイル追加のみ・既存ファイル変更ゼロ）

## ✅ チェックリスト

- [x] テストが正常に実行される
- [x] コミットメッセージが規約に沿っている
- [x] 関連 Issue が本文に記載されている
- [x] セルフレビュー（spec-based-code-review 5 エージェント並列）実施済み
- [x] 破壊的変更なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)