### PR TITLE
✨ [New Feature]: #402 lexer に read_name (PDF Name トークン解析) を追加

### DIFF
--- a/rust/crates/core/src/lexer.rs
+++ b/rust/crates/core/src/lexer.rs
@@ -17,8 +17,19 @@ pub mod byte_kind;
 pub mod eol;
 pub mod token;
 
+use crate::object::name::PdfName;
 use byte_kind::ByteKind;
 use eol::EolKind;
+
+// 内部ヘルパ: 16進数字 1 バイト ('0'-'9' / 'a'-'f' / 'A'-'F') を 0-15 に変換する。
+// 呼び出し側で is_ascii_hexdigit を確認済みであることを前提とする。
+fn hex_value(b: u8) -> u8 {
+    match b {
+        b'0'..=b'9' => b - b'0',
+        b'a'..=b'f' => b - b'a' + 10,
+        _ => b - b'A' + 10,
+    }
+}
 
 /// PDF バイト列を走査するカーソル付き Lexer。
 ///
@@ -329,6 +340,73 @@ impl<'a> Lexer<'a> {
         }
 
         Some(value)
+    }
+
+    /// ISO 32000-1 §7.3.5 に従う PDF Name トークンを読み取る。
+    ///
+    /// 受理する字句:
+    /// - 先頭バイト `/` の直後から、次の whitespace / delimiter / EOF までを Name 本体として読む
+    /// - 本体中の `#XX`（`#` + 2桁 ASCII 16進数字、大小混在可）を 1 バイトに復号する
+    /// - 復号後のバイト範囲 0x00〜0xFF（NUL 含む任意バイト）を受理する
+    /// - 空名前 `/`（`/` 直後に whitespace / delimiter / EOF が続く）は `Some(PdfName::new(b""))` で受理
+    /// - 名前長は無制限（仕様の推奨上限は実装上強制しない）
+    ///
+    /// 拒否する字句（`None` 返却 + `pos` を呼び出し前位置に完全巻き戻し）:
+    /// - 空入力 / EOF
+    /// - 先頭バイトが `/` でない（pos 不変で None）
+    /// - `#` の直後 2 バイトのうち、どちらかが EOF / whitespace / delimiter / 非16進 regular byte
+    ///
+    /// 戻り値の `PdfName` は `/` 接頭辞を含まない、`#XX` デコード後の名前本体バイト列を保持する。
+    /// 任意の入力・任意の `pos` で panic しない（`checked_add` / `slice::get` で範囲外を吸収）。
+    pub fn read_name(&mut self) -> Option<PdfName> {
+        let start = self.pos;
+
+        if self.peek() != Some(b'/') {
+            return None;
+        }
+        let Some(after_slash) = self.pos.checked_add(1) else {
+            self.pos = start;
+            return None;
+        };
+        self.pos = after_slash;
+
+        let mut bytes: Vec<u8> = Vec::new();
+        #[allow(clippy::while_let_loop)]
+        loop {
+            let Some(b) = self.peek() else { break };
+
+            if ByteKind::is_whitespace(b) || ByteKind::is_delimiter(b) {
+                break;
+            }
+
+            if b == b'#' {
+                let (Some(hi), Some(lo)) = (self.peek_at(1), self.peek_at(2)) else {
+                    self.pos = start;
+                    return None;
+                };
+                if !hi.is_ascii_hexdigit() || !lo.is_ascii_hexdigit() {
+                    self.pos = start;
+                    return None;
+                }
+                let decoded = hex_value(hi) * 16 + hex_value(lo);
+                bytes.push(decoded);
+                let Some(next) = self.pos.checked_add(3) else {
+                    self.pos = start;
+                    return None;
+                };
+                self.pos = next;
+                continue;
+            }
+
+            bytes.push(b);
+            let Some(next) = self.pos.checked_add(1) else {
+                self.pos = start;
+                return None;
+            };
+            self.pos = next;
+        }
+
+        Some(PdfName::new(bytes))
     }
 }
 
@@ -736,6 +814,7 @@ mod tests {
         lexer.skip_whitespace_and_comments();
         let _ = lexer.read_integer();
         let _ = lexer.read_real();
+        let _ = lexer.read_name();
         assert_eq!(lexer.position(), len);
         assert!(lexer.is_eof());
     }
@@ -753,6 +832,7 @@ mod tests {
         lexer.skip_whitespace_and_comments();
         let _ = lexer.read_integer();
         let _ = lexer.read_real();
+        let _ = lexer.read_name();
         assert_eq!(lexer.position(), 0);
     }
 
@@ -2000,5 +2080,369 @@ mod tests {
         let v = lexer.read_real().expect("expected Some(-0.002)");
         assert!((v - (-0.002)).abs() < 1e-12, "expected ~-0.002, got {v}");
         assert_eq!(lexer.position(), 5);
+    }
+
+    // ---------- Phase 10: read_name ----------
+
+    // Phase 10-A: 早期 None（先頭バイトが '/' でない / EOF / 空）
+
+    #[test]
+    fn read_name_returns_none_for_empty_input() {
+        // 空入力で read_name が None を返し pos が 0 のままであることを確認する
+        let mut lexer = Lexer::new(&[]);
+        assert_eq!(lexer.read_name(), None);
+        assert_eq!(lexer.position(), 0);
+    }
+
+    #[test]
+    fn read_name_returns_none_at_eof() {
+        // EOF 状態の read_name が None を返し pos 不変であることを確認する
+        let mut lexer = Lexer::new(b"a");
+        lexer.advance();
+        assert_eq!(lexer.read_name(), None);
+        assert_eq!(lexer.position(), 1);
+    }
+
+    #[test]
+    fn read_name_returns_none_for_non_slash_leading_byte() {
+        // 先頭が '/' でない 'abc' で None を返し pos 0 のままであることを確認する
+        let mut lexer = Lexer::new(b"abc");
+        assert_eq!(lexer.read_name(), None);
+        assert_eq!(lexer.position(), 0);
+    }
+
+    #[test]
+    fn read_name_returns_none_for_every_leading_whitespace_byte() {
+        // 仕様 §2.1 の whitespace 6 バイトを先頭に置いた場合、各々 None・pos 0 で停止することを確認する
+        let whitespace_bytes = [0x00, 0x09, 0x0A, 0x0C, 0x0D, 0x20];
+        for w in whitespace_bytes {
+            let input = [w, b'T', b'y', b'p', b'e'];
+            let mut lexer = Lexer::new(&input);
+            assert_eq!(
+                lexer.read_name(),
+                None,
+                "whitespace 0x{w:02X} should yield None"
+            );
+            assert_eq!(
+                lexer.position(),
+                0,
+                "whitespace 0x{w:02X} should keep pos 0"
+            );
+        }
+    }
+
+    #[test]
+    fn read_name_returns_none_for_every_leading_delimiter_byte() {
+        // 仕様 §2.2 の delimiter のうち '/' 以外 9 バイトを先頭に置いた場合、各々 None・pos 0 で停止することを確認する
+        // ('/' は 10-F で空名前として別途検証)
+        let delimiter_bytes = [0x28, 0x29, 0x3C, 0x3E, 0x5B, 0x5D, 0x7B, 0x7D, 0x25];
+        for d in delimiter_bytes {
+            let input = [d, b'T', b'y', b'p', b'e'];
+            let mut lexer = Lexer::new(&input);
+            assert_eq!(
+                lexer.read_name(),
+                None,
+                "delimiter 0x{d:02X} should yield None"
+            );
+            assert_eq!(lexer.position(), 0, "delimiter 0x{d:02X} should keep pos 0");
+        }
+    }
+
+    // Phase 10-B: 基本 ASCII 名前
+
+    #[test]
+    fn read_name_reads_simple_ascii_name() {
+        // '/Type' (EOF 終端) で Some(b"Type")・pos == 5 を確認する
+        let mut lexer = Lexer::new(b"/Type");
+        assert_eq!(lexer.read_name(), Some(PdfName::new(b"Type".to_vec())));
+        assert_eq!(lexer.position(), 5);
+    }
+
+    #[test]
+    fn read_name_reads_subtype_name() {
+        // 桁数の三角測量: '/Subtype' で Some(b"Subtype")・pos == 8 を確認する
+        let mut lexer = Lexer::new(b"/Subtype");
+        assert_eq!(lexer.read_name(), Some(PdfName::new(b"Subtype".to_vec())));
+        assert_eq!(lexer.position(), 8);
+    }
+
+    #[test]
+    fn read_name_reads_single_letter_name() {
+        // 三角測量: '/A' 単一文字で Some(b"A")・pos == 2 を確認する
+        let mut lexer = Lexer::new(b"/A");
+        assert_eq!(lexer.read_name(), Some(PdfName::new(b"A".to_vec())));
+        assert_eq!(lexer.position(), 2);
+    }
+
+    // Phase 10-C: #XX エスケープ単発
+
+    #[test]
+    fn read_name_decodes_uppercase_hex_escape() {
+        // '/A#42' (#42='B') で Some(b"AB")・pos == 5 を確認する
+        let mut lexer = Lexer::new(b"/A#42");
+        assert_eq!(lexer.read_name(), Some(PdfName::new(b"AB".to_vec())));
+        assert_eq!(lexer.position(), 5);
+    }
+
+    #[test]
+    fn read_name_decodes_lowercase_hex_escape() {
+        // '/a#ff' (#ff=0xFF) で Some(b"a\xFF")・pos == 5 を確認する
+        let mut lexer = Lexer::new(b"/a#ff");
+        assert_eq!(lexer.read_name(), Some(PdfName::new(b"a\xFF".to_vec())));
+        assert_eq!(lexer.position(), 5);
+    }
+
+    #[test]
+    fn read_name_decodes_mixed_case_hex_escape() {
+        // '/a#fF' 大小混在で Some(b"a\xFF")・pos == 5 を確認する
+        let mut lexer = Lexer::new(b"/a#fF");
+        assert_eq!(lexer.read_name(), Some(PdfName::new(b"a\xFF".to_vec())));
+        assert_eq!(lexer.position(), 5);
+    }
+
+    #[test]
+    fn read_name_decodes_whitespace_byte_via_escape() {
+        // '/Hello#20World' (#20=space) で Some(b"Hello World")・pos == 14 を確認する（境界判定は生バイトのみ）
+        let mut lexer = Lexer::new(b"/Hello#20World");
+        assert_eq!(
+            lexer.read_name(),
+            Some(PdfName::new(b"Hello World".to_vec()))
+        );
+        assert_eq!(lexer.position(), 14);
+    }
+
+    #[test]
+    fn read_name_decodes_delimiter_byte_via_escape() {
+        // '/A#28B' (#28='(') で Some(b"A(B")・pos == 6 を確認する
+        let mut lexer = Lexer::new(b"/A#28B");
+        assert_eq!(lexer.read_name(), Some(PdfName::new(b"A(B".to_vec())));
+        assert_eq!(lexer.position(), 6);
+    }
+
+    #[test]
+    fn read_name_decodes_nul_byte_via_escape() {
+        // '/A#00B' (#00=NUL) で Some(b"A\x00B")・pos == 6 を確認する（任意バイト 0x00 受理）
+        let mut lexer = Lexer::new(b"/A#00B");
+        assert_eq!(lexer.read_name(), Some(PdfName::new(b"A\x00B".to_vec())));
+        assert_eq!(lexer.position(), 6);
+    }
+
+    // Phase 10-D: #XX エスケープ複数
+
+    #[test]
+    fn read_name_decodes_consecutive_escapes() {
+        // '/paired#28#29parentheses' で連続エスケープを復号し Some(b"paired()parentheses")・pos == 24 を確認する
+        let mut lexer = Lexer::new(b"/paired#28#29parentheses");
+        assert_eq!(
+            lexer.read_name(),
+            Some(PdfName::new(b"paired()parentheses".to_vec()))
+        );
+        assert_eq!(lexer.position(), 24);
+    }
+
+    #[test]
+    fn read_name_decodes_escape_then_regular_then_escape() {
+        // '/A#42C#43' (#42='B', #43='C') で Some(b"ABCC")・pos == 9 を確認する
+        let mut lexer = Lexer::new(b"/A#42C#43");
+        assert_eq!(lexer.read_name(), Some(PdfName::new(b"ABCC".to_vec())));
+        assert_eq!(lexer.position(), 9);
+    }
+
+    // Phase 10-E: 終端境界
+
+    #[test]
+    fn read_name_stops_at_every_trailing_whitespace_byte() {
+        // '/Type' + whitespace 6 種の全組で Some(b"Type")・pos == 5 で停止することを確認する
+        let whitespace_bytes = [0x00, 0x09, 0x0A, 0x0C, 0x0D, 0x20];
+        for w in whitespace_bytes {
+            let input = [b'/', b'T', b'y', b'p', b'e', w];
+            let mut lexer = Lexer::new(&input);
+            assert_eq!(
+                lexer.read_name(),
+                Some(PdfName::new(b"Type".to_vec())),
+                "whitespace 0x{w:02X} should yield Some(b\"Type\")"
+            );
+            assert_eq!(lexer.position(), 5, "whitespace 0x{w:02X} should stop at 5");
+        }
+    }
+
+    #[test]
+    fn read_name_stops_at_every_trailing_delimiter_byte() {
+        // '/Type' + delimiter 10 種の全組で Some(b"Type")・pos == 5 で停止することを確認する
+        let delimiter_bytes = [0x28, 0x29, 0x3C, 0x3E, 0x5B, 0x5D, 0x7B, 0x7D, 0x2F, 0x25];
+        for d in delimiter_bytes {
+            let input = [b'/', b'T', b'y', b'p', b'e', d];
+            let mut lexer = Lexer::new(&input);
+            assert_eq!(
+                lexer.read_name(),
+                Some(PdfName::new(b"Type".to_vec())),
+                "delimiter 0x{d:02X} should yield Some(b\"Type\")"
+            );
+            assert_eq!(lexer.position(), 5, "delimiter 0x{d:02X} should stop at 5");
+        }
+    }
+
+    #[test]
+    fn read_name_stops_at_eof() {
+        // '/Type' (EOF 終端) で Some(b"Type")・pos == 5・is_eof() を確認する
+        let mut lexer = Lexer::new(b"/Type");
+        assert_eq!(lexer.read_name(), Some(PdfName::new(b"Type".to_vec())));
+        assert_eq!(lexer.position(), 5);
+        assert!(lexer.is_eof());
+    }
+
+    // Phase 10-F: 空名前 '/'
+
+    #[test]
+    fn read_name_returns_empty_name_at_eof() {
+        // '/' 単独で Some(b"")・pos == 1・is_eof() を確認する（空名前受理）
+        let mut lexer = Lexer::new(b"/");
+        assert_eq!(lexer.read_name(), Some(PdfName::new(Vec::new())));
+        assert_eq!(lexer.position(), 1);
+        assert!(lexer.is_eof());
+    }
+
+    #[test]
+    fn read_name_returns_empty_name_before_whitespace() {
+        // '/ rest' で Some(b"")・pos == 1 を確認する
+        let mut lexer = Lexer::new(b"/ rest");
+        assert_eq!(lexer.read_name(), Some(PdfName::new(Vec::new())));
+        assert_eq!(lexer.position(), 1);
+    }
+
+    #[test]
+    fn read_name_returns_empty_name_before_delimiter() {
+        // '/[' で Some(b"")・pos == 1 を確認する
+        let mut lexer = Lexer::new(b"/[");
+        assert_eq!(lexer.read_name(), Some(PdfName::new(Vec::new())));
+        assert_eq!(lexer.position(), 1);
+    }
+
+    // Phase 10-G: 不正 #XX エスケープ（巻き戻し検証）
+
+    #[test]
+    fn read_name_rejects_hash_at_eof() {
+        // '/A#' (# のあと EOF) で None・pos == 0 巻き戻しを確認する
+        let mut lexer = Lexer::new(b"/A#");
+        assert_eq!(lexer.read_name(), None);
+        assert_eq!(lexer.position(), 0);
+    }
+
+    #[test]
+    fn read_name_rejects_hash_with_one_hex_then_eof() {
+        // '/A#1' (#1 のあと EOF) で None・pos == 0 巻き戻しを確認する
+        let mut lexer = Lexer::new(b"/A#1");
+        assert_eq!(lexer.read_name(), None);
+        assert_eq!(lexer.position(), 0);
+    }
+
+    #[test]
+    fn read_name_rejects_hash_with_non_hex_high() {
+        // '/A#Z' (高位が非16進) で None・pos == 0 巻き戻しを確認する
+        let mut lexer = Lexer::new(b"/A#Z");
+        assert_eq!(lexer.read_name(), None);
+        assert_eq!(lexer.position(), 0);
+    }
+
+    #[test]
+    fn read_name_rejects_hash_with_non_hex_low() {
+        // '/A#1Z' (低位が非16進) で None・pos == 0 巻き戻しを確認する
+        let mut lexer = Lexer::new(b"/A#1Z");
+        assert_eq!(lexer.read_name(), None);
+        assert_eq!(lexer.position(), 0);
+    }
+
+    #[test]
+    fn read_name_rejects_hash_with_whitespace_low() {
+        // '/A#1 ' (低位が space) で None・pos == 0 巻き戻しを確認する
+        let mut lexer = Lexer::new(b"/A#1 ");
+        assert_eq!(lexer.read_name(), None);
+        assert_eq!(lexer.position(), 0);
+    }
+
+    #[test]
+    fn read_name_rejects_hash_with_delimiter_low() {
+        // '/A#1/' (低位が '/') で None・pos == 0 巻き戻しを確認する
+        let mut lexer = Lexer::new(b"/A#1/");
+        assert_eq!(lexer.read_name(), None);
+        assert_eq!(lexer.position(), 0);
+    }
+
+    #[test]
+    fn read_name_rejects_hash_with_nul_low() {
+        // '/A#1\0' (低位が NUL = is_ascii_hexdigit false) で None・pos == 0 巻き戻しを確認する
+        let input = [b'/', b'A', b'#', b'1', 0x00];
+        let mut lexer = Lexer::new(&input);
+        assert_eq!(lexer.read_name(), None);
+        assert_eq!(lexer.position(), 0);
+    }
+
+    #[test]
+    fn read_name_rejects_hash_with_whitespace_high() {
+        // '/A# ' (高位が space = is_ascii_hexdigit false) で None・pos == 0 巻き戻しを確認する
+        let mut lexer = Lexer::new(b"/A# ");
+        assert_eq!(lexer.read_name(), None);
+        assert_eq!(lexer.position(), 0);
+    }
+
+    #[test]
+    fn read_name_rejects_hash_with_delimiter_high() {
+        // '/A#/' (高位が '/' = is_ascii_hexdigit false) で None・pos == 0 巻き戻しを確認する
+        let mut lexer = Lexer::new(b"/A#/");
+        assert_eq!(lexer.read_name(), None);
+        assert_eq!(lexer.position(), 0);
+    }
+
+    #[test]
+    fn read_name_rejects_hash_with_non_hex_high_and_low() {
+        // '/A#GG' (高位・低位とも非16進) で None・pos == 0 巻き戻しを確認する（TS readName バグの代表入力）
+        let mut lexer = Lexer::new(b"/A#GG");
+        assert_eq!(lexer.read_name(), None);
+        assert_eq!(lexer.position(), 0);
+    }
+
+    // Phase 10-H: 長名前（仕様推奨上限 127 バイトを超えても受理）
+
+    #[test]
+    fn read_name_accepts_200_byte_ascii_name() {
+        // '/' + 'A' × 200 で Some([b'A'; 200])・pos == 201 を確認する（推奨上限非強制）
+        let mut input = Vec::with_capacity(201);
+        input.push(b'/');
+        input.extend(std::iter::repeat_n(b'A', 200));
+        let mut lexer = Lexer::new(&input);
+        assert_eq!(lexer.read_name(), Some(PdfName::new([b'A'; 200].to_vec())));
+        assert_eq!(lexer.position(), 201);
+    }
+
+    // Phase 10-I: 中間位置呼び出し（advance 後の起点）
+
+    #[test]
+    fn read_name_at_mid_buffer_succeeds_after_advance() {
+        // 'x/Type ' で advance 後 (pos == 1) に呼び Some(b"Type")・pos == 6 を確認する
+        let mut lexer = Lexer::new(b"x/Type ");
+        lexer.advance();
+        assert_eq!(lexer.position(), 1);
+        assert_eq!(lexer.read_name(), Some(PdfName::new(b"Type".to_vec())));
+        assert_eq!(lexer.position(), 6);
+    }
+
+    #[test]
+    fn read_name_failure_at_mid_buffer_rolls_back_to_call_site() {
+        // 'xabc' で advance 後 (pos == 1) に呼び None・pos == 1 巻き戻しを確認する
+        let mut lexer = Lexer::new(b"xabc");
+        lexer.advance();
+        assert_eq!(lexer.position(), 1);
+        assert_eq!(lexer.read_name(), None);
+        assert_eq!(lexer.position(), 1);
+    }
+
+    #[test]
+    fn read_name_invalid_escape_at_mid_buffer_rolls_back_to_call_site() {
+        // 'x/A#' で advance 後 (pos == 1) に不正エスケープ → pos == 1 巻き戻しを確認する
+        let mut lexer = Lexer::new(b"x/A#");
+        lexer.advance();
+        assert_eq!(lexer.position(), 1);
+        assert_eq!(lexer.read_name(), None);
+        assert_eq!(lexer.position(), 1);
     }
 }

--- a/rust/crates/core/src/lexer.rs
+++ b/rust/crates/core/src/lexer.rs
@@ -364,9 +364,6 @@ impl<'a> Lexer<'a> {
         if self.peek() != Some(b'/') {
             return None;
         }
-        // 以下の `checked_add` の None 分岐は self.pos == usize::MAX のときだけ発生する
-        // panic 不在契約上のガード。不変条件 0 ≦ pos ≦ input.len() のもとでは peek() が
-        // 先に None を返して break するため理論上到達不能だが、契約を機械的に守るために明示する。
         let Some(after_slash) = self.pos.checked_add(1) else {
             self.pos = start;
             return None;
@@ -384,6 +381,10 @@ impl<'a> Lexer<'a> {
 
             if b != b'#' {
                 bytes.push(b);
+                // checked_add の None 分岐は self.pos == usize::MAX のときだけ発生する
+                // panic 不在契約上のガード。不変条件 0 ≦ pos ≦ input.len() のもとでは
+                // peek() が先に None を返して break するため理論上到達不能だが、
+                // 契約を機械的に守るために明示する（以降の checked_add も同じ理由）。
                 let Some(next) = self.pos.checked_add(1) else {
                     self.pos = start;
                     return None;

--- a/rust/crates/core/src/lexer.rs
+++ b/rust/crates/core/src/lexer.rs
@@ -379,18 +379,9 @@ impl<'a> Lexer<'a> {
                 break;
             }
 
-            if b == b'#' {
-                let (Some(hi), Some(lo)) = (self.peek_at(1), self.peek_at(2)) else {
-                    self.pos = start;
-                    return None;
-                };
-                if !hi.is_ascii_hexdigit() || !lo.is_ascii_hexdigit() {
-                    self.pos = start;
-                    return None;
-                }
-                let decoded = hex_value(hi) * 16 + hex_value(lo);
-                bytes.push(decoded);
-                let Some(next) = self.pos.checked_add(3) else {
+            if b != b'#' {
+                bytes.push(b);
+                let Some(next) = self.pos.checked_add(1) else {
                     self.pos = start;
                     return None;
                 };
@@ -398,8 +389,18 @@ impl<'a> Lexer<'a> {
                 continue;
             }
 
-            bytes.push(b);
-            let Some(next) = self.pos.checked_add(1) else {
+            // '#XX' エスケープ: 直後 2 バイトを ASCII 16 進数字として 1 バイトに復号する
+            let (Some(hi), Some(lo)) = (self.peek_at(1), self.peek_at(2)) else {
+                self.pos = start;
+                return None;
+            };
+            if !hi.is_ascii_hexdigit() || !lo.is_ascii_hexdigit() {
+                self.pos = start;
+                return None;
+            }
+            let decoded = hex_value(hi) * 16 + hex_value(lo);
+            bytes.push(decoded);
+            let Some(next) = self.pos.checked_add(3) else {
                 self.pos = start;
                 return None;
             };

--- a/rust/crates/core/src/lexer.rs
+++ b/rust/crates/core/src/lexer.rs
@@ -364,6 +364,9 @@ impl<'a> Lexer<'a> {
         if self.peek() != Some(b'/') {
             return None;
         }
+        // 以下の `checked_add` の None 分岐は self.pos == usize::MAX のときだけ発生する
+        // panic 不在契約上のガード。不変条件 0 ≦ pos ≦ input.len() のもとでは peek() が
+        // 先に None を返して break するため理論上到達不能だが、契約を機械的に守るために明示する。
         let Some(after_slash) = self.pos.checked_add(1) else {
             self.pos = start;
             return None;
@@ -390,15 +393,16 @@ impl<'a> Lexer<'a> {
             }
 
             // '#XX' エスケープ: 直後 2 バイトを ASCII 16 進数字として 1 バイトに復号する
-            let (Some(hi), Some(lo)) = (self.peek_at(1), self.peek_at(2)) else {
+            // （high_bits が上位 4bit、low_bits が下位 4bit を担当する 16 進数字）
+            let (Some(high_bits), Some(low_bits)) = (self.peek_at(1), self.peek_at(2)) else {
                 self.pos = start;
                 return None;
             };
-            if !hi.is_ascii_hexdigit() || !lo.is_ascii_hexdigit() {
+            if !high_bits.is_ascii_hexdigit() || !low_bits.is_ascii_hexdigit() {
                 self.pos = start;
                 return None;
             }
-            let decoded = hex_value(hi) * 16 + hex_value(lo);
+            let decoded = hex_value(high_bits) * 16 + hex_value(low_bits);
             bytes.push(decoded);
             let Some(next) = self.pos.checked_add(3) else {
                 self.pos = start;


### PR DESCRIPTION
## 概要

ISO 32000-1 §7.3.5 / `docs/specs/01_lexical_conventions.md` §3.6 に従う PDF Name トークン（`/Name` 形式、`#XX` 16進エスケープ対応）を字句解析する `Lexer::read_name() -> Option<PdfName>` を `rust/crates/core/src/lexer.rs` に追加。Phase R1 Lexer API（Issue #400 / #430 / #433 の続編）として、既存 `read_integer` / `read_real` と同形のシグネチャ・巻き戻し方針・panic 不在契約・テスト粒度を踏襲。

## 変更内容

### 🎯 変更の種類

- [x] ✨ 新機能 (New feature)

### 📝 詳細な変更内容

#### 追加された機能

- `Lexer::read_name(&mut self) -> Option<PdfName>` メソッドを追加
  - 先頭 `/` の直後から、次の whitespace / delimiter / EOF までを Name 本体として読む
  - 本体中の `#XX`（`#` + 2 桁 ASCII 16進数字、大小混在可）を 1 バイトに復号
  - 復号後のバイト範囲 0x00〜0xFF（NUL 含む任意バイト）を受理
  - 空名前 `/`（`/` 直後に whitespace / delimiter / EOF）は `Some(PdfName::new(b""))` で受理
  - 不正 `#` エスケープは巻き戻し + `None` で厳格拒否（Issue #332 の TS 側 `parseInt("GG", 16) = NaN → fromCharCode(NaN) = " "` バグを **Rust では再現しない**）
- `hex_value` 内部ヘルパ関数（モジュール private 自由関数。将来 HexString 解析からの再利用を見越して `impl Lexer` 外配置）
- `use crate::object::name::PdfName;` を追加

#### 変更されたファイル

- `rust/crates/core/src/lexer.rs` (+444 行、削除なし)

#### テスト追加

- Phase 10-A〜I の 36 テスト追加
  - 10-A 早期 None 5 / 10-B 基本 ASCII 3 / 10-C エスケープ単発 6 / 10-D エスケープ複数 2 / 10-E 終端境界 3 / 10-F 空名前 3 / 10-G 不正エスケープ 10 / 10-H 長名前 1 / 10-I 中間位置 3
- Phase 7 横断 panic 不在テスト 2 件（`all_apis_do_not_panic_at_eof` / `all_apis_do_not_panic_for_empty_input`）に `let _ = lexer.read_name();` を 1 行ずつ追加

## 📊 システム図

### 状態マシン / フロー図

```mermaid
flowchart TD
    Start([read_name 呼び出し]) --> Entry["ENTRY<br/>start = self.pos"]
    Entry --> CheckSlash{"peek() == '/'?"}
    CheckSlash -->|No| EarlyNone[EARLY_NONE<br/>pos 不変で None]:::reject
    CheckSlash -->|Yes| Consume["CONSUME_SLASH<br/>pos += 1<br/>bytes = Vec::new"]
    Consume --> Loop{"peek()"}
    Loop -->|None EOF| Success[SUCCESS<br/>Some PdfName::new bytes]:::accept
    Loop -->|whitespace or delimiter| Success
    Loop -->|"'#'"| Escape{"hi = peek_at 1<br/>lo = peek_at 2<br/>両方 is_ascii_hexdigit?"}
    Loop -->|regular byte| Push["PUSH_REGULAR<br/>bytes.push b<br/>pos += 1"]
    Push --> Loop
    Escape -->|Yes| Decode["DECODE_HEX<br/>v = hex hi *16 + hex lo<br/>bytes.push v<br/>pos += 3"]
    Decode --> Loop
    Escape -->|No| Rollback[INVALID_ESC<br/>pos = start<br/>None]:::reject

    classDef accept fill:#d4edda,stroke:#28a745,stroke-width:2px
    classDef reject fill:#f8d7da,stroke:#dc3545,stroke-width:2px
```

### データフロー

```
入力バイト列 &'a [u8]
    ↓
Lexer<'a> { input, pos }
    ↓
  peek() / peek_at(n)              ← panic 不在: slice::get + checked_add
    ↓
  read_name()  [NEW]
    │
    ├─ ByteKind::is_whitespace     ← 既存 (lexer/byte_kind.rs)
    ├─ ByteKind::is_delimiter      ← 既存 (lexer/byte_kind.rs)
    ├─ u8::is_ascii_hexdigit       ← std
    ├─ hex_value(u8) -> u8         [NEW] モジュール private 自由関数
    └─ Vec<u8> (bytes 蓄積)
            ↓
        PdfName::new(Vec<u8>)      ← 既存 (object/name.rs)
            ↓
        Option<PdfName>
```

## 📋 関連 Issue

- Refs #402

## 🧪 テスト

### テスト実行方法

```bash
cargo test --workspace --manifest-path rust/Cargo.toml
cargo fmt --all --manifest-path rust/Cargo.toml -- --check
cargo clippy --workspace --manifest-path rust/Cargo.toml --all-targets -- -D warnings
```

### テスト項目

- [x] 単体テスト (Unit tests) — Phase 10-A〜I 全 36 件 PASS

### テスト結果

- `cargo test --workspace`: **527/527 PASS**（Phase 10 read_name 関連 36 件含む）
- `cargo fmt --all -- --check`: **PASS**
- `cargo clippy --workspace --all-targets -- -D warnings`: **PASS**
- spec-based-code-review (performance / design / spec-alignment / test-quality / comment-quality 5 並列): **CRITICAL 0 / WARNING 0 / INFO 17（方針内観察のみ、修正不要）**
- DoD: 13/13 項目すべて充足

## 🔍 レビューポイント

- **不正 `#XX` エスケープの厳格拒否** — `#`/`#1`/`#Z`/`#1Z`/`# `/`#/`/`#GG`/`#1 `/`#1/`/`#1\0` の 10 ケースをすべて `None` + `pos` 完全巻き戻しで拒否（Phase 10-G）。TS 側の `#GG` 暗黙 NUL 化バグ（Issue #332）を Rust では再現しない方針を明示固定。
- **panic 不在契約** — `pos` の全前進が `checked_add` 経由、先読みは `peek()` / `peek_at()` のみ（内部で `slice::get` + `checked_add`）。Phase 7 横断テスト 2 件に追加して契約への組み込みを確認。
- **空名前 `/` の受理** — `Some(PdfName::new(b""))` として受理（ISO 32000-1 が明示禁止しないため、UC-4 で確定）。
- **`hex_value` の配置** — `impl<'a> Lexer<'a>` の外（モジュール private 自由関数）に配置。将来 HexString 解析からの再利用とテスト容易性を考慮した確定方針。
- **Phase 7 横断テストへの 1 行追加** — 「Phase 10 末尾追加のみ」方針の明示的例外として、横断 panic 不在契約に新 API を含めるために許容。

## ⚠️ 破壊的変更

- [ ] この変更は既存の API に破壊的変更を含みます

破壊的変更なし。新規 API 追加のみで、既存 `Token` / `Primitive` enum や他 `Lexer` メソッドは無変更。外部依存追加もなし（`Cargo.toml` 無変更）。

## ✅ チェックリスト

- [x] コードレビューの準備ができている（spec-based-code-review 完了、CRITICAL/WARNING 0）
- [x] テストが正常に実行される
- [x] コミットメッセージが適切な形式で書かれている
- [x] 関連する Issue (#402) が本文に記載されている
- [x] セルフレビューを実施した
- [x] 破壊的変更なし