### PR TITLE
♻️ [Refactoring]: InlineImageDict コンパニオン拡張・利用箇所リファクタ

### DIFF
--- a/packages/core/src/__tests__/namespace-export.type.test.ts
+++ b/packages/core/src/__tests__/namespace-export.type.test.ts
@@ -164,19 +164,20 @@ type IsExact<A, B> =
     : false;
 type Assert<T extends true> = T;
 
-test("StringArrayEx.firstMissingがOption<string>を返す", () => {
-  // ジェネリクス化しない（Option<string> 固定）型回帰防止。
-  // 代入可能性ではなく完全一致で検証することで、将来の誤ったジェネリクス化を
-  // コンパイル時に検出する。
+test("StringArrayEx.firstMissingがrequiredKeysの要素型にnarrowされたOption<K>を返す", () => {
+  // firstMissing は <K extends string> でジェネリック化されており、
+  // requiredKeys の要素型 K に narrow された Option<K> を返す。
+  // 呼び出し側がリテラル union を持つ as const 配列を渡せば cast 依存なしで
+  // narrow された missing キーが得られる（handler 側の二重ロック型整合に利用）。
   const missing = StringArrayEx.firstMissing(
     ["Width"] as const,
     ["Width", "Height"] as const,
   );
   // 型アサーションを値に落とすことで lint で「未使用型」と検出されないようにし、
   // 同時にコンパイル時の型一致検証とランタイム expect の両方を兼ねる。
-  const returnTypeIsExactlyOptionString: Assert<
-    IsExact<typeof missing, Option.Option<string>>
+  const returnTypeIsExactlyOptionNarrowed: Assert<
+    IsExact<typeof missing, Option.Option<"Width" | "Height">>
   > = true;
-  expect(returnTypeIsExactlyOptionString).toBe(true);
+  expect(returnTypeIsExactlyOptionNarrowed).toBe(true);
   expect(missing).toEqual(Option.some("Height"));
 });

--- a/packages/core/src/content-stream/inline-image/handler/__tests__/handler.basic.test.ts
+++ b/packages/core/src/content-stream/inline-image/handler/__tests__/handler.basic.test.ts
@@ -9,6 +9,7 @@ import { ByteOffset } from "../../../../pdf/types/byte-offset/index";
 import { GraphicsStateStack } from "../../../graphics-state/index";
 import { OperandStack } from "../../../operand-stack/index";
 import type { OperatorHandlerContext } from "../../../operator-registry/index";
+import type { InlineImageDict } from "../../inline-image-dict/index";
 import { inlineImageHandler } from "../index";
 
 const buildEntry = (
@@ -32,7 +33,7 @@ const nameToken = (value: string): Token => ({
 });
 
 const buildInlineImageToken = (
-  entries: ReadonlyArray<TokenInlineImageDictEntry>,
+  entries: InlineImageDict,
   data: Uint8Array = new Uint8Array([]),
 ): TokenInlineImage => ({
   type: TokenType.InlineImage,
@@ -79,51 +80,6 @@ test("略号のみで揃った dict を受理する（W / H / BPC / CS）", () =
   expect(result.value.operandStack).toBe(context.operandStack);
 });
 
-test("混在パターン A: Width のみ完全名で受理する", () => {
-  // 先頭キー Width が完全名、残りは略号でも InlineImageDict.normalize 展開で通る
-  const token = buildInlineImageToken([
-    buildEntry("Width", integerToken(1)),
-    buildEntry("H", integerToken(1)),
-    buildEntry("BPC", integerToken(8)),
-    buildEntry("CS", nameToken("G")),
-  ]);
-  const context = buildContext();
-
-  const result = inlineImageHandler(context, token);
-
-  assert(result.ok);
-});
-
-test("混在パターン B: Width のみ略号で受理する", () => {
-  // 先頭キー W が略号、残りは完全名でも展開後に揃って通る
-  const token = buildInlineImageToken([
-    buildEntry("W", integerToken(1)),
-    buildEntry("Height", integerToken(1)),
-    buildEntry("BitsPerComponent", integerToken(8)),
-    buildEntry("ColorSpace", nameToken("DeviceGray")),
-  ]);
-  const context = buildContext();
-
-  const result = inlineImageHandler(context, token);
-
-  assert(result.ok);
-});
-
-test("混在パターン C: 前半完全名・後半略号で受理する", () => {
-  // 前半 Width/Height が完全名、後半 BPC/CS が略号でも通る
-  const token = buildInlineImageToken([
-    buildEntry("Width", integerToken(1)),
-    buildEntry("Height", integerToken(1)),
-    buildEntry("BPC", integerToken(8)),
-    buildEntry("CS", nameToken("G")),
-  ]);
-  const context = buildContext();
-
-  const result = inlineImageHandler(context, token);
-
-  assert(result.ok);
-});
-
 test("data が空 Uint8Array でも成功する", () => {
   // 本フェーズは data の中身を見ないため、長さ 0 でも検査は通る
   const token = buildInlineImageToken(
@@ -160,11 +116,13 @@ test("data が非空 Uint8Array でも成功する（中身は読まない）", 
   assert(result.ok);
 });
 
-test("成功時に operand stack の depth が変わらない", () => {
-  // InlineImage は operand を取らないため、事前に積んだ stack も影響を受けない
+test("成功時に operand stack と graphics state stack の参照を保持する", () => {
+  // InlineImage は operand を取らず graphics state も更新しないため、
+  // operand stack の depth と graphics state stack の current 参照がともに不変であることを 1 件で pin down
   const context = buildContext();
   OperandStack.push(context.operandStack, { type: "integer", value: 99 });
-  const before = OperandStack.depth(context.operandStack);
+  const beforeDepth = OperandStack.depth(context.operandStack);
+  const beforeCurrent = GraphicsStateStack.current(context.graphicsStateStack);
 
   const token = buildInlineImageToken([
     buildEntry("Width", integerToken(1)),
@@ -175,25 +133,9 @@ test("成功時に operand stack の depth が変わらない", () => {
   const result = inlineImageHandler(context, token);
 
   assert(result.ok);
-  expect(OperandStack.depth(result.value.operandStack)).toBe(before);
-});
-
-test("成功時に graphics state stack の current が同一参照", () => {
-  // graphics state は更新しないため current state も入力と同じ参照を返す
-  const context = buildContext();
-  const before = GraphicsStateStack.current(context.graphicsStateStack);
-
-  const token = buildInlineImageToken([
-    buildEntry("Width", integerToken(1)),
-    buildEntry("Height", integerToken(1)),
-    buildEntry("BitsPerComponent", integerToken(8)),
-    buildEntry("ColorSpace", nameToken("DeviceGray")),
-  ]);
-  const result = inlineImageHandler(context, token);
-
-  assert(result.ok);
+  expect(OperandStack.depth(result.value.operandStack)).toBe(beforeDepth);
   expect(GraphicsStateStack.current(result.value.graphicsStateStack)).toBe(
-    before,
+    beforeCurrent,
   );
 });
 

--- a/packages/core/src/content-stream/inline-image/handler/__tests__/handler.error.test.ts
+++ b/packages/core/src/content-stream/inline-image/handler/__tests__/handler.error.test.ts
@@ -13,6 +13,7 @@ import { ByteOffset } from "../../../../pdf/types/byte-offset/index";
 import { GraphicsStateStack } from "../../../graphics-state/index";
 import { OperandStack } from "../../../operand-stack/index";
 import type { OperatorHandlerContext } from "../../../operator-registry/index";
+import type { InlineImageDict } from "../../inline-image-dict/index";
 import { inlineImageHandler } from "../index";
 
 const TOKEN_OFFSET = ByteOffset.of(42);
@@ -37,9 +38,7 @@ const nameToken = (value: string): Token => ({
   offset: ByteOffset.of(0),
 });
 
-const buildToken = (
-  entries: ReadonlyArray<TokenInlineImageDictEntry>,
-): TokenInlineImage => ({
+const buildToken = (entries: InlineImageDict): TokenInlineImage => ({
   type: TokenType.InlineImage,
   dict: entries,
   data: new Uint8Array([]),
@@ -51,36 +50,11 @@ const buildContext = (): OperatorHandlerContext => ({
   graphicsStateStack: GraphicsStateStack.create(),
 });
 
-const fullEntries = (): TokenInlineImageDictEntry[] => [
-  buildEntry("Width", integerToken(1)),
-  buildEntry("Height", integerToken(1)),
-  buildEntry("BitsPerComponent", integerToken(8)),
-  buildEntry("ColorSpace", nameToken("DeviceGray")),
-];
-
-test.each<["Width" | "Height" | "BitsPerComponent" | "ColorSpace"]>([
-  ["Width"],
-  ["Height"],
-  ["BitsPerComponent"],
-  ["ColorSpace"],
-])("%s 欠落で INLINE_IMAGE_REQUIRED_KEY_MISSING を返す", (missingKey) => {
-  // 必須キー 4 種それぞれの単独欠落で対応する missingKey を持つ err が返る
-  const entries = fullEntries().filter((e) => e.key.value !== missingKey);
-  const token = buildToken(entries);
-
-  const result = inlineImageHandler(buildContext(), token);
-
-  assert(!result.ok);
-  expect(result.error.code).toBe("INLINE_IMAGE_REQUIRED_KEY_MISSING");
-  assert(result.error.code === "INLINE_IMAGE_REQUIRED_KEY_MISSING");
-  expect(result.error.missingKey).toBe(missingKey);
-  expect(result.error.offset).toBe(TOKEN_OFFSET);
-  expect(result.error.message).toContain(`'${missingKey}'`);
-});
-
-test("Width と Height の両方が欠落のとき最初に発見された Width を返す", () => {
-  // 検査順序は Width → Height → BitsPerComponent → ColorSpace。Width が先に検出される
+test("Width 欠落で err.code/missingKey/offset/message を載せる（err 生成と offset 伝搬の統合）", () => {
+  // 必須キー欠落バリエーションの網羅は dict 側 required-keys.test.ts に移植済み。
+  // ここでは handler 統合経路で err 生成・offset 伝搬・message 整形が動くことを 1 件 pin down する。
   const token = buildToken([
+    buildEntry("Height", integerToken(1)),
     buildEntry("BitsPerComponent", integerToken(8)),
     buildEntry("ColorSpace", nameToken("DeviceGray")),
   ]);
@@ -90,52 +64,8 @@ test("Width と Height の両方が欠落のとき最初に発見された Width
   assert(!result.ok);
   assert(result.error.code === "INLINE_IMAGE_REQUIRED_KEY_MISSING");
   expect(result.error.missingKey).toBe("Width");
-});
-
-test("Height のみ欠落で Height を返す", () => {
-  // 検査順序の 2 番目で初めて欠落するケース
-  const token = buildToken([
-    buildEntry("Width", integerToken(1)),
-    buildEntry("BitsPerComponent", integerToken(8)),
-    buildEntry("ColorSpace", nameToken("DeviceGray")),
-  ]);
-
-  const result = inlineImageHandler(buildContext(), token);
-
-  assert(!result.ok);
-  assert(result.error.code === "INLINE_IMAGE_REQUIRED_KEY_MISSING");
-  expect(result.error.missingKey).toBe("Height");
-});
-
-test("BitsPerComponent のみ欠落で BitsPerComponent を返す", () => {
-  // 検査順序の 3 番目で初めて欠落するケース
-  const token = buildToken([
-    buildEntry("Width", integerToken(1)),
-    buildEntry("Height", integerToken(1)),
-    buildEntry("ColorSpace", nameToken("DeviceGray")),
-  ]);
-
-  const result = inlineImageHandler(buildContext(), token);
-
-  assert(!result.ok);
-  assert(result.error.code === "INLINE_IMAGE_REQUIRED_KEY_MISSING");
-  expect(result.error.missingKey).toBe("BitsPerComponent");
-});
-
-test("エラーの offset は token.offset と一致する", () => {
-  // offset 伝搬: handler は token の開始位置をそのまま err に載せる
-  const token = buildToken([
-    buildEntry("Height", integerToken(1)),
-    buildEntry("BitsPerComponent", integerToken(8)),
-    buildEntry("ColorSpace", nameToken("DeviceGray")),
-  ]);
-
-  const result = inlineImageHandler(buildContext(), token);
-
-  assert(!result.ok);
-  expect(result.error.code).toBe("INLINE_IMAGE_REQUIRED_KEY_MISSING");
-  assert(result.error.code === "INLINE_IMAGE_REQUIRED_KEY_MISSING");
   expect(result.error.offset).toBe(TOKEN_OFFSET);
+  expect(result.error.message).toContain("'Width'");
 });
 
 test("エラーは PdfInlineImageRequiredKeyMissingError として narrow できる", () => {

--- a/packages/core/src/content-stream/inline-image/handler/__tests__/handler.image-mask.test.ts
+++ b/packages/core/src/content-stream/inline-image/handler/__tests__/handler.image-mask.test.ts
@@ -1,4 +1,4 @@
-import { assert, test } from "vitest";
+import { assert, expect, test } from "vitest";
 import type {
   Token,
   TokenInlineImage,
@@ -58,7 +58,8 @@ test("/ImageMask true + ColorSpace なしで成功する（stencil mask 例外�
 });
 
 test("/ImageMask false + ColorSpace なしで ColorSpace 欠落の err を返す（通常画像経路）", () => {
-  // imageMask=false に倒れて 4 必須キー集合に戻ることを統合経路で pin down
+  // imageMask=false に倒れて 4 必須キー集合に戻ることを統合経路で pin down。
+  // missingKey も明示的に検査し、handler の欠落キー判定が ColorSpace に倒れることをリグレッション検出可能にする。
   const token = buildToken([
     buildEntry("Width", integerToken(1)),
     buildEntry("Height", integerToken(1)),
@@ -70,6 +71,7 @@ test("/ImageMask false + ColorSpace なしで ColorSpace 欠落の err を返す
 
   assert(!result.ok);
   assert(result.error.code === "INLINE_IMAGE_REQUIRED_KEY_MISSING");
+  expect(result.error.missingKey).toBe("ColorSpace");
 });
 
 test("/IM true + /W /H の略号 dict で stencil mask 例外が成立する（略号→normalize→isImageMaskTrue→findMissingRequiredKey の完全鎖）", () => {

--- a/packages/core/src/content-stream/inline-image/handler/__tests__/handler.image-mask.test.ts
+++ b/packages/core/src/content-stream/inline-image/handler/__tests__/handler.image-mask.test.ts
@@ -1,4 +1,4 @@
-import { assert, expect, test } from "vitest";
+import { assert, test } from "vitest";
 import type {
   Token,
   TokenInlineImage,
@@ -9,6 +9,7 @@ import { ByteOffset } from "../../../../pdf/types/byte-offset/index";
 import { GraphicsStateStack } from "../../../graphics-state/index";
 import { OperandStack } from "../../../operand-stack/index";
 import type { OperatorHandlerContext } from "../../../operator-registry/index";
+import type { InlineImageDict } from "../../inline-image-dict/index";
 import { inlineImageHandler } from "../index";
 
 const buildEntry = (
@@ -31,15 +32,7 @@ const booleanToken = (value: boolean): Token => ({
   offset: ByteOffset.of(0),
 });
 
-const nameToken = (value: string): Token => ({
-  type: TokenType.Name,
-  value,
-  offset: ByteOffset.of(0),
-});
-
-const buildToken = (
-  entries: ReadonlyArray<TokenInlineImageDictEntry>,
-): TokenInlineImage => ({
+const buildToken = (entries: InlineImageDict): TokenInlineImage => ({
   type: TokenType.InlineImage,
   dict: entries,
   data: new Uint8Array([]),
@@ -51,26 +44,8 @@ const buildContext = (): OperatorHandlerContext => ({
   graphicsStateStack: GraphicsStateStack.create(),
 });
 
-const dimensions = (): TokenInlineImageDictEntry[] => [
-  buildEntry("Width", integerToken(1)),
-  buildEntry("Height", integerToken(1)),
-  buildEntry("BitsPerComponent", integerToken(1)),
-];
-
-test("/ImageMask true + ColorSpace なしで成功する（stencil mask 例外）", () => {
-  // PDF §8.9.6 で ImageMask=true のとき ColorSpace は不要
-  const token = buildToken([
-    ...dimensions(),
-    buildEntry("ImageMask", booleanToken(true)),
-  ]);
-
-  const result = inlineImageHandler(buildContext(), token);
-
-  assert(result.ok);
-});
-
-test("/ImageMask true + BitsPerComponent なしで成功する", () => {
-  // ISO 32000-1:2008 §8.9.5 Table 89: stencil mask では BPC も optional (default 1)
+test("/ImageMask true + ColorSpace なしで成功する（stencil mask 例外の統合）", () => {
+  // dict.normalize → dict.isImageMaskTrue → dict.findMissingRequiredKey の合流経路を最小ケースで pin down
   const token = buildToken([
     buildEntry("Width", integerToken(1)),
     buildEntry("Height", integerToken(1)),
@@ -82,127 +57,27 @@ test("/ImageMask true + BitsPerComponent なしで成功する", () => {
   assert(result.ok);
 });
 
-test("/IM true（略号）+ BitsPerComponent なし + ColorSpace なしで成功する", () => {
-  // stencil mask の最小構成: Width / Height / IM true のみで通る
+test("/ImageMask false + ColorSpace なしで ColorSpace 欠落の err を返す（通常画像経路）", () => {
+  // imageMask=false に倒れて 4 必須キー集合に戻ることを統合経路で pin down
   const token = buildToken([
-    buildEntry("Width", integerToken(8)),
-    buildEntry("Height", integerToken(8)),
-    buildEntry("IM", booleanToken(true)),
-  ]);
-
-  const result = inlineImageHandler(buildContext(), token);
-
-  assert(result.ok);
-});
-
-test("/IM true（略号）+ ColorSpace なしで成功する", () => {
-  // InlineImageDict.normalize が /IM → /ImageMask に展開するため stencil mask 例外が成立
-  const token = buildToken([
-    ...dimensions(),
-    buildEntry("IM", booleanToken(true)),
-  ]);
-
-  const result = inlineImageHandler(buildContext(), token);
-
-  assert(result.ok);
-});
-
-test("/ImageMask true でも ColorSpace を持つ dict を受理する", () => {
-  // 冗長な ColorSpace を含んでも検査は素通り（仕様外でも受理）
-  const token = buildToken([
-    ...dimensions(),
-    buildEntry("ImageMask", booleanToken(true)),
-    buildEntry("ColorSpace", nameToken("DeviceGray")),
-  ]);
-
-  const result = inlineImageHandler(buildContext(), token);
-
-  assert(result.ok);
-});
-
-test("/ImageMask false + ColorSpace なしで ColorSpace 欠落の err を返す", () => {
-  // 明示的に false の場合は通常の必須キー集合（ColorSpace 必須）に戻る
-  const token = buildToken([
-    ...dimensions(),
-    buildEntry("ImageMask", booleanToken(false)),
-  ]);
-
-  const result = inlineImageHandler(buildContext(), token);
-
-  assert(!result.ok);
-  assert(result.error.code === "INLINE_IMAGE_REQUIRED_KEY_MISSING");
-  expect(result.error.missingKey).toBe("ColorSpace");
-});
-
-test("/ImageMask が非 Boolean (Name) のとき ColorSpace 欠落で err を返す", () => {
-  // 不正型は false 扱い → ColorSpace 必須に戻る
-  const token = buildToken([
-    ...dimensions(),
-    buildEntry("ImageMask", nameToken("true")),
-  ]);
-
-  const result = inlineImageHandler(buildContext(), token);
-
-  assert(!result.ok);
-  assert(result.error.code === "INLINE_IMAGE_REQUIRED_KEY_MISSING");
-  expect(result.error.missingKey).toBe("ColorSpace");
-});
-
-test("/ImageMask が Boolean(false) のとき ColorSpace 必須に戻る", () => {
-  // value === true の厳密判定なので false でも当然 ColorSpace 必須
-  const token = buildToken([
-    ...dimensions(),
-    buildEntry("ImageMask", booleanToken(false)),
-    buildEntry("ColorSpace", nameToken("DeviceGray")),
-  ]);
-
-  const result = inlineImageHandler(buildContext(), token);
-
-  assert(result.ok);
-});
-
-test("/ImageMask true でも Width 欠落のときは Width を返す", () => {
-  // stencil mask 例外は ColorSpace のみをスキップする。他キーは依然必須
-  const token = buildToken([
+    buildEntry("Width", integerToken(1)),
     buildEntry("Height", integerToken(1)),
     buildEntry("BitsPerComponent", integerToken(1)),
-    buildEntry("ImageMask", booleanToken(true)),
-  ]);
-
-  const result = inlineImageHandler(buildContext(), token);
-
-  assert(!result.ok);
-  assert(result.error.code === "INLINE_IMAGE_REQUIRED_KEY_MISSING");
-  expect(result.error.missingKey).toBe("Width");
-});
-
-test("/ImageMask entry の value が空配列のとき false 扱いになり ColorSpace 必須", () => {
-  // isImageMaskTrue の undefined ガードを pin down
-  const token = buildToken([
-    ...dimensions(),
-    {
-      key: {
-        type: TokenType.Name,
-        value: "ImageMask",
-        offset: ByteOffset.of(0),
-      },
-      value: [],
-    },
-  ]);
-
-  const result = inlineImageHandler(buildContext(), token);
-
-  assert(!result.ok);
-  assert(result.error.code === "INLINE_IMAGE_REQUIRED_KEY_MISSING");
-  expect(result.error.missingKey).toBe("ColorSpace");
-});
-
-test("/ImageMask true と /ImageMask false 重複時は最初の true を採用する", () => {
-  // Array.find のセマンティクスを pin down: 仕様外 PDF への防御
-  const token = buildToken([
-    ...dimensions(),
-    buildEntry("ImageMask", booleanToken(true)),
     buildEntry("ImageMask", booleanToken(false)),
+  ]);
+
+  const result = inlineImageHandler(buildContext(), token);
+
+  assert(!result.ok);
+  assert(result.error.code === "INLINE_IMAGE_REQUIRED_KEY_MISSING");
+});
+
+test("/IM true + /W /H の略号 dict で stencil mask 例外が成立する（略号→normalize→isImageMaskTrue→findMissingRequiredKey の完全鎖）", () => {
+  // 略号入力が dict コンパニオン経由で完全鎖を辿り stencil mask 経路へ合流することを 1 件で pin down
+  const token = buildToken([
+    buildEntry("W", integerToken(8)),
+    buildEntry("H", integerToken(8)),
+    buildEntry("IM", booleanToken(true)),
   ]);
 
   const result = inlineImageHandler(buildContext(), token);

--- a/packages/core/src/content-stream/inline-image/handler/index.ts
+++ b/packages/core/src/content-stream/inline-image/handler/index.ts
@@ -1,51 +1,27 @@
-import { StringArrayEx } from "../../../ext/string-array/index";
-import type { PdfError } from "../../../pdf/errors/index";
 import type {
-  TokenInlineImage,
-  TokenInlineImageDictEntry,
-} from "../../../pdf/index";
-import { TokenType } from "../../../pdf/index";
+  PdfError,
+  PdfInlineImageRequiredKeyMissingError,
+} from "../../../pdf/errors/index";
+import type { TokenInlineImage } from "../../../pdf/index";
 import type { Result } from "../../../utils/result/index";
 import { err, ok } from "../../../utils/result/index";
 import type { OperatorHandlerContext } from "../../operator-registry/index";
 import { InlineImageDict } from "../inline-image-dict/index";
-
-/** ImageMask=false 時の必須キー列（検査順）。 */
-const REQUIRED_KEYS_NON_MASK = [
-  "Width",
-  "Height",
-  "BitsPerComponent",
-  "ColorSpace",
-] as const;
-
-/**
- * ImageMask=true 時の必須キー列。
- * ISO 32000-1:2008 §8.9.5 Table 89 における stencil mask の扱い:
- *   - BitsPerComponent: optional（不在時の default 値は 1）
- *   - ColorSpace: 禁止（仕様上 stencil mask では指定してはならない）
- * 本フェーズの handler は存在検査のみを行うため、CS が存在した場合も
- * 「禁止違反」としては弾かず（透過する）、後続フェーズでのバリデーション責務とする。
- */
-const REQUIRED_KEYS_MASK = ["Width", "Height"] as const;
-
-type RequiredKey = (typeof REQUIRED_KEYS_NON_MASK)[number];
 
 /**
  * PDF §8.9 InlineImage (`BI ... ID ... EI`) のハンドラ骨格。
  *
  * 検査順序（厳守）:
  *   (1) `InlineImageDict.normalize(token.dict)` で略号→完全名を展開
- *   (2) ImageMask の真偽判定（`TokenBoolean` かつ `value === true`）
- *   (3) 必須キー存在検査: Width → Height → BitsPerComponent → ColorSpace
- *       ImageMask=true（stencil mask）の場合、ISO 32000-1:2008 §8.9.5 Table 89 に従い:
- *         - BitsPerComponent は optional（不在時の default 値は 1）
- *         - ColorSpace は仕様上禁止（指定してはならない）。本フェーズの handler は存在
- *           検査のみのため、CS が存在しても禁止違反として弾かず透過する
+ *   (2) `InlineImageDict.isImageMaskTrue(normalized)` で ImageMask の真偽判定
+ *   (3) `InlineImageDict.findMissingRequiredKey(normalized, imageMask)` で必須キー検査
+ *       - imageMask=false: Width → Height → BitsPerComponent → ColorSpace
+ *       - imageMask=true (stencil mask): Width → Height のみ（BPC は optional / CS は仕様上禁止だが
+ *         本実装は禁止違反を検知しない）
  *
  * 重複キーの扱い:
- *   `TokenInlineImage.dict` は重複と順序を保持する `ReadonlyArray` 型である。本フェーズでは
- *   「最初に出現したエントリ」を採用する（`Array.prototype.find` / `some` のセマンティクスに従う）。
- *   ImageMask 判定も同じく最初の `/ImageMask` 系エントリのみを参照する。
+ *   `TokenInlineImage.dict` は重複と順序を保持する `ReadonlyArray` 型。本フェーズでは
+ *   「最初に出現したエントリ」を採用する（`InlineImageDict.isImageMaskTrue` のセマンティクス）。
  *
  * 本フェーズで行わないこと:
  *   - value 側の型検査（例: `/Width 16` の 16 が integer か否か）
@@ -66,14 +42,13 @@ export const inlineImageHandler = (
   token: TokenInlineImage,
 ): Result<OperatorHandlerContext, PdfError> => {
   const normalized = InlineImageDict.normalize(token.dict);
-  const imageMask = isImageMaskTrue(normalized);
-  const requiredKeys = imageMask ? REQUIRED_KEYS_MASK : REQUIRED_KEYS_NON_MASK;
-
-  const keys = normalized.map((e) => e.key.value);
-  const missing = StringArrayEx.firstMissing(keys, requiredKeys);
+  const imageMask = InlineImageDict.isImageMaskTrue(normalized);
+  const missing = InlineImageDict.findMissingRequiredKey(normalized, imageMask);
   if (missing.some) {
-    // requiredKeys は as const 由来の RequiredKey 列なので、some に乗る値は必ず RequiredKey のいずれか
-    const missingKey = missing.value as RequiredKey;
+    // dict 側 InlineImageRequiredKey と pdf/errors 側 PdfInlineImageRequiredKeyMissingError["missingKey"]
+    // の 2 union を変数代入で接続し、drift した瞬間に typecheck エラーで気付く二重ロックを構成する。
+    const missingKey: PdfInlineImageRequiredKeyMissingError["missingKey"] =
+      missing.value;
     return err({
       code: "INLINE_IMAGE_REQUIRED_KEY_MISSING",
       message: `Inline image is missing required key '${missingKey}'`,
@@ -87,20 +62,3 @@ export const inlineImageHandler = (
     graphicsStateStack: context.graphicsStateStack,
   });
 };
-
-/**
- * dict 内の最初の `/ImageMask` エントリが `TokenBoolean(true)` かを判定する。
- */
-function isImageMaskTrue(
-  entries: ReadonlyArray<TokenInlineImageDictEntry>,
-): boolean {
-  const entry = entries.find((e) => e.key.value === "ImageMask");
-  if (entry === undefined) {
-    return false;
-  }
-  const first = entry.value[0];
-  if (first === undefined) {
-    return false;
-  }
-  return first.type === TokenType.Boolean && first.value === true;
-}

--- a/packages/core/src/content-stream/inline-image/inline-image-dict/__tests__/inline-image-dict.basic.test.ts
+++ b/packages/core/src/content-stream/inline-image/inline-image-dict/__tests__/inline-image-dict.basic.test.ts
@@ -65,7 +65,7 @@ test("展開後の key.type は Name のまま", () => {
   expect(result[0]?.key.type).toBe(TokenType.Name);
 });
 
-test("スコープ境界: /CS の値配列に Name `RGB` があっても key のみ ColorSpace に展開され value は加工されない", () => {
+test("スコープ境界: normalize は /CS key のみ ColorSpace に展開し value は加工しない（値側展開は expandValueAbbrevs の責務）", () => {
   const value: ReadonlyArray<Token> = [
     { type: TokenType.Name, value: "RGB", offset: ByteOffset.of(3) },
   ];
@@ -82,7 +82,7 @@ test("スコープ境界: /CS の値配列に Name `RGB` があっても key の
   });
 });
 
-test("スコープ境界: /F の値配列に Name `Fl` があっても key のみ Filter に展開され value は加工されない", () => {
+test("スコープ境界: normalize は /F key のみ Filter に展開し value は加工しない（値側展開は expandValueAbbrevs の責務）", () => {
   const value: ReadonlyArray<Token> = [
     { type: TokenType.Name, value: "Fl", offset: ByteOffset.of(4) },
   ];

--- a/packages/core/src/content-stream/inline-image/inline-image-dict/__tests__/inline-image-dict.image-mask.test.ts
+++ b/packages/core/src/content-stream/inline-image/inline-image-dict/__tests__/inline-image-dict.image-mask.test.ts
@@ -1,0 +1,96 @@
+import { expect, test } from "vitest";
+import {
+  ByteOffset,
+  type Token,
+  type TokenInlineImageDictEntry,
+  TokenType,
+} from "../../../../pdf/index";
+import { InlineImageDict } from "../index";
+
+const makeEntry = (
+  key: string,
+  value: ReadonlyArray<Token>,
+): TokenInlineImageDictEntry => ({
+  key: { type: TokenType.Name, value: key, offset: ByteOffset.of(0) },
+  value,
+});
+
+const booleanToken = (value: boolean): Token => ({
+  type: TokenType.Boolean,
+  value,
+  offset: ByteOffset.of(0),
+});
+
+const nameToken = (value: string): Token => ({
+  type: TokenType.Name,
+  value,
+  offset: ByteOffset.of(0),
+});
+
+const integerToken = (value: number): Token => ({
+  type: TokenType.Integer,
+  value,
+  offset: ByteOffset.of(0),
+});
+
+test("/ImageMask Boolean(true) で true を返す", () => {
+  // 完全名 /ImageMask + value[0]=Boolean(true) が stencil mask 判定の基本ケース
+  const dict = [makeEntry("ImageMask", [booleanToken(true)])];
+
+  expect(InlineImageDict.isImageMaskTrue(dict)).toBe(true);
+});
+
+test("/ImageMask Boolean(false) で false を返す", () => {
+  // 厳密 === true 判定のため false は当然 false
+  const dict = [makeEntry("ImageMask", [booleanToken(false)])];
+
+  expect(InlineImageDict.isImageMaskTrue(dict)).toBe(false);
+});
+
+test("/ImageMask キーが存在しない dict で false を返す", () => {
+  // /ImageMask 不在は通常画像経路に倒す
+  const dict = [makeEntry("Width", [integerToken(1)])];
+
+  expect(InlineImageDict.isImageMaskTrue(dict)).toBe(false);
+});
+
+test("/ImageMask キーは存在するが value 配列が空のとき false を返す", () => {
+  // value[0] === undefined ガードを pin down
+  const dict = [makeEntry("ImageMask", [])];
+
+  expect(InlineImageDict.isImageMaskTrue(dict)).toBe(false);
+});
+
+test('/ImageMask の value[0] が Name("true") のとき false を返す', () => {
+  // 型一致のみ true を許容する。文字列 "true" は Boolean ではない
+  const dict = [makeEntry("ImageMask", [nameToken("true")])];
+
+  expect(InlineImageDict.isImageMaskTrue(dict)).toBe(false);
+});
+
+test("/ImageMask の value[0] が Integer(1) のとき false を返す", () => {
+  // 型一致のみ true を許容する。数値 1 は Boolean ではない
+  const dict = [makeEntry("ImageMask", [integerToken(1)])];
+
+  expect(InlineImageDict.isImageMaskTrue(dict)).toBe(false);
+});
+
+test("/ImageMask が複数あるとき最初の entry を採用する (true → false)", () => {
+  // Array.find のセマンティクスを pin down: 仕様外 PDF への防御
+  const dict = [
+    makeEntry("ImageMask", [booleanToken(true)]),
+    makeEntry("ImageMask", [booleanToken(false)]),
+  ];
+
+  expect(InlineImageDict.isImageMaskTrue(dict)).toBe(true);
+});
+
+test("/ImageMask が複数あるとき最初の entry を採用する (false → true)", () => {
+  // 最初が false なら以降に true があっても false で確定する
+  const dict = [
+    makeEntry("ImageMask", [booleanToken(false)]),
+    makeEntry("ImageMask", [booleanToken(true)]),
+  ];
+
+  expect(InlineImageDict.isImageMaskTrue(dict)).toBe(false);
+});

--- a/packages/core/src/content-stream/inline-image/inline-image-dict/__tests__/inline-image-dict.required-keys.test.ts
+++ b/packages/core/src/content-stream/inline-image/inline-image-dict/__tests__/inline-image-dict.required-keys.test.ts
@@ -1,0 +1,259 @@
+import { expect, test } from "vitest";
+import {
+  ByteOffset,
+  type Token,
+  type TokenInlineImageDictEntry,
+  TokenType,
+} from "../../../../pdf/index";
+import { InlineImageDict, type InlineImageRequiredKey } from "../index";
+
+const integerToken = (value: number): Token => ({
+  type: TokenType.Integer,
+  value,
+  offset: ByteOffset.of(0),
+});
+
+const nameToken = (value: string): Token => ({
+  type: TokenType.Name,
+  value,
+  offset: ByteOffset.of(0),
+});
+
+const makeEntry = (
+  key: string,
+  value: ReadonlyArray<Token> = [integerToken(1)],
+): TokenInlineImageDictEntry => ({
+  key: { type: TokenType.Name, value: key, offset: ByteOffset.of(0) },
+  value,
+});
+
+const fullDict = (): TokenInlineImageDictEntry[] => [
+  makeEntry("Width"),
+  makeEntry("Height"),
+  makeEntry("BitsPerComponent"),
+  makeEntry("ColorSpace", [nameToken("DeviceGray")]),
+];
+
+test("imageMask=false で必須 4 キーすべて完全名で揃っているとき none を返す", () => {
+  // 通常画像経路: Width/Height/BPC/ColorSpace の 4 キーがすべて存在
+  const result = InlineImageDict.findMissingRequiredKey(fullDict(), false);
+
+  expect(result.some).toBe(false);
+});
+
+test("imageMask=true で Width/Height のみ揃っているとき none を返す（stencil mask 最小集合）", () => {
+  // stencil mask 最小集合: Width/Height のみで十分。BPC を含まない最小ケース
+  const dict = [makeEntry("Width"), makeEntry("Height")];
+
+  const result = InlineImageDict.findMissingRequiredKey(dict, true);
+
+  expect(result.some).toBe(false);
+});
+
+test("BitsPerComponent は imageMask=true で optional、imageMask=false で必須（対比で BPC 扱い差分を pin down）", () => {
+  // ISO 32000-1:2008 §8.9.5 Table 89: stencil mask では BPC は optional (default 1)。
+  // 同じ dict [Width, Height] で imageMask フラグだけを切り替えると、
+  // - imageMask=true:  none（BPC は stencil で optional）
+  // - imageMask=false: some('BitsPerComponent')（通常画像で BPC は必須）
+  // 入力共有でフラグ差分のみが結果を変える対比により BPC の扱いそのものを単独 pin down する。
+  const dict = [makeEntry("Width"), makeEntry("Height")];
+
+  const stencil = InlineImageDict.findMissingRequiredKey(dict, true);
+  const normal = InlineImageDict.findMissingRequiredKey(dict, false);
+
+  expect(stencil.some).toBe(false);
+  expect(normal.some).toBe(true);
+  if (normal.some) {
+    expect(normal.value).toBe("BitsPerComponent");
+  }
+});
+
+test("imageMask=true で ColorSpace が dict に余分に含まれても none を返す（現実装の既存挙動）", () => {
+  // 仕様上は stencil mask で ColorSpace は禁止だが、本実装は禁止違反は検知しない
+  const dict = [
+    makeEntry("Width"),
+    makeEntry("Height"),
+    makeEntry("ColorSpace", [nameToken("DeviceGray")]),
+  ];
+
+  const result = InlineImageDict.findMissingRequiredKey(dict, true);
+
+  expect(result.some).toBe(false);
+});
+
+test.each<[InlineImageRequiredKey]>([
+  ["Width"],
+  ["Height"],
+  ["BitsPerComponent"],
+  ["ColorSpace"],
+])("imageMask=false で %s が単独欠落のとき some(%s) を返す", (missingKey) => {
+  // 必須 4 キーそれぞれを 1 つずつ欠いた 4 ケースで欠落キー検出を pin down
+  const dict = fullDict().filter((e) => e.key.value !== missingKey);
+
+  const result = InlineImageDict.findMissingRequiredKey(dict, false);
+
+  expect(result.some).toBe(true);
+  if (result.some) {
+    expect(result.value).toBe(missingKey);
+  }
+});
+
+test("imageMask=false で Width と Height が両方欠落のとき some('Width') を返す（先頭優先）", () => {
+  // 検査順序の決定性: Width → Height → BPC → ColorSpace で先頭が優先される
+  const dict = [
+    makeEntry("BitsPerComponent"),
+    makeEntry("ColorSpace", [nameToken("DeviceGray")]),
+  ];
+
+  const result = InlineImageDict.findMissingRequiredKey(dict, false);
+
+  expect(result.some).toBe(true);
+  if (result.some) {
+    expect(result.value).toBe("Width");
+  }
+});
+
+test("imageMask=false で Height のみ欠落のとき some('Height') を返す", () => {
+  // 検査順序の 2 番目で初めて欠落するケース
+  const dict = [
+    makeEntry("Width"),
+    makeEntry("BitsPerComponent"),
+    makeEntry("ColorSpace", [nameToken("DeviceGray")]),
+  ];
+
+  const result = InlineImageDict.findMissingRequiredKey(dict, false);
+
+  expect(result.some).toBe(true);
+  if (result.some) {
+    expect(result.value).toBe("Height");
+  }
+});
+
+test("imageMask=false で BitsPerComponent のみ欠落のとき some('BitsPerComponent') を返す", () => {
+  // 検査順序の 3 番目で初めて欠落するケース
+  const dict = [
+    makeEntry("Width"),
+    makeEntry("Height"),
+    makeEntry("ColorSpace", [nameToken("DeviceGray")]),
+  ];
+
+  const result = InlineImageDict.findMissingRequiredKey(dict, false);
+
+  expect(result.some).toBe(true);
+  if (result.some) {
+    expect(result.value).toBe("BitsPerComponent");
+  }
+});
+
+test("imageMask=true で Width が欠落のとき some('Width') を返す", () => {
+  // stencil mask 例外でも Width は依然必須
+  const dict = [makeEntry("Height")];
+
+  const result = InlineImageDict.findMissingRequiredKey(dict, true);
+
+  expect(result.some).toBe(true);
+  if (result.some) {
+    expect(result.value).toBe("Width");
+  }
+});
+
+test("imageMask=true で Height が欠落のとき some('Height') を返す", () => {
+  // stencil mask の Width 後に Height が検出される
+  const dict = [makeEntry("Width")];
+
+  const result = InlineImageDict.findMissingRequiredKey(dict, true);
+
+  expect(result.some).toBe(true);
+  if (result.some) {
+    expect(result.value).toBe("Height");
+  }
+});
+
+test("空 dict × imageMask=false で some('Width') を返す（先頭の必須キーから検査）", () => {
+  // 空入力でも検査順 1 番目の Width を返す
+  const result = InlineImageDict.findMissingRequiredKey([], false);
+
+  expect(result.some).toBe(true);
+  if (result.some) {
+    expect(result.value).toBe("Width");
+  }
+});
+
+test("空 dict × imageMask=true で some('Width') を返す", () => {
+  // stencil 経路でも先頭は Width
+  const result = InlineImageDict.findMissingRequiredKey([], true);
+
+  expect(result.some).toBe(true);
+  if (result.some) {
+    expect(result.value).toBe("Width");
+  }
+});
+
+test("略号のまま入力（normalize 未経由）すると some('Width') を返す（呼び出し前提の pin down）", () => {
+  // findMissingRequiredKey は完全名のみ知っているため略号 /W は欠落扱いになる
+  // 略号→完全名展開は normalize の責務であることを明示する
+  const dict = [
+    makeEntry("W"),
+    makeEntry("H"),
+    makeEntry("BPC"),
+    makeEntry("CS", [nameToken("G")]),
+  ];
+
+  const result = InlineImageDict.findMissingRequiredKey(dict, false);
+
+  expect(result.some).toBe(true);
+  if (result.some) {
+    expect(result.value).toBe("Width");
+  }
+});
+
+test("normalize 連鎖: 全略号 dict は完全名展開後に必須キー揃いと判定される", () => {
+  // 略号→ normalize → findMissingRequiredKey の鎖を dict 側でも 1 件 pin down
+  const dict = [
+    makeEntry("W"),
+    makeEntry("H"),
+    makeEntry("BPC"),
+    makeEntry("CS", [nameToken("G")]),
+  ];
+
+  const result = InlineImageDict.findMissingRequiredKey(
+    InlineImageDict.normalize(dict),
+    false,
+  );
+
+  expect(result.some).toBe(false);
+});
+
+test("normalize 連鎖: 混在パターン（完全名 W + 略号 H/BPC/CS）でも揃い", () => {
+  // 略号と完全名の混在を normalize が均すと findMissingRequiredKey は none を返す
+  const dict = [
+    makeEntry("Width"),
+    makeEntry("H"),
+    makeEntry("BPC"),
+    makeEntry("CS", [nameToken("G")]),
+  ];
+
+  const result = InlineImageDict.findMissingRequiredKey(
+    InlineImageDict.normalize(dict),
+    false,
+  );
+
+  expect(result.some).toBe(false);
+});
+
+test("normalize 連鎖: 混在パターン（完全名 Width + 略号 H + 完全名 BPC + 完全名 CS）でも揃い", () => {
+  // 完全名と略号が交互に並んでも normalize で展開され必須キーが揃う
+  const dict = [
+    makeEntry("Width"),
+    makeEntry("H"),
+    makeEntry("BitsPerComponent"),
+    makeEntry("ColorSpace", [nameToken("DeviceGray")]),
+  ];
+
+  const result = InlineImageDict.findMissingRequiredKey(
+    InlineImageDict.normalize(dict),
+    false,
+  );
+
+  expect(result.some).toBe(false);
+});

--- a/packages/core/src/content-stream/inline-image/inline-image-dict/__tests__/inline-image-dict.value-abbrev.test.ts
+++ b/packages/core/src/content-stream/inline-image/inline-image-dict/__tests__/inline-image-dict.value-abbrev.test.ts
@@ -63,7 +63,7 @@ test.each<[string, string]>([
   ["CMYK", "DeviceCMYK"],
   ["I", "Indexed"],
 ])("ColorSpace 略号 /%s は完全名 /%s に展開される", (abbrev, fullName) => {
-  // PDF §8.9.5.1 Table 89 の ColorSpace 値側略号 4 種を network 1 ケースずつ展開
+  // PDF §8.9.5.1 Table 89 の ColorSpace 値側略号 4 種をそれぞれ 1 ケースずつ展開
   const dict = [makeEntry("ColorSpace", [nameToken(abbrev)])];
 
   const result = InlineImageDict.expandValueAbbrevs(dict);

--- a/packages/core/src/content-stream/inline-image/inline-image-dict/__tests__/inline-image-dict.value-abbrev.test.ts
+++ b/packages/core/src/content-stream/inline-image/inline-image-dict/__tests__/inline-image-dict.value-abbrev.test.ts
@@ -1,0 +1,323 @@
+import { expect, test } from "vitest";
+import {
+  ByteOffset,
+  type Token,
+  type TokenInlineImageDictEntry,
+  TokenType,
+} from "../../../../pdf/index";
+import { InlineImageDict } from "../index";
+
+const nameToken = (value: string, offset = 0): Token => ({
+  type: TokenType.Name,
+  value,
+  offset: ByteOffset.of(offset),
+});
+
+const integerToken = (value: number): Token => ({
+  type: TokenType.Integer,
+  value,
+  offset: ByteOffset.of(0),
+});
+
+const booleanToken = (value: boolean): Token => ({
+  type: TokenType.Boolean,
+  value,
+  offset: ByteOffset.of(0),
+});
+
+const arrayBeginToken = (): Token => ({
+  type: TokenType.ArrayBegin,
+  value: "[",
+  offset: ByteOffset.of(0),
+});
+
+const arrayEndToken = (): Token => ({
+  type: TokenType.ArrayEnd,
+  value: "]",
+  offset: ByteOffset.of(0),
+});
+
+const dictBeginToken = (): Token => ({
+  type: TokenType.DictBegin,
+  value: "<<",
+  offset: ByteOffset.of(0),
+});
+
+const dictEndToken = (): Token => ({
+  type: TokenType.DictEnd,
+  value: ">>",
+  offset: ByteOffset.of(0),
+});
+
+const makeEntry = (
+  key: string,
+  value: ReadonlyArray<Token>,
+): TokenInlineImageDictEntry => ({
+  key: { type: TokenType.Name, value: key, offset: ByteOffset.of(0) },
+  value,
+});
+
+test.each<[string, string]>([
+  ["G", "DeviceGray"],
+  ["RGB", "DeviceRGB"],
+  ["CMYK", "DeviceCMYK"],
+  ["I", "Indexed"],
+])("ColorSpace 略号 /%s は完全名 /%s に展開される", (abbrev, fullName) => {
+  // PDF §8.9.5.1 Table 89 の ColorSpace 値側略号 4 種を network 1 ケースずつ展開
+  const dict = [makeEntry("ColorSpace", [nameToken(abbrev)])];
+
+  const result = InlineImageDict.expandValueAbbrevs(dict);
+
+  expect(result[0]?.value[0]).toEqual({
+    type: TokenType.Name,
+    value: fullName,
+    offset: ByteOffset.of(0),
+  });
+});
+
+test.each<[string, string]>([
+  ["AHx", "ASCIIHexDecode"],
+  ["A85", "ASCII85Decode"],
+  ["LZW", "LZWDecode"],
+  ["Fl", "FlateDecode"],
+  ["RL", "RunLengthDecode"],
+  ["CCF", "CCITTFaxDecode"],
+  ["DCT", "DCTDecode"],
+])("Filter 略号 /%s は完全名 /%s に展開される", (abbrev, fullName) => {
+  // PDF §8.9.5.1 Table 89 の Filter 値側略号 7 種を network 1 ケースずつ展開
+  const dict = [makeEntry("Filter", [nameToken(abbrev)])];
+
+  const result = InlineImageDict.expandValueAbbrevs(dict);
+
+  expect(result[0]?.value[0]).toEqual({
+    type: TokenType.Name,
+    value: fullName,
+    offset: ByteOffset.of(0),
+  });
+});
+
+test("ColorSpace entry に完全名 Name token を渡しても素通しする（同一参照）", () => {
+  // 既に完全名なら参照同一性を保ったまま素通し（最適化境界）
+  const value: ReadonlyArray<Token> = [nameToken("DeviceRGB")];
+  const dict = [makeEntry("ColorSpace", value)];
+
+  const result = InlineImageDict.expandValueAbbrevs(dict);
+
+  expect(result[0]?.value).toBe(value);
+  expect(result[0]).toBe(dict[0]);
+});
+
+test("ColorSpace entry に未知の Name token を渡しても素通しする（同一参照）", () => {
+  // テーブル未登録の名前は加工せず通す（hasOwn ガード）
+  const value: ReadonlyArray<Token> = [nameToken("Unknown")];
+  const dict = [makeEntry("ColorSpace", value)];
+
+  const result = InlineImageDict.expandValueAbbrevs(dict);
+
+  expect(result[0]?.value).toBe(value);
+});
+
+test("ColorSpace entry の value 配列が空のとき同一参照で素通しする", () => {
+  // 配列内置換ゼロ → value 同一参照 → entry 同一参照（4 階層ルール）
+  const value: ReadonlyArray<Token> = [];
+  const dict = [makeEntry("ColorSpace", value)];
+
+  const result = InlineImageDict.expandValueAbbrevs(dict);
+
+  expect(result[0]?.value).toBe(value);
+  expect(result[0]).toBe(dict[0]);
+});
+
+test("Filter entry の value 配列に複数 Name 略号があるとき各要素を展開する", () => {
+  // 配列フィルタ /Filter [/AHx /Fl] のケース
+  const dict = [makeEntry("Filter", [nameToken("AHx"), nameToken("Fl")])];
+
+  const result = InlineImageDict.expandValueAbbrevs(dict);
+
+  expect(result[0]?.value[0]).toEqual({
+    type: TokenType.Name,
+    value: "ASCIIHexDecode",
+    offset: ByteOffset.of(0),
+  });
+  expect(result[0]?.value[1]).toEqual({
+    type: TokenType.Name,
+    value: "FlateDecode",
+    offset: ByteOffset.of(0),
+  });
+});
+
+test("ColorSpace entry の value に Name 略号と Integer と未知 Name が混在するとき Name 略号のみ展開し他は同一参照で素通しする", () => {
+  // 4 階層参照同一性ルール（implementation-plan §「inline-image-dict コンパニオン本体」L264-267）の混在ケース最終確認:
+  // - value[0] Name("RGB"): hit → 新 TokenName(DeviceRGB)
+  // - value[1] Integer(1):  Name 以外 → 同一参照素通し
+  // - value[2] Name("Unknown"): table miss → 同一参照素通し（hasOwn ガード）
+  const intTok = integerToken(1);
+  const unknownTok = nameToken("Unknown");
+  const dict = [
+    makeEntry("ColorSpace", [nameToken("RGB"), intTok, unknownTok]),
+  ];
+
+  const result = InlineImageDict.expandValueAbbrevs(dict);
+
+  const value = result[0]?.value;
+  expect(value?.[0]).toEqual({
+    type: TokenType.Name,
+    value: "DeviceRGB",
+    offset: ByteOffset.of(0),
+  });
+  expect(value?.[1]).toBe(intTok);
+  expect(value?.[2]).toBe(unknownTok);
+});
+
+test("ColorSpace entry に Boolean token が現れたら素通しする", () => {
+  // 型不一致 token は走査対象外
+  const tok = booleanToken(true);
+  const dict = [makeEntry("ColorSpace", [tok])];
+
+  const result = InlineImageDict.expandValueAbbrevs(dict);
+
+  expect(result[0]?.value[0]).toBe(tok);
+});
+
+test("Filter entry に ArrayBegin / ArrayEnd token が含まれても再帰せず素通しする", () => {
+  // 配列 token は走査対象外（PDF §8.9.5.1 Table 89 は 1 階層の Name のみ）
+  const begin = arrayBeginToken();
+  const end = arrayEndToken();
+  const dict = [makeEntry("Filter", [begin, nameToken("Fl"), end])];
+
+  const result = InlineImageDict.expandValueAbbrevs(dict);
+
+  expect(result[0]?.value[0]).toBe(begin);
+  expect(result[0]?.value[1]).toEqual({
+    type: TokenType.Name,
+    value: "FlateDecode",
+    offset: ByteOffset.of(0),
+  });
+  expect(result[0]?.value[2]).toBe(end);
+});
+
+test("Filter entry に DictBegin / DictEnd token が含まれても再帰せず素通しする", () => {
+  // 辞書 token も走査対象外
+  const begin = dictBeginToken();
+  const end = dictEndToken();
+  const dict = [makeEntry("Filter", [begin, end])];
+
+  const result = InlineImageDict.expandValueAbbrevs(dict);
+
+  expect(result[0]?.value[0]).toBe(begin);
+  expect(result[0]?.value[1]).toBe(end);
+});
+
+test("ColorSpace entry value 先頭 (idx=0) で置換された Name の offset が元 token から継承される", () => {
+  // 置換後 TokenName.offset は元 Name token の offset
+  const dict = [makeEntry("ColorSpace", [nameToken("RGB", 17)])];
+
+  const result = InlineImageDict.expandValueAbbrevs(dict);
+
+  expect(result[0]?.value[0]?.offset).toBe(ByteOffset.of(17));
+});
+
+test("Filter entry value idx=2 で置換された Name の offset が元 token から継承される", () => {
+  // 配列内位置に依らず offset が伝搬する
+  const dict = [
+    makeEntry("Filter", [
+      nameToken("ASCII85Decode", 10),
+      nameToken("LZWDecode", 20),
+      nameToken("Fl", 30),
+    ]),
+  ];
+
+  const result = InlineImageDict.expandValueAbbrevs(dict);
+
+  expect(result[0]?.value[2]?.offset).toBe(ByteOffset.of(30));
+});
+
+test('key scoped: /Width entry の value 配列に Name("RGB") があっても展開せず entry 同一参照で素通しする', () => {
+  // ColorSpace / Filter 以外の key は value を一切走査しない（同一参照）
+  const value: ReadonlyArray<Token> = [nameToken("RGB"), nameToken("AHx")];
+  const entry = makeEntry("Width", value);
+  const dict = [entry];
+
+  const result = InlineImageDict.expandValueAbbrevs(dict);
+
+  expect(result[0]).toBe(entry);
+  expect(result[0]?.value).toBe(value);
+});
+
+test('key scoped: /Interpolate entry の value に Name("I") があっても展開しない', () => {
+  // CS テーブルに I→Indexed が定義されているが、key が /Interpolate の場合は対象外
+  const value: ReadonlyArray<Token> = [nameToken("I")];
+  const entry = makeEntry("Interpolate", value);
+  const dict = [entry];
+
+  const result = InlineImageDict.expandValueAbbrevs(dict);
+
+  expect(result[0]).toBe(entry);
+  expect(result[0]?.value).toBe(value);
+});
+
+test("入力 dict / entry / value 配列を破壊しない（非破壊保証）", () => {
+  // normalize と同じ pin down 観点: 入力は不変
+  const value: ReadonlyArray<Token> = [nameToken("RGB")];
+  const entry = makeEntry("ColorSpace", value);
+  const dict = [entry];
+  const snapshotDict = [...dict];
+  const snapshotEntry = { key: entry.key, value: [...entry.value] };
+
+  InlineImageDict.expandValueAbbrevs(dict);
+
+  expect(dict).toEqual(snapshotDict);
+  expect(entry.key).toBe(snapshotEntry.key);
+  expect(entry.value).toEqual(snapshotEntry.value);
+});
+
+test("トップレベル dict は常に新配列（参照同一性の境界）", () => {
+  // normalize と同じセマンティクス: dict.map により必ず新配列
+  const dict = [makeEntry("Width", [integerToken(1)])];
+
+  const result = InlineImageDict.expandValueAbbrevs(dict);
+
+  expect(result).not.toBe(dict);
+});
+
+test("4 階層ルール 0 置換: ColorSpace 全 token が未知/完全名のみで entry 同一参照", () => {
+  // 配列内置換ゼロ → value 同一参照 → entry 同一参照
+  const value: ReadonlyArray<Token> = [
+    nameToken("DeviceRGB"),
+    nameToken("Unknown"),
+  ];
+  const entry = makeEntry("ColorSpace", value);
+  const dict = [entry];
+
+  const result = InlineImageDict.expandValueAbbrevs(dict);
+
+  expect(result[0]).toBe(entry);
+  expect(result[0]?.value).toBe(value);
+});
+
+test("4 階層ルール 1 置換: ColorSpace value 内 1 token のみ略号で entry 新規・非対象 token 同一参照", () => {
+  // 配列内置換あり → entry 新規・value 新配列だが、置換しなかった token は同一参照を維持
+  const passthrough = nameToken("DeviceRGB");
+  const entry = makeEntry("ColorSpace", [nameToken("RGB"), passthrough]);
+  const dict = [entry];
+
+  const result = InlineImageDict.expandValueAbbrevs(dict);
+
+  expect(result[0]).not.toBe(entry);
+  expect(result[0]?.value).not.toBe(entry.value);
+  expect(result[0]?.value[0]).not.toBe(entry.value[0]);
+  expect(result[0]?.value[1]).toBe(passthrough);
+});
+
+test("4 階層ルール 全置換: Filter value の全要素が略号で各 token が新規", () => {
+  // 全 token 置換のとき entry / value / 各 token がすべて新規参照
+  const entry = makeEntry("Filter", [nameToken("AHx"), nameToken("Fl")]);
+  const dict = [entry];
+
+  const result = InlineImageDict.expandValueAbbrevs(dict);
+
+  expect(result[0]).not.toBe(entry);
+  expect(result[0]?.value).not.toBe(entry.value);
+  expect(result[0]?.value[0]).not.toBe(entry.value[0]);
+  expect(result[0]?.value[1]).not.toBe(entry.value[1]);
+});

--- a/packages/core/src/content-stream/inline-image/inline-image-dict/__tests__/inline-image-dict.value-abbrev.test.ts
+++ b/packages/core/src/content-stream/inline-image/inline-image-dict/__tests__/inline-image-dict.value-abbrev.test.ts
@@ -84,7 +84,7 @@ test.each<[string, string]>([
   ["CCF", "CCITTFaxDecode"],
   ["DCT", "DCTDecode"],
 ])("Filter 略号 /%s は完全名 /%s に展開される", (abbrev, fullName) => {
-  // PDF §8.9.5.1 Table 89 の Filter 値側略号 7 種を network 1 ケースずつ展開
+  // PDF §8.9.5.1 Table 89 の Filter 値側略号 7 種をそれぞれ 1 ケースずつ展開
   const dict = [makeEntry("Filter", [nameToken(abbrev)])];
 
   const result = InlineImageDict.expandValueAbbrevs(dict);

--- a/packages/core/src/content-stream/inline-image/inline-image-dict/index.ts
+++ b/packages/core/src/content-stream/inline-image/inline-image-dict/index.ts
@@ -1,11 +1,55 @@
-import type { TokenInlineImageDictEntry, TokenName } from "../../../pdf/index";
+import type {
+  Token,
+  TokenInlineImageDictEntry,
+  TokenName,
+} from "../../../pdf/index";
 import { TokenType } from "../../../pdf/index";
+import type { Option } from "../../../utils/option/index";
+import { none, some } from "../../../utils/option/index";
 
 /**
  * PDF §8.9.5.1 で定義される **インラインイメージ辞書** の正規化前/後の値域。
  * `BI` と `ID` の間に出現するキー/値ペア列を表す。
  */
 export type InlineImageDict = ReadonlyArray<TokenInlineImageDictEntry>;
+
+/**
+ * PDF §8.9.5.1 Table 89 で定義される必須キー（imageMask=false 時の検査順）。
+ * `findMissingRequiredKey` の検査ループと、戻り値のリテラル union 派生元を兼ねる。
+ */
+const REQUIRED_KEYS_NON_MASK = [
+  "Width",
+  "Height",
+  "BitsPerComponent",
+  "ColorSpace",
+] as const;
+
+/**
+ * stencil mask（ImageMask=true）時の必須キー列。
+ * - BitsPerComponent: optional（不在時の default 値は 1）
+ * - ColorSpace: 仕様上禁止（指定してはならない）。現実装は禁止違反を検知しない
+ */
+const REQUIRED_KEYS_MASK = ["Width", "Height"] as const;
+
+/**
+ * インラインイメージ辞書の必須キー名のリテラル union。
+ *
+ * `REQUIRED_KEYS_NON_MASK` が `REQUIRED_KEYS_MASK` の上位集合なので NON_MASK から派生で十分。
+ * `findMissingRequiredKey` の戻り値型を narrow するために export し、
+ * handler 側は `PdfInlineImageRequiredKeyMissingError["missingKey"]` 型変数への代入で
+ * コンパイル時に型整合（dict 側と pdf/errors 側の二重ロック）を検査できる。
+ */
+export type InlineImageRequiredKey = (typeof REQUIRED_KEYS_NON_MASK)[number];
+
+/**
+ * dict 内で最初に出現する指定キーの entry を返す module-private ヘルパ。
+ * `isImageMaskTrue` から利用する。重複キーは最初の entry のみ採用する仕様外 PDF 防御。
+ */
+const findFirstEntry = (
+  dict: InlineImageDict,
+  key: string,
+): TokenInlineImageDictEntry | undefined =>
+  dict.find((entry) => entry.key.value === key);
 
 /**
  * PDF §8.9.5.1 Table 89 で定義されるインラインイメージ辞書の略号 → 完全名対応表。
@@ -17,7 +61,7 @@ export type InlineImageDict = ReadonlyArray<TokenInlineImageDictEntry>;
  * 値型を `Partial<Record<string, string>>` で表現することで、未登録キーへの
  * インデックスアクセスが `string | undefined` を返す（型上の正直さ）。
  */
-const INLINE_IMAGE_DICT_ABBREVIATIONS: Partial<Record<string, string>> = {
+const INLINE_IMAGE_DICT_KEY_ABBREVIATIONS: Partial<Record<string, string>> = {
   W: "Width",
   H: "Height",
   BPC: "BitsPerComponent",
@@ -30,11 +74,100 @@ const INLINE_IMAGE_DICT_ABBREVIATIONS: Partial<Record<string, string>> = {
 };
 
 /**
+ * PDF §8.9.5.1 Table 89 で定義される ColorSpace の値側略号 → 完全名対応表。
+ *
+ * `/ColorSpace` entry の value 配列内 Name token のみに適用する key scoped テーブル。
+ * `expandValueAbbrevs` から消費する。`Object.hasOwn` ガード前提のため
+ * 値型を `Partial<Record<string, string>>` で表現する。
+ */
+const INLINE_IMAGE_DICT_VALUE_COLORSPACE_ABBREVIATIONS: Partial<
+  Record<string, string>
+> = {
+  G: "DeviceGray",
+  RGB: "DeviceRGB",
+  CMYK: "DeviceCMYK",
+  I: "Indexed",
+};
+
+/**
+ * PDF §8.9.5.1 Table 89 で定義される Filter の値側略号 → 完全名対応表。
+ *
+ * `/Filter` entry の value 配列内 Name token のみに適用する key scoped テーブル。
+ */
+const INLINE_IMAGE_DICT_VALUE_FILTER_ABBREVIATIONS: Partial<
+  Record<string, string>
+> = {
+  AHx: "ASCIIHexDecode",
+  A85: "ASCII85Decode",
+  LZW: "LZWDecode",
+  Fl: "FlateDecode",
+  RL: "RunLengthDecode",
+  CCF: "CCITTFaxDecode",
+  DCT: "DCTDecode",
+};
+
+/**
+ * Name token を指定テーブルで完全名に展開する module-private ヘルパ。
+ *
+ * - Name 以外の token はそのまま素通し（参照同一）。
+ * - テーブルに hit しない Name token もそのまま素通し（参照同一）。
+ * - hit した Name token は新 `TokenName` で置換する。`offset` は元 token を継承し
+ *   後続フェーズのエラー位置情報として活用できるようにする。
+ */
+const expandIfAbbrevName = (
+  token: Token,
+  table: Partial<Record<string, string>>,
+): Token => {
+  if (token.type !== TokenType.Name) {
+    return token;
+  }
+  const expanded = Object.hasOwn(table, token.value)
+    ? table[token.value]
+    : undefined;
+  if (expanded === undefined) {
+    return token;
+  }
+  const next: TokenName = {
+    type: TokenType.Name,
+    value: expanded,
+    offset: token.offset,
+  };
+  return next;
+};
+
+/**
+ * 値配列 (`ReadonlyArray<Token>`) 内の Name token を指定テーブルで展開する。
+ *
+ * 4 階層参照同一性ルールの value 階層を担う。
+ * - 配列内置換ゼロ → 入力配列を同一参照で返す（呼び出し側で entry も同一参照に倒せる）
+ * - 配列内置換あり → 新配列を生成し、非対象 token は同一参照、置換対象は新 token
+ */
+const expandValueArray = (
+  value: ReadonlyArray<Token>,
+  table: Partial<Record<string, string>>,
+): ReadonlyArray<Token> => {
+  let mutated = false;
+  const next: Token[] = [];
+  for (const original of value) {
+    const replaced = expandIfAbbrevName(original, table);
+    if (replaced !== original) {
+      mutated = true;
+    }
+    next.push(replaced);
+  }
+  return mutated ? next : value;
+};
+
+/**
  * インラインイメージ辞書 (`InlineImageDict`) に対する純粋関数を束ねる
  * ドメイン特化コンパニオン。
  *
- * 現状は `normalize`（略号→完全名展開）のみを公開する。
- * 将来 `expandValueAbbrevs`（値側 alias 展開）等を集約する余地を残す。
+ * 公開メソッド:
+ *   - `normalize`               キー側略号 → 完全名への展開
+ *   - `isImageMaskTrue`         `/ImageMask` Boolean(true) 判定
+ *   - `findMissingRequiredKey`  必須キー欠落検査（imageMask フラグ別）
+ *   - `expandValueAbbrevs`      `/ColorSpace` / `/Filter` の値側略号 → 完全名展開
+ *
  * 画像そのもの（width / height 等の高レベル API）は別ドメインの InlineImage
  * コンパニオン（`inline-image/inline-image/index.ts` 等）として将来切り出す。
  */
@@ -48,7 +181,7 @@ export const InlineImageDict = {
    * - 略号テーブルに miss したキー（完全名・未知キー・空文字）は元エントリをそのまま通す。
    * - 値配列 `value: ReadonlyArray<Token>` は加工しない。
    *   ColorSpace / Filter の値側略号（`/CS /RGB` → `/DeviceRGB` 等）は本 normalize のスコープ外で、
-   *   後続フェーズ（handler または別 normalize）の責務。
+   *   コンパニオンの `expandValueAbbrevs` の責務。
    * - 入力配列・入力エントリは破壊しない（新配列を返す）。
    * - 同一 dict に略号と完全名が両方ある場合も重複検査は行わず順序通り両方を出力する。
    *
@@ -60,8 +193,8 @@ export const InlineImageDict = {
       const key = entry.key.value;
       // Object.prototype 由来キー (`constructor` / `toString` / `__proto__` 等) が
       // 誤って略号として hit するのを防ぐため hasOwn ガードで自前プロパティのみ参照する。
-      const expanded = Object.hasOwn(INLINE_IMAGE_DICT_ABBREVIATIONS, key)
-        ? INLINE_IMAGE_DICT_ABBREVIATIONS[key]
+      const expanded = Object.hasOwn(INLINE_IMAGE_DICT_KEY_ABBREVIATIONS, key)
+        ? INLINE_IMAGE_DICT_KEY_ABBREVIATIONS[key]
         : undefined;
       if (expanded === undefined) {
         return entry;
@@ -72,6 +205,91 @@ export const InlineImageDict = {
         offset: entry.key.offset,
       };
       return { key: expandedKey, value: entry.value };
+    });
+  },
+
+  /**
+   * dict 内の最初の `/ImageMask` entry の value[0] が `TokenBoolean(true)` のときのみ true を返す。
+   *
+   * - 完全名キーのみ参照する（略号 `/IM` を解釈する責務は `normalize`）。
+   * - 重複 `/ImageMask` は最初の entry のみを採用する（仕様外 PDF への防御、Array.find のセマンティクス）。
+   * - value 配列が空、value[0] が Boolean 以外、Boolean(false) のときはすべて false。
+   *
+   * @param dict 既に `normalize` を経由した dict を想定するが、未経由でも安全に false を返す
+   */
+  isImageMaskTrue: (dict: InlineImageDict): boolean => {
+    const entry = findFirstEntry(dict, "ImageMask");
+    if (entry === undefined) {
+      return false;
+    }
+    const first = entry.value[0];
+    if (first === undefined) {
+      return false;
+    }
+    return first.type === TokenType.Boolean && first.value === true;
+  },
+
+  /**
+   * imageMask フラグに応じた必須キー集合（PDF §8.9.5.1 Table 89）が
+   * dict にすべて存在するか検査し、欠落キーを `Option<InlineImageRequiredKey>` で返す。
+   *
+   * - 戻り値型を `InlineImageRequiredKey` に narrow することで呼び出し側のキャスト依存を排除する。
+   * - dict は **`normalize` を経由した完全名キー** である前提（略号のまま渡すと欠落扱いになる）。
+   * - 必須キー以外の余分なエントリは検査せず通す（例: stencil mask に ColorSpace があっても none）。
+   * - 検査順は `REQUIRED_KEYS_NON_MASK` / `REQUIRED_KEYS_MASK` の配列順で決定論的に固定される。
+   */
+  findMissingRequiredKey: (
+    dict: InlineImageDict,
+    imageMask: boolean,
+  ): Option<InlineImageRequiredKey> => {
+    const required: ReadonlyArray<InlineImageRequiredKey> = imageMask
+      ? REQUIRED_KEYS_MASK
+      : REQUIRED_KEYS_NON_MASK;
+    const present = dict.map((entry) => entry.key.value);
+    for (const key of required) {
+      if (!present.includes(key)) {
+        return some(key);
+      }
+    }
+    return none;
+  },
+
+  /**
+   * 値側略号（PDF §8.9.5.1 Table 89）を完全名に展開した新 dict を返す純関数。
+   *
+   * **key scoped**: `/ColorSpace` または `/Filter` entry の value 配列内 Name token のみが対象。
+   * 他キー（`/Width` / `/Decode` / `/Interpolate` 等）の value は走査せず entry を同一参照で素通す。
+   *
+   * 4 階層参照同一性ルール:
+   *   - top-level dict: 常に新配列（`dict.map(...)` で必ず新規生成）
+   *   - entry:           value 内に置換がなければ同一参照、置換があれば新規 `{ key, value }`
+   *   - value:           配列内に置換がなければ同一参照、置換があれば新規配列
+   *   - token:           置換対象（hit した Name token）のみ新 `TokenName` を生成、非対象は同一参照
+   *
+   * 入力非破壊（`normalize` と同じ pin down）: 入力 dict / entry / value 配列はいずれも書き換えない。
+   *
+   * 配列内 token の扱い:
+   *   - Name 以外（Integer / Boolean / Array / Dict / Null / Real / String 等）は素通し
+   *   - Name token は table に hit すれば新 token で置換（`offset` 継承）、miss すれば素通し
+   *   - Array / Dict 系 token に対する **再帰展開はしない**（Table 89 は 1 階層の Name のみが対象）
+   */
+  expandValueAbbrevs: (dict: InlineImageDict): InlineImageDict => {
+    return dict.map((entry) => {
+      const key = entry.key.value;
+      const table =
+        key === "ColorSpace"
+          ? INLINE_IMAGE_DICT_VALUE_COLORSPACE_ABBREVIATIONS
+          : key === "Filter"
+            ? INLINE_IMAGE_DICT_VALUE_FILTER_ABBREVIATIONS
+            : undefined;
+      if (table === undefined) {
+        return entry;
+      }
+      const nextValue = expandValueArray(entry.value, table);
+      if (nextValue === entry.value) {
+        return entry;
+      }
+      return { key: entry.key, value: nextValue };
     });
   },
 } as const;

--- a/packages/core/src/content-stream/inline-image/inline-image-dict/index.ts
+++ b/packages/core/src/content-stream/inline-image/inline-image-dict/index.ts
@@ -245,9 +245,9 @@ export const InlineImageDict = {
     const required: ReadonlyArray<InlineImageRequiredKey> = imageMask
       ? REQUIRED_KEYS_MASK
       : REQUIRED_KEYS_NON_MASK;
-    const present = dict.map((entry) => entry.key.value);
+    const present = new Set(dict.map((entry) => entry.key.value));
     for (const key of required) {
-      if (!present.includes(key)) {
+      if (!present.has(key)) {
         return some(key);
       }
     }

--- a/packages/core/src/content-stream/inline-image/inline-image-dict/index.ts
+++ b/packages/core/src/content-stream/inline-image/inline-image-dict/index.ts
@@ -146,16 +146,22 @@ const expandValueArray = (
   value: ReadonlyArray<Token>,
   table: Partial<Record<string, string>>,
 ): ReadonlyArray<Token> => {
-  let mutated = false;
-  const next: Token[] = [];
-  for (const original of value) {
+  let next: Token[] | undefined;
+  for (let i = 0; i < value.length; i++) {
+    const original = value[i] as Token;
     const replaced = expandIfAbbrevName(original, table);
-    if (replaced !== original) {
-      mutated = true;
+    if (replaced === original) {
+      if (next !== undefined) {
+        next.push(original);
+      }
+      continue;
+    }
+    if (next === undefined) {
+      next = value.slice(0, i);
     }
     next.push(replaced);
   }
-  return mutated ? next : value;
+  return next ?? value;
 };
 
 /**

--- a/packages/core/src/content-stream/inline-image/inline-image-dict/index.ts
+++ b/packages/core/src/content-stream/inline-image/inline-image-dict/index.ts
@@ -263,6 +263,10 @@ export const InlineImageDict = {
   /**
    * 値側略号（PDF §8.9.5.1 Table 89）を完全名に展開した新 dict を返す純関数。
    *
+   * **前提条件**: 入力 dict は `normalize` を経由した **完全名キー** であること。
+   * 略号キーのまま（例: `/CS` / `/F`）渡された場合は key scope 判定に match せず value 側略号は展開されない。
+   * 呼び出し側は `expandValueAbbrevs(normalize(rawDict))` の順に必ず連鎖させること。
+   *
    * **key scoped**: `/ColorSpace` または `/Filter` entry の value 配列内 Name token のみが対象。
    * 他キー（`/Width` / `/Decode` / `/Interpolate` 等）の value は走査せず entry を同一参照で素通す。
    *

--- a/packages/core/src/content-stream/inline-image/inline-image-dict/index.ts
+++ b/packages/core/src/content-stream/inline-image/inline-image-dict/index.ts
@@ -1,3 +1,4 @@
+import { StringArrayEx } from "../../../ext/string-array/index";
 import type {
   Token,
   TokenInlineImageDictEntry,
@@ -5,7 +6,6 @@ import type {
 } from "../../../pdf/index";
 import { TokenType } from "../../../pdf/index";
 import type { Option } from "../../../utils/option/index";
-import { none, some } from "../../../utils/option/index";
 
 /**
  * PDF §8.9.5.1 で定義される **インラインイメージ辞書** の正規化前/後の値域。
@@ -251,13 +251,10 @@ export const InlineImageDict = {
     const required: ReadonlyArray<InlineImageRequiredKey> = imageMask
       ? REQUIRED_KEYS_MASK
       : REQUIRED_KEYS_NON_MASK;
-    const present = new Set(dict.map((entry) => entry.key.value));
-    for (const key of required) {
-      if (!present.has(key)) {
-        return some(key);
-      }
-    }
-    return none;
+    return StringArrayEx.firstMissing(
+      dict.map((entry) => entry.key.value),
+      required,
+    );
   },
 
   /**

--- a/packages/core/src/ext/string-array/index.ts
+++ b/packages/core/src/ext/string-array/index.ts
@@ -7,14 +7,18 @@ export const StringArrayEx = {
    * 必須キー列を順に走査し、入力に存在しない最初のキーを返す。
    * 全て存在すれば none を返す。
    *
+   * 戻り値型は `requiredKeys` の要素型 `K` に narrow される（`K extends string`）。
+   * 呼び出し側がリテラル union を持つ `as const` 由来の配列を渡せば、`Option<K>` として
+   * narrow された値が返るため cast 依存を排除できる。
+   *
    * @param keys - 検査対象のキー名集合（重複可、順序は意味を持たない）
    * @param requiredKeys - 必須キー名の列（走査順に意味あり）
    * @returns 欠落キーがあれば some(欠落キー名)、全て揃っていれば none
    */
-  firstMissing: (
+  firstMissing: <K extends string>(
     keys: ReadonlyArray<string>,
-    requiredKeys: ReadonlyArray<string>,
-  ): Option<string> => {
+    requiredKeys: ReadonlyArray<K>,
+  ): Option<K> => {
     for (const key of requiredKeys) {
       if (!keys.includes(key)) {
         return some(key);


### PR DESCRIPTION
## 概要

`InlineImageDict` コンパニオン（`packages/core/src/content-stream/inline-image/inline-image-dict/index.ts`）に dict ドメインの純関数 3 種（`isImageMaskTrue` / `findMissingRequiredKey` / `expandValueAbbrevs`）と値側略号テーブル 2 種を追加し、`inlineImageHandler` 側に散在していた dict ドメイン責務（private 関数 / 必須キー定数 / 検査ロジック / 型キャスト）を完全に集約する非破壊リファクタです。

同時に handler / そのテストの生 `ReadonlyArray<TokenInlineImageDictEntry>` 型注釈を `InlineImageDict` 型エイリアスに統一し、テスト責務の再分配（dict 側へ 3 ファイル新設、handler 側 3 ファイルを統合観点最小ケースへ削減）を実施しています。

## 変更の種類

- [x] ♻️ リファクタリング (Refactoring)
- [x] ✨ 新機能 (New feature) — `isImageMaskTrue` / `findMissingRequiredKey` / `expandValueAbbrevs` の dict API 追加
- [x] 🚨 テスト追加/修正 (Tests) — dict 側 3 ファイル新設、handler 側 3 ファイル最小化

## 詳細な変更内容

### 追加された機能・修正

`InlineImageDict` コンパニオンに 4 つの公開 API（既存 `normalize` 含む）を持つドメイン集約構造を確立:

| API | 役割 |
|---|---|
| `normalize` (既存) | キー側略号 → 完全名展開 |
| `isImageMaskTrue` (新規) | `/ImageMask` Boolean(true) 判定 |
| `findMissingRequiredKey` (新規) | 必須キー欠落検査（imageMask フラグ別、戻り値型 `Option<InlineImageRequiredKey>` で narrow） |
| `expandValueAbbrevs` (新規) | `/ColorSpace` / `/Filter` 値側略号 → 完全名展開（key scoped、4 階層参照同一性ルール準拠） |

新規 export 型: `InlineImageRequiredKey`（`PdfInlineImageRequiredKeyMissingError["missingKey"]` との **二重ロック型整合** に利用）。

### 変更されたファイル

| ファイル | 種別 | 概要 |
|---|---|---|
| `inline-image-dict/index.ts` | MODIFY | 3 純関数 + 値側略号テーブル 2 種 + ヘルパ追加、`INLINE_IMAGE_DICT_ABBREVIATIONS` → `INLINE_IMAGE_DICT_KEY_ABBREVIATIONS` 改名 |
| `handler/index.ts` | MODIFY | private 関数 / 必須キー定数 / 型エイリアス / キャスト / `StringArrayEx` 依存を削除し dict コンパニオン経由へ完全委譲 |
| `handler/__tests__/handler.basic.test.ts` | MODIFY | 混在パターン 3 ケース削除、stack 参照保持テスト 2 件を統合、計 6 件に最小化 |
| `handler/__tests__/handler.error.test.ts` | MODIFY | test.each 4 種と検査順 3 件を dict 側へ移植、計 2 件（err 詳細 / 型 narrow）に最小化 |
| `handler/__tests__/handler.image-mask.test.ts` | MODIFY | 単体 8 ケースを dict 側へ移植、計 3 件（stencil 例外 / 通常経路 / 略号統合鎖）に最小化 |
| `inline-image-dict/__tests__/inline-image-dict.basic.test.ts` | MODIFY | scope 境界 doc-comment を `expandValueAbbrevs` 責務明示に更新（テストロジック不変） |
| `inline-image-dict/__tests__/inline-image-dict.image-mask.test.ts` | **NEW** | `isImageMaskTrue` の 8 ケース pin down |
| `inline-image-dict/__tests__/inline-image-dict.required-keys.test.ts` | **NEW** | `findMissingRequiredKey` の 19 ケース pin down（必須キー欠落 + 検査順 + BPC 扱い対比 + 略号入力 + normalize 連鎖） |
| `inline-image-dict/__tests__/inline-image-dict.value-abbrev.test.ts` | **NEW** | `expandValueAbbrevs` の 28 ケース pin down（CS 4 + Filter 7 略号 test.each + 素通し + key scoped 境界 + offset 継承 + 4 階層ルール） |

### 削除されたファイル・機能

なし（既存ファイル削除は無し。handler 内の private 関数・定数・型・キャストのみ削除）。

## システム図

リファクタ後の `inlineImageHandler` フェーズ遷移:

```
       TokenInlineImage 受領
              │
              ▼
   ┌──────────────────────────────────────────┐
   │  P1: キー側略号正規化                      │
   │  InlineImageDict.normalize(token.dict)    │
   │  → normalized: InlineImageDict            │
   └──────────────────────────────────────────┘
              │
              ▼
   ┌──────────────────────────────────────────┐
   │  P2: ImageMask 判定                       │
   │  InlineImageDict.isImageMaskTrue(         │
   │      normalized                           │
   │  ) → imageMask: boolean                   │
   └──────────────────────────────────────────┘
              │
              ▼
   ┌──────────────────────────────────────────┐
   │  P3: 必須キー欠落検査                      │
   │  InlineImageDict.findMissingRequiredKey(  │
   │      normalized, imageMask                │
   │  ) → Option<InlineImageRequiredKey>       │
   │  (imageMask=true  → [Width, Height])      │
   │  (imageMask=false → [Width, Height,       │
   │                      BPC, ColorSpace])    │
   └──────────────────────────────────────────┘
              │
   ┌──────────┴────────────┐
   │                       │
 Some(missingKey)         None
   │                       │
   ▼                       ▼
Result.err              Result.ok
```

handler は dict ドメイン責務を一切持たず、3 段階の dict API 呼び出しと Result 詰めだけに専念する構造になっています。

## 関連 Issue

なし（spec フォルダ番号 073、`.plugin-workspace/.specs/073-inline-image-dict-refactor/`）。

## テスト

すべてのゲートが green:

```
pnpm test       → 224 files, 2872 tests passed
pnpm typecheck  → packages/core / packages/react ともに pass
pnpm lint       → 0 warnings / 0 errors (biome + oxlint)
pnpm build      → packages/core / packages/react ともに success
```

inline-image 配下のテスト構成:

| 場所 | 旧 | 新 |
|---|---|---|
| dict `__tests__/` ファイル数 | 2 (basic / passthrough) | **5** (+ image-mask / required-keys / value-abbrev) |
| handler `__tests__/` 3 ファイル合計行数 | 585 行 | **330 行** (255 行削減) |
| 既存テスト観点ロスト | — | **0** (移植マトリクスで担保) |

### DoD 検証 grep（実コマンドで確認済み）

- `ReadonlyArray<TokenInlineImageDictEntry>` hit 数 = **3**（dict alias 定義 + tokenizer + pdf/types のみ）
- handler 配下の `REQUIRED_KEYS_*` / `function isImageMaskTrue` hit = **0**
- `INLINE_IMAGE_DICT_ABBREVIATIONS\b` hit = **0**（改名済み）
- 3 新テーブル定数の hit ファイル = `inline-image-dict/index.ts` のみ

## レビューポイント

1. **二重ロック型整合の設計** — `inline-image-dict/index.ts` の `InlineImageRequiredKey` 型 export と `handler/index.ts` L48-49 の `PdfInlineImageRequiredKeyMissingError["missingKey"]` への代入による型整合検査。dict 側 union と pdf/errors 側 union が drift した瞬間に typecheck エラーで気付ける構成にしています（`as` キャストは廃止）。

2. **`expandValueAbbrevs` の先行実装扱い** — 本 PR の handler / interpreter / tokenizer のいずれからも未呼出ですが、spec の判断（implementation-plan「ユーザーレビューが必要な点」）に従い「dict 単体 API として完結させる」方針で追加しています。将来 ColorSpace / Filter 値読取 handler 追加時に消費される予定。ここを別 PR に分けるべきか統合 PR に置くべきかは設計レビュアー視点で意見が分かれた点でもあり、ご判断ください。

3. **4 階層参照同一性ルール** — `expandValueAbbrevs` は top-level dict / entry / value / token の 4 階層で「置換ゼロなら同一参照」を返す最適化を実装しています（top-level dict のみ常に新配列、`normalize` と同セマンティクス）。`value-abbrev.test.ts` の 0/1/全置換 3 ケースで境界を pin down しています。

4. **handler テストの責務再分配の妥当性** — handler 側を「dict コンパニオンとの統合経路の最小ケース」（基本受理 / 略号統合鎖 / stencil mask 例外 / 通常経路 err / err 詳細 / 型 narrow）に絞り、dict 単体テストとの観点重複を排除しています。implementation-plan §「テスト観点移植マトリクス」で観点ロストゼロを担保しています。

## 補足

`.plugin-workspace/.specs/073-inline-image-dict-refactor/` に hearing-notes / exploration-report / implementation-plan / tasks / test-cases / 5 専門エージェントレビュー結果（CRITICAL 0 / WARNING 3 / INFO 13、DoD 全 13 項目達成）が格納されています。WARNING 2 件はレビュー後に修正済み。残る WARNING 1 件（`expandValueAbbrevs` の dead code 評価）は spec の意図的先行実装としてレビューポイント 2 に記載の通り。

🤖 Generated with [Claude Code](https://claude.com/claude-code)