### PR TITLE
✨ [New Feature]: #426 xobject-operators barrel と registerXObjectOperators を追加

### DIFF
--- a/packages/core/src/content-stream/operators/xobject/xobject-operators/__tests__/xobject-operators.basic.test.ts
+++ b/packages/core/src/content-stream/operators/xobject/xobject-operators/__tests__/xobject-operators.basic.test.ts
@@ -1,4 +1,5 @@
 import { assert, expect, test } from "vitest";
+import { ok } from "../../../../../utils/result/index";
 import {
   type OperatorHandler,
   OperatorRegistry,
@@ -28,10 +29,7 @@ test("registerXObjectOperators の戻り値は ok で XObject 系 operator す�
 // 既存 operator を持つ registry に対しても非破壊で Do を追加できる（State Management 非破壊更新）
 test("registerXObjectOperators は既存 operator を持つ registry に対しても非破壊で Do を追加する", () => {
   // テスト用ダミー operator を 1 件登録した seed registry を用意
-  const dummyHandler: OperatorHandler = (context) => ({
-    ok: true,
-    value: context,
-  });
+  const dummyHandler: OperatorHandler = (context) => ok(context);
   const seed = OperatorRegistry.register(
     OperatorRegistry.create(),
     "__dummy__",

--- a/packages/core/src/content-stream/operators/xobject/xobject-operators/__tests__/xobject-operators.basic.test.ts
+++ b/packages/core/src/content-stream/operators/xobject/xobject-operators/__tests__/xobject-operators.basic.test.ts
@@ -1,0 +1,53 @@
+import { assert, expect, test } from "vitest";
+import {
+  type OperatorHandler,
+  OperatorRegistry,
+} from "../../../../operator-registry/index";
+import { doHandler, registerXObjectOperators } from "../index";
+
+// 空 registry に一括登録すると各 operator 名で同一参照の handler が lookup できる
+test.each<readonly [string, OperatorHandler]>([
+  ["Do", doHandler],
+])("registerXObjectOperators は %s に対応する handler を登録する", (name, expectedHandler) => {
+  const result = registerXObjectOperators(OperatorRegistry.create());
+  assert(result.ok);
+
+  const looked = OperatorRegistry.lookup(result.value, name);
+  assert(looked.some);
+  expect(looked.value).toBe(expectedHandler);
+});
+
+// 一括登録後の registry を OperatorRegistry.has で全件確認する
+test("registerXObjectOperators の戻り値は ok で XObject 系 operator すべてを保持する registry を返す", () => {
+  const result = registerXObjectOperators(OperatorRegistry.create());
+  assert(result.ok);
+
+  expect(OperatorRegistry.has(result.value, "Do")).toBe(true);
+});
+
+// 既存 operator を持つ registry に対しても非破壊で Do を追加できる（State Management 非破壊更新）
+test("registerXObjectOperators は既存 operator を持つ registry に対しても非破壊で Do を追加する", () => {
+  // テスト用ダミー operator を 1 件登録した seed registry を用意
+  const dummyHandler: OperatorHandler = (context) => ({
+    ok: true,
+    value: context,
+  });
+  const seed = OperatorRegistry.register(
+    OperatorRegistry.create(),
+    "__dummy__",
+    dummyHandler,
+  );
+  assert(seed.ok);
+
+  const result = registerXObjectOperators(seed.value);
+  assert(result.ok);
+
+  // 既存 operator と Do の両方が has で true
+  expect(OperatorRegistry.has(result.value, "__dummy__")).toBe(true);
+  expect(OperatorRegistry.has(result.value, "Do")).toBe(true);
+
+  // 既存 operator の handler 参照が変化していない
+  const lookedDummy = OperatorRegistry.lookup(result.value, "__dummy__");
+  assert(lookedDummy.some);
+  expect(lookedDummy.value).toBe(dummyHandler);
+});

--- a/packages/core/src/content-stream/operators/xobject/xobject-operators/__tests__/xobject-operators.error.test.ts
+++ b/packages/core/src/content-stream/operators/xobject/xobject-operators/__tests__/xobject-operators.error.test.ts
@@ -1,0 +1,30 @@
+import { assert, expect, test } from "vitest";
+import {
+  type OperatorHandler,
+  OperatorRegistry,
+} from "../../../../operator-registry/index";
+import { doHandler, registerXObjectOperators } from "../index";
+
+// [重複させる operator 名, その handler]
+test.each<readonly [string, OperatorHandler]>([
+  ["Do", doHandler],
+])("%s が登録済みのとき registerXObjectOperators は OPERATOR_ALREADY_REGISTERED の Err を返す", (name, handler) => {
+  // 事前に該当 operator を登録した seed registry を用意する
+  const seed = OperatorRegistry.register(
+    OperatorRegistry.create(),
+    name,
+    handler,
+  );
+  assert(seed.ok);
+
+  const result = registerXObjectOperators(seed.value);
+
+  // 観察可能な振る舞いのみを検証する:
+  // Err 戻り値・エラーコード・operatorName が重複させた名前と一致すること。
+  // reduce + flatMap による短絡そのものは実装詳細のため検証しない。
+  // operator が複数件になったタイミングで「短絡時点の後続 operator が has=false」を
+  // 振る舞いベースで追加検証する。
+  assert(!result.ok);
+  assert(result.error.code === "OPERATOR_ALREADY_REGISTERED");
+  expect(result.error.operatorName).toBe(name);
+});

--- a/packages/core/src/content-stream/operators/xobject/xobject-operators/__tests__/xobject-operators.integration.test.ts
+++ b/packages/core/src/content-stream/operators/xobject/xobject-operators/__tests__/xobject-operators.integration.test.ts
@@ -1,0 +1,82 @@
+import { assert, expect, test } from "vitest";
+import { flatMap, ok } from "../../../../../utils/result/index";
+import { GraphicsStateStack } from "../../../../graphics-state/index";
+import type { ContentStreamInterpreterResult } from "../../../../interpreter/index";
+import { ContentStreamInterpreter } from "../../../../interpreter/index";
+import { OperandStack } from "../../../../operand-stack/index";
+import type {
+  OperatorHandler,
+  OperatorHandlerContext,
+} from "../../../../operator-registry/index";
+import { OperatorRegistry } from "../../../../operator-registry/index";
+import { registerGraphicsStateOperators } from "../../../graphics-state/graphics-state-operators/index";
+import { registerTextStateOperators } from "../../../text/text-state-operators/index";
+import { registerXObjectOperators } from "../index";
+
+const encode = (s: string): Uint8Array => new TextEncoder().encode(s);
+
+// NOTE: q (gsave) / Q (grestore) operator は現状コードベース全体で未実装のため、
+// integration テスト用に inline 定義する。本実装されたら inline 定義は削除し、
+// 対応する register*Operators 経由の登録に置き換える。
+const qHandler: OperatorHandler = (context) =>
+  ok({
+    ...context,
+    graphicsStateStack: GraphicsStateStack.save(context.graphicsStateStack),
+  });
+
+const qRestoreHandler: OperatorHandler = (context) =>
+  ok({
+    ...context,
+    graphicsStateStack: GraphicsStateStack.restore(context.graphicsStateStack),
+  });
+
+// XObject + text-state + graphics-state (cm/w/J/j/M) + inline q/Q を併用登録した registry を作るヘルパ。
+// graphics-state barrel は q/Q を含まないため inline 定義との衝突は無い。
+// 登録失敗は assert で即座に検出する。
+const createRegistry = (): OperatorRegistry => {
+  const withXObject = registerXObjectOperators(OperatorRegistry.create());
+  const withTextState = flatMap(withXObject, registerTextStateOperators);
+  const withGraphicsState = flatMap(
+    withTextState,
+    registerGraphicsStateOperators,
+  );
+  const withQ = flatMap(withGraphicsState, (r) =>
+    OperatorRegistry.register(r, "q", qHandler),
+  );
+  const withQQ = flatMap(withQ, (r) =>
+    OperatorRegistry.register(r, "Q", qRestoreHandler),
+  );
+  assert(withQQ.ok);
+  return withQQ.value;
+};
+
+// 正常系用: content stream を実行し成功結果を返すヘルパ（失敗時は assert で即座に検出）。
+const execute = (
+  stream: string,
+  initialContext?: OperatorHandlerContext,
+): ContentStreamInterpreterResult => {
+  const result = ContentStreamInterpreter.execute({
+    data: encode(stream),
+    registry: createRegistry(),
+    initialContext,
+  });
+  assert(result.ok);
+  return result.value;
+};
+
+// q cm /Im0 Do Q の典型的な XObject 描画フローが warnings なく完走し
+// /Im0 Name operand が Do に消費されて operandStack が空になることを検証する
+test("q cm /Im0 Do Q のシーケンスで Do が dispatch され warnings が空・operand 消費される", () => {
+  const result = execute("q 200 0 0 300 50 400 cm /Im0 Do Q");
+  expect(result.warnings).toEqual([]);
+  // Do が /Im0 operand を pop している（消費せず残ると depth > 0 になる）
+  expect(OperandStack.depth(result.context.operandStack)).toBe(0);
+});
+
+// BT/ET 内側で Do が呼ばれてもテキストオブジェクト状態を破壊せず
+// /Fm1 operand が Do に消費されて operandStack が空になることを検証する
+test("BT /Fm1 Do ET のテキストオブジェクト内側でも Do が成功し operand 消費される", () => {
+  const result = execute("BT /Fm1 Do ET");
+  expect(result.warnings).toEqual([]);
+  expect(OperandStack.depth(result.context.operandStack)).toBe(0);
+});

--- a/packages/core/src/content-stream/operators/xobject/xobject-operators/index.ts
+++ b/packages/core/src/content-stream/operators/xobject/xobject-operators/index.ts
@@ -7,8 +7,6 @@ import { doHandler } from "../do/index";
 
 export { doHandler } from "../do/index";
 
-// 登録順は Issue 指定順（現状 Do のみ）。
-// この順序は error テストの fail-fast 呼び出し順検証に直結する。
 // 拡張時はこの配列末尾に追記する（例: ["BI", biHandler], ["ID", idHandler], ["EI", eiHandler]）。
 const XOBJECT_OPERATORS: ReadonlyArray<readonly [string, OperatorHandler]> = [
   ["Do", doHandler],

--- a/packages/core/src/content-stream/operators/xobject/xobject-operators/index.ts
+++ b/packages/core/src/content-stream/operators/xobject/xobject-operators/index.ts
@@ -1,0 +1,35 @@
+import type { PdfError } from "../../../../pdf/errors/index";
+import type { Result } from "../../../../utils/result/index";
+import { flatMap, ok } from "../../../../utils/result/index";
+import type { OperatorHandler } from "../../../operator-registry/index";
+import { OperatorRegistry } from "../../../operator-registry/index";
+import { doHandler } from "../do/index";
+
+export { doHandler } from "../do/index";
+
+// 登録順は Issue 指定順（現状 Do のみ）。
+// この順序は error テストの fail-fast 呼び出し順検証に直結する。
+// 拡張時はこの配列末尾に追記する（例: ["BI", biHandler], ["ID", idHandler], ["EI", eiHandler]）。
+const XOBJECT_OPERATORS: ReadonlyArray<readonly [string, OperatorHandler]> = [
+  ["Do", doHandler],
+];
+
+/**
+ * XObject 描画 operator (Do、将来 BI/ID/EI) を
+ * OperatorRegistry に一括登録するヘルパ。
+ *
+ * fail-fast: いずれかの register が Err を返した時点で reduce 内 flatMap が
+ * 短絡し、後続 operator の register は呼ばれない。重複登録時は
+ * OPERATOR_ALREADY_REGISTERED の PdfError を Err として伝播する。
+ *
+ * @param registry - 登録元 registry
+ * @returns 全 operator が登録された新しい registry、または重複登録時の PdfError
+ */
+export const registerXObjectOperators = (
+  registry: OperatorRegistry,
+): Result<OperatorRegistry, PdfError> =>
+  XOBJECT_OPERATORS.reduce<Result<OperatorRegistry, PdfError>>(
+    (acc, [name, handler]) =>
+      flatMap(acc, (r) => OperatorRegistry.register(r, name, handler)),
+    ok(registry),
+  );


### PR DESCRIPTION
## 概要

XObject 描画 operator (現状 `Do`、将来 `BI`/`ID`/`EI`) を `OperatorRegistry` に一括登録する barrel と `registerXObjectOperators` ヘルパを、既存 6 系列の `register*Operators`（text-showing / text-positioning / text-state / path / color / graphics-state）と完全同形で新規追加。Phase 4-H 拡張時に `XOBJECT_OPERATORS` 配列末尾に追記するだけで成長できる「先行 scaffolding」。

## 変更内容

### 🎯 変更の種類

- [x] ✨ 新機能 (New feature)
- [x] 🚨 テスト追加 (Tests)

### 📝 詳細な変更内容

#### 追加された機能

- `registerXObjectOperators(registry)`: XObject カテゴリの operator を fail-fast で一括登録するヘルパ。reduce + flatMap による短絡で、重複登録時は `OPERATOR_ALREADY_REGISTERED` を Err として伝播
- `doHandler` の re-export: barrel エントリポイントから XObject handler 群を参照可能に

#### 追加されたファイル

- `packages/core/src/content-stream/operators/xobject/xobject-operators/index.ts` — barrel + `registerXObjectOperators`
- `packages/core/src/content-stream/operators/xobject/xobject-operators/__tests__/xobject-operators.basic.test.ts` — 正常系（lookup / has / 非破壊更新）
- `packages/core/src/content-stream/operators/xobject/xobject-operators/__tests__/xobject-operators.error.test.ts` — 異常系（重複時 Err の振る舞い検証）
- `packages/core/src/content-stream/operators/xobject/xobject-operators/__tests__/xobject-operators.integration.test.ts` — `ContentStreamInterpreter.execute` 経由の統合検証

## 📊 システム図

### registerXObjectOperators の処理フロー

```mermaid
flowchart TD
    Start([registerXObjectOperators registry]) --> Init[acc = ok registry]
    Init --> Reduce[XOBJECT_OPERATORS を reduce]
    Reduce --> AccCheck{acc は Ok?}
    AccCheck -->|Err| Skip[flatMap が短絡<br/>register 未呼出]
    AccCheck -->|Ok| Register[OperatorRegistry.register]
    Register --> RegResult{結果}
    RegResult -->|Ok| Next[次の operator へ<br/>acc = ok new-registry]
    RegResult -->|Err OPERATOR_ALREADY_REGISTERED| Skip
    Next --> Reduce
    Skip --> Done([最終 acc を返す])
    Reduce -->|完了| Done
```

### XObject barrel と他 barrel の併用 (integration テスト)

```mermaid
flowchart LR
    Create[OperatorRegistry.create] --> XObj[registerXObjectOperators<br/>Do]
    XObj --> TextState[registerTextStateOperators<br/>BT/ET/Tf/Tc/Tw/Tz/TL/Tr/Ts]
    TextState --> Gfx[registerGraphicsStateOperators<br/>cm/w/J/j/M]
    Gfx --> InlineQ[inline q handler]
    InlineQ --> InlineQQ[inline Q handler]
    InlineQQ --> Registry([完全な registry])
```

## 📋 関連 Issue

- Closes #426

## 🧪 テスト

### テスト実行方法

```bash
pnpm --filter @pdfmod/core test xobject-operators
pnpm --filter @pdfmod/core test
pnpm --filter @pdfmod/core build
```

### テスト項目

- [x] 単体テスト (basic / error)
- [x] 統合テスト (`ContentStreamInterpreter.execute` 経由)

### テスト結果

- `pnpm --filter @pdfmod/core test xobject-operators` — **6 tests passed** (basic: 3 / error: 1 / integration: 2)
- `pnpm --filter @pdfmod/core test` — **2724 tests passed** (リグレッションなし)
- `pnpm --filter @pdfmod/core build` — ビルド成功
- `pnpm exec biome check packages/core/src` — 361 files, no issues

## 🔍 レビューポイント

- **既存 6 系列 barrel との同形性**: `registerTextShowingOperators` を写経元とした構造で、Phase 4-H 拡張時に `XOBJECT_OPERATORS = [["Do", doHandler], ["BI", biHandler], ...]` のように配列に追記するだけで成長可能
- **error テストの検証方針**: `vi.spyOn` による内部モジュール `OperatorRegistry.register` の spy アサーションは採用せず、観察可能な振る舞い (Err 戻り値・`code`・`operatorName`) のみで検証。古典学派 MOCK-SCOPE / BEHAVIOR-TEST 原則に整合。短絡そのものは現状 operator 1 件のため検証不能で、Phase 4-H で operator が複数件になったタイミングで「後続 operator が `has === false`」を振る舞いベースで追加検証する方針
- **integration テストの `q`/`Q` inline 定義**: `graphics-state-operators.integration.test.ts:17-27` の前例を踏襲。本物の `GraphicsStateStack.save`/`restore` を呼ぶ fake であり、`q`/`Q` operator が本実装されたタイミングで inline 定義を削除する旨を NOTE で明示
- **root export スコープ外**: 既存 6 系列 barrel と同様、`packages/core/src/index.ts` からは root export しない（barrel は内部利用と integration テスト消費のみ）

## ⚠️ 破壊的変更

- [ ] この変更は既存の API に破壊的変更を含みます

純粋な追加のみ。既存 barrel・interpreter・parser から `xobject-operators` への参照はなく、リグレッションなし。

## ✅ チェックリスト

- [x] コードレビューの準備ができている
- [x] テストが正常に実行される (6/6 + 2724/2724)
- [x] ドキュメントが更新されている (JSDoc を `registerTextShowingOperators` 同等の詳細度で記述)
- [x] コミットメッセージが適切な形式で書かれている (`✨ [New Feature]: #426 ...`)
- [x] 関連する Issue を PR の「Development」に Linked する
- [x] PR 本文に `Closes #426` を記載
- [x] セルフレビューを実施した (Codex CLI + 5 サブエージェント並列レビューで CRITICAL/WARNING 0 件)
- [x] 破壊的変更なし