### PR TITLE
✨ [New Feature]: #406 parser モジュール骨格と PdfObject スカラ 7 種のパース処理を追加

### DIFF
--- a/rust/crates/core/src/lib.rs
+++ b/rust/crates/core/src/lib.rs
@@ -14,3 +14,4 @@ pub mod byte_offset;
 pub mod error;
 pub mod lexer;
 pub mod object;
+pub mod parser;

--- a/rust/crates/core/src/parser.rs
+++ b/rust/crates/core/src/parser.rs
@@ -1,0 +1,541 @@
+//! PDF オブジェクトのパース層。
+//!
+//! lexer が返す [`Token`](crate::lexer::token::Token) を ISO 32000-1 §7.3 の
+//! スカラオブジェクトに意味付けして [`PdfObject`] に変換する。本モジュールは
+//! スカラ 7 種（Null / Boolean / Integer / Real / LiteralString / HexString /
+//! Name）のみを扱い、配列・辞書・stream・間接参照は対象外。
+//!
+//! `LiteralString` と `HexString` は出自情報を落として `PdfObject::String` に統合する
+//! （所有ムーブのため clone は発生しない）。`Token::Comment` は透過的にスキップする。
+
+pub mod error;
+
+use crate::byte_offset::ByteOffset;
+use crate::lexer::token::{Primitive, Token};
+use crate::lexer::Lexer;
+use crate::object::pdf_object::PdfObject;
+use crate::parser::error::ParseError;
+
+/// PDF バイト列から [`PdfObject`] を 1 つずつ取り出すパーサ。
+///
+/// 内部に [`Lexer`] をムーブで保持し、カーソル位置の管理を委譲する。
+/// `Parser` 自身は新たな割り当てを行わず、[`Primitive`] の所有データを
+/// [`PdfObject`] にそのままムーブする（`Vec<u8>` の clone を行わない）。
+///
+/// 任意の入力に対して panic しない契約を持つ（lexer の契約をそのまま継承）。
+#[derive(Debug)]
+pub struct Parser<'a> {
+    lexer: Lexer<'a>,
+}
+
+impl<'a> Parser<'a> {
+    /// 入力バイト列から新しいパーサを構築する。`pos` は 0 で初期化される。
+    pub fn new(input: &'a [u8]) -> Self {
+        Self {
+            lexer: Lexer::new(input),
+        }
+    }
+
+    /// 現在のカーソル位置をバイトオフセットで返す。
+    ///
+    /// 内部 [`Lexer`] の `position()` を [`ByteOffset`] にラップして返すだけで、
+    /// パース処理の副作用は伴わない。
+    pub fn position(&self) -> ByteOffset {
+        ByteOffset::new(self.lexer.position() as u64)
+    }
+
+    /// 次のスカラオブジェクトを 1 つ読み取る。
+    ///
+    /// [`Token::Comment`] は透過的にスキップする。スカラでないトークン
+    /// （配列・辞書開始/終了・`obj`/`endobj`/`stream`/`endstream`・キーワード）が
+    /// 来た場合は [`ParseErrorKind::UnexpectedToken`](error::ParseErrorKind::UnexpectedToken)、
+    /// 入力が尽きていれば [`ParseErrorKind::UnexpectedEof`](error::ParseErrorKind::UnexpectedEof)、
+    /// lexer が malformed を検知して `None` を返した場合は
+    /// [`ParseErrorKind::LexerError`](error::ParseErrorKind::LexerError) を返す。
+    pub fn parse_object(&mut self) -> Result<PdfObject, ParseError> {
+        loop {
+            let pos_before = self.lexer.position();
+            match self.lexer.next_token() {
+                Some(Token::Comment(_)) => continue,
+                Some(Token::Primitive(p)) => return Ok(Self::primitive_to_object(p)),
+                Some(other) => {
+                    return Err(ParseError::unexpected_token_at(
+                        ByteOffset::new(pos_before as u64),
+                        Self::token_kind_label(&other),
+                    ));
+                }
+                None => {
+                    let pos = ByteOffset::new(self.lexer.position() as u64);
+                    if self.lexer.is_eof() {
+                        return Err(ParseError::unexpected_eof_at(pos));
+                    }
+                    return Err(ParseError::lexer_error_at(pos));
+                }
+            }
+        }
+    }
+
+    /// [`Primitive`] を所有ムーブで受け取り、対応する [`PdfObject`] バリアントへ
+    /// マップする（スカラ 7 種 → 6 種、`LiteralString`/`HexString` は
+    /// `PdfObject::String` に統合）。`Vec<u8>` / `PdfName` は clone せずムーブする。
+    fn primitive_to_object(p: Primitive) -> PdfObject {
+        match p {
+            Primitive::Null => PdfObject::Null,
+            Primitive::Boolean(b) => PdfObject::Boolean(b),
+            Primitive::Integer(i) => PdfObject::Integer(i),
+            Primitive::Real(f) => PdfObject::Real(f),
+            Primitive::LiteralString(v) => PdfObject::String(v),
+            Primitive::HexString(v) => PdfObject::String(v),
+            Primitive::Name(n) => PdfObject::Name(n),
+        }
+    }
+
+    /// 想定外トークンの種別を [`ParseErrorKind::UnexpectedToken`](error::ParseErrorKind::UnexpectedToken)
+    /// の `actual_kind` フィールドに載せる短い `'static` 識別子にマップする。
+    fn token_kind_label(token: &Token) -> &'static str {
+        match token {
+            Token::Primitive(_) => "Primitive",
+            Token::ArrayBegin => "ArrayBegin",
+            Token::ArrayEnd => "ArrayEnd",
+            Token::DictBegin => "DictBegin",
+            Token::DictEnd => "DictEnd",
+            Token::ObjBegin => "ObjBegin",
+            Token::ObjEnd => "ObjEnd",
+            Token::StreamBegin => "StreamBegin",
+            Token::StreamEnd => "StreamEnd",
+            Token::Keyword(_) => "Keyword",
+            Token::Comment(_) => "Comment",
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::object::name::PdfName;
+    use crate::parser::error::ParseErrorKind;
+
+    fn parser(input: &[u8]) -> Parser<'_> {
+        Parser::new(input)
+    }
+
+    // ---------- Parser::new / Parser::position ----------
+
+    #[test]
+    fn new_then_position_returns_zero() {
+        // Parser::new 直後の position() が ByteOffset::new(0) を返すことを確認する
+        let p = parser(b"42");
+        assert_eq!(p.position(), ByteOffset::new(0));
+    }
+
+    #[test]
+    fn parse_object_advances_position() {
+        // 1 オブジェクト parse 後の position() がカーソル前進していること（>0）を確認する
+        let mut p = parser(b"42");
+        let _ = p.parse_object().expect("integer should parse");
+        assert!(p.position().value() > 0);
+    }
+
+    // ---------- 正常系: Null / Boolean ----------
+
+    #[test]
+    fn parse_object_returns_null_for_null_keyword() {
+        // 入力 b"null" で parse_object が Ok(PdfObject::Null) を返すことを確認する
+        let mut p = parser(b"null");
+        assert_eq!(p.parse_object(), Ok(PdfObject::Null));
+    }
+
+    #[test]
+    fn parse_object_returns_boolean_true_for_true_keyword() {
+        // 入力 b"true" で Ok(PdfObject::Boolean(true)) を返すことを確認する
+        let mut p = parser(b"true");
+        assert_eq!(p.parse_object(), Ok(PdfObject::Boolean(true)));
+    }
+
+    #[test]
+    fn parse_object_returns_boolean_false_for_false_keyword() {
+        // 入力 b"false" で Ok(PdfObject::Boolean(false)) を返すことを確認する
+        let mut p = parser(b"false");
+        assert_eq!(p.parse_object(), Ok(PdfObject::Boolean(false)));
+    }
+
+    // ---------- 正常系: Integer ----------
+
+    #[test]
+    fn parse_object_returns_integer_for_positive_digits() {
+        // 入力 b"42" で Ok(PdfObject::Integer(42)) を返すことを確認する
+        let mut p = parser(b"42");
+        assert_eq!(p.parse_object(), Ok(PdfObject::Integer(42)));
+    }
+
+    #[test]
+    fn parse_object_returns_integer_for_negative_digits() {
+        // 入力 b"-7" で Ok(PdfObject::Integer(-7)) を返すことを確認する
+        let mut p = parser(b"-7");
+        assert_eq!(p.parse_object(), Ok(PdfObject::Integer(-7)));
+    }
+
+    #[test]
+    fn parse_object_returns_integer_for_zero() {
+        // 境界値: 入力 b"0" で Ok(PdfObject::Integer(0)) を返すことを確認する
+        let mut p = parser(b"0");
+        assert_eq!(p.parse_object(), Ok(PdfObject::Integer(0)));
+    }
+
+    #[test]
+    fn parse_object_returns_integer_for_i64_max() {
+        // 境界値: i64::MAX を表す入力で Integer(i64::MAX) を透過保持することを確認する
+        let mut p = parser(b"9223372036854775807");
+        assert_eq!(p.parse_object(), Ok(PdfObject::Integer(i64::MAX)));
+    }
+
+    #[test]
+    fn parse_object_returns_integer_for_i64_min() {
+        // 境界値: i64::MIN を表す入力で Integer(i64::MIN) を透過保持することを確認する
+        let mut p = parser(b"-9223372036854775808");
+        assert_eq!(p.parse_object(), Ok(PdfObject::Integer(i64::MIN)));
+    }
+
+    // ---------- 正常系: Real ----------
+
+    #[test]
+    fn parse_object_returns_real_for_decimal() {
+        // 入力 b"1.25" で Ok(PdfObject::Real(1.25)) を返すことを確認する
+        let mut p = parser(b"1.25");
+        assert_eq!(p.parse_object(), Ok(PdfObject::Real(1.25)));
+    }
+
+    #[test]
+    fn parse_object_returns_real_for_leading_dot() {
+        // 入力 b".5" で Ok(PdfObject::Real(0.5)) を返すことを確認する
+        let mut p = parser(b".5");
+        assert_eq!(p.parse_object(), Ok(PdfObject::Real(0.5)));
+    }
+
+    #[test]
+    fn parse_object_returns_real_for_trailing_dot() {
+        // 入力 b"5." で Ok(PdfObject::Real(5.0)) を返すことを確認する
+        let mut p = parser(b"5.");
+        assert_eq!(p.parse_object(), Ok(PdfObject::Real(5.0)));
+    }
+
+    // ---------- 内部ヘルパ: primitive_to_object（NaN / Inf 透過） ----------
+
+    #[test]
+    fn primitive_to_object_preserves_real_nan() {
+        // Primitive::Real(NaN) を内部ヘルパで変換すると PdfObject::Real(NaN) として保持されることを確認する
+        let obj = Parser::primitive_to_object(Primitive::Real(f64::NAN));
+        match obj {
+            PdfObject::Real(f) => assert!(f.is_nan()),
+            _ => panic!("expected Real(NaN), got {:?}", obj),
+        }
+    }
+
+    #[test]
+    fn primitive_to_object_preserves_real_positive_infinity() {
+        // Primitive::Real(+Inf) を内部ヘルパで変換すると PdfObject::Real(+Inf) として保持されることを確認する
+        let obj = Parser::primitive_to_object(Primitive::Real(f64::INFINITY));
+        match obj {
+            PdfObject::Real(f) => assert!(f.is_infinite() && f.is_sign_positive()),
+            _ => panic!("expected Real(+Inf), got {:?}", obj),
+        }
+    }
+
+    #[test]
+    fn primitive_to_object_preserves_real_negative_infinity() {
+        // Primitive::Real(-Inf) を内部ヘルパで変換すると PdfObject::Real(-Inf) として保持されることを確認する
+        let obj = Parser::primitive_to_object(Primitive::Real(f64::NEG_INFINITY));
+        match obj {
+            PdfObject::Real(f) => assert!(f.is_infinite() && f.is_sign_negative()),
+            _ => panic!("expected Real(-Inf), got {:?}", obj),
+        }
+    }
+
+    // ---------- 正常系: String（LiteralString / HexString → PdfObject::String） ----------
+
+    #[test]
+    fn parse_object_returns_string_for_literal_string() {
+        // 入力 b"(hello)" で Ok(PdfObject::String(b"hello".to_vec())) を返すことを確認する
+        let mut p = parser(b"(hello)");
+        assert_eq!(p.parse_object(), Ok(PdfObject::String(b"hello".to_vec())));
+    }
+
+    #[test]
+    fn parse_object_returns_empty_string_for_empty_literal() {
+        // 境界値: 入力 b"()" で空の String(Vec::new()) を返すことを確認する
+        let mut p = parser(b"()");
+        assert_eq!(p.parse_object(), Ok(PdfObject::String(Vec::new())));
+    }
+
+    #[test]
+    fn parse_object_returns_string_with_nul_byte_for_literal() {
+        // エッジ: NUL バイトを含むリテラル文字列を忠実に保持することを確認する
+        let mut p = parser(b"(a\0b)");
+        assert_eq!(
+            p.parse_object(),
+            Ok(PdfObject::String(vec![b'a', 0x00, b'b']))
+        );
+    }
+
+    #[test]
+    fn parse_object_returns_string_for_hex_string() {
+        // 入力 b"<48656C6C6F>" で Ok(PdfObject::String(b"Hello".to_vec())) を返すことを確認する
+        let mut p = parser(b"<48656C6C6F>");
+        assert_eq!(p.parse_object(), Ok(PdfObject::String(b"Hello".to_vec())));
+    }
+
+    #[test]
+    fn parse_object_returns_empty_string_for_empty_hex() {
+        // 境界値: 入力 b"<>" で空の String(Vec::new()) を返すことを確認する
+        let mut p = parser(b"<>");
+        assert_eq!(p.parse_object(), Ok(PdfObject::String(Vec::new())));
+    }
+
+    // ---------- 正常系: Name ----------
+
+    #[test]
+    fn parse_object_returns_name_for_simple_name() {
+        // 入力 b"/Type" で Ok(PdfObject::Name(PdfName::new("Type"))) を返すことを確認する
+        let mut p = parser(b"/Type");
+        assert_eq!(
+            p.parse_object(),
+            Ok(PdfObject::Name(PdfName::new(b"Type".to_vec())))
+        );
+    }
+
+    #[test]
+    fn parse_object_returns_empty_name_for_slash_only() {
+        // 境界値: 入力 b"/" で空の Name(PdfName::new(Vec::new())) を返すことを確認する
+        let mut p = parser(b"/");
+        assert_eq!(
+            p.parse_object(),
+            Ok(PdfObject::Name(PdfName::new(Vec::new())))
+        );
+    }
+
+    #[test]
+    fn parse_object_returns_name_with_hex_escape() {
+        // エッジ: #20 エスケープを含む /A#20B が lexer で解決された "A B" バイト列を Name として保持することを確認する
+        let mut p = parser(b"/A#20B");
+        assert_eq!(
+            p.parse_object(),
+            Ok(PdfObject::Name(PdfName::new(b"A B".to_vec())))
+        );
+    }
+
+    // ---------- 異常系: UnexpectedEof ----------
+
+    #[test]
+    fn parse_object_returns_unexpected_eof_for_empty_input() {
+        // 空入力で parse_object が UnexpectedEof を返すことを確認する
+        let mut p = parser(b"");
+        let err = p.parse_object().expect_err("empty input must error");
+        assert_eq!(err.kind, ParseErrorKind::UnexpectedEof);
+    }
+
+    #[test]
+    fn parse_object_returns_unexpected_eof_after_consuming_all_tokens() {
+        // 1 つ parse 成功した後の 2 回目で UnexpectedEof が返ることを確認する
+        let mut p = parser(b"42");
+        let _ = p.parse_object().expect("first call succeeds");
+        let err = p.parse_object().expect_err("second call must error");
+        assert_eq!(err.kind, ParseErrorKind::UnexpectedEof);
+    }
+
+    // ---------- 異常系: UnexpectedToken ----------
+
+    #[test]
+    fn parse_object_returns_unexpected_token_for_array_begin() {
+        // 入力 b"[" で UnexpectedToken { actual_kind: "ArrayBegin" } を返すことを確認する
+        let mut p = parser(b"[");
+        let err = p.parse_object().expect_err("array begin must error");
+        assert_eq!(
+            err.kind,
+            ParseErrorKind::UnexpectedToken {
+                actual_kind: "ArrayBegin"
+            }
+        );
+    }
+
+    #[test]
+    fn parse_object_returns_unexpected_token_for_array_end() {
+        // 入力 b"]" で UnexpectedToken { actual_kind: "ArrayEnd" } を返すことを確認する
+        let mut p = parser(b"]");
+        let err = p.parse_object().expect_err("array end must error");
+        assert_eq!(
+            err.kind,
+            ParseErrorKind::UnexpectedToken {
+                actual_kind: "ArrayEnd"
+            }
+        );
+    }
+
+    #[test]
+    fn parse_object_returns_unexpected_token_for_dict_begin() {
+        // 入力 b"<<" で UnexpectedToken { actual_kind: "DictBegin" } を返すことを確認する
+        let mut p = parser(b"<<");
+        let err = p.parse_object().expect_err("dict begin must error");
+        assert_eq!(
+            err.kind,
+            ParseErrorKind::UnexpectedToken {
+                actual_kind: "DictBegin"
+            }
+        );
+    }
+
+    #[test]
+    fn parse_object_returns_unexpected_token_for_dict_end() {
+        // 入力 b">>" で UnexpectedToken { actual_kind: "DictEnd" } を返すことを確認する
+        let mut p = parser(b">>");
+        let err = p.parse_object().expect_err("dict end must error");
+        assert_eq!(
+            err.kind,
+            ParseErrorKind::UnexpectedToken {
+                actual_kind: "DictEnd"
+            }
+        );
+    }
+
+    #[test]
+    fn parse_object_returns_unexpected_token_for_obj_begin() {
+        // 入力 b"obj" で UnexpectedToken { actual_kind: "ObjBegin" } を返すことを確認する
+        let mut p = parser(b"obj");
+        let err = p.parse_object().expect_err("obj begin must error");
+        assert_eq!(
+            err.kind,
+            ParseErrorKind::UnexpectedToken {
+                actual_kind: "ObjBegin"
+            }
+        );
+    }
+
+    #[test]
+    fn parse_object_returns_unexpected_token_for_obj_end() {
+        // 入力 b"endobj" で UnexpectedToken { actual_kind: "ObjEnd" } を返すことを確認する
+        let mut p = parser(b"endobj");
+        let err = p.parse_object().expect_err("obj end must error");
+        assert_eq!(
+            err.kind,
+            ParseErrorKind::UnexpectedToken {
+                actual_kind: "ObjEnd"
+            }
+        );
+    }
+
+    #[test]
+    fn parse_object_returns_unexpected_token_for_stream_begin() {
+        // 入力 b"stream" で UnexpectedToken { actual_kind: "StreamBegin" } を返すことを確認する
+        let mut p = parser(b"stream");
+        let err = p.parse_object().expect_err("stream begin must error");
+        assert_eq!(
+            err.kind,
+            ParseErrorKind::UnexpectedToken {
+                actual_kind: "StreamBegin"
+            }
+        );
+    }
+
+    #[test]
+    fn parse_object_returns_unexpected_token_for_stream_end() {
+        // 入力 b"endstream" で UnexpectedToken { actual_kind: "StreamEnd" } を返すことを確認する
+        let mut p = parser(b"endstream");
+        let err = p.parse_object().expect_err("stream end must error");
+        assert_eq!(
+            err.kind,
+            ParseErrorKind::UnexpectedToken {
+                actual_kind: "StreamEnd"
+            }
+        );
+    }
+
+    #[test]
+    fn parse_object_returns_unexpected_token_for_keyword_r() {
+        // 入力 b"R" で UnexpectedToken { actual_kind: "Keyword" } を返すことを確認する
+        let mut p = parser(b"R");
+        let err = p.parse_object().expect_err("keyword R must error");
+        assert_eq!(
+            err.kind,
+            ParseErrorKind::UnexpectedToken {
+                actual_kind: "Keyword"
+            }
+        );
+    }
+
+    // ---------- 異常系: LexerError ----------
+
+    #[test]
+    fn parse_object_returns_lexer_error_for_unterminated_hex() {
+        // 入力 b"<48656C"（閉じ '>' のない hex string）で LexerError と pos=0 を返すことを確認する
+        let mut p = parser(b"<48656C");
+        let err = p.parse_object().expect_err("unterminated hex must error");
+        assert_eq!(err.kind, ParseErrorKind::LexerError);
+        assert_eq!(err.position, ByteOffset::new(0));
+    }
+
+    // ---------- Comment 透過スキップ ----------
+
+    #[test]
+    fn parse_object_skips_single_comment_and_returns_following_scalar() {
+        // 入力 b"% comment\nnull" で先頭コメントを透過スキップし Ok(Null) を返すことを確認する
+        let mut p = parser(b"% comment\nnull");
+        assert_eq!(p.parse_object(), Ok(PdfObject::Null));
+    }
+
+    #[test]
+    fn parse_object_skips_multiple_consecutive_comments() {
+        // 入力 b"%a\n%b\n%c\ntrue" で 3 行の連続コメントを透過スキップし Ok(Boolean(true)) を返すことを確認する
+        let mut p = parser(b"%a\n%b\n%c\ntrue");
+        assert_eq!(p.parse_object(), Ok(PdfObject::Boolean(true)));
+    }
+
+    #[test]
+    fn parse_object_returns_unexpected_eof_after_only_comments() {
+        // 入力 b"% only comment\n" のように Comment しかない入力で最終的に UnexpectedEof を返すことを確認する
+        let mut p = parser(b"% only comment\n");
+        let err = p.parse_object().expect_err("comment-only input must error");
+        assert_eq!(err.kind, ParseErrorKind::UnexpectedEof);
+    }
+
+    // ---------- panic 不在 ----------
+
+    #[test]
+    fn parse_object_returns_unexpected_eof_for_nul_only_bytes() {
+        // NUL は whitespace 分類のため skip_whitespace で消費 → EOF → UnexpectedEof, position=3 で panic しないことを確認する
+        let mut p = parser(&[0x00, 0x00, 0x00]);
+        let err = p.parse_object().expect_err("nul-only input must error");
+        assert_eq!(err.kind, ParseErrorKind::UnexpectedEof);
+        assert_eq!(err.position, ByteOffset::new(3));
+    }
+
+    #[test]
+    fn parse_object_returns_unexpected_token_for_control_chars() {
+        // 制御文字（regular 分類）は read_keyword で Token::Keyword になり UnexpectedToken { "Keyword" } を返すことを確認する
+        let mut p = parser(&[0x01, 0x02, 0x07, 0x1F]);
+        let err = p
+            .parse_object()
+            .expect_err("control bytes must error as keyword");
+        assert_eq!(
+            err.kind,
+            ParseErrorKind::UnexpectedToken {
+                actual_kind: "Keyword"
+            }
+        );
+        assert_eq!(err.position, ByteOffset::new(0));
+    }
+
+    #[test]
+    fn parse_object_returns_unexpected_token_for_high_bytes() {
+        // 高位バイト（regular 分類）も Keyword 経路で UnexpectedToken { "Keyword" } を返すことを確認する
+        let mut p = parser(&[0xFF, 0xFE, 0xCA, 0xFE]);
+        let err = p
+            .parse_object()
+            .expect_err("high bytes must error as keyword");
+        assert_eq!(
+            err.kind,
+            ParseErrorKind::UnexpectedToken {
+                actual_kind: "Keyword"
+            }
+        );
+        assert_eq!(err.position, ByteOffset::new(0));
+    }
+}

--- a/rust/crates/core/src/parser/error.rs
+++ b/rust/crates/core/src/parser/error.rs
@@ -1,0 +1,143 @@
+//! parser モジュール専用のエラー型。
+//!
+//! 位置情報（[`ByteOffset`]）は全バリアントで必須。
+//! `actual_kind` は `&'static str` を採用し、`PartialEq`/`Eq` を簡潔に保つ。
+//! 将来的に公開境界では `From<ParseError> for PdfError` 経由で
+//! 上位エラー型に変換できるよう、構造はフラットに保つ。
+
+use crate::byte_offset::ByteOffset;
+
+/// パースエラーの種別。
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ParseErrorKind {
+    /// 入力が尽きた状態でオブジェクトを要求された。
+    UnexpectedEof,
+    /// スカラでないトークンが来た（配列開始・辞書開始・キーワード等）。
+    UnexpectedToken {
+        /// 受け取ったトークンを表す短い識別子。
+        /// 例: `"ArrayBegin"` / `"DictBegin"` / `"Keyword"` / `"ObjBegin"` 等。
+        actual_kind: &'static str,
+    },
+    /// lexer が `None` を返した（malformed input）。入力末端ではない場合に発生する。
+    LexerError,
+}
+
+/// パースエラー。位置情報を必須で保持する。
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ParseError {
+    /// エラーの種別と付随情報。
+    pub kind: ParseErrorKind,
+    /// エラー発生位置（バイトオフセット）。
+    pub position: ByteOffset,
+}
+
+impl ParseError {
+    /// 任意の `kind` + `position` でエラーを構築する。
+    pub fn new(kind: ParseErrorKind, position: ByteOffset) -> ParseError {
+        ParseError { kind, position }
+    }
+
+    /// [`ParseErrorKind::UnexpectedEof`] を指定位置で構築する便利コンストラクタ。
+    pub fn unexpected_eof_at(position: ByteOffset) -> ParseError {
+        ParseError {
+            kind: ParseErrorKind::UnexpectedEof,
+            position,
+        }
+    }
+
+    /// [`ParseErrorKind::UnexpectedToken`] を指定位置・トークン識別子で構築する便利コンストラクタ。
+    pub fn unexpected_token_at(position: ByteOffset, actual_kind: &'static str) -> ParseError {
+        ParseError {
+            kind: ParseErrorKind::UnexpectedToken { actual_kind },
+            position,
+        }
+    }
+
+    /// [`ParseErrorKind::LexerError`] を指定位置で構築する便利コンストラクタ。
+    pub fn lexer_error_at(position: ByteOffset) -> ParseError {
+        ParseError {
+            kind: ParseErrorKind::LexerError,
+            position,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn new_constructs_with_given_kind_and_position() {
+        // 任意の kind と position を渡して new で構築すると、両フィールドが透過保持されることを確認する
+        let err = ParseError::new(ParseErrorKind::UnexpectedEof, ByteOffset::new(7));
+        assert_eq!(err.kind, ParseErrorKind::UnexpectedEof);
+        assert_eq!(err.position, ByteOffset::new(7));
+    }
+
+    #[test]
+    fn unexpected_eof_at_constructs_unexpected_eof_kind() {
+        // unexpected_eof_at が UnexpectedEof バリアントを kind に持ち、position を保持することを確認する
+        let err = ParseError::unexpected_eof_at(ByteOffset::new(42));
+        assert_eq!(err.kind, ParseErrorKind::UnexpectedEof);
+        assert_eq!(err.position, ByteOffset::new(42));
+    }
+
+    #[test]
+    fn unexpected_token_at_constructs_with_actual_kind() {
+        // unexpected_token_at が UnexpectedToken { actual_kind } を保持し、position も透過することを確認する
+        let err = ParseError::unexpected_token_at(ByteOffset::new(3), "ArrayBegin");
+        assert_eq!(
+            err.kind,
+            ParseErrorKind::UnexpectedToken {
+                actual_kind: "ArrayBegin"
+            }
+        );
+        assert_eq!(err.position, ByteOffset::new(3));
+    }
+
+    #[test]
+    fn lexer_error_at_constructs_lexer_error_kind() {
+        // lexer_error_at が LexerError バリアントを kind に持ち、position も透過することを確認する
+        let err = ParseError::lexer_error_at(ByteOffset::new(5));
+        assert_eq!(err.kind, ParseErrorKind::LexerError);
+        assert_eq!(err.position, ByteOffset::new(5));
+    }
+
+    #[test]
+    fn position_can_be_zero() {
+        // position に 0 を指定した ParseError がそのまま保持されることを確認する
+        let err = ParseError::unexpected_eof_at(ByteOffset::new(0));
+        assert_eq!(err.position, ByteOffset::new(0));
+    }
+
+    #[test]
+    fn position_can_be_u64_max() {
+        // position に u64::MAX を指定した ParseError がそのまま保持されることを確認する
+        let err = ParseError::lexer_error_at(ByteOffset::new(u64::MAX));
+        assert_eq!(err.position, ByteOffset::new(u64::MAX));
+    }
+
+    #[test]
+    fn same_kind_and_position_are_equal() {
+        // 同じ kind と position で構築した 2 つの ParseError が PartialEq で == となることを確認する
+        let a = ParseError::unexpected_token_at(ByteOffset::new(10), "DictBegin");
+        let b = ParseError::unexpected_token_at(ByteOffset::new(10), "DictBegin");
+        assert_eq!(a, b);
+    }
+
+    #[test]
+    fn different_kind_are_not_equal() {
+        // 同位置でも kind が異なる UnexpectedEof と LexerError が != と判定されることを確認する
+        let eof = ParseError::unexpected_eof_at(ByteOffset::new(1));
+        let lex = ParseError::lexer_error_at(ByteOffset::new(1));
+        assert_ne!(eof, lex);
+    }
+
+    #[test]
+    fn different_actual_kind_are_not_equal() {
+        // UnexpectedToken の actual_kind が異なる 2 つが != と判定されることを確認する
+        let a = ParseError::unexpected_token_at(ByteOffset::new(0), "ArrayBegin");
+        let b = ParseError::unexpected_token_at(ByteOffset::new(0), "DictBegin");
+        assert_ne!(a, b);
+    }
+}


### PR DESCRIPTION
## 概要

`pdfmod-core` クレートに `parser` モジュールを新設し、lexer の `Token::Primitive` を ISO 32000-1 §7.3 のスカラ 7 種から `PdfObject` 6 種への意味付け変換を実装した。後続の配列・辞書・stream・間接参照パーサを載せる土台。

## 変更内容

### 🎯 変更の種類

- [x] ✨ 新機能 (New feature)

### 📝 詳細な変更内容

#### 追加された機能・修正

- `Parser<'a>` 構造体と `Parser::new` / `Parser::position` / `Parser::parse_object` を実装（`Lexer<'a>` をムーブ保持しカーソル管理を委譲、任意入力で panic 不在）
- `Token::Primitive` のスカラ 7 種（Null / Boolean / Integer / Real / LiteralString / HexString / Name）を `PdfObject` 6 種へ意味付け変換（`LiteralString` と `HexString` は `PdfObject::String` に統合、`Vec<u8>` / `PdfName` はムーブで流して clone ゼロ）
- `ParseError` / `ParseErrorKind`（`UnexpectedEof` / `UnexpectedToken { actual_kind: &'static str }` / `LexerError`）を新設し、`new` / `unexpected_eof_at` / `unexpected_token_at` / `lexer_error_at` の構築ヘルパを追加（位置 `ByteOffset` 必須）
- `Token::Comment` の透過スキップ、想定外トークン（`[` `]` `<<` `>>` `obj` `endobj` `stream` `endstream` `Keyword`）の一律 `UnexpectedToken` 化、`is_eof` 偽の `None` 返却に対する `LexerError` 分岐
- 単体テスト 51 件を追加（スカラ正常系・境界値・NaN/±Inf・panic 不在・コメントスキップ 3 パターン）

#### 変更されたファイル

- `rust/crates/core/src/lib.rs` — `pub mod parser;` 追記
- `rust/crates/core/src/parser.rs` — 新規（`Parser`, `parse_object`, ヘルパ）
- `rust/crates/core/src/parser/error.rs` — 新規（`ParseError`, `ParseErrorKind`）

#### 削除されたファイル・機能

なし。既存 API への破壊的変更もなし。

## 📊 システム図

### フロー図

\`\`\`mermaid
flowchart TD
    Start([parse_object]) --> Loop[next_token]
    Loop --> Some{Some?}
    Some -->|Some Comment| Loop
    Some -->|Some Primitive| Map[primitive_to_object]
    Some -->|Some その他| UT[ParseError::UnexpectedToken]:::new
    Some -->|None| Eof{is_eof?}
    Eof -->|true| EOF[ParseError::UnexpectedEof]:::new
    Eof -->|false| LE[ParseError::LexerError]:::new
    Map --> Ok([Ok PdfObject])
    UT --> Err([Err ParseError])
    EOF --> Err
    LE --> Err

    classDef new fill:#ffe4b5,stroke:#d97706,stroke-width:2px
\`\`\`

### データフロー

\`\`\`
&[u8] (入力バイト列)
  ↓
Parser<'a>   [NEW]
  └─ Lexer<'a>（ムーブ保持・カーソル委譲）
  ↓
Lexer::next_token() → Option<Token>
  ├─ Some(Comment)        → ループ継続
  ├─ Some(Primitive(p))   → primitive_to_object(p)  [NEW]
  │                          ├ Null/Boolean/Integer/Real → 同名バリアント
  │                          ├ LiteralString/HexString    → PdfObject::String (統合)
  │                          └ Name(PdfName)              → PdfObject::Name
  ├─ Some(その他)         → ParseError::UnexpectedToken { actual_kind }  [NEW]
  └─ None                 → is_eof() ? UnexpectedEof : LexerError        [NEW]
  ↓
Result<PdfObject, ParseError>
\`\`\`

## 📋 関連 Issue

- Refs #406

## 🧪 テスト

### テスト実行方法

\`\`\`bash
cd rust
cargo fmt --check
cargo clippy -p pdfmod-core --all-targets -- -D warnings
cargo test -p pdfmod-core
\`\`\`

### テスト項目

- [x] 単体テスト (Unit tests) — parser 51 件 + parser/error 9 件 = 60 件追加
- [x] 手動テスト (Manual testing) — `cargo build` / `cargo fmt --check` / `cargo clippy` / `cargo test` 全パス

### テスト結果

- `cargo fmt --check`: pass
- `cargo clippy -p pdfmod-core --all-targets -- -D warnings`: pass（警告ゼロ）
- `cargo test -p pdfmod-core`: **790 passed**（既存 739 + parser 新規 51、リグレッションなし）
- parser 配下に `.clone()` 0 件（grep 確認、`Vec<u8>` / `PdfName` はすべてムーブ）

カバレッジ:

| 区分 | 件数 | 主な観点 |
|------|------|---------|
| スカラ正常系 | 12 | Null / Boolean / Integer±/0 / Real（小数・先頭ドット・末尾ドット）/ LiteralString / HexString / Name |
| 境界値 | 8 | `i64::MIN` / `i64::MAX` / 空 String / 空 Name / `#XX` 含む Name / NUL 含む文字列 |
| NaN・Inf | 3 | `Primitive::Real(NaN)` / `+Inf` / `-Inf` の透過保持 |
| 異常系 | 13 | 9 種類の `UnexpectedToken`（`[` `]` `<<` `>>` `obj` `endobj` `stream` `endstream` `R`）+ EOF 2 種 + 未終端 hex の `LexerError` |
| Comment スキップ | 3 | 単一・連続・コメントのみ EOF |
| panic 不在 | 3 | NUL 列 / 制御文字 / 高位バイト |
| 状態管理 | 2 | 初期 `position == 0` / `parse_object` 後にカーソル前進 |
| ParseError API | 9 | `new` / 各 `_at` ヘルパ / 境界値（0・`u64::MAX`）/ 等価性 3 種 |

## 🔍 レビューポイント

- `Parser::parse_object` の `loop` 構造と `Token::Comment` 透過スキップ（A1 設計判断）
- `primitive_to_object` のムーブセマンティクス（`Vec<u8>` / `PdfName` の clone を回避）
- `ParseErrorKind::UnexpectedToken { actual_kind: &'static str }` の `'static str` 採用（`PartialEq` / `Eq` の簡潔保持と短い識別子のメリット）
- `LexerError` の判定条件（`next_token()` が `None` かつ `is_eof()` が偽 → malformed と分類、未終端 hex でテスト確認）
- `parser/error.rs` を別ファイルに最初から分割（`lexer.rs` の単一巨大ファイル問題を意図的に踏襲しない）

## ⚠️ 破壊的変更

- [ ] この変更は既存の API に破壊的変更を含みます

なし。`lib.rs` への `pub mod parser;` 1 行追加と新規ファイル 2 つのみで、既存 API は不変。

## 📚 追加情報

- 仕様: `docs/specs/01_lexical_conventions.md` / `docs/specs/09_implementation_guide.md`、ISO 32000-1:2008 §7.3
- 実装計画: `.plugin-workspace/.specs/073-parser-skeleton-scalar/implementation-plan.md`
- AI レビュー（Codex CLI）結果: `.plugin-workspace/.specs/073-parser-skeleton-scalar/code-review/review-001.md` — **問題なし**

### 注意事項

- `Primitive::Real(f64)` は NaN / ±Inf を透過保持する（`primitive_to_object` で追加検証なし）
- `LiteralString` と `HexString` は出自情報を落として `PdfObject::String` に統合（合意済み）
- 将来 `From<ParseError> for PdfError` で公開境界に流す余地を残してフラット構造を採用

🤖 Generated with [Claude Code](https://claude.com/claude-code)