### PR TITLE
✨ [New Feature]: #446 InlineImage token handler (骨格) を実装

### DIFF
--- a/packages/core/src/content-stream/inline-image/handler/__tests__/handler.basic.test.ts
+++ b/packages/core/src/content-stream/inline-image/handler/__tests__/handler.basic.test.ts
@@ -1,0 +1,216 @@
+import { assert, expect, test } from "vitest";
+import type {
+  Token,
+  TokenInlineImage,
+  TokenInlineImageDictEntry,
+} from "../../../../pdf/index";
+import { TokenType } from "../../../../pdf/index";
+import { ByteOffset } from "../../../../pdf/types/byte-offset/index";
+import { GraphicsStateStack } from "../../../graphics-state/index";
+import { OperandStack } from "../../../operand-stack/index";
+import type { OperatorHandlerContext } from "../../../operator-registry/index";
+import { inlineImageHandler } from "../index";
+
+const buildEntry = (
+  key: string,
+  valueToken: Token,
+): TokenInlineImageDictEntry => ({
+  key: { type: TokenType.Name, value: key, offset: ByteOffset.of(0) },
+  value: [valueToken],
+});
+
+const integerToken = (value: number): Token => ({
+  type: TokenType.Integer,
+  value,
+  offset: ByteOffset.of(0),
+});
+
+const nameToken = (value: string): Token => ({
+  type: TokenType.Name,
+  value,
+  offset: ByteOffset.of(0),
+});
+
+const buildInlineImageToken = (
+  entries: ReadonlyArray<TokenInlineImageDictEntry>,
+  data: Uint8Array = new Uint8Array([]),
+): TokenInlineImage => ({
+  type: TokenType.InlineImage,
+  dict: entries,
+  data,
+  offset: ByteOffset.of(42),
+});
+
+const buildContext = (): OperatorHandlerContext => ({
+  operandStack: OperandStack.create(),
+  graphicsStateStack: GraphicsStateStack.create(),
+});
+
+test("完全名のみで揃った dict を受理する", () => {
+  // Width / Height / BitsPerComponent / ColorSpace の 4 必須キーが完全名で揃っていれば成功する
+  const token = buildInlineImageToken([
+    buildEntry("Width", integerToken(1)),
+    buildEntry("Height", integerToken(1)),
+    buildEntry("BitsPerComponent", integerToken(8)),
+    buildEntry("ColorSpace", nameToken("DeviceGray")),
+  ]);
+  const context = buildContext();
+
+  const result = inlineImageHandler(context, token);
+
+  assert(result.ok);
+  expect(result.value.operandStack).toBe(context.operandStack);
+  expect(result.value.graphicsStateStack).toBe(context.graphicsStateStack);
+});
+
+test("略号のみで揃った dict を受理する（W / H / BPC / CS）", () => {
+  // PDF §8.9.5.1 Table 89 の略号も normalizer が完全名へ展開して通る
+  const token = buildInlineImageToken([
+    buildEntry("W", integerToken(1)),
+    buildEntry("H", integerToken(1)),
+    buildEntry("BPC", integerToken(8)),
+    buildEntry("CS", nameToken("G")),
+  ]);
+  const context = buildContext();
+
+  const result = inlineImageHandler(context, token);
+
+  assert(result.ok);
+  expect(result.value.operandStack).toBe(context.operandStack);
+});
+
+test("混在パターン A: Width のみ完全名で受理する", () => {
+  // 先頭キー Width が完全名、残りは略号でも normalizer 展開で通る
+  const token = buildInlineImageToken([
+    buildEntry("Width", integerToken(1)),
+    buildEntry("H", integerToken(1)),
+    buildEntry("BPC", integerToken(8)),
+    buildEntry("CS", nameToken("G")),
+  ]);
+  const context = buildContext();
+
+  const result = inlineImageHandler(context, token);
+
+  assert(result.ok);
+});
+
+test("混在パターン B: Width のみ略号で受理する", () => {
+  // 先頭キー W が略号、残りは完全名でも展開後に揃って通る
+  const token = buildInlineImageToken([
+    buildEntry("W", integerToken(1)),
+    buildEntry("Height", integerToken(1)),
+    buildEntry("BitsPerComponent", integerToken(8)),
+    buildEntry("ColorSpace", nameToken("DeviceGray")),
+  ]);
+  const context = buildContext();
+
+  const result = inlineImageHandler(context, token);
+
+  assert(result.ok);
+});
+
+test("混在パターン C: 前半完全名・後半略号で受理する", () => {
+  // 前半 Width/Height が完全名、後半 BPC/CS が略号でも通る
+  const token = buildInlineImageToken([
+    buildEntry("Width", integerToken(1)),
+    buildEntry("Height", integerToken(1)),
+    buildEntry("BPC", integerToken(8)),
+    buildEntry("CS", nameToken("G")),
+  ]);
+  const context = buildContext();
+
+  const result = inlineImageHandler(context, token);
+
+  assert(result.ok);
+});
+
+test("data が空 Uint8Array でも成功する", () => {
+  // 本フェーズは data の中身を見ないため、長さ 0 でも検査は通る
+  const token = buildInlineImageToken(
+    [
+      buildEntry("Width", integerToken(1)),
+      buildEntry("Height", integerToken(1)),
+      buildEntry("BitsPerComponent", integerToken(8)),
+      buildEntry("ColorSpace", nameToken("DeviceGray")),
+    ],
+    new Uint8Array([]),
+  );
+  const context = buildContext();
+
+  const result = inlineImageHandler(context, token);
+
+  assert(result.ok);
+});
+
+test("data が非空 Uint8Array でも成功する（中身は読まない）", () => {
+  // zlib magic header のようなバイト列を渡しても decode せず素通しする
+  const token = buildInlineImageToken(
+    [
+      buildEntry("Width", integerToken(1)),
+      buildEntry("Height", integerToken(1)),
+      buildEntry("BitsPerComponent", integerToken(8)),
+      buildEntry("ColorSpace", nameToken("DeviceGray")),
+    ],
+    new Uint8Array([0x78, 0x9c, 0x00, 0x01, 0x02, 0x03]),
+  );
+  const context = buildContext();
+
+  const result = inlineImageHandler(context, token);
+
+  assert(result.ok);
+});
+
+test("成功時に operand stack の depth が変わらない", () => {
+  // InlineImage は operand を取らないため、事前に積んだ stack も影響を受けない
+  const context = buildContext();
+  OperandStack.push(context.operandStack, { type: "integer", value: 99 });
+  const before = OperandStack.depth(context.operandStack);
+
+  const token = buildInlineImageToken([
+    buildEntry("Width", integerToken(1)),
+    buildEntry("Height", integerToken(1)),
+    buildEntry("BitsPerComponent", integerToken(8)),
+    buildEntry("ColorSpace", nameToken("DeviceGray")),
+  ]);
+  const result = inlineImageHandler(context, token);
+
+  assert(result.ok);
+  expect(OperandStack.depth(result.value.operandStack)).toBe(before);
+});
+
+test("成功時に graphics state stack の current が同一参照", () => {
+  // graphics state は更新しないため current state も入力と同じ参照を返す
+  const context = buildContext();
+  const before = GraphicsStateStack.current(context.graphicsStateStack);
+
+  const token = buildInlineImageToken([
+    buildEntry("Width", integerToken(1)),
+    buildEntry("Height", integerToken(1)),
+    buildEntry("BitsPerComponent", integerToken(8)),
+    buildEntry("ColorSpace", nameToken("DeviceGray")),
+  ]);
+  const result = inlineImageHandler(context, token);
+
+  assert(result.ok);
+  expect(GraphicsStateStack.current(result.value.graphicsStateStack)).toBe(
+    before,
+  );
+});
+
+test("Width キーが存在し value が空配列でも成功する（本フェーズはキー存在のみ検査）", () => {
+  // 値配列の中身（型 / 値域）は後続フェーズの責務で、handler は空配列を許容する
+  const token = buildInlineImageToken([
+    {
+      key: { type: TokenType.Name, value: "Width", offset: ByteOffset.of(0) },
+      value: [],
+    },
+    buildEntry("Height", integerToken(1)),
+    buildEntry("BitsPerComponent", integerToken(8)),
+    buildEntry("ColorSpace", nameToken("DeviceGray")),
+  ]);
+  const context = buildContext();
+
+  const result = inlineImageHandler(context, token);
+
+  assert(result.ok);
+});

--- a/packages/core/src/content-stream/inline-image/handler/__tests__/handler.error.test.ts
+++ b/packages/core/src/content-stream/inline-image/handler/__tests__/handler.error.test.ts
@@ -1,0 +1,159 @@
+import { assert, expect, test } from "vitest";
+import type {
+  PdfError,
+  PdfInlineImageRequiredKeyMissingError,
+} from "../../../../pdf/errors/index";
+import type {
+  Token,
+  TokenInlineImage,
+  TokenInlineImageDictEntry,
+} from "../../../../pdf/index";
+import { TokenType } from "../../../../pdf/index";
+import { ByteOffset } from "../../../../pdf/types/byte-offset/index";
+import { GraphicsStateStack } from "../../../graphics-state/index";
+import { OperandStack } from "../../../operand-stack/index";
+import type { OperatorHandlerContext } from "../../../operator-registry/index";
+import { inlineImageHandler } from "../index";
+
+const TOKEN_OFFSET = ByteOffset.of(42);
+
+const buildEntry = (
+  key: string,
+  valueToken: Token,
+): TokenInlineImageDictEntry => ({
+  key: { type: TokenType.Name, value: key, offset: ByteOffset.of(0) },
+  value: [valueToken],
+});
+
+const integerToken = (value: number): Token => ({
+  type: TokenType.Integer,
+  value,
+  offset: ByteOffset.of(0),
+});
+
+const nameToken = (value: string): Token => ({
+  type: TokenType.Name,
+  value,
+  offset: ByteOffset.of(0),
+});
+
+const buildToken = (
+  entries: ReadonlyArray<TokenInlineImageDictEntry>,
+): TokenInlineImage => ({
+  type: TokenType.InlineImage,
+  dict: entries,
+  data: new Uint8Array([]),
+  offset: TOKEN_OFFSET,
+});
+
+const buildContext = (): OperatorHandlerContext => ({
+  operandStack: OperandStack.create(),
+  graphicsStateStack: GraphicsStateStack.create(),
+});
+
+const fullEntries = (): TokenInlineImageDictEntry[] => [
+  buildEntry("Width", integerToken(1)),
+  buildEntry("Height", integerToken(1)),
+  buildEntry("BitsPerComponent", integerToken(8)),
+  buildEntry("ColorSpace", nameToken("DeviceGray")),
+];
+
+test.each<["Width" | "Height" | "BitsPerComponent" | "ColorSpace"]>([
+  ["Width"],
+  ["Height"],
+  ["BitsPerComponent"],
+  ["ColorSpace"],
+])("%s 欠落で INLINE_IMAGE_REQUIRED_KEY_MISSING を返す", (missingKey) => {
+  // 必須キー 4 種それぞれの単独欠落で対応する missingKey を持つ err が返る
+  const entries = fullEntries().filter((e) => e.key.value !== missingKey);
+  const token = buildToken(entries);
+
+  const result = inlineImageHandler(buildContext(), token);
+
+  assert(!result.ok);
+  expect(result.error.code).toBe("INLINE_IMAGE_REQUIRED_KEY_MISSING");
+  assert(result.error.code === "INLINE_IMAGE_REQUIRED_KEY_MISSING");
+  expect(result.error.missingKey).toBe(missingKey);
+  expect(result.error.offset).toBe(TOKEN_OFFSET);
+  expect(result.error.message).toContain(`'${missingKey}'`);
+});
+
+test("Width と Height の両方が欠落のとき最初に発見された Width を返す", () => {
+  // 検査順序は Width → Height → BitsPerComponent → ColorSpace。Width が先に検出される
+  const token = buildToken([
+    buildEntry("BitsPerComponent", integerToken(8)),
+    buildEntry("ColorSpace", nameToken("DeviceGray")),
+  ]);
+
+  const result = inlineImageHandler(buildContext(), token);
+
+  assert(!result.ok);
+  assert(result.error.code === "INLINE_IMAGE_REQUIRED_KEY_MISSING");
+  expect(result.error.missingKey).toBe("Width");
+});
+
+test("Height のみ欠落で Height を返す", () => {
+  // 検査順序の 2 番目で初めて欠落するケース
+  const token = buildToken([
+    buildEntry("Width", integerToken(1)),
+    buildEntry("BitsPerComponent", integerToken(8)),
+    buildEntry("ColorSpace", nameToken("DeviceGray")),
+  ]);
+
+  const result = inlineImageHandler(buildContext(), token);
+
+  assert(!result.ok);
+  assert(result.error.code === "INLINE_IMAGE_REQUIRED_KEY_MISSING");
+  expect(result.error.missingKey).toBe("Height");
+});
+
+test("BitsPerComponent のみ欠落で BitsPerComponent を返す", () => {
+  // 検査順序の 3 番目で初めて欠落するケース
+  const token = buildToken([
+    buildEntry("Width", integerToken(1)),
+    buildEntry("Height", integerToken(1)),
+    buildEntry("ColorSpace", nameToken("DeviceGray")),
+  ]);
+
+  const result = inlineImageHandler(buildContext(), token);
+
+  assert(!result.ok);
+  assert(result.error.code === "INLINE_IMAGE_REQUIRED_KEY_MISSING");
+  expect(result.error.missingKey).toBe("BitsPerComponent");
+});
+
+test("エラーの offset は token.offset と一致する", () => {
+  // offset 伝搬: handler は token の開始位置をそのまま err に載せる
+  const token = buildToken([
+    buildEntry("Height", integerToken(1)),
+    buildEntry("BitsPerComponent", integerToken(8)),
+    buildEntry("ColorSpace", nameToken("DeviceGray")),
+  ]);
+
+  const result = inlineImageHandler(buildContext(), token);
+
+  assert(!result.ok);
+  expect(result.error.code).toBe("INLINE_IMAGE_REQUIRED_KEY_MISSING");
+  assert(result.error.code === "INLINE_IMAGE_REQUIRED_KEY_MISSING");
+  expect(result.error.offset).toBe(TOKEN_OFFSET);
+});
+
+test("エラーは PdfInlineImageRequiredKeyMissingError として narrow できる", () => {
+  // PdfError union から discriminant code で narrow できる構造を pin down
+  const token = buildToken([
+    buildEntry("Height", integerToken(1)),
+    buildEntry("BitsPerComponent", integerToken(8)),
+    buildEntry("ColorSpace", nameToken("DeviceGray")),
+  ]);
+
+  const result = inlineImageHandler(buildContext(), token);
+
+  assert(!result.ok);
+  const error: PdfError = result.error;
+  if (error.code === "INLINE_IMAGE_REQUIRED_KEY_MISSING") {
+    const narrowed: PdfInlineImageRequiredKeyMissingError = error;
+    expect(narrowed.missingKey).toBe("Width");
+  } else {
+    throw new Error("expected INLINE_IMAGE_REQUIRED_KEY_MISSING error code");
+  }
+});

--- a/packages/core/src/content-stream/inline-image/handler/__tests__/handler.error.test.ts
+++ b/packages/core/src/content-stream/inline-image/handler/__tests__/handler.error.test.ts
@@ -150,10 +150,7 @@ test("エラーは PdfInlineImageRequiredKeyMissingError として narrow でき
 
   assert(!result.ok);
   const error: PdfError = result.error;
-  if (error.code === "INLINE_IMAGE_REQUIRED_KEY_MISSING") {
-    const narrowed: PdfInlineImageRequiredKeyMissingError = error;
-    expect(narrowed.missingKey).toBe("Width");
-  } else {
-    throw new Error("expected INLINE_IMAGE_REQUIRED_KEY_MISSING error code");
-  }
+  assert(error.code === "INLINE_IMAGE_REQUIRED_KEY_MISSING");
+  const narrowed: PdfInlineImageRequiredKeyMissingError = error;
+  expect(narrowed.missingKey).toBe("Width");
 });

--- a/packages/core/src/content-stream/inline-image/handler/__tests__/handler.image-mask.test.ts
+++ b/packages/core/src/content-stream/inline-image/handler/__tests__/handler.image-mask.test.ts
@@ -69,6 +69,32 @@ test("/ImageMask true + ColorSpace なしで成功する（stencil mask 例外�
   assert(result.ok);
 });
 
+test("/ImageMask true + BitsPerComponent なしで成功する", () => {
+  // ISO 32000-1:2008 §8.9.5 Table 89: stencil mask では BPC も optional (default 1)
+  const token = buildToken([
+    buildEntry("Width", integerToken(1)),
+    buildEntry("Height", integerToken(1)),
+    buildEntry("ImageMask", booleanToken(true)),
+  ]);
+
+  const result = inlineImageHandler(buildContext(), token);
+
+  assert(result.ok);
+});
+
+test("/IM true（略号）+ BitsPerComponent なし + ColorSpace なしで成功する", () => {
+  // stencil mask の最小構成: Width / Height / IM true のみで通る
+  const token = buildToken([
+    buildEntry("Width", integerToken(8)),
+    buildEntry("Height", integerToken(8)),
+    buildEntry("IM", booleanToken(true)),
+  ]);
+
+  const result = inlineImageHandler(buildContext(), token);
+
+  assert(result.ok);
+});
+
 test("/IM true（略号）+ ColorSpace なしで成功する", () => {
   // normalizer が /IM → /ImageMask に展開するため stencil mask 例外が成立
   const token = buildToken([

--- a/packages/core/src/content-stream/inline-image/handler/__tests__/handler.image-mask.test.ts
+++ b/packages/core/src/content-stream/inline-image/handler/__tests__/handler.image-mask.test.ts
@@ -1,0 +1,185 @@
+import { assert, expect, test } from "vitest";
+import type {
+  Token,
+  TokenInlineImage,
+  TokenInlineImageDictEntry,
+} from "../../../../pdf/index";
+import { TokenType } from "../../../../pdf/index";
+import { ByteOffset } from "../../../../pdf/types/byte-offset/index";
+import { GraphicsStateStack } from "../../../graphics-state/index";
+import { OperandStack } from "../../../operand-stack/index";
+import type { OperatorHandlerContext } from "../../../operator-registry/index";
+import { inlineImageHandler } from "../index";
+
+const buildEntry = (
+  key: string,
+  valueToken: Token,
+): TokenInlineImageDictEntry => ({
+  key: { type: TokenType.Name, value: key, offset: ByteOffset.of(0) },
+  value: [valueToken],
+});
+
+const integerToken = (value: number): Token => ({
+  type: TokenType.Integer,
+  value,
+  offset: ByteOffset.of(0),
+});
+
+const booleanToken = (value: boolean): Token => ({
+  type: TokenType.Boolean,
+  value,
+  offset: ByteOffset.of(0),
+});
+
+const nameToken = (value: string): Token => ({
+  type: TokenType.Name,
+  value,
+  offset: ByteOffset.of(0),
+});
+
+const buildToken = (
+  entries: ReadonlyArray<TokenInlineImageDictEntry>,
+): TokenInlineImage => ({
+  type: TokenType.InlineImage,
+  dict: entries,
+  data: new Uint8Array([]),
+  offset: ByteOffset.of(0),
+});
+
+const buildContext = (): OperatorHandlerContext => ({
+  operandStack: OperandStack.create(),
+  graphicsStateStack: GraphicsStateStack.create(),
+});
+
+const dimensions = (): TokenInlineImageDictEntry[] => [
+  buildEntry("Width", integerToken(1)),
+  buildEntry("Height", integerToken(1)),
+  buildEntry("BitsPerComponent", integerToken(1)),
+];
+
+test("/ImageMask true + ColorSpace なしで成功する（stencil mask 例外）", () => {
+  // PDF §8.9.6 で ImageMask=true のとき ColorSpace は不要
+  const token = buildToken([
+    ...dimensions(),
+    buildEntry("ImageMask", booleanToken(true)),
+  ]);
+
+  const result = inlineImageHandler(buildContext(), token);
+
+  assert(result.ok);
+});
+
+test("/IM true（略号）+ ColorSpace なしで成功する", () => {
+  // normalizer が /IM → /ImageMask に展開するため stencil mask 例外が成立
+  const token = buildToken([
+    ...dimensions(),
+    buildEntry("IM", booleanToken(true)),
+  ]);
+
+  const result = inlineImageHandler(buildContext(), token);
+
+  assert(result.ok);
+});
+
+test("/ImageMask true でも ColorSpace を持つ dict を受理する", () => {
+  // 冗長な ColorSpace を含んでも検査は素通り（仕様外でも受理）
+  const token = buildToken([
+    ...dimensions(),
+    buildEntry("ImageMask", booleanToken(true)),
+    buildEntry("ColorSpace", nameToken("DeviceGray")),
+  ]);
+
+  const result = inlineImageHandler(buildContext(), token);
+
+  assert(result.ok);
+});
+
+test("/ImageMask false + ColorSpace なしで ColorSpace 欠落の err を返す", () => {
+  // 明示的に false の場合は通常の必須キー集合（ColorSpace 必須）に戻る
+  const token = buildToken([
+    ...dimensions(),
+    buildEntry("ImageMask", booleanToken(false)),
+  ]);
+
+  const result = inlineImageHandler(buildContext(), token);
+
+  assert(!result.ok);
+  assert(result.error.code === "INLINE_IMAGE_REQUIRED_KEY_MISSING");
+  expect(result.error.missingKey).toBe("ColorSpace");
+});
+
+test("/ImageMask が非 Boolean (Name) のとき ColorSpace 欠落で err を返す", () => {
+  // 不正型は false 扱い → ColorSpace 必須に戻る
+  const token = buildToken([
+    ...dimensions(),
+    buildEntry("ImageMask", nameToken("true")),
+  ]);
+
+  const result = inlineImageHandler(buildContext(), token);
+
+  assert(!result.ok);
+  assert(result.error.code === "INLINE_IMAGE_REQUIRED_KEY_MISSING");
+  expect(result.error.missingKey).toBe("ColorSpace");
+});
+
+test("/ImageMask が Boolean(false) のとき ColorSpace 必須に戻る", () => {
+  // value === true の厳密判定なので false でも当然 ColorSpace 必須
+  const token = buildToken([
+    ...dimensions(),
+    buildEntry("ImageMask", booleanToken(false)),
+    buildEntry("ColorSpace", nameToken("DeviceGray")),
+  ]);
+
+  const result = inlineImageHandler(buildContext(), token);
+
+  assert(result.ok);
+});
+
+test("/ImageMask true でも Width 欠落のときは Width を返す", () => {
+  // stencil mask 例外は ColorSpace のみをスキップする。他キーは依然必須
+  const token = buildToken([
+    buildEntry("Height", integerToken(1)),
+    buildEntry("BitsPerComponent", integerToken(1)),
+    buildEntry("ImageMask", booleanToken(true)),
+  ]);
+
+  const result = inlineImageHandler(buildContext(), token);
+
+  assert(!result.ok);
+  assert(result.error.code === "INLINE_IMAGE_REQUIRED_KEY_MISSING");
+  expect(result.error.missingKey).toBe("Width");
+});
+
+test("/ImageMask entry の value が空配列のとき false 扱いになり ColorSpace 必須", () => {
+  // isImageMaskTrue の undefined ガードを pin down
+  const token = buildToken([
+    ...dimensions(),
+    {
+      key: {
+        type: TokenType.Name,
+        value: "ImageMask",
+        offset: ByteOffset.of(0),
+      },
+      value: [],
+    },
+  ]);
+
+  const result = inlineImageHandler(buildContext(), token);
+
+  assert(!result.ok);
+  assert(result.error.code === "INLINE_IMAGE_REQUIRED_KEY_MISSING");
+  expect(result.error.missingKey).toBe("ColorSpace");
+});
+
+test("/ImageMask true と /ImageMask false 重複時は最初の true を採用する", () => {
+  // Array.find のセマンティクスを pin down: 仕様外 PDF への防御
+  const token = buildToken([
+    ...dimensions(),
+    buildEntry("ImageMask", booleanToken(true)),
+    buildEntry("ImageMask", booleanToken(false)),
+  ]);
+
+  const result = inlineImageHandler(buildContext(), token);
+
+  assert(result.ok);
+});

--- a/packages/core/src/content-stream/inline-image/handler/index.ts
+++ b/packages/core/src/content-stream/inline-image/handler/index.ts
@@ -19,8 +19,11 @@ const REQUIRED_KEYS_NON_MASK = [
 
 /**
  * ImageMask=true 時の必須キー列。
- * ISO 32000-1:2008 §8.9.5 Table 89 により、stencil mask 時は
- * BitsPerComponent と ColorSpace の双方が optional（BPC は default 1、CS は不可）。
+ * ISO 32000-1:2008 §8.9.5 Table 89 における stencil mask の扱い:
+ *   - BitsPerComponent: optional（不在時の default 値は 1）
+ *   - ColorSpace: 禁止（仕様上 stencil mask では指定してはならない）
+ * 本フェーズの handler は存在検査のみを行うため、CS が存在した場合も
+ * 「禁止違反」としては弾かず（透過する）、後続フェーズでのバリデーション責務とする。
  */
 const REQUIRED_KEYS_MASK = ["Width", "Height"] as const;
 
@@ -33,9 +36,10 @@ type RequiredKey = (typeof REQUIRED_KEYS_NON_MASK)[number];
  *   (1) `normalizeInlineImageDict(token.dict)` で略号→完全名を展開
  *   (2) ImageMask の真偽判定（`TokenBoolean` かつ `value === true`）
  *   (3) 必須キー存在検査: Width → Height → BitsPerComponent → ColorSpace
- *       （ImageMask=true 時は BitsPerComponent / ColorSpace をスキップ。
- *        ISO 32000-1:2008 §8.9.5 Table 89: stencil mask では BPC は optional
- *        (default 1)、CS は不可）
+ *       ImageMask=true（stencil mask）の場合、ISO 32000-1:2008 §8.9.5 Table 89 に従い:
+ *         - BitsPerComponent は optional（不在時の default 値は 1）
+ *         - ColorSpace は仕様上禁止（指定してはならない）。本フェーズの handler は存在
+ *           検査のみのため、CS が存在しても禁止違反として弾かず透過する
  *
  * 重複キーの扱い:
  *   `TokenInlineImage.dict` は重複と順序を保持する `ReadonlyArray` 型である。本フェーズでは

--- a/packages/core/src/content-stream/inline-image/handler/index.ts
+++ b/packages/core/src/content-stream/inline-image/handler/index.ts
@@ -1,0 +1,108 @@
+import type { PdfError } from "../../../pdf/errors/index";
+import type {
+  TokenInlineImage,
+  TokenInlineImageDictEntry,
+} from "../../../pdf/index";
+import { TokenType } from "../../../pdf/index";
+import type { Result } from "../../../utils/result/index";
+import { err, ok } from "../../../utils/result/index";
+import type { OperatorHandlerContext } from "../../operator-registry/index";
+import { normalizeInlineImageDict } from "../normalizer/index";
+
+/** ImageMask=false 時の必須キー列（検査順）。 */
+const REQUIRED_KEYS_NON_MASK = [
+  "Width",
+  "Height",
+  "BitsPerComponent",
+  "ColorSpace",
+] as const;
+
+/** ImageMask=true 時の必須キー列（PDF §8.9.6 で ColorSpace を除く）。 */
+const REQUIRED_KEYS_MASK = ["Width", "Height", "BitsPerComponent"] as const;
+
+type RequiredKey = (typeof REQUIRED_KEYS_NON_MASK)[number];
+
+/**
+ * PDF §8.9 InlineImage (`BI ... ID ... EI`) のハンドラ骨格。
+ *
+ * 検査順序（厳守）:
+ *   (1) `normalizeInlineImageDict(token.dict)` で略号→完全名を展開
+ *   (2) ImageMask の真偽判定（`TokenBoolean` かつ `value === true`）
+ *   (3) 必須キー存在検査: Width → Height → BitsPerComponent → ColorSpace
+ *       （ImageMask=true 時は ColorSpace をスキップ。PDF §8.9.6 stencil mask 例外）
+ *
+ * 重複キーの扱い:
+ *   `TokenInlineImage.dict` は重複と順序を保持する `ReadonlyArray` 型である。本フェーズでは
+ *   「最初に出現したエントリ」を採用する（`Array.prototype.find` / `some` のセマンティクスに従う）。
+ *   ImageMask 判定も同じく最初の `/ImageMask` 系エントリのみを参照する。
+ *
+ * 本フェーズで行わないこと:
+ *   - value 側の型検査（例: `/Width 16` の 16 が integer か否か）
+ *   - filter (`/Filter`) チェイン適用
+ *   - `data: Uint8Array` の decode
+ *   - 画像描画
+ *
+ * 不変条件:
+ *   - 成功時は `operandStack` / `graphicsStateStack` を同一参照で返す
+ *   - InlineImage は operand を取らないため operand stack は触らない
+ *
+ * @param context - 実行コンテキスト (operand stack / graphics state stack)
+ * @param token - 解釈対象の inline image token
+ * @returns 成功なら入力と同一参照の context、失敗なら PdfError
+ */
+export const inlineImageHandler = (
+  context: OperatorHandlerContext,
+  token: TokenInlineImage,
+): Result<OperatorHandlerContext, PdfError> => {
+  const normalized = normalizeInlineImageDict(token.dict);
+  const imageMask = isImageMaskTrue(normalized);
+  const requiredKeys = imageMask ? REQUIRED_KEYS_MASK : REQUIRED_KEYS_NON_MASK;
+
+  const missing = findFirstMissingKey(normalized, requiredKeys);
+  if (missing !== undefined) {
+    return err({
+      code: "INLINE_IMAGE_REQUIRED_KEY_MISSING",
+      message: `Inline image is missing required key '${missing}'`,
+      missingKey: missing,
+      offset: token.offset,
+    });
+  }
+
+  return ok({
+    operandStack: context.operandStack,
+    graphicsStateStack: context.graphicsStateStack,
+  });
+};
+
+/**
+ * dict 内の最初の `/ImageMask` エントリが `TokenBoolean(true)` かを判定する。
+ */
+function isImageMaskTrue(
+  entries: ReadonlyArray<TokenInlineImageDictEntry>,
+): boolean {
+  const entry = entries.find((e) => e.key.value === "ImageMask");
+  if (entry === undefined) {
+    return false;
+  }
+  const first = entry.value[0];
+  if (first === undefined) {
+    return false;
+  }
+  return first.type === TokenType.Boolean && first.value === true;
+}
+
+/**
+ * 必須キー列を順に走査し、最初に欠落したキーを返す。すべて存在すれば undefined。
+ */
+function findFirstMissingKey(
+  entries: ReadonlyArray<TokenInlineImageDictEntry>,
+  requiredKeys: ReadonlyArray<RequiredKey>,
+): RequiredKey | undefined {
+  for (const key of requiredKeys) {
+    const exists = entries.some((e) => e.key.value === key);
+    if (!exists) {
+      return key;
+    }
+  }
+  return undefined;
+}

--- a/packages/core/src/content-stream/inline-image/handler/index.ts
+++ b/packages/core/src/content-stream/inline-image/handler/index.ts
@@ -17,8 +17,12 @@ const REQUIRED_KEYS_NON_MASK = [
   "ColorSpace",
 ] as const;
 
-/** ImageMask=true 時の必須キー列（PDF §8.9.6 で ColorSpace を除く）。 */
-const REQUIRED_KEYS_MASK = ["Width", "Height", "BitsPerComponent"] as const;
+/**
+ * ImageMask=true 時の必須キー列。
+ * ISO 32000-1:2008 §8.9.5 Table 89 により、stencil mask 時は
+ * BitsPerComponent と ColorSpace の双方が optional（BPC は default 1、CS は不可）。
+ */
+const REQUIRED_KEYS_MASK = ["Width", "Height"] as const;
 
 type RequiredKey = (typeof REQUIRED_KEYS_NON_MASK)[number];
 
@@ -29,7 +33,9 @@ type RequiredKey = (typeof REQUIRED_KEYS_NON_MASK)[number];
  *   (1) `normalizeInlineImageDict(token.dict)` で略号→完全名を展開
  *   (2) ImageMask の真偽判定（`TokenBoolean` かつ `value === true`）
  *   (3) 必須キー存在検査: Width → Height → BitsPerComponent → ColorSpace
- *       （ImageMask=true 時は ColorSpace をスキップ。PDF §8.9.6 stencil mask 例外）
+ *       （ImageMask=true 時は BitsPerComponent / ColorSpace をスキップ。
+ *        ISO 32000-1:2008 §8.9.5 Table 89: stencil mask では BPC は optional
+ *        (default 1)、CS は不可）
  *
  * 重複キーの扱い:
  *   `TokenInlineImage.dict` は重複と順序を保持する `ReadonlyArray` 型である。本フェーズでは

--- a/packages/core/src/content-stream/interpreter/__tests__/interpreter.dispatch.test.ts
+++ b/packages/core/src/content-stream/interpreter/__tests__/interpreter.dispatch.test.ts
@@ -147,7 +147,6 @@ test.each([
 test.each([
   { input: "[ (A) 120 ] TJ", code: "NOT_IMPLEMENTED" },
   { input: "<< /K /V >> op", code: "NOT_IMPLEMENTED" },
-  { input: "BI /W 1 /H 1 ID abc EI op", code: "NOT_IMPLEMENTED" },
   { input: "] op", code: "OBJECT_PARSE_UNEXPECTED_TOKEN" },
   { input: ">> op", code: "OBJECT_PARSE_UNEXPECTED_TOKEN" },
 ])("composite tokenはstackを汚染せずErrで中断する: $input", ({

--- a/packages/core/src/content-stream/interpreter/__tests__/interpreter.inline-image.test.ts
+++ b/packages/core/src/content-stream/interpreter/__tests__/interpreter.inline-image.test.ts
@@ -1,0 +1,130 @@
+import { assert, expect, test } from "vitest";
+import type { PdfObject } from "../../../pdf/types/pdf-types/index";
+import { ok } from "../../../utils/result/index";
+import { GraphicsStateStack } from "../../graphics-state/index";
+import { OperandStack } from "../../operand-stack/index";
+import {
+  type OperatorHandler,
+  OperatorRegistry,
+} from "../../operator-registry/index";
+import { ContentStreamInterpreter } from "../index";
+
+const encode = (value: string): Uint8Array => new TextEncoder().encode(value);
+
+function registerOperator(
+  registry: ReturnType<typeof OperatorRegistry.create>,
+  name: string,
+  handler: OperatorHandler,
+): ReturnType<typeof OperatorRegistry.create> {
+  const result = OperatorRegistry.register(registry, name, handler);
+  assert(result.ok);
+  return result.value;
+}
+
+test("BI /W 1 /H 1 /CS /G /BPC 8 ID x EI を含む stream が green に流れる", () => {
+  // 標準的な inline image: NOT_IMPLEMENTED で中断していた挙動が解消されることを pin down
+  const result = ContentStreamInterpreter.execute({
+    data: encode("BI /W 1 /H 1 /CS /G /BPC 8 ID x EI"),
+    registry: OperatorRegistry.create(),
+  });
+
+  assert(result.ok);
+  expect(result.value.warnings).toEqual([]);
+  expect(OperandStack.depth(result.value.context.operandStack)).toBe(0);
+});
+
+test("inline image の前後で operand stack / graphics state stack は同一参照", () => {
+  // initialContext を渡して参照同一性を比較する。inline image は state を変更しない
+  const initialContext = {
+    operandStack: OperandStack.create(),
+    graphicsStateStack: GraphicsStateStack.create(),
+  };
+  const before = GraphicsStateStack.current(initialContext.graphicsStateStack);
+
+  const result = ContentStreamInterpreter.execute({
+    data: encode("BI /W 1 /H 1 /CS /G /BPC 8 ID x EI"),
+    registry: OperatorRegistry.create(),
+    initialContext,
+  });
+
+  assert(result.ok);
+  expect(result.value.context.operandStack).toBe(initialContext.operandStack);
+  expect(result.value.context.graphicsStateStack).toBe(
+    initialContext.graphicsStateStack,
+  );
+  expect(
+    GraphicsStateStack.current(result.value.context.graphicsStateStack),
+  ).toBe(before);
+});
+
+test("必須キー欠落の inline image は INLINE_IMAGE_REQUIRED_KEY_MISSING で中断する", () => {
+  // /W (Width) を欠落させると handler が err を返し interpreter が伝搬する
+  const result = ContentStreamInterpreter.execute({
+    data: encode("BI /H 1 /CS /G /BPC 8 ID x EI"),
+    registry: OperatorRegistry.create(),
+  });
+
+  assert(!result.ok);
+  expect(result.error.code).toBe("INLINE_IMAGE_REQUIRED_KEY_MISSING");
+  assert(result.error.code === "INLINE_IMAGE_REQUIRED_KEY_MISSING");
+  expect(result.error.missingKey).toBe("Width");
+});
+
+test("/IM true ImageMask は ColorSpace なしでも green に流れる", () => {
+  // PDF §8.9.6 stencil mask 例外が end-to-end で動作する
+  const result = ContentStreamInterpreter.execute({
+    data: encode("BI /W 1 /H 1 /BPC 1 /IM true ID x EI"),
+    registry: OperatorRegistry.create(),
+  });
+
+  assert(result.ok);
+  expect(result.value.warnings).toEqual([]);
+});
+
+test("BI ... EI の後に登録済み operator が呼ばれる", () => {
+  // inline image 通過後も interpreter loop が継続し後続 operator が dispatch される
+  let called = false;
+  const registry = registerOperator(
+    OperatorRegistry.create(),
+    "op",
+    (context) => {
+      called = true;
+      return ok(context);
+    },
+  );
+
+  const result = ContentStreamInterpreter.execute({
+    data: encode("BI /W 1 /H 1 /CS /G /BPC 8 ID x EI op"),
+    registry,
+  });
+
+  assert(result.ok);
+  expect(called).toBe(true);
+});
+
+test("BI ... EI の前に積まれた operand は inline image 後も残る", () => {
+  // operand stack は inline image で変化しない不変条件を pin down
+  const observed: PdfObject[][] = [];
+  const registry = registerOperator(
+    OperatorRegistry.create(),
+    "capture",
+    (context) => {
+      observed.push(
+        Array.from({ length: OperandStack.depth(context.operandStack) }, () => {
+          const popped = OperandStack.pop(context.operandStack);
+          assert(popped.some);
+          return popped.value;
+        }),
+      );
+      return ok(context);
+    },
+  );
+
+  const result = ContentStreamInterpreter.execute({
+    data: encode("42 BI /W 1 /H 1 /CS /G /BPC 8 ID x EI capture"),
+    registry,
+  });
+
+  assert(result.ok);
+  expect(observed).toEqual([[{ type: "integer", value: 42 }]]);
+});

--- a/packages/core/src/content-stream/interpreter/index.ts
+++ b/packages/core/src/content-stream/interpreter/index.ts
@@ -10,6 +10,7 @@ import { none, some } from "../../utils/option/index";
 import type { Result } from "../../utils/result/index";
 import { err, ok } from "../../utils/result/index";
 import { GraphicsStateStack } from "../graphics-state/index";
+import { inlineImageHandler } from "../inline-image/handler/index";
 import { OperandStack } from "../operand-stack/index";
 import {
   type OperatorHandlerContext,
@@ -103,6 +104,13 @@ function executeToken(options: {
     });
   }
 
+  if (options.token.type === TokenType.InlineImage) {
+    return dispatchInlineImage({
+      token: options.token,
+      context: options.context,
+    });
+  }
+
   return pushPrimitiveOperand(options.token, options.context);
 }
 
@@ -135,6 +143,25 @@ function dispatchOperator(options: {
     return err(handled.error);
   }
 
+  return ok({ type: "continue", context: handled.value });
+}
+
+/**
+ * TokenInlineImage を inlineImageHandler に委譲する。
+ * OperatorRegistry は経由しない（token 種別レベルで直接分岐するため、
+ * 既存 operator 系の登録経路とは別経路で扱う）。
+ *
+ * @param options - inline image token と現在context
+ * @returns 次step、または検査エラー
+ */
+function dispatchInlineImage(options: {
+  readonly token: Extract<Token, { readonly type: TokenType.InlineImage }>;
+  readonly context: OperatorHandlerContext;
+}): Result<InterpreterStep, PdfError> {
+  const handled = inlineImageHandler(options.context, options.token);
+  if (!handled.ok) {
+    return err(handled.error);
+  }
   return ok({ type: "continue", context: handled.value });
 }
 
@@ -206,7 +233,6 @@ function tokenToPrimitivePdfObject(
       return ok(some({ type: "null" }));
     case TokenType.ArrayBegin:
     case TokenType.DictBegin:
-    case TokenType.InlineImage:
       return err({
         code: "NOT_IMPLEMENTED",
         message: `Composite content stream operand is not supported in Phase 3: ${token.type}`,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -71,6 +71,7 @@ export type {
   PdfErrorCode,
   PdfIndirectObject,
   PdfIndirectRef,
+  PdfInlineImageRequiredKeyMissingError,
   PdfInteger,
   PdfName,
   PdfNull,

--- a/packages/core/src/pdf/errors/error/__tests__/error.type-export.test.ts
+++ b/packages/core/src/pdf/errors/error/__tests__/error.type-export.test.ts
@@ -4,6 +4,7 @@ import type {
   PdfCircularReferenceError,
   PdfError,
   PdfErrorCode,
+  PdfInlineImageRequiredKeyMissingError,
   PdfOperatorIllegalStateError,
   PdfOperatorOperandMissingError,
   PdfOperatorOperandTypeMismatchError,
@@ -16,6 +17,7 @@ import type {
   PdfWarning,
   PdfWarningCode,
 } from "../../../../index";
+import { ByteOffset } from "../../../types/byte-offset/index";
 import { GenerationNumber } from "../../../types/generation-number/index";
 import { ObjectNumber } from "../../../types/object-number/index";
 
@@ -204,4 +206,23 @@ test("PdfOperatorIllegalStateError は PdfError union から narrow できる", 
   expect(narrowed).toBe(true);
   expect(error.code).toBe("OPERATOR_ILLEGAL_STATE");
   expect(illegalStateError.operatorName).toBe("BT");
+});
+
+test("PdfInlineImageRequiredKeyMissingError は PdfError union から narrow できる", () => {
+  const inlineImageError: PdfInlineImageRequiredKeyMissingError = {
+    code: "INLINE_IMAGE_REQUIRED_KEY_MISSING",
+    message: "Inline image is missing required key 'Width'",
+    missingKey: "Width",
+    offset: ByteOffset.of(0),
+  };
+  const error: PdfError = inlineImageError;
+
+  const narrowed: Exact<
+    Extract<PdfError, { code: "INLINE_IMAGE_REQUIRED_KEY_MISSING" }>,
+    PdfInlineImageRequiredKeyMissingError
+  > = true;
+
+  expect(narrowed).toBe(true);
+  expect(error.code).toBe("INLINE_IMAGE_REQUIRED_KEY_MISSING");
+  expect(inlineImageError.missingKey).toBe("Width");
 });

--- a/packages/core/src/pdf/errors/error/index.ts
+++ b/packages/core/src/pdf/errors/error/index.ts
@@ -284,9 +284,12 @@ export interface PdfOperatorIllegalStateError {
 
 /**
  * Inline image (`BI ... ID ... EI`) dict の必須キー欠落エラー。
- * ISO 32000-1:2008 §8.9.5 で必須とされる Width / Height / BitsPerComponent /
- * ColorSpace のいずれかが dict 内に存在しない場合に発生する。
- * ImageMask=true の場合（PDF §8.9.6 stencil mask）は ColorSpace は不要。
+ * ISO 32000-1:2008 §8.9.5 Table 89 で必須とされる Width / Height /
+ * BitsPerComponent / ColorSpace のいずれかが dict 内に存在しない場合に発生する。
+ * ImageMask=true（stencil mask）の場合、Table 89 に従い:
+ *   - BitsPerComponent は optional（不在時の default 値は 1）
+ *   - ColorSpace は仕様上禁止（指定してはならない）
+ * このため stencil mask 時は Width / Height のみが必須となる。
  *
  * @example
  * ```ts

--- a/packages/core/src/pdf/errors/error/index.ts
+++ b/packages/core/src/pdf/errors/error/index.ts
@@ -59,7 +59,8 @@ export type PdfErrorCode =
   | "OPERATOR_OPERAND_TYPE_MISMATCH"
   | "OPERATOR_OPERAND_VALUE_OUT_OF_RANGE"
   | "OPERATOR_PATH_NO_CURRENT_POINT"
-  | "OPERATOR_ILLEGAL_STATE";
+  | "OPERATOR_ILLEGAL_STATE"
+  | "INLINE_IMAGE_REQUIRED_KEY_MISSING";
 
 /**
  * PDFパースエラーを表すインターフェース。
@@ -282,6 +283,33 @@ export interface PdfOperatorIllegalStateError {
 }
 
 /**
+ * Inline image (`BI ... ID ... EI`) dict の必須キー欠落エラー。
+ * ISO 32000-1:2008 §8.9.5 で必須とされる Width / Height / BitsPerComponent /
+ * ColorSpace のいずれかが dict 内に存在しない場合に発生する。
+ * ImageMask=true の場合（PDF §8.9.6 stencil mask）は ColorSpace は不要。
+ *
+ * @example
+ * ```ts
+ * const error: PdfInlineImageRequiredKeyMissingError = {
+ *   code: "INLINE_IMAGE_REQUIRED_KEY_MISSING",
+ *   message: "Inline image is missing required key 'Width'",
+ *   missingKey: "Width",
+ *   offset: ByteOffset.of(42),
+ * };
+ * ```
+ */
+export interface PdfInlineImageRequiredKeyMissingError {
+  /** エラーコード（常に "INLINE_IMAGE_REQUIRED_KEY_MISSING"） */
+  readonly code: "INLINE_IMAGE_REQUIRED_KEY_MISSING";
+  /** 人間可読なエラーメッセージ */
+  readonly message: string;
+  /** 欠落していた必須キー名 */
+  readonly missingKey: "Width" | "Height" | "BitsPerComponent" | "ColorSpace";
+  /** 該当 inline image token の開始バイト位置 */
+  readonly offset: ByteOffset;
+}
+
+/**
  * 全致命的PDFエラーの判別共用体型。
  * パースエラー、循環参照エラー、型不一致エラー、operator registry エラー、
  * operator オペランド不足／型不一致／値域外エラー、
@@ -309,4 +337,5 @@ export type PdfError =
   | PdfOperatorOperandTypeMismatchError
   | PdfOperatorOperandValueOutOfRangeError
   | PdfOperatorPathNoCurrentPointError
-  | PdfOperatorIllegalStateError;
+  | PdfOperatorIllegalStateError
+  | PdfInlineImageRequiredKeyMissingError;

--- a/packages/core/src/pdf/errors/index.ts
+++ b/packages/core/src/pdf/errors/index.ts
@@ -7,6 +7,7 @@ export type {
   PdfCircularReferenceError,
   PdfError,
   PdfErrorCode,
+  PdfInlineImageRequiredKeyMissingError,
   PdfOperatorIllegalStateError,
   PdfOperatorOperandMissingError,
   PdfOperatorOperandTypeMismatchError,


### PR DESCRIPTION
## 概要

`ContentStreamInterpreter` が `TokenType.InlineImage` を `NOT_IMPLEMENTED` で中断していた現状を解消する。`inlineImageHandler` を新規導入し、**normalizer → ImageMask 判定 → 必須キー検査** の順で context を不変で返す骨格 handler を提供する。画像 decode / 描画は本フェーズでは行わない（既存 `tjHandler` #415 / `doHandler` #425 と同パターン）。

## 変更内容

### 🎯 変更の種類

- [x] ✨ 新機能 (New feature)

### 📝 詳細な変更内容

#### 追加された機能

- `inlineImageHandler(context, token): Result<OperatorHandlerContext, PdfError>` — InlineImage token の検査骨格（純関数）
- `PdfInlineImageRequiredKeyMissingError` interface と `PdfErrorCode` への `"INLINE_IMAGE_REQUIRED_KEY_MISSING"` メンバ追加
- `ContentStreamInterpreter.executeToken` の `TokenType.InlineImage` 分岐 + `dispatchInlineImage` wrapper（OperatorRegistry を経由しない直接分岐）
- 単体テスト 28 件（basic 10 / error 9 / image-mask 9）+ interpreter 統合テスト 6 件 + 型 narrow テスト 1 件

#### 変更されたファイル

- `packages/core/src/pdf/errors/error/index.ts` — エラー型追加
- `packages/core/src/pdf/errors/index.ts` — barrel re-export
- `packages/core/src/index.ts` — 公開 barrel re-export
- `packages/core/src/pdf/errors/error/__tests__/error.type-export.test.ts` — `PdfError` union narrow テスト追加
- `packages/core/src/content-stream/interpreter/index.ts` — InlineImage 分岐 + `dispatchInlineImage` 新設、`tokenToPrimitivePdfObject` の `case TokenType.InlineImage:` 削除
- `packages/core/src/content-stream/interpreter/__tests__/interpreter.dispatch.test.ts` — 旧 `NOT_IMPLEMENTED` 期待ケース行を削除

#### 新規ファイル

- `packages/core/src/content-stream/inline-image/handler/index.ts`
- `packages/core/src/content-stream/inline-image/handler/__tests__/handler.basic.test.ts`
- `packages/core/src/content-stream/inline-image/handler/__tests__/handler.error.test.ts`
- `packages/core/src/content-stream/inline-image/handler/__tests__/handler.image-mask.test.ts`
- `packages/core/src/content-stream/interpreter/__tests__/interpreter.inline-image.test.ts`

## ⚠️ 破壊的変更（互換性のある拡張）

- `BI ... EI` を含む content stream が `NOT_IMPLEMENTED` で中断しなくなる
- `PdfErrorCode` union に `"INLINE_IMAGE_REQUIRED_KEY_MISSING"` メンバが 1 つ追加される
- `PdfError` discriminated union に `PdfInlineImageRequiredKeyMissingError` が追加される

`PdfParseErrorCode` 集合（`allPdfParseErrorCodes.toHaveLength(26)`）は変更なし — 新エラーコードは `PdfErrorCode` 拡張 union 側に属する。

## 📊 システム図

### `inlineImageHandler` 内部フロー

```mermaid
flowchart TD
    Start([TokenInlineImage]) --> Normalize[normalizeInlineImageDict<br/>略号 → 完全名展開]
    Normalize --> MaskCheck{ImageMask?<br/>TokenBoolean かつ true}
    MaskCheck -->|true| KeyMask[必須キー列:<br/>Width / Height]
    MaskCheck -->|false| KeyNonMask[必須キー列:<br/>Width / Height / BitsPerComponent / ColorSpace]
    KeyMask --> Find[findFirstMissingKey<br/>順次走査]
    KeyNonMask --> Find
    Find --> Missing{欠落あり?}
    Missing -->|yes| Err[err INLINE_IMAGE_REQUIRED_KEY_MISSING<br/>missingKey + token.offset]
    Missing -->|no| Ok[ok operandStack / graphicsStateStack<br/>同一参照]

    classDef new fill:#ffe4b5,stroke:#d97706,stroke-width:2px
    class Normalize,MaskCheck,KeyMask,KeyNonMask,Find,Missing,Err,Ok new
```

### Interpreter 統合

```mermaid
flowchart TD
    Token([Token]) --> Type{token.type}
    Type -->|EOF| Done([done])
    Type -->|Operator| DispOp[dispatchOperator<br/>via OperatorRegistry]
    Type -->|InlineImage| DispInline[dispatchInlineImage<br/>: NEW]:::new
    Type -->|primitive| Push[pushPrimitiveOperand]
    DispInline --> Handler[inlineImageHandler]:::new
    Handler --> Continue([continue / err])
    DispOp --> Continue
    Push --> Continue

    classDef new fill:#ffe4b5,stroke:#d97706,stroke-width:2px
```

## 🔗 関連 Issue

Refs #446

本フェーズは骨格実装（検査のみ）であり画像 decode / 描画は未実装のため、Issue は閉じない。

## 🚨 テスト

- ✅ `pnpm --filter @pdfmod/core test` (2783 tests passed)
- ✅ `pnpm test:run` (リポジトリ全体 2803 tests passed)
- ✅ `pnpm --filter @pdfmod/core typecheck`
- ✅ `pnpm --filter @pdfmod/core build`
- ✅ `pnpm lint` (biome + oxlint)
- ✅ codex code review — MEDIUM 1 件は plan 散文中の省略表現「context 同一参照」を字義通り読んだ false positive と判定（DoD・plan literal code・既存 tj/do pattern いずれも stack 単位の同一参照を要求しており現実装は完全整合）。判断根拠は `.plugin-workspace/.specs/073-inline-image-handler/code-review/review-002.md` に記録。

### 検査順序（厳守）

1. `normalizeInlineImageDict(token.dict)` で略号 → 完全名展開
2. ImageMask の真偽判定（`TokenBoolean` かつ `value === true`）
3. 必須キー存在検査: Width → Height → BitsPerComponent → ColorSpace
   - ImageMask=true（stencil mask）の場合、ISO 32000-1:2008 §8.9.5 Table 89 に従い:
     - BitsPerComponent: optional（不在時の default 値は 1）
     - ColorSpace: 仕様上禁止（指定してはならない）
     - 必須となるのは Width / Height のみ（本フェーズ handler は存在検査のみのため CS 禁止違反は弾かず透過）

### 不変条件

- 成功時は `operandStack` / `graphicsStateStack` を入力と同一参照で返す
- InlineImage は operand を取らないため operand stack は触らない

## 👀 レビューポイント

1. **registry を経由しない分岐**: `dispatchInlineImage` は token 種別レベルで直接分岐する（既存 operator 系の `OperatorRegistry.lookup` 経路とは別経路）。`Tj`/`Do` の operator 系とは独立した経路で扱う設計判断の妥当性
2. **重複キーの扱い**: `Array.find` / `Array.some` のセマンティクスに従い「最初に出現したエントリ」を採用。`/ImageMask true` と `/ImageMask false` が重複する場合の挙動を pin down 済み
3. **エラーコード prefix の分裂**: handler 側 `INLINE_IMAGE_REQUIRED_KEY_MISSING`（semantic）と tokenizer 側 `CONTENT_STREAM_INLINE_IMAGE_INVALID`（syntactic, `PdfParseErrorCode` メンバ）で prefix が分裂しているが、層の違いを表現するため Issue #446 指定どおり採用
4. **本フェーズで行わないこと**: value 側の型検査（例: `/Width 16` の 16 が integer か否か）、filter チェイン適用、`data: Uint8Array` の decode、画像描画 — いずれも後続フェーズの責務
