### PR TITLE
✨ [New Feature]: #425 Do operator handler (draw XObject 骨格) を実装

### DIFF
--- a/packages/core/src/content-stream/operators/xobject/do/__tests__/do.basic.test.ts
+++ b/packages/core/src/content-stream/operators/xobject/do/__tests__/do.basic.test.ts
@@ -1,0 +1,126 @@
+import { assert, expect, test } from "vitest";
+import type { PdfObject } from "../../../../../pdf/types/pdf-types/index";
+import {
+  GraphicsState,
+  GraphicsStateStack,
+  TextObject,
+} from "../../../../graphics-state/index";
+import { OperandStack } from "../../../../operand-stack/index";
+import type { OperatorHandlerContext } from "../../../../operator-registry/index";
+import { doHandler } from "../index";
+
+// inactive な textObject（GraphicsStateStack.create() 直後）でビルド
+const buildContext = (operands: PdfObject[]): OperatorHandlerContext => {
+  const operandStack = OperandStack.create();
+  for (const operand of operands) {
+    OperandStack.push(operandStack, operand);
+  }
+  const graphicsStateStack = GraphicsStateStack.create();
+  return { operandStack, graphicsStateStack };
+};
+
+// active な textObject（BT 後相当）に差し替えてビルド
+const buildActiveContext = (operands: PdfObject[]): OperatorHandlerContext => {
+  const operandStack = OperandStack.create();
+  for (const operand of operands) {
+    OperandStack.push(operandStack, operand);
+  }
+  const activeState = GraphicsState.update(GraphicsState.create(), {
+    textObject: TextObject.begin(),
+  });
+  const graphicsStateStack = GraphicsStateStack.replaceCurrent(
+    GraphicsStateStack.create(),
+    activeState,
+  );
+  return { operandStack, graphicsStateStack };
+};
+
+test("name { type: 'name', value: 'Im1' } を受理し ok を返す", () => {
+  const ctx = buildContext([{ type: "name", value: "Im1" }]);
+
+  const result = doHandler(ctx);
+
+  assert(result.ok);
+});
+
+test("成功時に operandStack は入力と同一参照で返る（in-place mutate）", () => {
+  const ctx = buildContext([{ type: "name", value: "Im1" }]);
+
+  const result = doHandler(ctx);
+
+  assert(result.ok);
+  expect(result.value.operandStack).toBe(ctx.operandStack);
+});
+
+test("成功時に graphicsStateStack は入力と同一参照で返る", () => {
+  const ctx = buildContext([{ type: "name", value: "Im1" }]);
+
+  const result = doHandler(ctx);
+
+  assert(result.ok);
+  expect(result.value.graphicsStateStack).toBe(ctx.graphicsStateStack);
+});
+
+test("成功時に operand が 1 個消費され depth=0 になる", () => {
+  const ctx = buildContext([{ type: "name", value: "Im1" }]);
+
+  const result = doHandler(ctx);
+
+  assert(result.ok);
+  expect(OperandStack.depth(result.value.operandStack)).toBe(0);
+});
+
+test("余剰 operand があれば末尾 1 個のみ消費する（depth=3 → depth=2）", () => {
+  const surplus0: PdfObject = { type: "integer", value: 1 };
+  const surplus1: PdfObject = { type: "integer", value: 2 };
+  const ctx = buildContext([
+    surplus0,
+    surplus1,
+    { type: "name", value: "Im1" },
+  ]);
+
+  const result = doHandler(ctx);
+
+  assert(result.ok);
+  expect(OperandStack.depth(result.value.operandStack)).toBe(2);
+  const top = OperandStack.peek(result.value.operandStack);
+  assert(top.some);
+  expect(top.value).toEqual(surplus1);
+});
+
+test("name 値が空文字 ('') でも受理する（値域検証なし pin down）", () => {
+  const ctx = buildContext([{ type: "name", value: "" }]);
+
+  const result = doHandler(ctx);
+
+  assert(result.ok);
+});
+
+test("inactive な textObject でも ok を返す（active 検査なし pin down）", () => {
+  const ctx = buildContext([{ type: "name", value: "Im1" }]);
+
+  const result = doHandler(ctx);
+
+  assert(result.ok);
+});
+
+test("active な textObject でも ok を返す（BT/ET 内対称、active 検査なし pin down）", () => {
+  const ctx = buildActiveContext([{ type: "name", value: "Im1" }]);
+
+  const result = doHandler(ctx);
+
+  assert(result.ok);
+});
+
+test("成功時に graphics state stack の current は完全に不変", () => {
+  const ctx = buildActiveContext([{ type: "name", value: "Im1" }]);
+  const before = GraphicsStateStack.current(ctx.graphicsStateStack);
+
+  const result = doHandler(ctx);
+
+  assert(result.ok);
+  const after = GraphicsStateStack.current(result.value.graphicsStateStack);
+  expect(after).toBe(before);
+  expect(after.textState).toBe(before.textState);
+  expect(after.textObject).toBe(before.textObject);
+});

--- a/packages/core/src/content-stream/operators/xobject/do/__tests__/do.error.test.ts
+++ b/packages/core/src/content-stream/operators/xobject/do/__tests__/do.error.test.ts
@@ -1,0 +1,119 @@
+import { assert, expect, test } from "vitest";
+import type { PdfObject } from "../../../../../pdf/types/pdf-types/index";
+import { GraphicsStateStack } from "../../../../graphics-state/index";
+import { OperandStack } from "../../../../operand-stack/index";
+import type { OperatorHandlerContext } from "../../../../operator-registry/index";
+import { doHandler } from "../index";
+
+const buildContext = (operands: PdfObject[]): OperatorHandlerContext => {
+  const operandStack = OperandStack.create();
+  for (const operand of operands) {
+    OperandStack.push(operandStack, operand);
+  }
+  const graphicsStateStack = GraphicsStateStack.create();
+  return { operandStack, graphicsStateStack };
+};
+
+const NON_NAME_CASES: ReadonlyArray<[string, PdfObject]> = [
+  ["integer", { type: "integer", value: 42 }],
+  ["real", { type: "real", value: 3.14 }],
+  ["string", { type: "string", value: new Uint8Array(), encoding: "literal" }],
+  ["boolean", { type: "boolean", value: true }],
+  ["null", { type: "null" }],
+  ["array", { type: "array", elements: [] }],
+  ["dictionary", { type: "dictionary", entries: new Map() }],
+  [
+    "indirect-ref",
+    { type: "indirect-ref", objectNumber: 1, generationNumber: 0 },
+  ],
+  [
+    "stream",
+    {
+      type: "stream",
+      dictionary: { type: "dictionary", entries: new Map() },
+      data: new Uint8Array(),
+    },
+  ],
+];
+
+test("operand 0 個のとき MISSING を返す（required:1, actual:0, operatorName:'Do'）", () => {
+  const ctx = buildContext([]);
+
+  const result = doHandler(ctx);
+
+  assert(!result.ok);
+  assert(result.error.code === "OPERATOR_OPERAND_MISSING");
+  expect(result.error.operatorName).toBe("Do");
+  expect(result.error.required).toBe(1);
+  expect(result.error.actual).toBe(0);
+});
+
+test("MISSING メッセージは 'Operator 'Do' requires 1 operand(s), got 0' と完全一致", () => {
+  const ctx = buildContext([]);
+
+  const result = doHandler(ctx);
+
+  assert(!result.ok);
+  assert(result.error.code === "OPERATOR_OPERAND_MISSING");
+  expect(result.error.message).toBe(
+    "Operator 'Do' requires 1 operand(s), got 0",
+  );
+});
+
+test("MISSING 時 graphics state stack の current は不変", () => {
+  const ctx = buildContext([]);
+  const before = GraphicsStateStack.current(ctx.graphicsStateStack);
+
+  const result = doHandler(ctx);
+
+  assert(!result.ok);
+  const after = GraphicsStateStack.current(ctx.graphicsStateStack);
+  expect(after).toBe(before);
+});
+
+test.each<[string, PdfObject]>(
+  NON_NAME_CASES,
+)("top が %s のとき TYPE_MISMATCH を返す（expected:'name', actual:%s）", (type, operand) => {
+  const ctx = buildContext([operand]);
+
+  const result = doHandler(ctx);
+
+  assert(!result.ok);
+  assert(result.error.code === "OPERATOR_OPERAND_TYPE_MISMATCH");
+  expect(result.error.expected).toBe("name");
+  expect(result.error.actual).toBe(type);
+});
+
+test("TYPE_MISMATCH の operatorName が 'Do' でメッセージが完全一致する（top: integer）", () => {
+  const ctx = buildContext([{ type: "integer", value: 42 }]);
+
+  const result = doHandler(ctx);
+
+  assert(!result.ok);
+  assert(result.error.code === "OPERATOR_OPERAND_TYPE_MISMATCH");
+  expect(result.error.operatorName).toBe("Do");
+  expect(result.error.message).toBe(
+    "Operator 'Do' expected name operand, got integer",
+  );
+});
+
+test("TYPE_MISMATCH 時 graphics state stack の current は不変", () => {
+  const ctx = buildContext([{ type: "integer", value: 42 }]);
+  const before = GraphicsStateStack.current(ctx.graphicsStateStack);
+
+  const result = doHandler(ctx);
+
+  assert(!result.ok);
+  const after = GraphicsStateStack.current(ctx.graphicsStateStack);
+  expect(after).toBe(before);
+});
+
+test("TYPE_MISMATCH 後に部分消費した operand は復元しない（depth=1 → depth=0 のまま）", () => {
+  const ctx = buildContext([{ type: "integer", value: 42 }]);
+  expect(OperandStack.depth(ctx.operandStack)).toBe(1);
+
+  const result = doHandler(ctx);
+
+  assert(!result.ok);
+  expect(OperandStack.depth(ctx.operandStack)).toBe(0);
+});

--- a/packages/core/src/content-stream/operators/xobject/do/__tests__/do.error.test.ts
+++ b/packages/core/src/content-stream/operators/xobject/do/__tests__/do.error.test.ts
@@ -73,7 +73,7 @@ test("MISSING 時 graphics state stack の current は不変", () => {
 
 test.each<[string, PdfObject]>(
   NON_NAME_CASES,
-)("top が %s のとき TYPE_MISMATCH を返す（expected:'name', actual:%s）", (type, operand) => {
+)("top が %s のとき TYPE_MISMATCH を返す（expected:'name', actual=top の type 名）", (type, operand) => {
   const ctx = buildContext([operand]);
 
   const result = doHandler(ctx);

--- a/packages/core/src/content-stream/operators/xobject/do/index.ts
+++ b/packages/core/src/content-stream/operators/xobject/do/index.ts
@@ -1,0 +1,63 @@
+import type { PdfError } from "../../../../pdf/errors/index";
+import { PdfName } from "../../../../pdf/types/pdf-types/index";
+import { err, ok } from "../../../../utils/result/index";
+import { OperandStack } from "../../../operand-stack/index";
+import type {
+  OperatorHandler,
+  OperatorHandlerContext,
+} from "../../../operator-registry/index";
+
+const OPERATOR_NAME = "Do";
+const OPERAND_COUNT = 1;
+
+/**
+ * PDF §8.8 `Do` operator (invoke named XObject) のハンドラ。
+ *
+ * operand stack から name 1 個を pop し、name 型であれば受理して
+ * operand を消費する骨格実装。XObject 解決と実体描画
+ * (画像 decode / form XObject 再帰実行) は本フェーズでは行わず、
+ * 後続フェーズで本 handler に追加する。
+ *
+ * 検査順序（厳守）:
+ *   (1) operand pop（none なら `OPERATOR_OPERAND_MISSING`）
+ *   (2) 型検査（PdfName.is が false なら `OPERATOR_OPERAND_TYPE_MISMATCH`）
+ *
+ * - 本フェーズの仕様により `textObject.active` は検査しない（BT/ET 内外で同じ動作）。
+ * - name の妥当性（`/Resources` の `/XObject` への存在性）と value の値域（空文字 等）
+ *   は本フェーズでは検証しない。
+ * - graphics state は更新しないため、`graphicsStateStack` は入力と同一参照で返す。
+ * - エラー時に部分消費した operand stack は復元しない（既存ハンドラ規約）。
+ *
+ * @param context - 実行コンテキスト (operand stack / graphics state stack)
+ * @returns 成功なら更新後コンテキスト、失敗なら PdfError
+ */
+export const doHandler: OperatorHandler = (context: OperatorHandlerContext) => {
+  const popped = OperandStack.pop(context.operandStack);
+  if (!popped.some) {
+    const error: PdfError = {
+      code: "OPERATOR_OPERAND_MISSING",
+      message: `Operator '${OPERATOR_NAME}' requires ${OPERAND_COUNT} operand(s), got 0`,
+      operatorName: OPERATOR_NAME,
+      required: OPERAND_COUNT,
+      actual: 0,
+    };
+    return err(error);
+  }
+
+  const operand = popped.value;
+  if (!PdfName.is(operand)) {
+    const error: PdfError = {
+      code: "OPERATOR_OPERAND_TYPE_MISMATCH",
+      message: `Operator '${OPERATOR_NAME}' expected name operand, got ${operand.type}`,
+      operatorName: OPERATOR_NAME,
+      expected: "name",
+      actual: operand.type,
+    };
+    return err(error);
+  }
+
+  return ok({
+    operandStack: context.operandStack,
+    graphicsStateStack: context.graphicsStateStack,
+  });
+};


### PR DESCRIPTION
## 概要

PDF §8.8 `Do` (invoke named XObject) operator の骨格 handler を実装します。本フェーズでは XObject 解決機構が未整備のため、name operand 1 個を pop・型検証して content stream のスタック整合性を保ち、graphics state は変更せず同一参照で返します。XObject 解決と実体描画（画像 decode / form XObject 再帰実行）は後続フェーズの責務です。

## 変更内容

### 🎯 変更の種類

- [x] ✨ 新機能 (New feature)
- [x] 🚨 テスト追加/修正 (Tests)

### 📝 詳細な変更内容

#### 追加された機能

- `Do` operator handler (`doHandler`) — `OperatorHandler` シグネチャ準拠の骨格実装
- 検査順序: (1) operand pop → `OPERATOR_OPERAND_MISSING`、(2) `PdfName.is` → `OPERATOR_OPERAND_TYPE_MISMATCH`、(3) 成功時 `operandStack` / `graphicsStateStack` を同一参照で返却
- 既存 handler 規約準拠: throw なし全 `Result<T, E>` / エラー時 operand stack 部分消費復元なし / エラーメッセージ書式統一

#### 追加されたファイル

- `packages/core/src/content-stream/operators/xobject/do/index.ts` — handler 本体（63 行）
- `packages/core/src/content-stream/operators/xobject/do/__tests__/do.basic.test.ts` — 正常系 9 tests
- `packages/core/src/content-stream/operators/xobject/do/__tests__/do.error.test.ts` — 異常系 15 tests（test.each で非 name 型 9 種網羅）

## 📊 システム図

### 状態マシン / フロー図

```mermaid
flowchart TD
    Start([doHandler context]) --> Pop[OperandStack.pop]
    Pop -->|none| MISSING[OPERATOR_OPERAND_MISSING<br/>required=1, actual=0]:::err
    Pop -->|some operand| TypeCheck{PdfName.is operand}
    TypeCheck -->|false| MISMATCH[OPERATOR_OPERAND_TYPE_MISMATCH<br/>expected name, actual operand.type]:::err
    TypeCheck -->|true| OK[ok operandStack/graphicsStateStack<br/>いずれも入力と同一参照]:::ok
    MISSING --> End([次の token])
    MISMATCH --> End
    OK --> End

    classDef err fill:#fee2e2,stroke:#dc2626,stroke-width:2px
    classDef ok fill:#dcfce7,stroke:#16a34a,stroke-width:2px
```

**仕様上の注意点**:
- `Do` は BT/ET の内外どちらでも呼べる → **active 検査（`TextObject.isActive`）は意図的に入れない**（Issue #425 仕様に明示）
- graphics state は更新しないため、`graphicsStateStack` は同一参照のまま返却
- name `value` の妥当性（`/Resources` の `/XObject` への存在性 / 空文字弾き）は本フェーズで検証しない

### データフロー

```
content-stream interpreter
        │
        ▼
  doHandler (context)
        │
        ├─→ OperandStack.pop  (in-place mutate)
        │       ↓
        │   Option<PdfObject>
        │       ↓
        ├─→ PdfName.is (type guard)
        │       ↓
        └─→ ok / err
                ↓
        Result<OperatorHandlerContext, PdfError>
```

## 📋 関連 Issue

- Closes #425
- 親 Epic: #424
- 関連: #415 (Tj), #421 (apostrophe), #422 (quote)

## 🧪 テスト

### テスト実行方法

```bash
pnpm --filter @pdfmod/core test
pnpm --filter @pdfmod/core build
```

### テスト項目

- [x] 単体テスト (Unit tests) — basic 9 件 + error 15 件 = 24 件
- [x] ビルド検証

### テスト結果

- **`pnpm --filter @pdfmod/core test`**: 全 **2718 tests passed** (206 files) ✅
- **`pnpm --filter @pdfmod/core build`**: 成功 ✅
- **Biome lint**: pass ✅

### 網羅したテストケース

正常系 (do.basic.test.ts — 9 件):
- name `{ type: 'name', value: 'Im1' }` の受理
- 成功時 `operandStack` / `graphicsStateStack` がそれぞれ入力と同一参照
- depth=1 → depth=0 の消費、余剰 operand での末尾 1 個のみ消費 (depth=3→2)
- エッジケース: 空文字 name 受理 / inactive textObject 受理 / active textObject 受理 (BT/ET 内対称)
- 成功時 graphics state stack の current 完全不変

異常系 (do.error.test.ts — 15 件):
- `OPERATOR_OPERAND_MISSING` (operand 0 個): code / operatorName / required / actual / message 完全一致
- `OPERATOR_OPERAND_TYPE_MISMATCH` (test.each で 9 種): integer / real / string / boolean / null / array / dictionary / indirect-ref / stream
- TYPE_MISMATCH 時 operatorName 'Do' + メッセージ完全一致 (`Operator 'Do' expected name operand, got integer`)
- MISSING 時 / TYPE_MISMATCH 時いずれも graphics state stack の current 不変
- TYPE_MISMATCH 後の operand stack は部分消費したまま (depth=1 → depth=0 のまま、復元しない既存規約 pin down)

## 🔍 レビューポイント

- **active 検査が入っていないこと** — Issue #425 仕様で「`Do` は BT/ET 内外どちらでも呼べる」と明示指定。Tj/quote/apostrophe からのコピー時に active 検査ブロックが混入していないか確認をお願いします
- **graphics-state 配下の import が `index.ts` 本体に含まれないこと** — `Tf` と異なり state 更新なし、`Tj` と異なり active 検査なし
- **既存 handler との一貫性** — `Tf` の type 検査パターン + `Tj` の同一参照返却パターンを合成
- **test.each による非 name 型 9 種網羅** — `pdf-types/index.ts` の現行型定義（`PdfString.encoding` 必須、`PdfArray.elements`、`PdfDictionary.entries: Map`、`PdfStream.dictionary.entries: Map`）に準拠

## ⚠️ 破壊的変更

- [ ] この変更は既存の API に破壊的変更を含みます

新規追加のみ。既存 operator / barrel / register には一切触れていません。

## 📚 追加情報

### スコープ外（後続フェーズ）

本 Issue では以下を**実装しません**（親 Epic #424 配下の Sub-issue で対応予定）:
- barrel ファイル (`xobject/xobject-operators/index.ts`) の作成
- `registerXobjectOperators` 関数の実装と `OperatorRegistry` への登録
- XObject 解決機構（`/Resources` の `/XObject` 辞書参照と subtype 判別）
- 画像 XObject の decode / 描画イベント発火
- form XObject の content stream 再帰実行（循環参照検出 / ネスト深度制限）
- name `value` の妥当性検証

### 参考資料

- ISO 32000-1:2008 §8.8 (`Do` operator)
- 先行 handler: `text/tf/index.ts` (name + size 型検査) / `text/tj/index.ts` (同一参照返却パターン)
- 設計仕様: `.plugin-workspace/.specs/archive/073-do-operator-handler/implementation-plan.md`

## ✅ チェックリスト

- [x] コードレビューの準備ができている
- [x] テストが正常に実行される (2718/2718 pass)
- [x] コミットメッセージが適切な形式で書かれている
- [x] 関連する Issue (#425) を本文に記載 (`Closes #425`)
- [x] セルフレビューを実施した（codex + spec-based-code-review の 5 reviewer で CRITICAL/WARNING ゼロを確認）
- [x] 破壊的変更なし