### PR TITLE
♻️ [Refactoring]: StringArrayEx 抽出と inline-image handler のリファクタ

### DIFF
--- a/packages/core/src/__tests__/namespace-export.runtime.test.ts
+++ b/packages/core/src/__tests__/namespace-export.runtime.test.ts
@@ -27,6 +27,7 @@ import {
   parseTrailer,
   parseXRefTable,
   Result,
+  StringArrayEx,
   scanFallback,
   scanStartXRef,
   Tokenizer,
@@ -115,4 +116,12 @@ test("OperatorRegistry.registerでルート公開済みのAPIだけからoperato
     some: true,
     value: handler,
   });
+});
+
+test("StringArrayExがルートからexportされている", () => {
+  // firstMissing / containsAll / allMissing の 3 メソッドが root から
+  // 取り出せることを確認。runtime 露出の回帰防止。
+  expect(typeof StringArrayEx.firstMissing).toBe("function");
+  expect(typeof StringArrayEx.containsAll).toBe("function");
+  expect(typeof StringArrayEx.allMissing).toBe("function");
 });

--- a/packages/core/src/__tests__/namespace-export.type.test.ts
+++ b/packages/core/src/__tests__/namespace-export.type.test.ts
@@ -20,6 +20,7 @@ import {
   Option,
   PdfVersion,
   Result,
+  StringArrayEx,
 } from "../index";
 
 test("Result.okがランタイムで動作する", () => {
@@ -150,4 +151,32 @@ test("LoadOptions 型がルートから参照できる", () => {
 test("PdfDocumentLoadError 型がルートから参照できる", () => {
   const error: PdfDocumentLoadError = new RangeError("cacheCapacity");
   expect(error.message).toBe("cacheCapacity");
+});
+
+// IsExact: 型 A と B が完全一致するかをコンパイル時に判定するヘルパー。
+// 代入可能性ではなく型の完全一致を見るため、Option<string> から
+// Option<"Width" | "Height"> 等の narrower な型への変化も検出できる。
+type IsExact<A, B> =
+  (<T>() => T extends A ? 1 : 2) extends <T>() => T extends B ? 1 : 2
+    ? (<T>() => T extends B ? 1 : 2) extends <T>() => T extends A ? 1 : 2
+      ? true
+      : false
+    : false;
+type Assert<T extends true> = T;
+
+test("StringArrayEx.firstMissingがOption<string>を返す", () => {
+  // ジェネリクス化しない（Option<string> 固定）型回帰防止。
+  // 代入可能性ではなく完全一致で検証することで、将来の誤ったジェネリクス化を
+  // コンパイル時に検出する。
+  const missing = StringArrayEx.firstMissing(
+    ["Width"] as const,
+    ["Width", "Height"] as const,
+  );
+  // 型アサーションを値に落とすことで lint で「未使用型」と検出されないようにし、
+  // 同時にコンパイル時の型一致検証とランタイム expect の両方を兼ねる。
+  const returnTypeIsExactlyOptionString: Assert<
+    IsExact<typeof missing, Option.Option<string>>
+  > = true;
+  expect(returnTypeIsExactlyOptionString).toBe(true);
+  expect(missing).toEqual(Option.some("Height"));
 });

--- a/packages/core/src/content-stream/inline-image/handler/index.ts
+++ b/packages/core/src/content-stream/inline-image/handler/index.ts
@@ -1,3 +1,4 @@
+import { StringArrayEx } from "../../../ext/string-array/index";
 import type { PdfError } from "../../../pdf/errors/index";
 import type {
   TokenInlineImage,
@@ -68,12 +69,15 @@ export const inlineImageHandler = (
   const imageMask = isImageMaskTrue(normalized);
   const requiredKeys = imageMask ? REQUIRED_KEYS_MASK : REQUIRED_KEYS_NON_MASK;
 
-  const missing = findFirstMissingKey(normalized, requiredKeys);
-  if (missing !== undefined) {
+  const keys = normalized.map((e) => e.key.value);
+  const missing = StringArrayEx.firstMissing(keys, requiredKeys);
+  if (missing.some) {
+    // requiredKeys は as const 由来の RequiredKey 列なので、some に乗る値は必ず RequiredKey のいずれか
+    const missingKey = missing.value as RequiredKey;
     return err({
       code: "INLINE_IMAGE_REQUIRED_KEY_MISSING",
-      message: `Inline image is missing required key '${missing}'`,
-      missingKey: missing,
+      message: `Inline image is missing required key '${missingKey}'`,
+      missingKey,
       offset: token.offset,
     });
   }
@@ -99,20 +103,4 @@ function isImageMaskTrue(
     return false;
   }
   return first.type === TokenType.Boolean && first.value === true;
-}
-
-/**
- * 必須キー列を順に走査し、最初に欠落したキーを返す。すべて存在すれば undefined。
- */
-function findFirstMissingKey(
-  entries: ReadonlyArray<TokenInlineImageDictEntry>,
-  requiredKeys: ReadonlyArray<RequiredKey>,
-): RequiredKey | undefined {
-  for (const key of requiredKeys) {
-    const exists = entries.some((e) => e.key.value === key);
-    if (!exists) {
-      return key;
-    }
-  }
-  return undefined;
 }

--- a/packages/core/src/ext/string-array/__tests__/string-array.basic.test.ts
+++ b/packages/core/src/ext/string-array/__tests__/string-array.basic.test.ts
@@ -1,0 +1,130 @@
+import { expect, test } from "vitest";
+import { none, some } from "../../../utils/option/index";
+import { StringArrayEx } from "../index";
+
+// firstMissing: 必須キーが全て揃っているとき欠落なしを示す none を返すこと
+test("firstMissing: 全て揃っているとき none を返す", () => {
+  expect(
+    StringArrayEx.firstMissing(
+      ["Width", "Height", "BitsPerComponent", "ColorSpace"],
+      ["Width", "Height", "BitsPerComponent", "ColorSpace"],
+    ),
+  ).toBe(none);
+});
+
+// firstMissing: 先頭の必須キーが欠落しているとき走査順最初の欠落キーを返すこと
+test("firstMissing: 先頭の必須キーが欠落しているとき some(先頭キー) を返す", () => {
+  expect(
+    StringArrayEx.firstMissing(
+      ["Height", "BitsPerComponent", "ColorSpace"],
+      ["Width", "Height", "BitsPerComponent", "ColorSpace"],
+    ),
+  ).toStrictEqual(some("Width"));
+});
+
+// firstMissing: 中間の必須キーが欠落しているとき走査順最初の欠落キーを返すこと
+test("firstMissing: 中間の必須キーが欠落しているとき some(中間キー) を返す", () => {
+  expect(
+    StringArrayEx.firstMissing(
+      ["Width", "Height", "ColorSpace"],
+      ["Width", "Height", "BitsPerComponent", "ColorSpace"],
+    ),
+  ).toStrictEqual(some("BitsPerComponent"));
+});
+
+// firstMissing: 末尾の必須キーが欠落しているとき走査順最後の欠落キーを返すこと
+test("firstMissing: 末尾の必須キーが欠落しているとき some(末尾キー) を返す", () => {
+  expect(
+    StringArrayEx.firstMissing(
+      ["Width", "Height", "BitsPerComponent"],
+      ["Width", "Height", "BitsPerComponent", "ColorSpace"],
+    ),
+  ).toStrictEqual(some("ColorSpace"));
+});
+
+// firstMissing: 複数欠落しているとき requiredKeys の走査順で最初の欠落キーのみを返すこと
+test("firstMissing: 複数欠落しているとき requiredKeys 順で最初のキーを返す", () => {
+  expect(
+    StringArrayEx.firstMissing(
+      ["Height", "ColorSpace"],
+      ["Width", "Height", "BitsPerComponent", "ColorSpace"],
+    ),
+  ).toStrictEqual(some("Width"));
+});
+
+// containsAll: 必須キーが全て揃っているとき true を返すこと
+test("containsAll: 全て揃っているとき true を返す", () => {
+  expect(
+    StringArrayEx.containsAll(
+      ["Width", "Height", "BitsPerComponent", "ColorSpace"],
+      ["Width", "Height", "BitsPerComponent", "ColorSpace"],
+    ),
+  ).toBe(true);
+});
+
+// containsAll: 必須キーが 1 つ欠落しているとき false を返すこと
+test("containsAll: 1 つ欠落しているとき false を返す", () => {
+  expect(
+    StringArrayEx.containsAll(
+      ["Width", "Height", "BitsPerComponent"],
+      ["Width", "Height", "BitsPerComponent", "ColorSpace"],
+    ),
+  ).toBe(false);
+});
+
+// containsAll: 必須キーがすべて欠落しているとき false を返すこと
+test("containsAll: 全欠落のとき false を返す", () => {
+  expect(
+    StringArrayEx.containsAll(
+      [],
+      ["Width", "Height", "BitsPerComponent", "ColorSpace"],
+    ),
+  ).toBe(false);
+});
+
+// allMissing: 全て揃っているとき欠落なしを示す空配列を返すこと
+test("allMissing: 全て揃っているとき空配列を返す", () => {
+  expect(
+    StringArrayEx.allMissing(
+      ["Width", "Height", "BitsPerComponent", "ColorSpace"],
+      ["Width", "Height", "BitsPerComponent", "ColorSpace"],
+    ),
+  ).toEqual([]);
+});
+
+// allMissing: 単独欠落のとき該当キー 1 件のみを含む配列を返すこと
+test("allMissing: 単独欠落のとき該当キー 1 件の配列を返す", () => {
+  expect(
+    StringArrayEx.allMissing(
+      ["Width", "BitsPerComponent", "ColorSpace"],
+      ["Width", "Height", "BitsPerComponent", "ColorSpace"],
+    ),
+  ).toEqual(["Height"]);
+});
+
+// allMissing: 複数欠落のとき requiredKeys の走査順で欠落キー一覧を返すこと
+test("allMissing: 複数欠落のとき requiredKeys 順の配列を返す", () => {
+  expect(
+    StringArrayEx.allMissing(
+      ["Height", "ColorSpace"],
+      ["Width", "Height", "BitsPerComponent", "ColorSpace"],
+    ),
+  ).toEqual(["Width", "BitsPerComponent"]);
+});
+
+// 戻り値型: firstMissing が返す some の中身は string 型であること
+test("firstMissing: some の中身が string 型である", () => {
+  const result = StringArrayEx.firstMissing(["Width"], ["Width", "Height"]);
+  expect(result.some).toBe(true);
+  if (result.some) {
+    // value が文字列であることをランタイムで pin down する
+    expect(typeof result.value).toBe("string");
+    expect(result.value).toBe("Height");
+  }
+});
+
+// 戻り値型: firstMissing が none を返すときは utils/option の singleton と参照一致すること
+test("firstMissing: none は singleton（参照比較で一致）", () => {
+  const result = StringArrayEx.firstMissing(["Width"], ["Width"]);
+  expect(result).toBe(none);
+});

--- a/packages/core/src/ext/string-array/__tests__/string-array.edge.test.ts
+++ b/packages/core/src/ext/string-array/__tests__/string-array.edge.test.ts
@@ -1,0 +1,133 @@
+import { expect, test } from "vitest";
+import { none, some } from "../../../utils/option/index";
+import { StringArrayEx } from "../index";
+
+// 境界値: 両方が空配列のときは「欠落なし」を示す none を返すこと
+test("firstMissing: keys 空 + requiredKeys 空 のとき none を返す", () => {
+  expect(StringArrayEx.firstMissing([], [])).toBe(none);
+});
+
+// 境界値: requiredKeys が空ならば走査対象なしで none を返すこと
+test("firstMissing: keys 非空 + requiredKeys 空 のとき none を返す", () => {
+  expect(StringArrayEx.firstMissing(["Width", "Height"], [])).toBe(none);
+});
+
+// 境界値: keys が空かつ requiredKeys が非空なら走査順最初のキーが欠落として返ること
+test("firstMissing: keys 空 + requiredKeys 非空 のとき some(先頭) を返す", () => {
+  expect(StringArrayEx.firstMissing([], ["Width", "Height"])).toStrictEqual(
+    some("Width"),
+  );
+});
+
+// 境界値: containsAll は両者空のとき vacuous truth で true を返すこと
+test("containsAll: keys 空 + requiredKeys 空 のとき true を返す（vacuous truth）", () => {
+  expect(StringArrayEx.containsAll([], [])).toBe(true);
+});
+
+// 境界値: containsAll は requiredKeys が空なら keys の中身に関係なく true を返すこと
+test("containsAll: keys 非空 + requiredKeys 空 のとき true を返す", () => {
+  expect(StringArrayEx.containsAll(["Width"], [])).toBe(true);
+});
+
+// 境界値: allMissing は requiredKeys が空なら欠落なしで空配列を返すこと
+test("allMissing: requiredKeys 空 のとき空配列を返す", () => {
+  expect(StringArrayEx.allMissing(["Width"], [])).toEqual([]);
+});
+
+// keys 側重複: PDF dict は重複キーを許容する仕様だが、存在判定は重複に依存しないこと
+test("firstMissing: keys 側に重複があっても結果に影響しない", () => {
+  expect(
+    StringArrayEx.firstMissing(
+      ["Width", "Width", "Height"],
+      ["Width", "Height"],
+    ),
+  ).toBe(none);
+});
+
+// keys 側重複: containsAll も重複の有無に依らない充足判定であること
+test("containsAll: keys 側に重複があっても充足判定に影響しない", () => {
+  expect(
+    StringArrayEx.containsAll(
+      ["Width", "Width", "Height"],
+      ["Width", "Height"],
+    ),
+  ).toBe(true);
+});
+
+// keys 側重複: allMissing は keys 側の重複に依存しないこと
+test("allMissing: keys 側に重複があっても欠落一覧に影響しない", () => {
+  expect(
+    StringArrayEx.allMissing(["Width", "Width"], ["Width", "Height"]),
+  ).toEqual(["Height"]);
+});
+
+// requiredKeys 側重複: 走査順序通り最初の欠落が返ること
+test("firstMissing: requiredKeys 側に重複があるとき最初の欠落を返す", () => {
+  expect(
+    StringArrayEx.firstMissing(["Height"], ["Width", "Width", "Height"]),
+  ).toStrictEqual(some("Width"));
+});
+
+// requiredKeys 側重複: 重複指定があっても結果に重複は出ないこと
+test("containsAll: requiredKeys 側に重複があっても充足判定に影響しない", () => {
+  expect(StringArrayEx.containsAll(["Width"], ["Width", "Width"])).toBe(true);
+});
+
+// requiredKeys 側重複: allMissing は重複指定でも 1 件にデデュープすること
+test("allMissing: requiredKeys 側に重複があっても結果に重複を含めない", () => {
+  expect(StringArrayEx.allMissing([], ["Width", "Width"])).toEqual(["Width"]);
+});
+
+// 大文字小文字: includes による厳密一致のため別キー扱いになること
+test('firstMissing: "Width" と "width" は別キーとして扱う', () => {
+  expect(StringArrayEx.firstMissing(["width"], ["Width"])).toStrictEqual(
+    some("Width"),
+  );
+});
+
+// 大文字小文字: containsAll も大文字小文字差を欠落として扱うこと
+test("containsAll: 大文字小文字の不一致は欠落として扱う", () => {
+  expect(StringArrayEx.containsAll(["width"], ["Width"])).toBe(false);
+});
+
+// 多数キー: ナイーブ O(n·m) 実装でも 16+ 件の必須キーで正しく動くこと
+test("firstMissing: 16+ 件の必須キーでも線形走査で正しく動く", () => {
+  const requiredKeys = [
+    "K01",
+    "K02",
+    "K03",
+    "K04",
+    "K05",
+    "K06",
+    "K07",
+    "K08",
+    "K09",
+    "K10",
+    "K11",
+    "K12",
+    "K13",
+    "K14",
+    "K15",
+    "K16",
+    "K17",
+    "K18",
+  ];
+  // K17 のみ欠落させ、走査順で K17 が返ることを確認する
+  const keys = requiredKeys.filter((k) => k !== "K17");
+  expect(StringArrayEx.firstMissing(keys, requiredKeys)).toStrictEqual(
+    some("K17"),
+  );
+});
+
+// 不変性: 純関数として 1 回目の戻り値を mutate しても 2 回目の結果は独立した新規配列であること。
+// 戻り値型は ReadonlyArray<string> のため、テスト側で意図的に readonly を破ってから push する。
+test("allMissing: 戻り値を mutate しても次回呼び出しに影響しない", () => {
+  const first = StringArrayEx.allMissing(
+    ["Width"],
+    ["Width", "Height"],
+  ) as string[];
+  first.push("MUTATED");
+
+  const second = StringArrayEx.allMissing(["Width"], ["Width", "Height"]);
+  expect(second).toEqual(["Height"]);
+});

--- a/packages/core/src/ext/string-array/index.ts
+++ b/packages/core/src/ext/string-array/index.ts
@@ -55,6 +55,9 @@ export const StringArrayEx = {
     keys: ReadonlyArray<string>,
     requiredKeys: ReadonlyArray<string>,
   ): ReadonlyArray<string> => {
+    // 入力は PDF dict の必須キー列など数件〜十数件規模を想定するため、
+    // Set による重複排除や keys 側のハッシュ化は行わず、includes ベースの
+    // 素直な O(n·m) ナイーブ実装を維持する。
     const missing: string[] = [];
     for (const key of requiredKeys) {
       if (!keys.includes(key) && !missing.includes(key)) {

--- a/packages/core/src/ext/string-array/index.ts
+++ b/packages/core/src/ext/string-array/index.ts
@@ -1,0 +1,66 @@
+import type { Option } from "../../utils/option/index";
+import { none, some } from "../../utils/option/index";
+
+/** ReadonlyArray<string> に対する集合演算ユーティリティ。 */
+export const StringArrayEx = {
+  /**
+   * 必須キー列を順に走査し、入力に存在しない最初のキーを返す。
+   * 全て存在すれば none を返す。
+   *
+   * @param keys - 検査対象のキー名集合（重複可、順序は意味を持たない）
+   * @param requiredKeys - 必須キー名の列（走査順に意味あり）
+   * @returns 欠落キーがあれば some(欠落キー名)、全て揃っていれば none
+   */
+  firstMissing: (
+    keys: ReadonlyArray<string>,
+    requiredKeys: ReadonlyArray<string>,
+  ): Option<string> => {
+    for (const key of requiredKeys) {
+      if (!keys.includes(key)) {
+        return some(key);
+      }
+    }
+    return none;
+  },
+
+  /**
+   * 必須キー列が全て入力に含まれているかを判定する。
+   * requiredKeys が空配列なら true を返す（vacuous truth）。
+   *
+   * @param keys - 検査対象のキー名集合
+   * @param requiredKeys - 必須キー名の列
+   * @returns 全て含まれていれば true、1 つでも欠落していれば false
+   */
+  containsAll: (
+    keys: ReadonlyArray<string>,
+    requiredKeys: ReadonlyArray<string>,
+  ): boolean => {
+    for (const key of requiredKeys) {
+      if (!keys.includes(key)) {
+        return false;
+      }
+    }
+    return true;
+  },
+
+  /**
+   * 必須キー列のうち、入力に存在しないキーを全て返す。
+   * 順序は requiredKeys の出現順。requiredKeys 側に重複があっても結果に重複は出さない。
+   *
+   * @param keys - 検査対象のキー名集合
+   * @param requiredKeys - 必須キー名の列
+   * @returns 欠落キー名の配列（全て揃っていれば空配列）
+   */
+  allMissing: (
+    keys: ReadonlyArray<string>,
+    requiredKeys: ReadonlyArray<string>,
+  ): ReadonlyArray<string> => {
+    const missing: string[] = [];
+    for (const key of requiredKeys) {
+      if (!keys.includes(key) && !missing.includes(key)) {
+        missing.push(key);
+      }
+    }
+    return missing;
+  },
+} as const;

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -46,6 +46,7 @@ export {
   PdfTrapped,
 } from "./document/index";
 export { NumberEx } from "./ext/number/index";
+export { StringArrayEx } from "./ext/string-array/index";
 export { Tokenizer } from "./lexer/index";
 export type {
   ObjectResolver,


### PR DESCRIPTION
## 概要

inline-image handler に閉じていた必須キー存在検査 (`findFirstMissingKey`) を、`@pdfmod/core` の `StringArrayEx`（`ext/string-array`）名前空間オブジェクトへ抽出する。`NumberEx` / `StringEx` と同形式のヘルパーで、将来の dict 系トークン（XObject / Resources / Trailer 等）の必須キー検査でも再利用できる汎用基盤を整える。

handler の public シグネチャ・`Result` 構造・エラーコード `INLINE_IMAGE_REQUIRED_KEY_MISSING`・`missingKey` literal union は完全に不変で、既存 inline-image 関連テスト 30 ケース（handler 配下 10+9+11 + interpreter e2e 6）は**修正ゼロ**でパスする。

## 変更内容

### 🎯 変更の種類

- [x] ✨ 新機能 (`StringArrayEx` ヘルパー追加 + root export)
- [x] ♻️ リファクタリング (inline-image handler の private 関数を抽出)
- [x] 🚨 テスト追加 (basic 13 + edge 16 + namespace-export 2)

### 📝 詳細な変更内容

#### 追加されたファイル

- `packages/core/src/ext/string-array/index.ts` — `StringArrayEx`（`firstMissing` / `containsAll` / `allMissing`）
- `packages/core/src/ext/string-array/__tests__/string-array.basic.test.ts` — 基本動作 13 ケース
- `packages/core/src/ext/string-array/__tests__/string-array.edge.test.ts` — 空配列 / vacuous truth / 重複 / case-sensitive / 16+ 件 / 不変性 16 ケース

#### 変更されたファイル

- `packages/core/src/content-stream/inline-image/handler/index.ts` — private な `findFirstMissingKey` を削除し `StringArrayEx.firstMissing` 呼び出しに置換
- `packages/core/src/index.ts` — `export { StringArrayEx } from "./ext/string-array/index";` を `NumberEx` の近傍に追加（`utils/index.ts` barrel は経由しない）
- `packages/core/src/__tests__/namespace-export.runtime.test.ts` — `StringArrayEx` の 3 メソッドが root から runtime export されていることを pin down
- `packages/core/src/__tests__/namespace-export.type.test.ts` — `StringArrayEx.firstMissing` が `Option<string>` を返す型シグネチャを `IsExact` で pin down（ジェネリクス化への退行防止）

#### 削除された機能

- inline-image handler 内の private function `findFirstMissingKey`（grep 0 ヒットで完全削除確認）

## 📊 システム図

### リファクタ前後の呼び出しグラフ

```mermaid
flowchart LR
    subgraph Before["BEFORE: handler 内 private function"]
        H1[inlineImageHandler] --> N1[normalizeInlineImageDict]
        N1 --> M1[isImageMaskTrue]
        M1 --> F1[findFirstMissingKey<br/>handler private]
        F1 --> R1{missing?}
        R1 -->|yes| E1[err]
        R1 -->|no| O1[ok]
    end

    subgraph After["AFTER: 汎用ヘルパー経由"]
        H2[inlineImageHandler] --> N2[normalizeInlineImageDict]
        N2 --> M2[isImageMaskTrue]
        M2 --> K2[keys = normalized.map e.key.value]
        K2 --> SA[StringArrayEx.firstMissing<br/>ext/string-array]:::new
        SA --> R2{missing.some?}
        R2 -->|yes| E2[err with missing.value as RequiredKey]
        R2 -->|no| O2[ok]
    end

    classDef new fill:#ffe4b5,stroke:#d97706,stroke-width:2px
```

### データフロー

```
inlineImageHandler.input
        ↓
token: TokenInlineImage
        ↓
normalized: TokenInlineImageDictEntry[]   ← normalizeInlineImageDict()
        ↓
keys = normalized.map(e => e.key.value)    [NEW] string[] へ flatten
        ↓
StringArrayEx.firstMissing(keys, requiredKeys)   [NEW] 純粋関数
        ↓
missing: Option<string>
   ├─ some → err({ code: INLINE_IMAGE_REQUIRED_KEY_MISSING, missingKey, offset })
   └─ none → ok({ operandStack, graphicsStateStack })
```

## 📋 関連 Issue

- なし（implementation-plan.md に関連 Issue 番号の記載なし）

## 🧪 テスト

### テスト実行方法

```bash
pnpm --filter @pdfmod/core test
pnpm --filter @pdfmod/core test -- --coverage
pnpm --filter @pdfmod/core typecheck
pnpm --filter @pdfmod/core build
pnpm lint
```

### テスト項目

- [x] 単体テスト（`StringArrayEx` basic 13 + edge 16 = 29 ケース）
- [x] 統合テスト（inline-image handler 30 ケース修正ゼロでパス、interpreter inline-image e2e 6 ケース）
- [x] 型回帰テスト（`namespace-export.type.test.ts` で `Option<string>` 戻り値型を `IsExact` で pin down）
- [x] runtime 回帰テスト（`namespace-export.runtime.test.ts` で root export を pin down）

### テスト結果

- `pnpm --filter @pdfmod/core test`: **217 files / 2816 tests passed**（ベースライン +2 files / +31 tests）
- `StringArrayEx` カバレッジ: **line 100% / branch 100% / function 100%**
- `pnpm --filter @pdfmod/core typecheck`: 0 errors
- `pnpm lint`（biome + oxlint）: 0 warnings / 0 errors
- `pnpm --filter @pdfmod/core build`: 成功（`dist/index.{js,cjs,d.ts}` 全てに `StringArrayEx` を含む）
- `grep -rEn "findFirstMissingKey" packages/core/src`: 0 ヒット（private 定義完全削除確認）
- AI レビュー（Codex CLI）: **「問題なし」**（1 ラウンドで終了）

## 🔍 レビューポイント

- `StringArrayEx` の戻り値型は `Option<string>` / `boolean` / `ReadonlyArray<string>` 固定（D-8: ジェネリクス化しない）
- `RequiredKey` literal union への narrow は呼び出し側 (`missing.value as RequiredKey`) で実施（`requiredKeys` が `as const` 由来）
- 性能最適化（Set 化）は **要件 N-2 に従い禁止**。素直な O(n·m) ナイーブ実装を採用
- 公開 API は `NumberEx` と同じ named export 直接スタイル（`utils/index.ts` barrel を経由しない既存パターン踏襲）
- handler の error code / `missingKey` literal union は不変（既存 28+ テスト修正ゼロでパスすることが必達条件）

## ✅ チェックリスト

- [x] コードレビューの準備ができている
- [x] テストが正常に実行される（2816 全グリーン）
- [x] コミットメッセージが適切な形式で書かれている（3 コミットに分割）
- [x] セルフレビュー実施（Codex CLI で AI レビュー実施、指摘なし）
- [x] 破壊的変更なし（additive な公開 API 追加 + 内部リファクタのみ）