### PR TITLE
✨ #445 inline-image-dict-normalizer (略号→完全名展開) を追加

### DIFF
--- a/docs/specs/05_content_streams.md
+++ b/docs/specs/05_content_streams.md
@@ -496,6 +496,7 @@ EI
 | `/BPC` | `/BitsPerComponent` |
 | `/CS` | `/ColorSpace` |
 | `/F` | `/Filter` |
+| `/D` | `/Decode` |
 | `/DP` | `/DecodeParms` |
 | `/IM` | `/ImageMask` |
 | `/I` | `/Interpolate` |

--- a/packages/core/src/content-stream/inline-image/normalizer/__tests__/normalizer.basic.test.ts
+++ b/packages/core/src/content-stream/inline-image/normalizer/__tests__/normalizer.basic.test.ts
@@ -1,0 +1,99 @@
+import { expect, test } from "vitest";
+import {
+  ByteOffset,
+  TokenType,
+  type Token,
+  type TokenInlineImageDictEntry,
+} from "../../../../pdf/index";
+import { normalizeInlineImageDict } from "../index";
+
+const makeEntry = (
+  abbrev: string,
+  offset = 0,
+  value: ReadonlyArray<Token> = [],
+): TokenInlineImageDictEntry => ({
+  key: {
+    type: TokenType.Name,
+    value: abbrev,
+    offset: ByteOffset.of(offset),
+  },
+  value,
+});
+
+test.each<[string, string]>([
+  ["W", "Width"],
+  ["H", "Height"],
+  ["BPC", "BitsPerComponent"],
+  ["CS", "ColorSpace"],
+  ["F", "Filter"],
+  ["DP", "DecodeParms"],
+  ["IM", "ImageMask"],
+  ["I", "Interpolate"],
+])("略号 /%s は完全名 /%s へ展開される", (abbrev, fullName) => {
+  const entry = makeEntry(abbrev);
+
+  const result = normalizeInlineImageDict([entry]);
+
+  expect(result[0]?.key.value).toBe(fullName);
+});
+
+test("展開後の TokenName.offset は略号 entry の元 offset を保持する", () => {
+  const entry = makeEntry("W", 42);
+
+  const result = normalizeInlineImageDict([entry]);
+
+  expect(result[0]?.key.offset).toBe(ByteOffset.of(42));
+});
+
+test("展開後の entry.value は元 entry の value 参照と同一", () => {
+  const value: ReadonlyArray<Token> = [
+    { type: TokenType.Integer, value: 1, offset: ByteOffset.of(2) },
+  ];
+  const entry = makeEntry("W", 0, value);
+
+  const result = normalizeInlineImageDict([entry]);
+
+  expect(result[0]?.value).toBe(value);
+});
+
+test("展開後の key.type は Name のまま", () => {
+  const entry = makeEntry("W");
+
+  const result = normalizeInlineImageDict([entry]);
+
+  expect(result[0]?.key.type).toBe(TokenType.Name);
+});
+
+test("スコープ境界: /CS の値配列に Name `RGB` があっても key のみ ColorSpace に展開され value は加工されない", () => {
+  const value: ReadonlyArray<Token> = [
+    { type: TokenType.Name, value: "RGB", offset: ByteOffset.of(3) },
+  ];
+  const entry = makeEntry("CS", 0, value);
+
+  const result = normalizeInlineImageDict([entry]);
+
+  expect(result[0]?.key.value).toBe("ColorSpace");
+  expect(result[0]?.value).toBe(value);
+  expect(result[0]?.value[0]).toEqual({
+    type: TokenType.Name,
+    value: "RGB",
+    offset: ByteOffset.of(3),
+  });
+});
+
+test("スコープ境界: /F の値配列に Name `Fl` があっても key のみ Filter に展開され value は加工されない", () => {
+  const value: ReadonlyArray<Token> = [
+    { type: TokenType.Name, value: "Fl", offset: ByteOffset.of(4) },
+  ];
+  const entry = makeEntry("F", 0, value);
+
+  const result = normalizeInlineImageDict([entry]);
+
+  expect(result[0]?.key.value).toBe("Filter");
+  expect(result[0]?.value).toBe(value);
+  expect(result[0]?.value[0]).toEqual({
+    type: TokenType.Name,
+    value: "Fl",
+    offset: ByteOffset.of(4),
+  });
+});

--- a/packages/core/src/content-stream/inline-image/normalizer/__tests__/normalizer.basic.test.ts
+++ b/packages/core/src/content-stream/inline-image/normalizer/__tests__/normalizer.basic.test.ts
@@ -1,9 +1,9 @@
 import { expect, test } from "vitest";
 import {
   ByteOffset,
-  TokenType,
   type Token,
   type TokenInlineImageDictEntry,
+  TokenType,
 } from "../../../../pdf/index";
 import { normalizeInlineImageDict } from "../index";
 

--- a/packages/core/src/content-stream/inline-image/normalizer/__tests__/normalizer.basic.test.ts
+++ b/packages/core/src/content-stream/inline-image/normalizer/__tests__/normalizer.basic.test.ts
@@ -26,6 +26,7 @@ test.each<[string, string]>([
   ["BPC", "BitsPerComponent"],
   ["CS", "ColorSpace"],
   ["F", "Filter"],
+  ["D", "Decode"],
   ["DP", "DecodeParms"],
   ["IM", "ImageMask"],
   ["I", "Interpolate"],

--- a/packages/core/src/content-stream/inline-image/normalizer/__tests__/normalizer.passthrough.test.ts
+++ b/packages/core/src/content-stream/inline-image/normalizer/__tests__/normalizer.passthrough.test.ts
@@ -1,0 +1,117 @@
+import { expect, test } from "vitest";
+import {
+  ByteOffset,
+  TokenType,
+  type TokenInlineImageDictEntry,
+} from "../../../../pdf/index";
+import { normalizeInlineImageDict } from "../index";
+
+const makeEntry = (
+  name: string,
+  offset = 0,
+): TokenInlineImageDictEntry => ({
+  key: {
+    type: TokenType.Name,
+    value: name,
+    offset: ByteOffset.of(offset),
+  },
+  value: [],
+});
+
+test("空配列入力は空配列を返す", () => {
+  const result = normalizeInlineImageDict([]);
+
+  expect(result).toEqual([]);
+});
+
+test("完全名キー (Width) はそのまま通過し元 entry が参照同一で返る", () => {
+  const entry = makeEntry("Width");
+
+  const result = normalizeInlineImageDict([entry]);
+
+  expect(result[0]).toBe(entry);
+});
+
+test("未知キー (Foo) はそのまま通過し元 entry が参照同一で返る", () => {
+  const entry = makeEntry("Foo");
+
+  const result = normalizeInlineImageDict([entry]);
+
+  expect(result[0]).toBe(entry);
+});
+
+test("空文字キーは略号テーブルに hit しないので passthrough", () => {
+  const entry = makeEntry("");
+
+  const result = normalizeInlineImageDict([entry]);
+
+  expect(result[0]).toBe(entry);
+});
+
+test.each<[string]>([
+  ["constructor"],
+  ["toString"],
+  ["__proto__"],
+])(
+  "Object.prototype 由来キー (%s) は hasOwn ガードで誤展開されず passthrough",
+  (protoKey) => {
+    const entry = makeEntry(protoKey);
+
+    const result = normalizeInlineImageDict([entry]);
+
+    expect(result[0]).toBe(entry);
+    expect(result[0]?.key.value).toBe(protoKey);
+  },
+);
+
+test("入力順 [/W, /H, /CS] は [Width, Height, ColorSpace] の順で返る", () => {
+  const entries = [makeEntry("W"), makeEntry("H"), makeEntry("CS")];
+
+  const result = normalizeInlineImageDict(entries);
+
+  expect(result.map((e) => e.key.value)).toEqual([
+    "Width",
+    "Height",
+    "ColorSpace",
+  ]);
+});
+
+test("重複検査なし: [/W, /Width, /H] は [Width(展開), Width(完全名), Height(展開)] の順で 3 件返る", () => {
+  const widthAbbrev = makeEntry("W");
+  const widthFull = makeEntry("Width");
+  const heightAbbrev = makeEntry("H");
+
+  const result = normalizeInlineImageDict([
+    widthAbbrev,
+    widthFull,
+    heightAbbrev,
+  ]);
+
+  expect(result).toHaveLength(3);
+  expect(result.map((e) => e.key.value)).toEqual(["Width", "Width", "Height"]);
+  expect(result[1]).toBe(widthFull);
+});
+
+test("入力配列・入力エントリを破壊しない", () => {
+  const entries = [makeEntry("W", 1), makeEntry("Width", 2)];
+  const snapshot = entries.map((e) => ({
+    keyValue: e.key.value,
+    keyOffset: e.key.offset,
+  }));
+  const originalLength = entries.length;
+
+  normalizeInlineImageDict(entries);
+
+  expect(entries.length).toBe(originalLength);
+  expect(
+    entries.map((e) => ({ keyValue: e.key.value, keyOffset: e.key.offset })),
+  ).toEqual(snapshot);
+});
+
+test("戻り値は入力配列と別インスタンス", () => {
+  const entries = [makeEntry("W")];
+
+  const result = normalizeInlineImageDict(entries);
+
+  expect(result).not.toBe(entries);
+});

--- a/packages/core/src/content-stream/inline-image/normalizer/__tests__/normalizer.passthrough.test.ts
+++ b/packages/core/src/content-stream/inline-image/normalizer/__tests__/normalizer.passthrough.test.ts
@@ -1,15 +1,12 @@
 import { expect, test } from "vitest";
 import {
   ByteOffset,
-  TokenType,
   type TokenInlineImageDictEntry,
+  TokenType,
 } from "../../../../pdf/index";
 import { normalizeInlineImageDict } from "../index";
 
-const makeEntry = (
-  name: string,
-  offset = 0,
-): TokenInlineImageDictEntry => ({
+const makeEntry = (name: string, offset = 0): TokenInlineImageDictEntry => ({
   key: {
     type: TokenType.Name,
     value: name,
@@ -52,17 +49,14 @@ test.each<[string]>([
   ["constructor"],
   ["toString"],
   ["__proto__"],
-])(
-  "Object.prototype 由来キー (%s) は hasOwn ガードで誤展開されず passthrough",
-  (protoKey) => {
-    const entry = makeEntry(protoKey);
+])("Object.prototype 由来キー (%s) は hasOwn ガードで誤展開されず passthrough", (protoKey) => {
+  const entry = makeEntry(protoKey);
 
-    const result = normalizeInlineImageDict([entry]);
+  const result = normalizeInlineImageDict([entry]);
 
-    expect(result[0]).toBe(entry);
-    expect(result[0]?.key.value).toBe(protoKey);
-  },
-);
+  expect(result[0]).toBe(entry);
+  expect(result[0]?.key.value).toBe(protoKey);
+});
 
 test("入力順 [/W, /H, /CS] は [Width, Height, ColorSpace] の順で返る", () => {
   const entries = [makeEntry("W"), makeEntry("H"), makeEntry("CS")];

--- a/packages/core/src/content-stream/inline-image/normalizer/index.ts
+++ b/packages/core/src/content-stream/inline-image/normalizer/index.ts
@@ -17,6 +17,7 @@ const INLINE_IMAGE_DICT_ABBREVIATIONS: Partial<Record<string, string>> = {
   BPC: "BitsPerComponent",
   CS: "ColorSpace",
   F: "Filter",
+  D: "Decode",
   DP: "DecodeParms",
   IM: "ImageMask",
   I: "Interpolate",

--- a/packages/core/src/content-stream/inline-image/normalizer/index.ts
+++ b/packages/core/src/content-stream/inline-image/normalizer/index.ts
@@ -1,7 +1,4 @@
-import type {
-  TokenInlineImageDictEntry,
-  TokenName,
-} from "../../../pdf/index";
+import type { TokenInlineImageDictEntry, TokenName } from "../../../pdf/index";
 import { TokenType } from "../../../pdf/index";
 
 /**
@@ -48,10 +45,7 @@ export const normalizeInlineImageDict = (
     const key = entry.key.value;
     // Object.prototype 由来キー (`constructor` / `toString` / `__proto__` 等) が
     // 誤って略号として hit するのを防ぐため hasOwn ガードで自前プロパティのみ参照する。
-    const expanded = Object.prototype.hasOwnProperty.call(
-      INLINE_IMAGE_DICT_ABBREVIATIONS,
-      key,
-    )
+    const expanded = Object.hasOwn(INLINE_IMAGE_DICT_ABBREVIATIONS, key)
       ? INLINE_IMAGE_DICT_ABBREVIATIONS[key]
       : undefined;
     if (expanded === undefined) {

--- a/packages/core/src/content-stream/inline-image/normalizer/index.ts
+++ b/packages/core/src/content-stream/inline-image/normalizer/index.ts
@@ -1,0 +1,67 @@
+import type {
+  TokenInlineImageDictEntry,
+  TokenName,
+} from "../../../pdf/index";
+import { TokenType } from "../../../pdf/index";
+
+/**
+ * PDF §8.9.5.1 Table 89 で定義されるインラインイメージ辞書の略号 → 完全名対応表。
+ *
+ * BI / ID / EI で囲まれたインラインイメージ辞書は、サイズ削減のため
+ * 以下のキーを 1〜3 文字の略号で記述できる。本テーブルは normalizer が
+ * 略号 entry を完全名 entry に展開するためのルックアップ表として使う。
+ *
+ * 値型を `Partial<Record<string, string>>` で表現することで、未登録キーへの
+ * インデックスアクセスが `string | undefined` を返す（型上の正直さ）。
+ */
+const INLINE_IMAGE_DICT_ABBREVIATIONS: Partial<Record<string, string>> = {
+  W: "Width",
+  H: "Height",
+  BPC: "BitsPerComponent",
+  CS: "ColorSpace",
+  F: "Filter",
+  DP: "DecodeParms",
+  IM: "ImageMask",
+  I: "Interpolate",
+};
+
+/**
+ * インラインイメージ辞書の **キーのみ** を略号から完全名に展開する純関数。
+ *
+ * - 略号テーブルに hit したキーは完全名で置換した新エントリを返す。
+ *   新 `TokenName.offset` は略号 entry の元 offset を保持する
+ *   （後続 handler のエラー位置情報として活用）。
+ * - 略号テーブルに miss したキー（完全名・未知キー・空文字）は元エントリをそのまま通す。
+ * - 値配列 `value: ReadonlyArray<Token>` は加工しない。
+ *   ColorSpace / Filter の値側略号（`/CS /RGB` → `/DeviceRGB` 等）は本 normalizer のスコープ外で、
+ *   後続フェーズ（handler または別 normalizer）の責務。
+ * - 入力配列・入力エントリは破壊しない（新配列を返す）。
+ * - 同一 dict に略号と完全名が両方ある場合も重複検査は行わず順序通り両方を出力する。
+ *
+ * @param entries tokenizer が組み立てた inline image 辞書 entry 列
+ * @returns 略号を完全名に展開した新しい entry 列（順序保持）
+ */
+export const normalizeInlineImageDict = (
+  entries: ReadonlyArray<TokenInlineImageDictEntry>,
+): ReadonlyArray<TokenInlineImageDictEntry> => {
+  return entries.map((entry) => {
+    const key = entry.key.value;
+    // Object.prototype 由来キー (`constructor` / `toString` / `__proto__` 等) が
+    // 誤って略号として hit するのを防ぐため hasOwn ガードで自前プロパティのみ参照する。
+    const expanded = Object.prototype.hasOwnProperty.call(
+      INLINE_IMAGE_DICT_ABBREVIATIONS,
+      key,
+    )
+      ? INLINE_IMAGE_DICT_ABBREVIATIONS[key]
+      : undefined;
+    if (expanded === undefined) {
+      return entry;
+    }
+    const expandedKey: TokenName = {
+      type: TokenType.Name,
+      value: expanded,
+      offset: entry.key.offset,
+    };
+    return { key: expandedKey, value: entry.value };
+  });
+};


### PR DESCRIPTION
## 概要

PDF §8.9.5.1 Table 89 で定義されるインラインイメージ辞書の略号キー（`/W`, `/H`, `/BPC`, `/CS`, `/F`, `/D`, `/DP`, `/IM`, `/I`）を完全名（`/Width`, `/Height`, `/BitsPerComponent`, `/ColorSpace`, `/Filter`, `/Decode`, `/DecodeParms`, `/ImageMask`, `/Interpolate`）に展開する純関数 `normalizeInlineImageDict` を新規追加します。後続の inline image handler が **辞書キーは完全名のみ**を相手にできるようにする前提部品です。

> **スコープ更新の経緯**: 初版では Issue/spec の 8 略号のみを対象としていましたが、Codex レビュー指摘を受けて `/D` → `/Decode` を追加し、PDF 2.0 §8.9.5.1 Table 89 完全準拠の 9 略号に拡張しました。これに伴い `docs/specs/05_content_streams.md` の省略形キー表も 9 略号に更新しています。

## 変更内容

### 🎯 変更の種類

- [x] ✨ 新機能 (New feature)
- [x] 🚨 テスト追加/修正 (Tests)
- [x] 📖 ドキュメント更新 (Documentation)

### 📝 詳細な変更内容

#### 追加された機能・修正

- `normalizeInlineImageDict` 純関数（throw 禁止 / `Result`・`Option` 不使用 / 副作用なし）
- 略号テーブル `INLINE_IMAGE_DICT_ABBREVIATIONS`（PDF §8.9.5.1 Table 89 準拠の 9 略号: `W`/`H`/`BPC`/`CS`/`F`/`D`/`DP`/`IM`/`I`）
  - 型は `Partial<Record<string, string>>` を採用。未登録キーのインデックスアクセスが `string | undefined` を返すよう型上正直に表現
- `Object.hasOwn(...)` ガードで `Object.prototype` 由来キー（`constructor` / `toString` / `__proto__`）の誤展開を防御
- 展開時の `TokenName.offset` は略号 entry の元 offset を保持（後続 handler のエラー位置情報として活用）
- 値配列 `value: ReadonlyArray<Token>` は加工せず参照同一で渡す（ColorSpace/Filter の値略号は本 normalizer の責務外＝後続フェーズで対応）
- 重複検査は行わず順序通り両方出力（重複検査は handler の責務）

#### 変更されたファイル

- `[NEW]` `packages/core/src/content-stream/inline-image/normalizer/index.ts`
- `[NEW]` `packages/core/src/content-stream/inline-image/normalizer/__tests__/normalizer.basic.test.ts`（14 tests）
- `[NEW]` `packages/core/src/content-stream/inline-image/normalizer/__tests__/normalizer.passthrough.test.ts`（11 tests）
- `[MODIFY]` `docs/specs/05_content_streams.md` — 省略形キー表に `/D` → `/Decode` を 1 行追加（9 略号化、PDF 2.0 仕様準拠）

#### 削除されたファイル・機能

- なし

#### 既存ソースコード

- 既存ソースコード（tokenizer / interpreter / operator-registry / `packages/core/src/index.ts` バレル）への変更は **一切なし**（破壊的変更なし）。`packages/core` バレル export 追加は後続 handler Issue が消費側になった時点で行う

## 📊 システム図

### 処理フロー

```mermaid
flowchart TD
    In([entries: ReadonlyArray TokenInlineImageDictEntry]) --> Map[entries.map で 1 entry ずつ走査]
    Map --> Guard{Object.hasOwn<br/>略号テーブル参照}
    Guard -- hit --> Expand[新 TokenName を生成<br/>value: 完全名<br/>offset: 略号 entry の元 offset<br/>value 配列は参照そのまま]:::new
    Guard -- miss --> Pass[元 entry を参照同一で passthrough<br/>完全名 / 未知キー / 空文字 / prototype キー]
    Expand --> Out([ReadonlyArray TokenInlineImageDictEntry<br/>順序保持・重複検査なし])
    Pass --> Out

    classDef new fill:#ffe4b5,stroke:#d97706,stroke-width:2px
```

### スコープ境界

```
[呼出側: 後続 inline image handler (別Issue)]
        ↓ entries
normalizeInlineImageDict   ←── 本PRで追加 [NEW]
        ├─ キーのみを完全名化 (W/H/BPC/CS/F/D/DP/IM/I → 9 略号)
        └─ 値配列は加工しない (CS /RGB や F /Fl の値略号は触らない)
        ↓ 新配列
[呼出側で必須キー検査・パラメータ解釈・値略号展開] ← 後続フェーズの責務
```

## 📋 関連 Issue

- Closes #445

## 🧪 テスト

### テスト実行方法

```bash
pnpm --filter @pdfmod/core test normalizer
pnpm --filter @pdfmod/core test
pnpm --filter @pdfmod/core typecheck
pnpm --filter @pdfmod/core build
```

### テスト項目

- [x] 単体テスト (Unit tests) — basic 14 / passthrough 11
- [ ] 統合テスト (Integration tests) — 本PRスコープ外（後続 handler Issue で追加）
- [ ] E2E テスト — 該当なし
- [x] 手動テスト — `git status` / `grep` で既存ソースコード無変更を確認

### テスト結果

- normalizer 単独: **25 tests passed**（basic 14 / passthrough 11）
- core 全体: 全テスト pass
- typecheck: ✅
- build: ✅

#### テストTODOカバレッジ

- basic (14)
  - 9 略号 → 完全名展開（`test.each` で網羅: W/H/BPC/CS/F/D/DP/IM/I）
  - `TokenName.offset` の保持
  - `entry.value` 参照同一の pin-down
  - `key.type === TokenType.Name` の pin-down
  - スコープ境界 `/CS /RGB`（値側 Name は加工されない）
  - スコープ境界 `/F /Fl`（値側 Name は加工されない）
- passthrough (11)
  - 空配列 → 空配列
  - 完全名 / 未知キー / 空文字 → 参照同一で passthrough
  - `Object.prototype` 由来キー（`constructor` / `toString` / `__proto__`）→ `Object.hasOwn` ガードで誤展開されず passthrough
  - 入力順 `[/W, /H, /CS]` → `[Width, Height, ColorSpace]`
  - 重複 `[/W, /Width, /H]` → `[Width(展開), Width(完全名), Height(展開)]`（順序保持・重複検査なし）
  - 入力配列・入力エントリ非破壊
  - 戻り値が入力と別配列インスタンス

## 🔍 レビューポイント

- `Object.hasOwn(INLINE_IMAGE_DICT_ABBREVIATIONS, key)` ガードがプロトタイプ汚染防御の意図通りか
- 略号テーブル定数の型 `Partial<Record<string, string>>` の選択（`as Record<string, string>` アサーション回避の意図）
- スコープ境界の妥当性 — 値側略号（ColorSpace `/G`/`/RGB`/`/CMYK`、Filter `/Fl`/`/A85` 等）は **本 PR の責務外** とした点
- 展開後の `TokenName.offset` を「BI トークンの offset」ではなく「略号 entry の key.offset」にしている設計（後続 handler のエラー位置情報として使う前提）
- spec ドキュメント (`docs/specs/05_content_streams.md`) を実装と同じ 9 略号に揃えた点（PDF 2.0 §8.9.5.1 Table 89 完全準拠）

## ⚠️ 破壊的変更

- [ ] この変更は既存の API に破壊的変更を含みます

なし。コードは新規ファイル 3 件のみ。既存ソースコード（tokenizer / interpreter / operator-registry / `packages/core/src/index.ts` バレル）への変更はゼロです。`docs/specs/05_content_streams.md` は省略形キー表に `/D` → `/Decode` 行を 1 行追加するだけのドキュメント整合性更新です。`packages/core` のバレル export 更新は後続 handler Issue が消費側になった時点で追加予定（本 PR では行わない）。

## 📚 追加情報

### 参考資料

- `docs/specs/05_content_streams.md` §493-501（省略形キー表、本 PR で `/D` 行を追加して 9 略号化）
- `.plugin-workspace/.specs/archive/073-inline-image-dict-normalizer/`（実装計画 / tasks / Codex レビュー結果）
- ISO 32000-2:2020 §8.9.5.1 Table 89

### 注意事項

- 本 PR で追加した normalizer はまだバレル export しません（後続 inline image handler Issue で消費する際に追加）
- AI レビュー（Codex / read-only sandbox）で「問題なし」を確認済み（`code-review/review-001.md`）
- PR レビュー指摘により `/D` → `/Decode` 略号を後追いで追加（PDF 2.0 仕様準拠）。spec docs も同時に 9 略号化して整合済み

## ✅ チェックリスト

- [x] コードレビューの準備ができている
- [x] テストが正常に実行される
- [x] ドキュメントが更新されている（`docs/specs/05_content_streams.md` 略号表を 9 略号化）
- [x] コミットメッセージが適切な形式で書かれている
- [x] 関連する Issue が PR の「Development」に Linked されている（Closes #445）
- [x] PR 本文に `Closes #` で Issue が記載されている
- [x] セルフレビューを実施した
- [x] 破壊的変更がある場合は明記されている（破壊的変更なし）