### PR TITLE
✨ [New Feature]: #422 " (quote) operator handler を実装

### DIFF
--- a/packages/core/src/content-stream/operators/text/quote/__tests__/quote.basic.test.ts
+++ b/packages/core/src/content-stream/operators/text/quote/__tests__/quote.basic.test.ts
@@ -1,0 +1,299 @@
+import { assert, expect, test } from "vitest";
+import type { PdfObject } from "../../../../../pdf/types/pdf-types/index";
+import {
+  GraphicsState,
+  GraphicsStateStack,
+  Matrix,
+  TextObject,
+  TextState,
+} from "../../../../graphics-state/index";
+import { OperandStack } from "../../../../operand-stack/index";
+import type { OperatorHandlerContext } from "../../../../operator-registry/index";
+import { quoteHandler } from "../index";
+
+// leading / textObject を仕込んだ active コンテキストを組むビルダ。
+// テストヘルパは共通化せず各テストファイル内にローカル定義する規約（apostrophe と同型）。
+const buildActiveContext = (
+  operands: PdfObject[],
+  leading: number = 0,
+  textObject: TextObject = TextObject.begin(),
+): OperatorHandlerContext => {
+  const operandStack = OperandStack.create();
+  for (const operand of operands) {
+    OperandStack.push(operandStack, operand);
+  }
+  const activeState = GraphicsState.update(GraphicsState.create(), {
+    textObject,
+    textState: TextState.update(TextState.create(), { leading }),
+  });
+  const graphicsStateStack = GraphicsStateStack.replaceCurrent(
+    GraphicsStateStack.create(),
+    activeState,
+  );
+  return { operandStack, graphicsStateStack };
+};
+
+// active かつ任意の Tm / Tlm を持つ TextObject を生で組むヘルパ（dirty state 構築用）。
+// translateLine(0, 0) が「Tlm 不変・Tm を Tlm にリセット」する挙動を pin down するため、
+// TextObject.begin() ではなく Tm ≠ Tlm な fixture を構築する必要がある。
+const buildDirtyTextObject = (
+  textMatrix: Matrix,
+  textLineMatrix: Matrix,
+): TextObject =>
+  ({
+    active: true,
+    textMatrix,
+    textLineMatrix,
+  }) as unknown as TextObject;
+
+const literalString = (bytes: number[]): PdfObject => ({
+  type: "string",
+  value: new Uint8Array(bytes),
+  encoding: "literal",
+});
+
+const int = (value: number): PdfObject => ({ type: "integer", value });
+const real = (value: number): PdfObject => ({ type: "real", value });
+
+test("leading=14 の active context で aw=2 / ac=1 (integer) / string=literal を受理する", () => {
+  // `aw ac string "` ≡ `aw Tw ac Tc string '` の代表ケース。
+  // wordSpace/charSpace が更新され、両 matrix が translate(0, -leading) になること
+  const context = buildActiveContext(
+    [int(2), int(1), literalString([0x48, 0x69])],
+    14,
+  );
+
+  const result = quoteHandler(context);
+
+  assert(result.ok);
+  const current = GraphicsStateStack.current(result.value.graphicsStateStack);
+  expect(current.textState.wordSpace).toBe(2);
+  expect(current.textState.charSpace).toBe(1);
+  expect(current.textObject.textMatrix).toEqual(
+    Matrix.create(1, 0, 0, 1, 0, -14),
+  );
+  expect(current.textObject.textLineMatrix).toEqual(
+    Matrix.create(1, 0, 0, 1, 0, -14),
+  );
+  // 3 個 pop され stack は空であること
+  expect(OperandStack.depth(result.value.operandStack)).toBe(0);
+});
+
+test('" を 2 回連続実行すると f 成分が -2*leading に累積する（三角測量）', () => {
+  // 連続 " は Tlm への translate 乗算が累積する（固定値実装の排除）
+  const first = quoteHandler(
+    buildActiveContext([int(2), int(1), literalString([0x48])], 14),
+  );
+  assert(first.ok);
+
+  const firstObject = GraphicsStateStack.current(
+    first.value.graphicsStateStack,
+  ).textObject;
+  const second = quoteHandler(
+    buildActiveContext(
+      [int(2), int(1), literalString([0x69])],
+      14,
+      firstObject,
+    ),
+  );
+
+  assert(second.ok);
+  const current = GraphicsStateStack.current(second.value.graphicsStateStack);
+  expect(current.textObject.textMatrix).toEqual(
+    Matrix.create(1, 0, 0, 1, 0, -28),
+  );
+  expect(current.textObject.textLineMatrix).toEqual(
+    Matrix.create(1, 0, 0, 1, 0, -28),
+  );
+});
+
+test("aw=real(2.5) + ac=integer(1) の混在を受理する", () => {
+  // NumericPdfObject.is は integer/real を同一に扱う
+  const context = buildActiveContext(
+    [real(2.5), int(1), literalString([0x48])],
+    14,
+  );
+
+  const result = quoteHandler(context);
+
+  assert(result.ok);
+  const current = GraphicsStateStack.current(result.value.graphicsStateStack);
+  expect(current.textState.wordSpace).toBe(2.5);
+  expect(current.textState.charSpace).toBe(1);
+});
+
+test("aw=integer(2) + ac=real(0.5) の逆混在を受理する", () => {
+  // 反対側の組み合わせでも整合すること
+  const context = buildActiveContext(
+    [int(2), real(0.5), literalString([0x48])],
+    14,
+  );
+
+  const result = quoteHandler(context);
+
+  assert(result.ok);
+  const current = GraphicsStateStack.current(result.value.graphicsStateStack);
+  expect(current.textState.wordSpace).toBe(2);
+  expect(current.textState.charSpace).toBe(0.5);
+});
+
+test("leading=0 + clean state で両 matrix が identity のまま（translate(0,0) は no-op 相当）", () => {
+  // BT 直後 (clean state) + leading=0 では translateLine(0, 0) が no-op
+  const context = buildActiveContext(
+    [int(2), int(1), literalString([0x48])],
+    0,
+  );
+
+  const result = quoteHandler(context);
+
+  assert(result.ok);
+  const current = GraphicsStateStack.current(result.value.graphicsStateStack);
+  expect(current.textObject.textMatrix).toEqual(Matrix.identity());
+  expect(current.textObject.textLineMatrix).toEqual(Matrix.identity());
+  expect(current.textState.wordSpace).toBe(2);
+  expect(current.textState.charSpace).toBe(1);
+});
+
+test("leading=0 + dirty state（Tm ≠ Tlm）で Tlm 不変・Tm が Tlm にリセット", () => {
+  // translateLine(0, 0) は Tlm 不変だが Tm を Tlm に揃える。apostrophe と同型。
+  const dirtyTm = Matrix.create(5, 0, 0, 5, 1, 2);
+  const lineTlm = Matrix.create(1, 0, 0, 1, 72, 720);
+  const context = buildActiveContext(
+    [int(2), int(1), literalString([0x48])],
+    0,
+    buildDirtyTextObject(dirtyTm, lineTlm),
+  );
+
+  const result = quoteHandler(context);
+
+  assert(result.ok);
+  const current = GraphicsStateStack.current(result.value.graphicsStateStack);
+  expect(current.textObject.textLineMatrix).toEqual(lineTlm);
+  expect(current.textObject.textMatrix).toEqual(lineTlm);
+  // wordSpace/charSpace は更新される
+  expect(current.textState.wordSpace).toBe(2);
+  expect(current.textState.charSpace).toBe(1);
+});
+
+test("leading=-3.5 のとき translate(0, 3.5) が適用される", () => {
+  // 値域検証なし。`-leading` の符号反転だけが行われること
+  const context = buildActiveContext(
+    [int(2), int(1), literalString([0x48])],
+    -3.5,
+  );
+
+  const result = quoteHandler(context);
+
+  assert(result.ok);
+  const current = GraphicsStateStack.current(result.value.graphicsStateStack);
+  expect(current.textObject.textMatrix).toEqual(
+    Matrix.create(1, 0, 0, 1, 0, 3.5),
+  );
+  expect(current.textObject.textLineMatrix).toEqual(
+    Matrix.create(1, 0, 0, 1, 0, 3.5),
+  );
+});
+
+test("string operand を受理しても textState の wordSpace/charSpace 以外と textObject の active 以外は変化しない", () => {
+  // 描画機構未実装のため、副作用は spacing 更新と行送りのみ。
+  // 他フィールド（leading, fontSize, horizontalScaling, renderingMode, rise）は不変
+  const context = buildActiveContext(
+    [int(2), int(1), literalString([0x48])],
+    14,
+  );
+  const before = GraphicsStateStack.current(context.graphicsStateStack);
+
+  const result = quoteHandler(context);
+
+  assert(result.ok);
+  const after = GraphicsStateStack.current(result.value.graphicsStateStack);
+  // 不変フィールド
+  expect(after.textState.leading).toBe(before.textState.leading);
+  expect(after.textState.fontSize).toBe(before.textState.fontSize);
+  expect(after.textState.horizontalScaling).toBe(
+    before.textState.horizontalScaling,
+  );
+  expect(after.textState.renderingMode).toBe(before.textState.renderingMode);
+  expect(after.textState.rise).toBe(before.textState.rise);
+  expect(after.textState.fontName).toEqual(before.textState.fontName);
+  // active は維持される
+  expect(after.textObject.active).toBe(true);
+});
+
+test("operand 4 個 push 状態でも先頭 3 個のみ pop し残 1 個は stack に残る", () => {
+  // dispatcher が誤って余剰 operand を残した状態 — quote は 3 個のみ消費
+  const remaining = int(999);
+  const context = buildActiveContext(
+    [remaining, int(2), int(1), literalString([0x48])],
+    14,
+  );
+
+  const result = quoteHandler(context);
+
+  assert(result.ok);
+  expect(OperandStack.depth(result.value.operandStack)).toBe(1);
+  const top = OperandStack.peek(result.value.operandStack);
+  assert(top.some);
+  expect(top.value).toEqual(remaining);
+});
+
+test("実行後の textState.leading が更新前と同値（不変量）", () => {
+  // Tc/Tw 更新が leading を汚さない pin down
+  const inputLeading = 14;
+  const context = buildActiveContext(
+    [int(2), int(1), literalString([0x48])],
+    inputLeading,
+  );
+
+  const result = quoteHandler(context);
+
+  assert(result.ok);
+  const current = GraphicsStateStack.current(result.value.graphicsStateStack);
+  expect(current.textState.leading).toBe(inputLeading);
+});
+
+test("aw=NaN, ac=Infinity を素通しで受け取る（値域検証なし）", () => {
+  // apostrophe / Tc / Tw と同じく値域検証なし
+  const context = buildActiveContext(
+    [
+      { type: "real", value: Number.NaN },
+      { type: "real", value: Number.POSITIVE_INFINITY },
+      literalString([0x48]),
+    ],
+    14,
+  );
+
+  const result = quoteHandler(context);
+
+  assert(result.ok);
+  const current = GraphicsStateStack.current(result.value.graphicsStateStack);
+  expect(Number.isNaN(current.textState.wordSpace)).toBe(true);
+  expect(current.textState.charSpace).toBe(Number.POSITIVE_INFINITY);
+});
+
+test("成功時に operandStack は入力と同一参照で返る（in-place mutate）", () => {
+  // OperandStack.pop は in-place mutate のため、handler は新しい stack を作らず
+  // 入力の operand stack をそのまま（pop 済みで）返すこと
+  const context = buildActiveContext(
+    [int(2), int(1), literalString([0x48])],
+    14,
+  );
+
+  const result = quoteHandler(context);
+
+  assert(result.ok);
+  expect(result.value.operandStack).toBe(context.operandStack);
+});
+
+test("成功時に graphicsStateStack は入力と異なる新規参照で返る", () => {
+  // replaceCurrent は必ず呼ばれるため、stack 自体は新インスタンスになること
+  const context = buildActiveContext(
+    [int(2), int(1), literalString([0x48])],
+    14,
+  );
+
+  const result = quoteHandler(context);
+
+  assert(result.ok);
+  expect(result.value.graphicsStateStack).not.toBe(context.graphicsStateStack);
+});

--- a/packages/core/src/content-stream/operators/text/quote/__tests__/quote.error.test.ts
+++ b/packages/core/src/content-stream/operators/text/quote/__tests__/quote.error.test.ts
@@ -1,0 +1,393 @@
+import { assert, expect, test } from "vitest";
+import type { PdfObject } from "../../../../../pdf/types/pdf-types/index";
+import {
+  GraphicsState,
+  GraphicsStateStack,
+  Matrix,
+  TextObject,
+  TextState,
+} from "../../../../graphics-state/index";
+import { OperandStack } from "../../../../operand-stack/index";
+import type { OperatorHandlerContext } from "../../../../operator-registry/index";
+import { quoteHandler } from "../index";
+
+// active=true / leading 任意 の context を組み立てる。
+const buildActiveContext = (
+  operands: PdfObject[],
+  leading: number = 0,
+): OperatorHandlerContext => {
+  const operandStack = OperandStack.create();
+  for (const operand of operands) {
+    OperandStack.push(operandStack, operand);
+  }
+  const activeState = GraphicsState.update(GraphicsState.create(), {
+    textObject: TextObject.begin(),
+    textState: TextState.update(TextState.create(), { leading }),
+  });
+  const graphicsStateStack = GraphicsStateStack.replaceCurrent(
+    GraphicsStateStack.create(),
+    activeState,
+  );
+  return { operandStack, graphicsStateStack };
+};
+
+// active=false (BT 未発行) の context を組み立てる。
+const buildInactiveContext = (
+  operands: PdfObject[] = [],
+): OperatorHandlerContext => {
+  const operandStack = OperandStack.create();
+  for (const operand of operands) {
+    OperandStack.push(operandStack, operand);
+  }
+  const graphicsStateStack = GraphicsStateStack.create();
+  return { operandStack, graphicsStateStack };
+};
+
+// inactive かつ非 identity の matrix / 非 default の leading を持つ context。
+// ガードを通らず translateLine が誤って呼ばれた場合に matrix が変化することを検出するための fixture。
+const NON_IDENTITY_MATRIX = Matrix.create(2, 0, 0, 2, 10, 20);
+const buildInactiveNonIdentityContext = (): OperatorHandlerContext => {
+  const operandStack = OperandStack.create();
+  const inactiveNonIdentity = {
+    active: false,
+    textMatrix: NON_IDENTITY_MATRIX,
+    textLineMatrix: NON_IDENTITY_MATRIX,
+  } as unknown as TextObject;
+  const state = GraphicsState.update(GraphicsState.create(), {
+    textObject: inactiveNonIdentity,
+    textState: TextState.update(TextState.create(), { leading: 14 }),
+  });
+  const graphicsStateStack = GraphicsStateStack.replaceCurrent(
+    GraphicsStateStack.create(),
+    state,
+  );
+  return { operandStack, graphicsStateStack };
+};
+
+const literalString = (bytes: number[]): PdfObject => ({
+  type: "string",
+  value: new Uint8Array(bytes),
+  encoding: "literal",
+});
+
+const int = (value: number): PdfObject => ({ type: "integer", value });
+const real = (value: number): PdfObject => ({ type: "real", value });
+
+test('inactive な state で " を実行すると OPERATOR_ILLEGAL_STATE を返す', () => {
+  // BT/ET の外（textObject 非 active）で " が出現したとき illegal state として失敗すること
+  const context = buildInactiveContext([int(2), int(1), literalString([0x48])]);
+
+  const result = quoteHandler(context);
+
+  assert(!result.ok);
+  expect(result.error.code).toBe("OPERATOR_ILLEGAL_STATE");
+});
+
+test('inactive で " を実行したときエラーの operatorName が " である', () => {
+  // エラーに反映される operator 名が PDF 表記の '"' であること
+  const context = buildInactiveContext([int(2), int(1), literalString([0x48])]);
+
+  const result = quoteHandler(context);
+
+  assert(!result.ok);
+  assert(result.error.code === "OPERATOR_ILLEGAL_STATE");
+  expect(result.error.operatorName).toBe('"');
+});
+
+test('inactive で " を実行したときエラーの message が BT/ET 外を示す', () => {
+  // ユーザー向けに BT/ET 外であることを説明する固定メッセージを返すこと
+  const context = buildInactiveContext([int(2), int(1), literalString([0x48])]);
+
+  const result = quoteHandler(context);
+
+  assert(!result.ok);
+  expect(result.error.message).toBe(
+    '": text object is not active (" must appear within BT/ET)',
+  );
+});
+
+test("illegal state 時、operand stack は pop されず内容が保持される", () => {
+  // active 検査は pop の前に置くため operand stack が一切触られないこと
+  const aw = int(2);
+  const ac = int(1);
+  const stringOperand = literalString([0x48]);
+  const context = buildInactiveContext([aw, ac, stringOperand]);
+
+  const result = quoteHandler(context);
+
+  assert(!result.ok);
+  expect(OperandStack.depth(context.operandStack)).toBe(3);
+});
+
+test("illegal state 時、graphics state stack は差し替えられず current が変更されない", () => {
+  // ガードの early-return により replaceCurrent が呼ばれず、非 identity の matrix と
+  // 非 default の textState（leading=14）がそのまま保持されること
+  const context = buildInactiveNonIdentityContext();
+  const stackBefore = context.graphicsStateStack;
+
+  const result = quoteHandler(context);
+
+  assert(!result.ok);
+  expect(context.graphicsStateStack).toBe(stackBefore);
+  const current = GraphicsStateStack.current(context.graphicsStateStack);
+  expect(current.textObject.textMatrix).toEqual(NON_IDENTITY_MATRIX);
+  expect(current.textObject.textLineMatrix).toEqual(NON_IDENTITY_MATRIX);
+  expect(current.textState.leading).toBe(14);
+  expect(TextObject.isActive(current.textObject)).toBe(false);
+});
+
+test("active かつ operand が 0 個のとき OPERAND_MISSING(actual=0) を返す", () => {
+  // active 検査を通過した後の string pop で空が検出されエラーになること
+  const context = buildActiveContext([], 14);
+
+  const result = quoteHandler(context);
+
+  assert(!result.ok);
+  assert(result.error.code === "OPERATOR_OPERAND_MISSING");
+  expect(result.error.operatorName).toBe('"');
+  expect(result.error.required).toBe(3);
+  expect(result.error.actual).toBe(0);
+  expect(result.error.message).toBe(
+    `Operator '"' requires 3 operand(s), got 0`,
+  );
+});
+
+test("active かつ operand が 1 個（string のみ正しい）のとき OPERAND_MISSING(actual=1)", () => {
+  // string pop は成功、ac pop で空が検出されること
+  const context = buildActiveContext([literalString([0x48])], 14);
+
+  const result = quoteHandler(context);
+
+  assert(!result.ok);
+  assert(result.error.code === "OPERATOR_OPERAND_MISSING");
+  expect(result.error.required).toBe(3);
+  expect(result.error.actual).toBe(1);
+  expect(result.error.message).toBe(
+    `Operator '"' requires 3 operand(s), got 1`,
+  );
+});
+
+test("active かつ operand が 2 個（string + ac 正しい）のとき OPERAND_MISSING(actual=2)", () => {
+  // string と ac の pop は成功、aw pop で空が検出されること
+  const context = buildActiveContext([int(1), literalString([0x48])], 14);
+
+  const result = quoteHandler(context);
+
+  assert(!result.ok);
+  assert(result.error.code === "OPERATOR_OPERAND_MISSING");
+  expect(result.error.required).toBe(3);
+  expect(result.error.actual).toBe(2);
+  expect(result.error.message).toBe(
+    `Operator '"' requires 3 operand(s), got 2`,
+  );
+});
+
+test("OPERAND_MISSING 時、graphics state stack の current は変化しない", () => {
+  // pop 失敗で early-return するため replaceCurrent が呼ばれず current 内部参照が維持されること
+  const context = buildActiveContext([], 14);
+  const currentBefore = GraphicsStateStack.current(context.graphicsStateStack);
+
+  const result = quoteHandler(context);
+
+  assert(!result.ok);
+  const currentAfter = GraphicsStateStack.current(context.graphicsStateStack);
+  expect(currentAfter.textObject).toBe(currentBefore.textObject);
+  expect(currentAfter.textState).toBe(currentBefore.textState);
+});
+
+test('active で string operand が非 string（integer）のとき TYPE_MISMATCH(expected="string")', () => {
+  // string 型検査ブロックが先に発火すること（pop 順 string→ac→aw）
+  const context = buildActiveContext([int(2), int(1), int(99)], 14);
+
+  const result = quoteHandler(context);
+
+  assert(!result.ok);
+  assert(result.error.code === "OPERATOR_OPERAND_TYPE_MISMATCH");
+  expect(result.error.operatorName).toBe('"');
+  expect(result.error.expected).toBe("string");
+  expect(result.error.actual).toBe("integer");
+  expect(result.error.message).toBe(
+    `Operator '"' expected string operand, got integer`,
+  );
+});
+
+test('active で ac が非 numeric（name）のとき TYPE_MISMATCH(expected="number")', () => {
+  // string 型検査を通った後、ac 型検査で発火すること
+  const context = buildActiveContext(
+    [int(2), { type: "name", value: "F1" }, literalString([0x48])],
+    14,
+  );
+
+  const result = quoteHandler(context);
+
+  assert(!result.ok);
+  assert(result.error.code === "OPERATOR_OPERAND_TYPE_MISMATCH");
+  expect(result.error.expected).toBe("number");
+  expect(result.error.actual).toBe("name");
+  expect(result.error.message).toBe(
+    `Operator '"' expected number operand, got name`,
+  );
+});
+
+test('active で aw が非 numeric（boolean）のとき TYPE_MISMATCH(expected="number")', () => {
+  // string と ac の型検査を通った後、aw 型検査で発火すること
+  const context = buildActiveContext(
+    [{ type: "boolean", value: true }, int(1), literalString([0x48])],
+    14,
+  );
+
+  const result = quoteHandler(context);
+
+  assert(!result.ok);
+  assert(result.error.code === "OPERATOR_OPERAND_TYPE_MISMATCH");
+  expect(result.error.expected).toBe("number");
+  expect(result.error.actual).toBe("boolean");
+  expect(result.error.message).toBe(
+    `Operator '"' expected number operand, got boolean`,
+  );
+});
+
+const NON_STRING_OPERANDS: ReadonlyArray<readonly [string, PdfObject]> = [
+  ["integer", int(1)],
+  ["real", real(1.5)],
+  ["name", { type: "name", value: "F1" }],
+  ["boolean", { type: "boolean", value: true }],
+  ["null", { type: "null" }],
+  ["array", { type: "array", elements: [] }],
+  ["dictionary", { type: "dictionary", entries: new Map() }],
+  [
+    "indirect-ref",
+    { type: "indirect-ref", objectNumber: 1, generationNumber: 0 },
+  ],
+  [
+    "stream",
+    {
+      type: "stream",
+      dictionary: { type: "dictionary", entries: new Map() },
+      data: new Uint8Array(),
+    },
+  ],
+];
+
+test.each(
+  NON_STRING_OPERANDS,
+)('active で string 位置に %s が渡ると expected="string" の TYPE_MISMATCH', (typeName, operand) => {
+  const context = buildActiveContext([int(2), int(1), operand], 14);
+
+  const result = quoteHandler(context);
+
+  assert(!result.ok);
+  assert(result.error.code === "OPERATOR_OPERAND_TYPE_MISMATCH");
+  expect(result.error.expected).toBe("string");
+  expect(result.error.actual).toBe(typeName);
+  expect(result.error.message).toBe(
+    `Operator '"' expected string operand, got ${typeName}`,
+  );
+});
+
+const NON_NUMERIC_OPERANDS: ReadonlyArray<readonly [string, PdfObject]> = [
+  ["string", literalString([0x41])],
+  ["name", { type: "name", value: "F1" }],
+  ["boolean", { type: "boolean", value: true }],
+  ["null", { type: "null" }],
+  ["array", { type: "array", elements: [] }],
+  ["dictionary", { type: "dictionary", entries: new Map() }],
+  [
+    "indirect-ref",
+    { type: "indirect-ref", objectNumber: 1, generationNumber: 0 },
+  ],
+  [
+    "stream",
+    {
+      type: "stream",
+      dictionary: { type: "dictionary", entries: new Map() },
+      data: new Uint8Array(),
+    },
+  ],
+];
+
+test.each(
+  NON_NUMERIC_OPERANDS,
+)('active で ac 位置に %s が渡ると expected="number" の TYPE_MISMATCH', (typeName, operand) => {
+  const context = buildActiveContext(
+    [int(2), operand, literalString([0x48])],
+    14,
+  );
+
+  const result = quoteHandler(context);
+
+  assert(!result.ok);
+  assert(result.error.code === "OPERATOR_OPERAND_TYPE_MISMATCH");
+  expect(result.error.expected).toBe("number");
+  expect(result.error.actual).toBe(typeName);
+  expect(result.error.message).toBe(
+    `Operator '"' expected number operand, got ${typeName}`,
+  );
+});
+
+test.each(
+  NON_NUMERIC_OPERANDS,
+)('active で aw 位置に %s が渡ると expected="number" の TYPE_MISMATCH', (typeName, operand) => {
+  const context = buildActiveContext(
+    [operand, int(1), literalString([0x48])],
+    14,
+  );
+
+  const result = quoteHandler(context);
+
+  assert(!result.ok);
+  assert(result.error.code === "OPERATOR_OPERAND_TYPE_MISMATCH");
+  expect(result.error.expected).toBe("number");
+  expect(result.error.actual).toBe(typeName);
+  expect(result.error.message).toBe(
+    `Operator '"' expected number operand, got ${typeName}`,
+  );
+});
+
+test("TYPE_MISMATCH(string) 時、graphics state stack の current は変化しない", () => {
+  // string 型検査失敗で early-return するため replaceCurrent が呼ばれず維持されること
+  const context = buildActiveContext([int(2), int(1), int(99)], 14);
+  const currentBefore = GraphicsStateStack.current(context.graphicsStateStack);
+
+  const result = quoteHandler(context);
+
+  assert(!result.ok);
+  const currentAfter = GraphicsStateStack.current(context.graphicsStateStack);
+  expect(currentAfter.textObject).toBe(currentBefore.textObject);
+  expect(currentAfter.textState).toBe(currentBefore.textState);
+});
+
+test("検査順序: string mismatch が先に発火し ac/aw は pop されない（残 2 個）", () => {
+  // string が非 string、ac/aw が numeric の場合、string TYPE_MISMATCH のみで離脱し
+  // ac/aw は operand stack に残ること
+  const awRemaining = int(2);
+  const acRemaining = int(1);
+  const context = buildActiveContext([awRemaining, acRemaining, int(99)], 14);
+
+  const result = quoteHandler(context);
+
+  assert(!result.ok);
+  assert(result.error.code === "OPERATOR_OPERAND_TYPE_MISMATCH");
+  expect(result.error.expected).toBe("string");
+  // string 1 個だけ pop され、残 2 個が stack に残る
+  expect(OperandStack.depth(context.operandStack)).toBe(2);
+});
+
+test("検査順序: ac mismatch が先に発火し aw は pop されない（残 1 個）", () => {
+  // string ok + ac 非 numeric + aw 非 numeric の場合、ac TYPE_MISMATCH のみで離脱し
+  // aw は operand stack に残ること
+  const awRemaining: PdfObject = { type: "boolean", value: true };
+  const context = buildActiveContext(
+    [awRemaining, { type: "name", value: "F1" }, literalString([0x48])],
+    14,
+  );
+
+  const result = quoteHandler(context);
+
+  assert(!result.ok);
+  assert(result.error.code === "OPERATOR_OPERAND_TYPE_MISMATCH");
+  expect(result.error.expected).toBe("number");
+  expect(result.error.actual).toBe("name");
+  // string と ac で 2 個 pop され、aw 1 個が stack に残る
+  expect(OperandStack.depth(context.operandStack)).toBe(1);
+});

--- a/packages/core/src/content-stream/operators/text/quote/index.ts
+++ b/packages/core/src/content-stream/operators/text/quote/index.ts
@@ -1,0 +1,164 @@
+import type { PdfError } from "../../../../pdf/errors/index";
+import { err, ok } from "../../../../utils/result/index";
+import {
+  GraphicsState,
+  GraphicsStateStack,
+  TextObject,
+  TextState,
+} from "../../../graphics-state/index";
+import { OperandStack } from "../../../operand-stack/index";
+import type {
+  OperatorHandler,
+  OperatorHandlerContext,
+} from "../../../operator-registry/index";
+import { NumericPdfObject } from "../../graphics-state/numeric-pdf-object/index";
+
+/** PDF 表記を保持した operator 名（'"'）。 */
+const OPERATOR_NAME = '"';
+/** PDF §9.4.3 `"` の operand 個数 (aw, ac, string)。 */
+const OPERAND_COUNT = 3;
+
+/**
+ * PDF §9.4.3 `"` (quote / set word & character spacing, move to next line,
+ * show text) operator のハンドラ。
+ *
+ * `aw ac string "` は `aw Tw ac Tc string '` と等価。current の
+ * `textState.leading` を参照し、`TextState.update({ wordSpace, charSpace })`
+ * で spacing を更新したうえで、`TextObject.translateLine(textObject, 0,
+ * -leading)` でテキスト行列を次行頭へ移動し、string operand を受理する。
+ *
+ * operand 順序（stack pop 順）: string → ac → aw
+ *
+ * 検査順序（厳守。段階的 pop & 型検査交互パターン）:
+ *   (1) active 検査（false なら `OPERATOR_ILLEGAL_STATE` を返す）
+ *   (2-a) string pop（none なら `OPERATOR_OPERAND_MISSING` actual=0）
+ *   (3-a) string 型検査（type !== "string" なら `OPERATOR_OPERAND_TYPE_MISMATCH`
+ *         expected: "string"）
+ *   (2-b) ac pop（none なら `OPERATOR_OPERAND_MISSING` actual=1）
+ *   (3-b) ac 型検査（!NumericPdfObject.is なら `OPERATOR_OPERAND_TYPE_MISMATCH`
+ *         expected: "number"）
+ *   (2-c) aw pop（none なら `OPERATOR_OPERAND_MISSING` actual=2）
+ *   (3-c) aw 型検査（!NumericPdfObject.is なら `OPERATOR_OPERAND_TYPE_MISMATCH`
+ *         expected: "number"）
+ *   (4) state 更新（1 回の GraphicsState.update +
+ *       1 回の GraphicsStateStack.replaceCurrent）
+ *
+ * - text object が active でない場合は `OPERATOR_ILLEGAL_STATE` を返す
+ *   （operand stack / graphics state stack は変更しない）
+ * - operand 不足のとき `OPERATOR_OPERAND_MISSING` を返す
+ *   （graphics state stack は変更しない。部分消費した operand stack は
+ *   復元しない — 既存ハンドラ規約）
+ * - 型不一致のときも部分消費した operand stack は復元しない
+ * - `aw` / `ac` / `leading` の値域（負値 / `NaN` / `Infinity`）は本 handler
+ *   では検証しない（apostrophe / Tc / Tw / T* と同一規約）
+ * - フォント幅辞書が未実装のため、本フェーズでは描画後の advance 計算と
+ *   glyph 描画は行わない（イベント機構自体が未導入のため、string operand は
+ *   consume するだけで観測可能な副作用は spacing 更新と行送り以外に発生しない。
+ *   tjHandler / apostropheHandler と同一規約）
+ *
+ * @param context - 実行コンテキスト (operand stack / graphics state stack)
+ * @returns 成功なら更新後コンテキスト、失敗なら PdfError
+ */
+export const quoteHandler: OperatorHandler = (
+  context: OperatorHandlerContext,
+) => {
+  const current = GraphicsStateStack.current(context.graphicsStateStack);
+  if (!TextObject.isActive(current.textObject)) {
+    const error: PdfError = {
+      code: "OPERATOR_ILLEGAL_STATE",
+      message: '": text object is not active (" must appear within BT/ET)',
+      operatorName: OPERATOR_NAME,
+    };
+    return err(error);
+  }
+
+  const poppedString = OperandStack.pop(context.operandStack);
+  if (!poppedString.some) {
+    const error: PdfError = {
+      code: "OPERATOR_OPERAND_MISSING",
+      message: `Operator '${OPERATOR_NAME}' requires ${OPERAND_COUNT} operand(s), got 0`,
+      operatorName: OPERATOR_NAME,
+      required: OPERAND_COUNT,
+      actual: 0,
+    };
+    return err(error);
+  }
+
+  const stringOperand = poppedString.value;
+  if (stringOperand.type !== "string") {
+    const error: PdfError = {
+      code: "OPERATOR_OPERAND_TYPE_MISMATCH",
+      message: `Operator '${OPERATOR_NAME}' expected string operand, got ${stringOperand.type}`,
+      operatorName: OPERATOR_NAME,
+      expected: "string",
+      actual: stringOperand.type,
+    };
+    return err(error);
+  }
+
+  const poppedAc = OperandStack.pop(context.operandStack);
+  if (!poppedAc.some) {
+    const error: PdfError = {
+      code: "OPERATOR_OPERAND_MISSING",
+      message: `Operator '${OPERATOR_NAME}' requires ${OPERAND_COUNT} operand(s), got 1`,
+      operatorName: OPERATOR_NAME,
+      required: OPERAND_COUNT,
+      actual: 1,
+    };
+    return err(error);
+  }
+
+  const acOperand = poppedAc.value;
+  if (!NumericPdfObject.is(acOperand)) {
+    const error: PdfError = {
+      code: "OPERATOR_OPERAND_TYPE_MISMATCH",
+      message: `Operator '${OPERATOR_NAME}' expected number operand, got ${acOperand.type}`,
+      operatorName: OPERATOR_NAME,
+      expected: "number",
+      actual: acOperand.type,
+    };
+    return err(error);
+  }
+
+  const poppedAw = OperandStack.pop(context.operandStack);
+  if (!poppedAw.some) {
+    const error: PdfError = {
+      code: "OPERATOR_OPERAND_MISSING",
+      message: `Operator '${OPERATOR_NAME}' requires ${OPERAND_COUNT} operand(s), got 2`,
+      operatorName: OPERATOR_NAME,
+      required: OPERAND_COUNT,
+      actual: 2,
+    };
+    return err(error);
+  }
+
+  const awOperand = poppedAw.value;
+  if (!NumericPdfObject.is(awOperand)) {
+    const error: PdfError = {
+      code: "OPERATOR_OPERAND_TYPE_MISMATCH",
+      message: `Operator '${OPERATOR_NAME}' expected number operand, got ${awOperand.type}`,
+      operatorName: OPERATOR_NAME,
+      expected: "number",
+      actual: awOperand.type,
+    };
+    return err(error);
+  }
+
+  // state 更新（TD パターン: 1 回の GraphicsState.update で textState と textObject を atomic 反映）
+  // leading は TextState.update を呼ぶ前に保持する（Tc/Tw は leading を変えないが規約として徹底）。
+  const leading = current.textState.leading;
+  const textState = TextState.update(current.textState, {
+    wordSpace: awOperand.value,
+    charSpace: acOperand.value,
+  });
+  const textObject = TextObject.translateLine(current.textObject, 0, -leading);
+  const next = GraphicsState.update(current, { textState, textObject });
+  const graphicsStateStack = GraphicsStateStack.replaceCurrent(
+    context.graphicsStateStack,
+    next,
+  );
+  return ok({
+    operandStack: context.operandStack,
+    graphicsStateStack,
+  });
+};


### PR DESCRIPTION
## 概要

PDF §9.4.3 `"` (quote / set word & character spacing, move to next line, show text) operator のハンドラ `quoteHandler` を新規追加します。

`aw ac string "` は `aw Tw ac Tc string '` と等価で、`wordSpace`/`charSpace` を更新したのち、`'` (apostrophe) と同じく `translateLine(0, -leading)` で行送りを行います。フォントメトリクスが未実装のため、描画後の advance / glyph 描画は本フェーズではスコープ外（apostrophe / Tj と同じ規約）。

## 変更内容

### 🎯 変更の種類

- [x] ✨ 新機能 (New feature)

### 📝 詳細な変更内容

#### 追加された機能

- `quoteHandler` (`OperatorHandler` 型) を新規追加
  - 検査順序: active → string pop → string 型検査 → ac pop → ac 型検査 → aw pop → aw 型検査 → state 更新
  - `OPERAND_COUNT = 3` 定数化（tf 規約踏襲、マジックナンバー散布防止）
  - state 更新は TD パターン: `TextState.update({ wordSpace, charSpace })` + `TextObject.translateLine(0, -leading)` を 1 回の `GraphicsState.update` + 1 回の `GraphicsStateStack.replaceCurrent` で atomic 反映
  - `leading` は `TextState.update` 呼出前に保持（Tc/Tw は leading を変えない規約として徹底）
- 値域検証なし規約（apostrophe / Tc / Tw / T* と同一）— `NaN` / `Infinity` / 負値は素通し

#### 変更されたファイル（新規追加のみ）

- `packages/core/src/content-stream/operators/text/quote/index.ts` — ハンドラ本体
- `packages/core/src/content-stream/operators/text/quote/__tests__/quote.basic.test.ts` — 正常系 13 tests
- `packages/core/src/content-stream/operators/text/quote/__tests__/quote.error.test.ts` — 異常系 40 tests

barrel registry (`text-state-operators/index.ts` / `text-positioning-operators/index.ts`) には登録していません（Epic #413 で別途対応）。

## 📊 システム図

### 状態マシン / フロー図

```mermaid
flowchart TD
    Start([quoteHandler context]) --> Active{textObject.active?}
    Active -->|false| ErrIllegal[ERR_ILLEGAL_STATE<br/>stack 不変]:::err
    Active -->|true| PopString[POP string]:::new
    PopString -->|none| ErrMiss0[ERR_OPERAND_MISSING<br/>actual=0]:::err
    PopString -->|some| TypeString{type === string?}:::new
    TypeString -->|no| ErrTypeString[ERR_TYPE_MISMATCH<br/>expected=string]:::err
    TypeString -->|yes| PopAc[POP ac]:::new
    PopAc -->|none| ErrMiss1[ERR_OPERAND_MISSING<br/>actual=1]:::err
    PopAc -->|some| TypeAc{NumericPdfObject.is?}:::new
    TypeAc -->|no| ErrTypeAc[ERR_TYPE_MISMATCH<br/>expected=number]:::err
    TypeAc -->|yes| PopAw[POP aw]:::new
    PopAw -->|none| ErrMiss2[ERR_OPERAND_MISSING<br/>actual=2]:::err
    PopAw -->|some| TypeAw{NumericPdfObject.is?}:::new
    TypeAw -->|no| ErrTypeAw[ERR_TYPE_MISMATCH<br/>expected=number]:::err
    TypeAw -->|yes| Update[UPDATE_STATE<br/>leading = textState.leading<br/>TextState.update wordSpace charSpace<br/>TextObject.translateLine 0 -leading<br/>GraphicsState.update<br/>replaceCurrent]:::new
    Update --> OK([Result.ok])

    classDef new fill:#ffe4b5,stroke:#d97706,stroke-width:2px
    classDef err fill:#ffd6d6,stroke:#c2410c,stroke-width:1px
```

### データフロー

```
OperatorHandlerContext
  ├─ operandStack
  └─ graphicsStateStack
        │
        ▼
  quoteHandler(context)   [NEW]
        │
        ├─▶ GraphicsStateStack.current(stack)
        │       └─▶ current.textObject.active   (guard)
        │       └─▶ current.textState.leading   (UPDATE_STATE で読む)
        │
        ├─▶ OperandStack.pop(operandStack) × 3
        │       (string → ac → aw の順で pop / 部分消費は復元しない)
        │
        ▼
  TextState.update(current.textState,
    { wordSpace: aw.value, charSpace: ac.value })  → nextTextState   [NEW]
        │
        ▼
  TextObject.translateLine(
    current.textObject, 0, -leading)              → nextTextObject  [NEW]
        │
        ▼
  GraphicsState.update(current,
    { textState: nextTextState,
      textObject: nextTextObject })               → nextGraphicsState  [NEW]
        │
        ▼
  GraphicsStateStack.replaceCurrent(stack, next)  → nextGraphicsStateStack
        │
        ▼
  Result.ok({ operandStack, graphicsStateStack })
```

## 📋 関連 Issue

- Closes #422

## 🧪 テスト

### テスト実行方法

```bash
pnpm --filter @pdfmod/core test src/content-stream/operators/text/quote
pnpm test:run
pnpm --filter @pdfmod/core typecheck
pnpm lint
pnpm --filter @pdfmod/core build
```

### テスト項目

- [x] 単体テスト (Unit tests)

### テスト結果

- `pnpm --filter @pdfmod/core test src/content-stream/operators/text/quote` → **53 tests passed**（basic 13 + error 40）
- `pnpm test:run` → **2698 tests passed**（リグレッションなし）
- `pnpm --filter @pdfmod/core typecheck` → pass
- `pnpm lint` (biome + oxlint) → 0 warnings, 0 errors
- `pnpm --filter @pdfmod/core build` → pass

#### テストケース内訳

**quote.basic.test.ts (13 tests)**:
- leading=14 / aw=2 / ac=1 (integer) / string=literal の代表ケース
- 三角測量: 連続 2 回実行で `textMatrix.f === -2*leading`
- integer / real 混在 (両方向)
- 境界値: leading=0 clean state / leading=0 dirty state (Tlm 不変・Tm リセット) / 負値 leading
- string operand 受理のみで他フィールド不変
- 余剰 operand 4 個 → 先頭 3 個のみ pop
- 不変量: 実行後 `textState.leading` が更新前と同値
- NaN / Infinity 素通し
- 参照同一性: operandStack は同一参照、graphicsStateStack は新規

**quote.error.test.ts (40 tests)**:
- inactive で `OPERATOR_ILLEGAL_STATE` (operatorName / message 含む)
- operand 0 / 1 / 2 個で `OPERAND_MISSING` (required=3, actual=0/1/2)
- string / ac / aw 各位置の `TYPE_MISMATCH` 個別 + `test.each` で計 25 ケース網羅 (integer/real/name/boolean/null/array/dictionary/indirect-ref/stream)
- 検査順序 pin down: string mismatch 先発火 (残 2 個) / ac mismatch 先発火 (残 1 個)
- 全エラーケースで graphics state stack 不変

## 🔍 レビューポイント

- **apostrophe (#421) との構造ミラーリング**: 行送り側（`active` 検査・`leading` 読取タイミング・`translateLine(0, -leading)`）が apostrophe と整合しているか
- **tf との構造ミラーリング**: `OPERAND_COUNT` 定数化と段階的 pop & 型検査交互パターンが tf と整合しているか
- **td-leading との構造ミラーリング**: `{ textState, textObject }` を 1 回の `GraphicsState.update` + 1 回の `replaceCurrent` で atomic 反映する点
- **エラー時の部分消費非復元規約**: pop 済み operand は復元しない（既存ハンドラ規約）

## 📚 追加情報

### 参考資料

- ISO 32000-1:2008 PDF 1.7 §9.4.3 Text-Showing Operators
- 計画書: `.plugin-workspace/.specs/archive/073-quote-operator-handler/implementation-plan.md`
- 兄弟ハンドラ: apostrophe (#421), tf, td-leading, tc, tw

### 注意事項

- フォントメトリクス未実装のため、本フェーズでは描画後の advance 計算と glyph 描画は行いません（`tjHandler` / `apostropheHandler` と同一規約）
- barrel registry への登録は Epic #413 で別途対応します

## ✅ チェックリスト

- [x] コードレビューの準備ができている
- [x] テストが正常に実行される（53 + 2698 tests）
- [x] コミットメッセージが適切な形式で書かれている
- [x] 関連する Issue が記載されている（Closes #422）
- [x] セルフレビューを実施した（codex + spec-based-code-review 5エージェント、CRITICAL/WARNING 共に 0 件）
- [x] 破壊的変更はなし