### PR TITLE
✨ [New Feature]: #423 text-showing-operators barrel と registerTextShowingOperators を追加

### DIFF
--- a/packages/core/src/content-stream/operators/text/text-showing-operators/__tests__/text-showing-operators.basic.test.ts
+++ b/packages/core/src/content-stream/operators/text/text-showing-operators/__tests__/text-showing-operators.basic.test.ts
@@ -1,0 +1,38 @@
+import { assert, expect, test } from "vitest";
+import {
+  type OperatorHandler,
+  OperatorRegistry,
+} from "../../../../operator-registry/index";
+import {
+  apostropheHandler,
+  quoteHandler,
+  registerTextShowingOperators,
+  tjArrayHandler,
+  tjHandler,
+} from "../index";
+
+// 空 registry に一括登録すると各 operator 名で同一参照の handler が lookup できる
+test.each<readonly [string, OperatorHandler]>([
+  ["Tj", tjHandler],
+  ["TJ", tjArrayHandler],
+  ["'", apostropheHandler],
+  ['"', quoteHandler],
+])("registerTextShowingOperators は %s に対応する handler を登録する", (name, expectedHandler) => {
+  const result = registerTextShowingOperators(OperatorRegistry.create());
+  assert(result.ok);
+
+  const looked = OperatorRegistry.lookup(result.value, name);
+  assert(looked.some);
+  expect(looked.value).toBe(expectedHandler);
+});
+
+// 一括登録後の registry を OperatorRegistry.has で全件確認する
+test("registerTextShowingOperators の戻り値は ok で 4 operator すべてを保持する registry を返す", () => {
+  const result = registerTextShowingOperators(OperatorRegistry.create());
+  assert(result.ok);
+
+  expect(OperatorRegistry.has(result.value, "Tj")).toBe(true);
+  expect(OperatorRegistry.has(result.value, "TJ")).toBe(true);
+  expect(OperatorRegistry.has(result.value, "'")).toBe(true);
+  expect(OperatorRegistry.has(result.value, '"')).toBe(true);
+});

--- a/packages/core/src/content-stream/operators/text/text-showing-operators/__tests__/text-showing-operators.error.test.ts
+++ b/packages/core/src/content-stream/operators/text/text-showing-operators/__tests__/text-showing-operators.error.test.ts
@@ -1,0 +1,41 @@
+import { afterEach, assert, expect, test, vi } from "vitest";
+import {
+  type OperatorHandler,
+  OperatorRegistry,
+} from "../../../../operator-registry/index";
+import {
+  apostropheHandler,
+  quoteHandler,
+  registerTextShowingOperators,
+  tjArrayHandler,
+  tjHandler,
+} from "../index";
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+// [重複させる operator 名, その handler, 短絡までに register が呼ばれる名列（登録順の prefix）]
+test.each<readonly [string, OperatorHandler, readonly string[]]>([
+  ["Tj", tjHandler, ["Tj"]],
+  ["TJ", tjArrayHandler, ["Tj", "TJ"]],
+  ["'", apostropheHandler, ["Tj", "TJ", "'"]],
+  ['"', quoteHandler, ["Tj", "TJ", "'", '"']],
+])("%s が登録済みのとき registerTextShowingOperators は Err を返し reduce が登録順 prefix で短絡する", (name, handler, expectedCalledNames) => {
+  const seed = OperatorRegistry.register(
+    OperatorRegistry.create(),
+    name,
+    handler,
+  );
+  assert(seed.ok);
+
+  const registerSpy = vi.spyOn(OperatorRegistry, "register");
+  const result = registerTextShowingOperators(seed.value);
+
+  assert(!result.ok);
+  assert(result.error.code === "OPERATOR_ALREADY_REGISTERED");
+  expect(result.error.operatorName).toBe(name);
+  expect(registerSpy.mock.calls.map((call) => call[1])).toEqual(
+    expectedCalledNames,
+  );
+});

--- a/packages/core/src/content-stream/operators/text/text-showing-operators/__tests__/text-showing-operators.integration.test.ts
+++ b/packages/core/src/content-stream/operators/text/text-showing-operators/__tests__/text-showing-operators.integration.test.ts
@@ -88,9 +88,16 @@ test("TJ: barrel が TJ を登録し initialContext で渡した配列 operand �
   expect(TextObject.isActive(current.textObject)).toBe(true);
   // Tm で (72, 720) に絶対配置 → TJ の数値要素 40 が `textMatrix.e` を `-40 * fontSize / 1000 = -0.48` 移動。
   // 結果: textMatrix.e === 72 + (-40 * 12 / 1000) === 71.52
-  expect(current.textObject.textMatrix).toEqual(
-    Matrix.create(1, 0, 0, 1, 71.52, 720),
-  );
+  // e のみ浮動小数演算の丸め誤差が乗るため `toBeCloseTo` で検証する。
+  // 残りの 5 成分 (a/b/c/d/f) は Tm の整数値そのままなので等値比較で良い。
+  // Matrix は `[a, b, c, d, e, f]` のタプル表現。
+  const [a, b, c, d, e, f] = current.textObject.textMatrix;
+  expect(a).toBe(1);
+  expect(b).toBe(0);
+  expect(c).toBe(0);
+  expect(d).toBe(1);
+  expect(f).toBe(720);
+  expect(e).toBeCloseTo(71.52);
 });
 
 test("': BT 14 TL (Hi) ' で改行 (leading=14) が発生する", () => {

--- a/packages/core/src/content-stream/operators/text/text-showing-operators/__tests__/text-showing-operators.integration.test.ts
+++ b/packages/core/src/content-stream/operators/text/text-showing-operators/__tests__/text-showing-operators.integration.test.ts
@@ -1,0 +1,158 @@
+import { assert, expect, test } from "vitest";
+import { flatMap } from "../../../../../utils/result/index";
+import {
+  GraphicsStateStack,
+  Matrix,
+  TextObject,
+} from "../../../../graphics-state/index";
+import type { ContentStreamInterpreterResult } from "../../../../interpreter/index";
+import { ContentStreamInterpreter } from "../../../../interpreter/index";
+import { OperandStack } from "../../../../operand-stack/index";
+import type { OperatorHandlerContext } from "../../../../operator-registry/index";
+import { OperatorRegistry } from "../../../../operator-registry/index";
+import { registerTextPositioningOperators } from "../../text-positioning-operators/index";
+import { registerTextStateOperators } from "../../text-state-operators/index";
+import { registerTextShowingOperators } from "../index";
+
+const encode = (s: string): Uint8Array => new TextEncoder().encode(s);
+
+// text-state（BT/ET/TL 等）+ text-positioning（Tm 等）+ text-showing の
+// 3 barrel を併用登録した registry を作るテストヘルパ。
+// 登録失敗は assert で即座に検出する。
+const createRegistry = (): OperatorRegistry => {
+  const withState = registerTextStateOperators(OperatorRegistry.create());
+  const withPositioning = flatMap(withState, registerTextPositioningOperators);
+  const registered = flatMap(withPositioning, registerTextShowingOperators);
+  assert(registered.ok);
+  return registered.value;
+};
+
+// 正常系用: content stream を実行し成功結果を返すヘルパ（失敗時は assert で即座に検出）。
+// 異常系（BT 外 Tj → Err）はこのヘルパを使わず execute を直接呼んで Err を検証する。
+const execute = (
+  stream: string,
+  initialContext?: OperatorHandlerContext,
+): ContentStreamInterpreterResult => {
+  const result = ContentStreamInterpreter.execute({
+    data: encode(stream),
+    registry: createRegistry(),
+    initialContext,
+  });
+  assert(result.ok);
+  return result.value;
+};
+
+// シナリオ 1 用: TJ に渡す PdfObject 配列を operand stack に事前 push した初期 context を作る。
+// 配列リテラル `[...]` は interpreter で NOT_IMPLEMENTED のため、content stream には
+// 含めず、operand stack に直接 push してから `TJ` を流す。
+// PdfString には `encoding: "literal"` が必須。
+const createInitialContextWithArrayOperand = (): OperatorHandlerContext => {
+  const operandStack = OperandStack.create();
+  OperandStack.push(operandStack, {
+    type: "array",
+    elements: [
+      { type: "string", value: encode("H"), encoding: "literal" },
+      { type: "integer", value: 40 },
+      { type: "string", value: encode("ello"), encoding: "literal" },
+    ],
+  });
+  return {
+    operandStack,
+    graphicsStateStack: GraphicsStateStack.create(),
+  };
+};
+
+test("TJ: barrel が TJ を登録し initialContext で渡した配列 operand を tjArrayHandler が消費し textMatrix を水平移動する", () => {
+  // シナリオ 1: stream には配列リテラル `[...]` を含めない（interpreter で NOT_IMPLEMENTED）。
+  // initialContext.operandStack に PdfObject の array を事前 push し、
+  // `BT /F1 12 Tf 1 0 0 1 72 720 Tm TJ` を流す。
+  // - /F1 12 Tf: fontSize=12 を設定（fontSize=0 だと TJ 数値要素の textMatrix 移動量が常に 0 になり short-circuit する）
+  // - Tm で (72, 720) に絶対配置
+  // - TJ で initialContext の配列を pop し、数値要素 40 を反映して textMatrix.e を移動
+  // ET は含めない（ET は textMatrix / textLineMatrix を identity にリセットするため、移動結果を観測できなくなる）。
+  const executed = execute(
+    "BT /F1 12 Tf 1 0 0 1 72 720 Tm TJ",
+    createInitialContextWithArrayOperand(),
+  );
+  // UNKNOWN_OPERATOR が一切出ていない = barrel が 4 operator (および Tf/Tm/BT) を正しく登録した
+  expect(executed.warnings).toEqual([]);
+
+  // tjArrayHandler が dispatch されて配列を pop した結果、operand stack は空。
+  // operand stack は context 直下にあり、GraphicsState の中ではない。
+  expect(OperandStack.depth(executed.context.operandStack)).toBe(0);
+
+  const current = GraphicsStateStack.current(
+    executed.context.graphicsStateStack,
+  );
+  // BT 後 ET なしのため、text object は active のまま。
+  expect(TextObject.isActive(current.textObject)).toBe(true);
+  // Tm で (72, 720) に絶対配置 → TJ の数値要素 40 が `textMatrix.e` を `-40 * fontSize / 1000 = -0.48` 移動。
+  // 結果: textMatrix.e === 72 + (-40 * 12 / 1000) === 71.52
+  expect(current.textObject.textMatrix).toEqual(
+    Matrix.create(1, 0, 0, 1, 71.52, 720),
+  );
+});
+
+test("': BT 14 TL (Hi) ' で改行 (leading=14) が発生する", () => {
+  // シナリオ 2: ' は (Hi) の描画 + T* 相当の改行を発生させる。
+  // ET なし → textLineMatrix の最終状態を観測する。
+  const executed = execute("BT 14 TL (Hi) '");
+  expect(executed.warnings).toEqual([]);
+
+  const current = GraphicsStateStack.current(
+    executed.context.graphicsStateStack,
+  );
+  // ' の T* 相当処理で leading=14 を反映し、textLineMatrix.f = -14 へ移動。
+  // textMatrix も同じ位置（' の Tj は文字列描画のみで matrix を動かさず、
+  // 続く T* 相当処理が textMatrix = textLineMatrix とする既存仕様）。
+  expect(current.textObject.textLineMatrix).toEqual(
+    Matrix.create(1, 0, 0, 1, 0, -14),
+  );
+  expect(current.textObject.textMatrix).toEqual(
+    Matrix.create(1, 0, 0, 1, 0, -14),
+  );
+  expect(current.textState.leading).toBe(14);
+});
+
+test('": BT 14 TL 2 1 (Hi) " で wordSpace=2 / charSpace=1 を設定し改行する', () => {
+  // シナリオ 3: " は aw=2, ac=1, string の 3 operand で wordSpace / charSpace を更新し
+  // ' 相当の (Hi) + 改行を発生させる。ET なしで最終 textState / textLineMatrix を観測。
+  const executed = execute('BT 14 TL 2 1 (Hi) "');
+  expect(executed.warnings).toEqual([]);
+
+  const current = GraphicsStateStack.current(
+    executed.context.graphicsStateStack,
+  );
+  expect(current.textState.wordSpace).toBe(2);
+  expect(current.textState.charSpace).toBe(1);
+  expect(current.textState.leading).toBe(14);
+  // " の改行 (T* 相当) で textLineMatrix.f = -14。
+  expect(current.textObject.textLineMatrix).toEqual(
+    Matrix.create(1, 0, 0, 1, 0, -14),
+  );
+});
+
+// シナリオ 4: BT 外で **登録した 4 operator すべて**を実行 → 各 handler の active 検査で fail。
+// barrel が 4 operator を正しく登録し、かつ 4 つすべてが interpreter 経由で
+// active 検査エラーを返すことを test.each で網羅する（UNKNOWN_OPERATOR ではなく
+// OPERATOR_ILLEGAL_STATE が返ることが barrel 登録の確証になる）。
+// 異常系のため execute ヘルパは使わず ContentStreamInterpreter.execute を直接呼ぶ。
+test.each<readonly [string, string, OperatorHandlerContext | undefined]>([
+  // [operator, BT 外 stream, initialContext]
+  // - Tj / ' / " は operand を stream で積める
+  // - TJ は配列リテラル `[...]` が interpreter で NOT_IMPLEMENTED のため
+  //   initialContext.operandStack に配列を事前 push し、stream は `TJ` のみ
+  ["Tj", "(Hi) Tj", undefined],
+  ["TJ", "TJ", createInitialContextWithArrayOperand()],
+  ["'", "(Hi) '", undefined],
+  ['"', '2 1 (Hi) "', undefined],
+])("%s: BT なしで実行すると execute が OPERATOR_ILLEGAL_STATE の Err を返す", (_name, stream, initialContext) => {
+  const result = ContentStreamInterpreter.execute({
+    data: encode(stream),
+    registry: createRegistry(),
+    initialContext,
+  });
+
+  assert(!result.ok);
+  expect(result.error.code).toBe("OPERATOR_ILLEGAL_STATE");
+});

--- a/packages/core/src/content-stream/operators/text/text-showing-operators/index.ts
+++ b/packages/core/src/content-stream/operators/text/text-showing-operators/index.ts
@@ -1,0 +1,44 @@
+import type { PdfError } from "../../../../pdf/errors/index";
+import type { Result } from "../../../../utils/result/index";
+import { flatMap, ok } from "../../../../utils/result/index";
+import type { OperatorHandler } from "../../../operator-registry/index";
+import { OperatorRegistry } from "../../../operator-registry/index";
+import { apostropheHandler } from "../apostrophe/index";
+import { quoteHandler } from "../quote/index";
+import { tjHandler } from "../tj/index";
+import { tjArrayHandler } from "../tj-array/index";
+
+export { apostropheHandler } from "../apostrophe/index";
+export { quoteHandler } from "../quote/index";
+export { tjHandler } from "../tj/index";
+export { tjArrayHandler } from "../tj-array/index";
+
+// 登録順は Issue 指定順（Tj, TJ, ', "）。
+// この順序は error テストの fail-fast 呼び出し順検証に直結する。
+const TEXT_SHOWING_OPERATORS: ReadonlyArray<
+  readonly [string, OperatorHandler]
+> = [
+  ["Tj", tjHandler],
+  ["TJ", tjArrayHandler],
+  ["'", apostropheHandler],
+  ['"', quoteHandler],
+];
+
+/**
+ * Text showing operator (Tj / TJ / ' / ") を
+ * OperatorRegistry に一括登録するヘルパ。
+ *
+ * fail-fast: いずれかの register が Err を返した時点で reduce 内 flatMap が
+ * 短絡し、後続 operator の register は呼ばれない。
+ *
+ * @param registry - 登録元 registry
+ * @returns 全 operator が登録された新しい registry、または重複登録時の PdfError
+ */
+export const registerTextShowingOperators = (
+  registry: OperatorRegistry,
+): Result<OperatorRegistry, PdfError> =>
+  TEXT_SHOWING_OPERATORS.reduce<Result<OperatorRegistry, PdfError>>(
+    (acc, [name, handler]) =>
+      flatMap(acc, (r) => OperatorRegistry.register(r, name, handler)),
+    ok(registry),
+  );


### PR DESCRIPTION
## 概要

Phase 4-F で実装済みの 4 つの text showing operator (`Tj` / `TJ` / `'` / `"`) を `OperatorRegistry` に一括登録する barrel ヘルパ `registerTextShowingOperators` と、エントリポイントとなる barrel ファイルを追加する。既存の `text-positioning-operators` / `text-state-operators` の barrel と同形・同 API・fail-fast 規約に従う。

## 変更内容

### 🎯 変更の種類

- [x] ✨ 新機能 (New feature)

### 📝 詳細な変更内容

#### 追加された機能

- `registerTextShowingOperators(registry)` — `Tj → TJ → ' → "` の順で 4 handler を `OperatorRegistry` に畳み込み登録するヘルパ。`reduce + flatMap` で fail-fast、重複時は `OPERATOR_ALREADY_REGISTERED` の `PdfError` を返す
- 4 handler (`tjHandler` / `tjArrayHandler` / `apostropheHandler` / `quoteHandler`) の named re-export

#### 追加されたファイル

- `packages/core/src/content-stream/operators/text/text-showing-operators/index.ts` — barrel 本体（4 handler re-export + `registerTextShowingOperators`）
- `packages/core/src/content-stream/operators/text/text-showing-operators/__tests__/text-showing-operators.basic.test.ts` — 正常系テスト（5 ケース）
- `packages/core/src/content-stream/operators/text/text-showing-operators/__tests__/text-showing-operators.error.test.ts` — 重複登録時の fail-fast prefix テスト（4 ケース）
- `packages/core/src/content-stream/operators/text/text-showing-operators/__tests__/text-showing-operators.integration.test.ts` — `ContentStreamInterpreter.execute` 経由の 4 シナリオ統合テスト（7 ケース）

#### 変更されたファイル

なし（既存 4 handler / 既存 2 barrel には一切変更なし）

## 📊 システム図

### fail-fast 畳み込みフロー

```mermaid
flowchart TD
    Start([registry]) --> Init[ok registry / reduce 初期値]
    Init --> Tj[STEP Tj: flatMap → register Tj]
    Tj -->|ok| TJ[STEP TJ: register TJ]
    Tj -->|err| Errout[Err OPERATOR_ALREADY_REGISTERED]
    TJ -->|ok| Apos[STEP ' : register apostrophe]
    TJ -->|err| Errout
    Apos -->|ok| Quote[STEP \" : register quote]
    Apos -->|err| Errout
    Quote -->|ok| Done([ok newRegistry / 4 handler 登録済])
    Quote -->|err| Errout
    Errout --> Skip[後続 register は呼ばれない]
```

## 関連Issue

Closes #423

## テスト

- `pnpm --filter @pdfmod/core test` GREEN（204 ファイル / 2694 テスト、新規 16 ケース含む）
- `pnpm --filter @pdfmod/core typecheck` GREEN
- `pnpm --filter @pdfmod/core build` GREEN（`dist/.../text-showing-operators/index.d.ts` に `registerTextShowingOperators` + 4 handler の export を確認）
- `pnpm run lint`（biome + oxlint）GREEN
- Codex code review: **問題なし**

### 新規テストケース内訳（計 16 ケース）

| ファイル | カテゴリ | 件数 | 内容 |
|:-|:-|:-|:-|
| basic | 正常系 | 5 | 4 operator の個別 lookup（test.each）+ 4 operator 全件 has 確認 |
| error | 異常系 | 4 | 重複登録時の fail-fast prefix 検証（`["Tj"]` / `["Tj","TJ"]` / `["Tj","TJ","'"]` / `["Tj","TJ","'", '"']`） |
| integration | 正常系 | 3 | TJ で textMatrix 水平移動 / `'` で改行 (leading=14) / `\"` で wordSpace=2/charSpace=1 設定+改行 |
| integration | 異常系 | 4 | BT 外で 4 operator 実行 → `OPERATOR_ILLEGAL_STATE` |

## レビューポイント

- 登録順 `Tj → TJ → ' → "` の固定（error テストの fail-fast prefix 検証に直結）
- import/export 順は biome 既定のアルファベット順 `apostropheHandler → quoteHandler → tjHandler → tjArrayHandler`（登録順とは意図的に異なる、既存 2 barrel と同規約）
- integration の `createRegistry` は **3 barrel 併用**（text-state + text-positioning + text-showing）でチェーン
- シナリオ 1（TJ）は配列リテラル `[...]` が interpreter で `NOT_IMPLEMENTED` のため、`initialContext.operandStack` に `PdfObject` 型 `array` を事前 push し、stream は `BT /F1 12 Tf 1 0 0 1 72 720 Tm TJ`（配列リテラル含めず、ET なし）
- シナリオ 1〜3 は `ET` を含めない（`ET` は textMatrix / textLineMatrix を identity リセットするため移動結果を観測できなくなる）
- エラーコードは `OPERATOR_ALREADY_REGISTERED`（`OPERATOR_DUPLICATE` ではない）