### PR TITLE
✨ [New Feature]: #407 parser に配列パース ([ ... ]) を実装

### DIFF
--- a/rust/crates/core/src/parser.rs
+++ b/rust/crates/core/src/parser.rs
@@ -1,9 +1,9 @@
 //! PDF オブジェクトのパース層。
 //!
 //! lexer が返す [`Token`](crate::lexer::token::Token) を ISO 32000-1 §7.3 の
-//! スカラオブジェクトに意味付けして [`PdfObject`] に変換する。本モジュールは
+//! オブジェクトに意味付けして [`PdfObject`] に変換する。本モジュールは
 //! スカラ 7 種（Null / Boolean / Integer / Real / LiteralString / HexString /
-//! Name）のみを扱い、配列・辞書・stream・間接参照は対象外。
+//! Name）と配列（要素はスカラまたは配列）を扱い、辞書・stream・間接参照は対象外。
 //!
 //! `LiteralString` と `HexString` は出自情報を落として `PdfObject::String` に統合する
 //! （所有ムーブのため clone は発生しない）。`Token::Comment` は透過的にスキップする。
@@ -44,20 +44,60 @@ impl<'a> Parser<'a> {
         ByteOffset::new(self.lexer.position() as u64)
     }
 
-    /// 次のスカラオブジェクトを 1 つ読み取る。
+    /// 次のオブジェクトを 1 つ読み取る。
     ///
-    /// [`Token::Comment`] は透過的にスキップする。スカラでないトークン
-    /// （配列・辞書開始/終了・`obj`/`endobj`/`stream`/`endstream`・キーワード）が
-    /// 来た場合は [`ParseErrorKind::UnexpectedToken`](error::ParseErrorKind::UnexpectedToken)、
+    /// スカラ 7 種に加え [`Token::ArrayBegin`] を検出した場合は配列パスに分岐し
+    /// [`PdfObject::Array`] を構築する。[`Token::Comment`] は透過的にスキップする。
+    /// 辞書開始/終了・`obj`/`endobj`/`stream`/`endstream`・キーワード等の対象外
+    /// トークンが来た場合は [`ParseErrorKind::UnexpectedToken`](error::ParseErrorKind::UnexpectedToken)、
     /// 入力が尽きていれば [`ParseErrorKind::UnexpectedEof`](error::ParseErrorKind::UnexpectedEof)、
     /// lexer が malformed を検知して `None` を返した場合は
     /// [`ParseErrorKind::LexerError`](error::ParseErrorKind::LexerError) を返す。
     pub fn parse_object(&mut self) -> Result<PdfObject, ParseError> {
         loop {
+            self.lexer.skip_whitespace();
             let pos_before = self.lexer.position();
             match self.lexer.next_token() {
                 Some(Token::Comment(_)) => continue,
                 Some(Token::Primitive(p)) => return Ok(Self::primitive_to_object(p)),
+                Some(Token::ArrayBegin) => return self.parse_array_body(),
+                Some(other) => {
+                    return Err(ParseError::unexpected_token_at(
+                        ByteOffset::new(pos_before as u64),
+                        Self::token_kind_label(&other),
+                    ));
+                }
+                None => {
+                    let pos = ByteOffset::new(self.lexer.position() as u64);
+                    if self.lexer.is_eof() {
+                        return Err(ParseError::unexpected_eof_at(pos));
+                    }
+                    return Err(ParseError::lexer_error_at(pos));
+                }
+            }
+        }
+    }
+
+    /// `[` を消費済の状態から配列ボディをパースし [`PdfObject::Array`] を返す
+    /// （ISO 32000-1 §7.3.6）。要素間 [`Token::Comment`] は透過スキップ、
+    /// [`Token::Primitive`] は所有ムーブで [`PdfObject`] に変換して `items` に
+    /// push、[`Token::ArrayBegin`] はネストとして自身を再帰呼び出しする。
+    /// [`Token::ArrayEnd`] でループを脱出する。対象外トークンは
+    /// [`ParseErrorKind::UnexpectedToken`](error::ParseErrorKind::UnexpectedToken)、
+    /// `]` 不在で入力が尽きた場合は
+    /// [`ParseErrorKind::UnexpectedEof`](error::ParseErrorKind::UnexpectedEof)、
+    /// lexer が malformed を検知して `None` を返した場合は
+    /// [`ParseErrorKind::LexerError`](error::ParseErrorKind::LexerError) を fail-fast で返す。
+    fn parse_array_body(&mut self) -> Result<PdfObject, ParseError> {
+        let mut items: Vec<PdfObject> = Vec::new();
+        loop {
+            self.lexer.skip_whitespace();
+            let pos_before = self.lexer.position();
+            match self.lexer.next_token() {
+                Some(Token::Comment(_)) => continue,
+                Some(Token::ArrayEnd) => return Ok(PdfObject::Array(items)),
+                Some(Token::Primitive(p)) => items.push(Self::primitive_to_object(p)),
+                Some(Token::ArrayBegin) => items.push(self.parse_array_body()?),
                 Some(other) => {
                     return Err(ParseError::unexpected_token_at(
                         ByteOffset::new(pos_before as u64),
@@ -108,6 +148,9 @@ impl<'a> Parser<'a> {
         }
     }
 }
+
+#[cfg(test)]
+mod array_tests;
 
 #[cfg(test)]
 mod tests {
@@ -345,16 +388,11 @@ mod tests {
     // ---------- 異常系: UnexpectedToken ----------
 
     #[test]
-    fn parse_object_returns_unexpected_token_for_array_begin() {
-        // 入力 b"[" で UnexpectedToken { actual_kind: "ArrayBegin" } を返すことを確認する
+    fn parse_object_returns_unexpected_eof_for_unclosed_array_begin() {
+        // 入力 b"[" で配列パスに入った結果 `]` 不在 EOF として UnexpectedEof を返すことを確認する
         let mut p = parser(b"[");
-        let err = p.parse_object().expect_err("array begin must error");
-        assert_eq!(
-            err.kind,
-            ParseErrorKind::UnexpectedToken {
-                actual_kind: "ArrayBegin"
-            }
-        );
+        let err = p.parse_object().expect_err("unclosed array must error");
+        assert_eq!(err.kind, ParseErrorKind::UnexpectedEof);
     }
 
     #[test]

--- a/rust/crates/core/src/parser.rs
+++ b/rust/crates/core/src/parser.rs
@@ -385,8 +385,6 @@ mod tests {
         assert_eq!(err.kind, ParseErrorKind::UnexpectedEof);
     }
 
-    // ---------- 異常系: UnexpectedToken ----------
-
     #[test]
     fn parse_object_returns_unexpected_eof_for_unclosed_array_begin() {
         // 入力 b"[" で配列パスに入った結果 `]` 不在 EOF として UnexpectedEof を返すことを確認する
@@ -394,6 +392,8 @@ mod tests {
         let err = p.parse_object().expect_err("unclosed array must error");
         assert_eq!(err.kind, ParseErrorKind::UnexpectedEof);
     }
+
+    // ---------- 異常系: UnexpectedToken ----------
 
     #[test]
     fn parse_object_returns_unexpected_token_for_array_end() {

--- a/rust/crates/core/src/parser/array_tests.rs
+++ b/rust/crates/core/src/parser/array_tests.rs
@@ -1,0 +1,17 @@
+mod comment_interleaved;
+mod deep_nested;
+mod empty;
+mod flat_scalars;
+mod lexer_error_propagation;
+mod mixed_types;
+mod nested;
+mod pdf_sample;
+mod unexpected_token;
+mod unmatched_eof;
+mod whitespace_variants;
+
+use super::Parser;
+
+fn parser(input: &[u8]) -> Parser<'_> {
+    Parser::new(input)
+}

--- a/rust/crates/core/src/parser/array_tests/comment_interleaved.rs
+++ b/rust/crates/core/src/parser/array_tests/comment_interleaved.rs
@@ -1,0 +1,38 @@
+use super::super::super::object::pdf_object::PdfObject;
+use super::parser;
+
+#[test]
+fn parse_object_returns_array_skipping_inline_comment() {
+    // 入力 b"[1 % comment\n 2]" で要素間の % コメントが透過スキップされ AST に現れないことを確認する
+    let mut p = parser(b"[1 % comment\n 2]");
+    assert_eq!(
+        p.parse_object(),
+        Ok(PdfObject::Array(vec![
+            PdfObject::Integer(1),
+            PdfObject::Integer(2),
+        ]))
+    );
+}
+
+#[test]
+fn parse_object_returns_array_skipping_leading_comments() {
+    // 入力 b"[%a\n%b\n 1]" で配列先頭の連続コメントが透過スキップされ単一要素を返すことを確認する
+    let mut p = parser(b"[%a\n%b\n 1]");
+    assert_eq!(
+        p.parse_object(),
+        Ok(PdfObject::Array(vec![PdfObject::Integer(1)]))
+    );
+}
+
+#[test]
+fn parse_object_returns_array_skipping_trailing_comment() {
+    // 入力 b"[1 2 %tail\n]" で末尾コメントが透過スキップされ ArrayEnd まで進むことを確認する
+    let mut p = parser(b"[1 2 %tail\n]");
+    assert_eq!(
+        p.parse_object(),
+        Ok(PdfObject::Array(vec![
+            PdfObject::Integer(1),
+            PdfObject::Integer(2),
+        ]))
+    );
+}

--- a/rust/crates/core/src/parser/array_tests/deep_nested.rs
+++ b/rust/crates/core/src/parser/array_tests/deep_nested.rs
@@ -1,0 +1,26 @@
+use super::super::super::object::pdf_object::PdfObject;
+use super::parser;
+
+#[test]
+fn parse_object_returns_array_for_three_level_nest() {
+    // 入力 b"[[[1]]]" で 3 段ネストの Array が再帰的に構築されることを確認する
+    let mut p = parser(b"[[[1]]]");
+    assert_eq!(
+        p.parse_object(),
+        Ok(PdfObject::Array(vec![PdfObject::Array(vec![
+            PdfObject::Array(vec![PdfObject::Integer(1)])
+        ])]))
+    );
+}
+
+#[test]
+fn parse_object_returns_array_for_four_level_nest() {
+    // 境界値: 入力 b"[[[[1]]]]" で 4 段ネストの Array が再帰的に構築されることを確認する
+    let mut p = parser(b"[[[[1]]]]");
+    assert_eq!(
+        p.parse_object(),
+        Ok(PdfObject::Array(vec![PdfObject::Array(vec![
+            PdfObject::Array(vec![PdfObject::Array(vec![PdfObject::Integer(1)])])
+        ])]))
+    );
+}

--- a/rust/crates/core/src/parser/array_tests/empty.rs
+++ b/rust/crates/core/src/parser/array_tests/empty.rs
@@ -1,0 +1,23 @@
+use super::super::super::object::pdf_object::PdfObject;
+use super::parser;
+
+#[test]
+fn parse_object_returns_empty_array_for_brackets() {
+    // 入力 b"[]" で空配列 Ok(PdfObject::Array(vec![])) を返すことを確認する
+    let mut p = parser(b"[]");
+    assert_eq!(p.parse_object(), Ok(PdfObject::Array(Vec::new())));
+}
+
+#[test]
+fn parse_object_returns_empty_array_for_brackets_with_space() {
+    // 入力 b"[ ]" で SP 入り空配列が Ok(Array(vec![])) を返すことを確認する
+    let mut p = parser(b"[ ]");
+    assert_eq!(p.parse_object(), Ok(PdfObject::Array(Vec::new())));
+}
+
+#[test]
+fn parse_object_returns_empty_array_for_brackets_with_newlines() {
+    // 入力 b"[\n\n]" で改行のみで囲まれた空配列が Ok(Array(vec![])) を返すことを確認する
+    let mut p = parser(b"[\n\n]");
+    assert_eq!(p.parse_object(), Ok(PdfObject::Array(Vec::new())));
+}

--- a/rust/crates/core/src/parser/array_tests/flat_scalars.rs
+++ b/rust/crates/core/src/parser/array_tests/flat_scalars.rs
@@ -1,0 +1,80 @@
+use super::super::super::object::name::PdfName;
+use super::super::super::object::pdf_object::PdfObject;
+use super::parser;
+
+#[test]
+fn parse_object_returns_array_for_three_integers() {
+    // 入力 b"[1 2 3]" で整数 3 要素の Array を返すことを確認する
+    let mut p = parser(b"[1 2 3]");
+    assert_eq!(
+        p.parse_object(),
+        Ok(PdfObject::Array(vec![
+            PdfObject::Integer(1),
+            PdfObject::Integer(2),
+            PdfObject::Integer(3),
+        ]))
+    );
+}
+
+#[test]
+fn parse_object_returns_array_for_boolean_and_null_mix() {
+    // 入力 b"[true false null]" で Boolean / Null 混在の Array を返すことを確認する
+    let mut p = parser(b"[true false null]");
+    assert_eq!(
+        p.parse_object(),
+        Ok(PdfObject::Array(vec![
+            PdfObject::Boolean(true),
+            PdfObject::Boolean(false),
+            PdfObject::Null,
+        ]))
+    );
+}
+
+#[test]
+fn parse_object_returns_array_for_two_names() {
+    // 入力 b"[/A /B]" で Name 2 要素の Array を返すことを確認する
+    let mut p = parser(b"[/A /B]");
+    assert_eq!(
+        p.parse_object(),
+        Ok(PdfObject::Array(vec![
+            PdfObject::Name(PdfName::new(b"A".to_vec())),
+            PdfObject::Name(PdfName::new(b"B".to_vec())),
+        ]))
+    );
+}
+
+#[test]
+fn parse_object_returns_array_for_two_literal_strings() {
+    // 入力 b"[(s1) (s2)]" で LiteralString 2 要素の Array を返すことを確認する
+    let mut p = parser(b"[(s1) (s2)]");
+    assert_eq!(
+        p.parse_object(),
+        Ok(PdfObject::Array(vec![
+            PdfObject::String(b"s1".to_vec()),
+            PdfObject::String(b"s2".to_vec()),
+        ]))
+    );
+}
+
+#[test]
+fn parse_object_returns_array_for_two_hex_strings() {
+    // 入力 b"[<41> <42>]" で HexString 2 要素 (A / B) の Array を返すことを確認する
+    let mut p = parser(b"[<41> <42>]");
+    assert_eq!(
+        p.parse_object(),
+        Ok(PdfObject::Array(vec![
+            PdfObject::String(b"A".to_vec()),
+            PdfObject::String(b"B".to_vec()),
+        ]))
+    );
+}
+
+#[test]
+fn parse_object_returns_array_for_single_integer() {
+    // 境界値: 入力 b"[1]" で単一要素の Array を返すことを確認する
+    let mut p = parser(b"[1]");
+    assert_eq!(
+        p.parse_object(),
+        Ok(PdfObject::Array(vec![PdfObject::Integer(1)]))
+    );
+}

--- a/rust/crates/core/src/parser/array_tests/lexer_error_propagation.rs
+++ b/rust/crates/core/src/parser/array_tests/lexer_error_propagation.rs
@@ -1,0 +1,36 @@
+use super::super::super::byte_offset::ByteOffset;
+use super::super::error::ParseErrorKind;
+use super::parser;
+
+#[test]
+fn parse_object_returns_lexer_error_for_unterminated_hex_in_array() {
+    // 入力 b"[<48656C" で配列要素中の未終端 HexString が LexerError として fail-fast 伝播し、position=1 (`<` の開始位置) に固定されることを確認する
+    let mut p = parser(b"[<48656C");
+    let err = p
+        .parse_object()
+        .expect_err("unterminated hex in array must error");
+    assert_eq!(err.kind, ParseErrorKind::LexerError);
+    assert_eq!(err.position, ByteOffset::new(1));
+}
+
+#[test]
+fn parse_object_returns_lexer_error_for_unterminated_literal_in_array() {
+    // 入力 b"[(abc" で配列要素中の未終端 LiteralString が LexerError として fail-fast 伝播し、position=1 (`(` の開始位置) に固定されることを確認する
+    let mut p = parser(b"[(abc");
+    let err = p
+        .parse_object()
+        .expect_err("unterminated literal in array must error");
+    assert_eq!(err.kind, ParseErrorKind::LexerError);
+    assert_eq!(err.position, ByteOffset::new(1));
+}
+
+#[test]
+fn parse_object_returns_lexer_error_for_scalar_then_unterminated_literal() {
+    // 入力 b"[1 (abc" で先頭にスカラがある状態の未終端 LiteralString が LexerError として伝播し、position=3 (`(` の開始位置) に固定されることを確認する
+    let mut p = parser(b"[1 (abc");
+    let err = p
+        .parse_object()
+        .expect_err("scalar then unterminated must error");
+    assert_eq!(err.kind, ParseErrorKind::LexerError);
+    assert_eq!(err.position, ByteOffset::new(3));
+}

--- a/rust/crates/core/src/parser/array_tests/mixed_types.rs
+++ b/rust/crates/core/src/parser/array_tests/mixed_types.rs
@@ -1,0 +1,74 @@
+use super::super::super::object::name::PdfName;
+use super::super::super::object::pdf_object::PdfObject;
+use super::parser;
+
+#[test]
+fn parse_object_returns_array_for_five_scalar_mix() {
+    // 入力 b"[null true /N (s) <414243>]" で 5 種スカラ混在配列が型ごと正しく分配されることを確認する
+    let mut p = parser(b"[null true /N (s) <414243>]");
+    assert_eq!(
+        p.parse_object(),
+        Ok(PdfObject::Array(vec![
+            PdfObject::Null,
+            PdfObject::Boolean(true),
+            PdfObject::Name(PdfName::new(b"N".to_vec())),
+            PdfObject::String(b"s".to_vec()),
+            PdfObject::String(b"ABC".to_vec()),
+        ]))
+    );
+}
+
+#[test]
+#[allow(clippy::approx_constant)]
+fn parse_object_returns_array_for_integer_and_real_mix() {
+    // 入力 b"[1 3.14 -0]" で Integer / Real / 符号付き混在が正しく振り分けられることを確認する
+    let mut p = parser(b"[1 3.14 -0]");
+    assert_eq!(
+        p.parse_object(),
+        Ok(PdfObject::Array(vec![
+            PdfObject::Integer(1),
+            PdfObject::Real(3.14),
+            PdfObject::Integer(0),
+        ]))
+    );
+}
+
+#[test]
+fn parse_object_returns_array_for_eight_repeated_integers() {
+    // 入力 b"[1 1 1 1 1 1 1 1]" で同型反復長尺 8 要素の Array を返すことを確認する
+    let mut p = parser(b"[1 1 1 1 1 1 1 1]");
+    assert_eq!(
+        p.parse_object(),
+        Ok(PdfObject::Array(vec![PdfObject::Integer(1); 8]))
+    );
+}
+
+#[test]
+fn parse_object_returns_array_for_bool_name_adjacent() {
+    // 入力 b"[true /A false /B]" で Bool / Name が隣接した 4 要素配列が順序保存で返ることを確認する
+    let mut p = parser(b"[true /A false /B]");
+    assert_eq!(
+        p.parse_object(),
+        Ok(PdfObject::Array(vec![
+            PdfObject::Boolean(true),
+            PdfObject::Name(PdfName::new(b"A".to_vec())),
+            PdfObject::Boolean(false),
+            PdfObject::Name(PdfName::new(b"B".to_vec())),
+        ]))
+    );
+}
+
+#[test]
+#[allow(clippy::approx_constant)]
+fn parse_object_returns_array_for_negative_and_zero_real() {
+    // 入力 b"[-1 -3.14 0.0]" で負数 Integer / 負数 Real / ゼロ Real が正しく振り分けられることを確認する
+    let mut p = parser(b"[-1 -3.14 0.0]");
+    assert_eq!(
+        p.parse_object(),
+        Ok(PdfObject::Array(vec![
+            PdfObject::Integer(-1),
+            PdfObject::Real(-3.14),
+            PdfObject::Real(0.0),
+        ]))
+    );
+}

--- a/rust/crates/core/src/parser/array_tests/nested.rs
+++ b/rust/crates/core/src/parser/array_tests/nested.rs
@@ -1,0 +1,39 @@
+use super::super::super::object::pdf_object::PdfObject;
+use super::parser;
+
+#[test]
+fn parse_object_returns_array_for_two_sub_arrays() {
+    // 入力 b"[[1 2] [3 4]]" で 2 つのサブ配列を持つネスト Array を返すことを確認する
+    let mut p = parser(b"[[1 2] [3 4]]");
+    assert_eq!(
+        p.parse_object(),
+        Ok(PdfObject::Array(vec![
+            PdfObject::Array(vec![PdfObject::Integer(1), PdfObject::Integer(2)]),
+            PdfObject::Array(vec![PdfObject::Integer(3), PdfObject::Integer(4)]),
+        ]))
+    );
+}
+
+#[test]
+fn parse_object_returns_array_for_single_empty_nested() {
+    // 入力 b"[[]]" で空ネストの Array(Array(vec![])) を返すことを確認する
+    let mut p = parser(b"[[]]");
+    assert_eq!(
+        p.parse_object(),
+        Ok(PdfObject::Array(vec![PdfObject::Array(Vec::new())]))
+    );
+}
+
+#[test]
+fn parse_object_returns_array_for_scalar_sub_array_scalar() {
+    // 入力 b"[1 [2] 3]" でスカラ+サブ配列+スカラの順序保存ネスト 1 段を返すことを確認する
+    let mut p = parser(b"[1 [2] 3]");
+    assert_eq!(
+        p.parse_object(),
+        Ok(PdfObject::Array(vec![
+            PdfObject::Integer(1),
+            PdfObject::Array(vec![PdfObject::Integer(2)]),
+            PdfObject::Integer(3),
+        ]))
+    );
+}

--- a/rust/crates/core/src/parser/array_tests/pdf_sample.rs
+++ b/rust/crates/core/src/parser/array_tests/pdf_sample.rs
@@ -1,0 +1,38 @@
+use super::super::super::byte_offset::ByteOffset;
+use super::super::super::object::name::PdfName;
+use super::super::super::object::pdf_object::PdfObject;
+use super::parser;
+
+#[test]
+#[allow(clippy::approx_constant)]
+fn parse_object_returns_array_for_iso_3_7_example() {
+    // ISO 32000-1 §3.7 仕様例 b"[549 3.14 false (Ralph) /SomeName]" を 5 種スカラ混在配列としてパースし、末尾到達 position が入力長一致であることを確認する
+    let input: &[u8] = b"[549 3.14 false (Ralph) /SomeName]";
+    let mut p = parser(input);
+    assert_eq!(
+        p.parse_object(),
+        Ok(PdfObject::Array(vec![
+            PdfObject::Integer(549),
+            PdfObject::Real(3.14),
+            PdfObject::Boolean(false),
+            PdfObject::String(b"Ralph".to_vec()),
+            PdfObject::Name(PdfName::new(b"SomeName".to_vec())),
+        ]))
+    );
+    assert_eq!(p.position(), ByteOffset::new(input.len() as u64));
+}
+
+#[test]
+fn parse_object_returns_array_for_media_box() {
+    // MediaBox 相当の実 PDF 由来 b"[0 0 612 792]" が 4 要素 Integer の Array として返ることを確認する
+    let mut p = parser(b"[0 0 612 792]");
+    assert_eq!(
+        p.parse_object(),
+        Ok(PdfObject::Array(vec![
+            PdfObject::Integer(0),
+            PdfObject::Integer(0),
+            PdfObject::Integer(612),
+            PdfObject::Integer(792),
+        ]))
+    );
+}

--- a/rust/crates/core/src/parser/array_tests/unexpected_token.rs
+++ b/rust/crates/core/src/parser/array_tests/unexpected_token.rs
@@ -1,0 +1,122 @@
+use super::super::super::byte_offset::ByteOffset;
+use super::super::error::ParseErrorKind;
+use super::parser;
+
+#[test]
+fn parse_object_returns_unexpected_token_for_dict_begin_in_array() {
+    // 入力 b"[<<]" で配列要素中の DictBegin が UnexpectedToken { "DictBegin" } で fail-fast されることを確認する
+    let mut p = parser(b"[<<]");
+    let err = p.parse_object().expect_err("dict begin must error");
+    assert_eq!(
+        err.kind,
+        ParseErrorKind::UnexpectedToken {
+            actual_kind: "DictBegin"
+        }
+    );
+}
+
+#[test]
+fn parse_object_returns_unexpected_token_for_dict_end_in_array() {
+    // 入力 b"[>>]" で配列要素中の DictEnd が UnexpectedToken { "DictEnd" } で fail-fast されることを確認する
+    let mut p = parser(b"[>>]");
+    let err = p.parse_object().expect_err("dict end must error");
+    assert_eq!(
+        err.kind,
+        ParseErrorKind::UnexpectedToken {
+            actual_kind: "DictEnd"
+        }
+    );
+}
+
+#[test]
+fn parse_object_returns_unexpected_token_for_obj_begin_in_array() {
+    // 入力 b"[obj]" で配列要素中の ObjBegin が UnexpectedToken { "ObjBegin" } で fail-fast されることを確認する
+    let mut p = parser(b"[obj]");
+    let err = p.parse_object().expect_err("obj begin must error");
+    assert_eq!(
+        err.kind,
+        ParseErrorKind::UnexpectedToken {
+            actual_kind: "ObjBegin"
+        }
+    );
+}
+
+#[test]
+fn parse_object_returns_unexpected_token_for_obj_end_in_array() {
+    // 入力 b"[endobj]" で配列要素中の ObjEnd が UnexpectedToken { "ObjEnd" } で fail-fast されることを確認する
+    let mut p = parser(b"[endobj]");
+    let err = p.parse_object().expect_err("obj end must error");
+    assert_eq!(
+        err.kind,
+        ParseErrorKind::UnexpectedToken {
+            actual_kind: "ObjEnd"
+        }
+    );
+}
+
+#[test]
+fn parse_object_returns_unexpected_token_for_stream_begin_in_array() {
+    // 入力 b"[stream]" で配列要素中の StreamBegin が UnexpectedToken { "StreamBegin" } で fail-fast されることを確認する
+    let mut p = parser(b"[stream]");
+    let err = p.parse_object().expect_err("stream begin must error");
+    assert_eq!(
+        err.kind,
+        ParseErrorKind::UnexpectedToken {
+            actual_kind: "StreamBegin"
+        }
+    );
+}
+
+#[test]
+fn parse_object_returns_unexpected_token_for_stream_end_in_array() {
+    // 入力 b"[endstream]" で配列要素中の StreamEnd が UnexpectedToken { "StreamEnd" } で fail-fast されることを確認する
+    let mut p = parser(b"[endstream]");
+    let err = p.parse_object().expect_err("stream end must error");
+    assert_eq!(
+        err.kind,
+        ParseErrorKind::UnexpectedToken {
+            actual_kind: "StreamEnd"
+        }
+    );
+}
+
+#[test]
+fn parse_object_returns_unexpected_token_for_keyword_r_in_array() {
+    // 入力 b"[R]" で配列要素中の R キーワード (Keyword) が UnexpectedToken { "Keyword" } で fail-fast されることを確認する
+    let mut p = parser(b"[R]");
+    let err = p.parse_object().expect_err("keyword R must error");
+    assert_eq!(
+        err.kind,
+        ParseErrorKind::UnexpectedToken {
+            actual_kind: "Keyword"
+        }
+    );
+}
+
+#[test]
+fn parse_object_returns_unexpected_token_for_array_end_only() {
+    // 入力 b"]" で parse_object 直 dispatch における ArrayEnd 単独が UnexpectedToken { "ArrayEnd" }, position=0 で返ることを確認する
+    let mut p = parser(b"]");
+    let err = p.parse_object().expect_err("array end alone must error");
+    assert_eq!(
+        err.kind,
+        ParseErrorKind::UnexpectedToken {
+            actual_kind: "ArrayEnd"
+        }
+    );
+    assert_eq!(err.position, ByteOffset::new(0));
+}
+
+#[test]
+fn parse_object_returns_unexpected_token_for_dict_begin_inside_nested_array() {
+    // 入力 b"[1 <<]" でネスト 1 段内の禁止トークン DictBegin が内側 parse_array_body の Some(other) arm で fail-fast し、position が `<<` の開始位置 (3) に固定されることを確認する
+    let mut p = parser(b"[1 <<]");
+    let err = p.parse_object().expect_err("nested dict begin must error");
+    assert_eq!(
+        err.kind,
+        ParseErrorKind::UnexpectedToken {
+            actual_kind: "DictBegin"
+        }
+    );
+    assert_eq!(err.position, ByteOffset::new(3));
+}

--- a/rust/crates/core/src/parser/array_tests/unmatched_eof.rs
+++ b/rust/crates/core/src/parser/array_tests/unmatched_eof.rs
@@ -1,0 +1,83 @@
+use super::super::super::byte_offset::ByteOffset;
+use super::super::error::ParseErrorKind;
+use super::parser;
+
+#[test]
+fn parse_object_returns_unexpected_eof_for_open_bracket_only() {
+    // 入力 b"[" で `[` 直後 EOF が UnexpectedEof, position=1 で返ることを確認する
+    let mut p = parser(b"[");
+    let err = p.parse_object().expect_err("unclosed array must error");
+    assert_eq!(err.kind, ParseErrorKind::UnexpectedEof);
+    assert_eq!(err.position, ByteOffset::new(1));
+}
+
+#[test]
+fn parse_object_returns_unexpected_eof_for_elements_then_eof() {
+    // 入力 b"[1 2" で要素途中 EOF が UnexpectedEof, position=4 で返ることを確認する
+    let mut p = parser(b"[1 2");
+    let err = p.parse_object().expect_err("eof after elements must error");
+    assert_eq!(err.kind, ParseErrorKind::UnexpectedEof);
+    assert_eq!(err.position, ByteOffset::new(4));
+}
+
+#[test]
+fn parse_object_returns_unexpected_eof_for_nested_open_eof() {
+    // 入力 b"[[1 " でネスト中 EOF が内側 parse_array_body の None arm で UnexpectedEof, position=4 (末尾) で返ることを確認する
+    let mut p = parser(b"[[1 ");
+    let err = p.parse_object().expect_err("nested eof must error");
+    assert_eq!(err.kind, ParseErrorKind::UnexpectedEof);
+    assert_eq!(err.position, ByteOffset::new(4));
+}
+
+#[test]
+fn parse_object_returns_unexpected_eof_for_trailing_space_then_eof() {
+    // 入力 b"[1 2 3" で末尾要素直後 EOF が UnexpectedEof, position=6 で返ることを確認する
+    let mut p = parser(b"[1 2 3");
+    let err = p.parse_object().expect_err("trailing eof must error");
+    assert_eq!(err.kind, ParseErrorKind::UnexpectedEof);
+    assert_eq!(err.position, ByteOffset::new(6));
+}
+
+#[test]
+fn parse_object_returns_unexpected_eof_for_double_open_bracket() {
+    // 入力 b"[[" でネスト入口直後 EOF が UnexpectedEof, position=2 で返ることを確認する
+    let mut p = parser(b"[[");
+    let err = p
+        .parse_object()
+        .expect_err("double open bracket must error");
+    assert_eq!(err.kind, ParseErrorKind::UnexpectedEof);
+    assert_eq!(err.position, ByteOffset::new(2));
+}
+
+#[test]
+fn parse_object_returns_unexpected_eof_for_nested_close_then_eof() {
+    // 入力 b"[[1] " でネスト出口待ち EOF が外側 parse_array_body の None arm で UnexpectedEof, position=5 (末尾) で返ることを確認する
+    let mut p = parser(b"[[1] ");
+    let err = p
+        .parse_object()
+        .expect_err("nested close then eof must error");
+    assert_eq!(err.kind, ParseErrorKind::UnexpectedEof);
+    assert_eq!(err.position, ByteOffset::new(5));
+}
+
+#[test]
+fn parse_object_handles_comment_without_eol_then_eof() {
+    // 入力 b"[1 %comment" でコメントが EOL なしで EOF に到達する場合、lexer 挙動に応じて UnexpectedEof または LexerError のいずれかになることを確認する
+    let mut p = parser(b"[1 %comment");
+    let err = p
+        .parse_object()
+        .expect_err("comment without eol then eof must error");
+    assert!(matches!(
+        err.kind,
+        ParseErrorKind::UnexpectedEof | ParseErrorKind::LexerError
+    ));
+}
+
+#[test]
+fn parse_object_returns_unexpected_eof_for_triple_nested_open_then_int_eof() {
+    // 入力 b"[[[1" で 3 段ネスト中 EOF が UnexpectedEof で内側 parse_array_body の None arm から伝播し、position=4 (末尾) に固定されることを確認する
+    let mut p = parser(b"[[[1");
+    let err = p.parse_object().expect_err("triple nested eof must error");
+    assert_eq!(err.kind, ParseErrorKind::UnexpectedEof);
+    assert_eq!(err.position, ByteOffset::new(4));
+}

--- a/rust/crates/core/src/parser/array_tests/unmatched_eof.rs
+++ b/rust/crates/core/src/parser/array_tests/unmatched_eof.rs
@@ -61,16 +61,14 @@ fn parse_object_returns_unexpected_eof_for_nested_close_then_eof() {
 }
 
 #[test]
-fn parse_object_handles_comment_without_eol_then_eof() {
-    // 入力 b"[1 %comment" でコメントが EOL なしで EOF に到達する場合、lexer 挙動に応じて UnexpectedEof または LexerError のいずれかになることを確認する
+fn parse_object_returns_unexpected_eof_for_comment_without_eol_then_eof() {
+    // 入力 b"[1 %comment" でコメントが EOL なしで EOF に到達する場合、Lexer::skip_comment が EOF without EOL を本文として返すため Token::Comment が透過スキップされ、次の next_token で UnexpectedEof, position=11 が確定的に返ることを確認する
     let mut p = parser(b"[1 %comment");
     let err = p
         .parse_object()
         .expect_err("comment without eol then eof must error");
-    assert!(matches!(
-        err.kind,
-        ParseErrorKind::UnexpectedEof | ParseErrorKind::LexerError
-    ));
+    assert_eq!(err.kind, ParseErrorKind::UnexpectedEof);
+    assert_eq!(err.position, ByteOffset::new(11));
 }
 
 #[test]

--- a/rust/crates/core/src/parser/array_tests/whitespace_variants.rs
+++ b/rust/crates/core/src/parser/array_tests/whitespace_variants.rs
@@ -1,0 +1,66 @@
+use super::super::super::object::pdf_object::PdfObject;
+use super::parser;
+
+#[test]
+fn parse_object_returns_array_for_mixed_whitespace() {
+    // 入力 b"[\t1\r\n2\x0C3 ]" で TAB / CRLF / FF / SP 混在のホワイトスペースを正しく要素境界として解釈することを確認する
+    let mut p = parser(b"[\t1\r\n2\x0C3 ]");
+    assert_eq!(
+        p.parse_object(),
+        Ok(PdfObject::Array(vec![
+            PdfObject::Integer(1),
+            PdfObject::Integer(2),
+            PdfObject::Integer(3),
+        ]))
+    );
+}
+
+#[test]
+fn parse_object_returns_array_for_nul_separator_compound() {
+    // 入力 b"[1\x002]" で NUL 区切り (複合) のホワイトスペース処理を確認する
+    let mut p = parser(b"[1\x002]");
+    assert_eq!(
+        p.parse_object(),
+        Ok(PdfObject::Array(vec![
+            PdfObject::Integer(1),
+            PdfObject::Integer(2),
+        ]))
+    );
+}
+
+#[test]
+fn parse_object_returns_array_for_multiple_spaces() {
+    // 境界値: 入力 b"[   1   ]" で多重 SP に囲まれた単一要素を確認する
+    let mut p = parser(b"[   1   ]");
+    assert_eq!(
+        p.parse_object(),
+        Ok(PdfObject::Array(vec![PdfObject::Integer(1)]))
+    );
+}
+
+#[test]
+fn parse_object_returns_array_for_crlf_only_separator() {
+    // 入力 b"[1\r\n2\r\n3]" で CRLF のみで要素分離された 3 要素配列を返すことを確認する
+    let mut p = parser(b"[1\r\n2\r\n3]");
+    assert_eq!(
+        p.parse_object(),
+        Ok(PdfObject::Array(vec![
+            PdfObject::Integer(1),
+            PdfObject::Integer(2),
+            PdfObject::Integer(3),
+        ]))
+    );
+}
+
+#[test]
+fn parse_object_returns_array_for_nul_only_separator() {
+    // 入力 b"[\x001\x002\x00]" で NUL 単独区切りの 2 要素配列を返すことを確認する
+    let mut p = parser(b"[\x001\x002\x00]");
+    assert_eq!(
+        p.parse_object(),
+        Ok(PdfObject::Array(vec![
+            PdfObject::Integer(1),
+            PdfObject::Integer(2),
+        ]))
+    );
+}


### PR DESCRIPTION
## 概要

`Parser::parse_object` に配列パスを追加し、`[` ... `]` のトークン列を `PdfObject::Array(Vec<PdfObject>)` に意味付けする。スカラ・配列（ネスト含む）・要素間 `%comment` の透過スキップに対応し、`]` 不在の EOF / 配列要素中の lexer error / 未対応トークンを既存 `ParseErrorKind` 3 種で fail-fast 伝播する。

## 変更内容

### 🎯 変更の種類

- [x] ✨ 新機能 (New feature)

### 📝 詳細な変更内容

#### 追加された機能

- `Parser::parse_array_body` private method 新規追加
  - 要素間 `Token::Comment` は透過スキップ
  - `Token::Primitive` は所有ムーブで `PdfObject` に変換し `items` に push
  - `Token::ArrayBegin` はネストとして自身を再帰呼び出し
  - `Token::ArrayEnd` でループ脱出
  - 不許可トークンは `UnexpectedToken { actual_kind }` で fail-fast
  - `None` は `is_eof()` で `UnexpectedEof` / `LexerError` を切り分け
- `Parser::parse_object` に `Some(Token::ArrayBegin) => return self.parse_array_body();` arm を追加
- `parse_object` / `parse_array_body` のループ冒頭で `skip_whitespace()` を明示呼び出し（要件 F9「`UnexpectedToken` の position はトークン開始位置」を厳密に満たすため）

#### 変更されたファイル

- `rust/crates/core/src/parser.rs`
  - `parse_object` に ArrayBegin arm 追加 + 冒頭 `skip_whitespace` 追加
  - `parse_array_body` 新規追加
  - 既存テスト `parse_object_returns_unexpected_token_for_array_begin` を `parse_object_returns_unexpected_eof_for_unclosed_array_begin` にリネームし期待値を `UnexpectedEof` に更新（破壊的変更 C9）
  - モジュール doc コメントを「スカラ + 配列」対応に更新
  - 末尾に `#[cfg(test)] mod array_tests;` を追加

#### 新規ファイル（テスト物理分割）

`rust/crates/core/src/parser/array_tests/` 配下に観点別 11 ファイル + 集約 `array_tests.rs`:

| ファイル | 役割 |
|---|---|
| `empty.rs` | 空配列 `[]` / `[ ]` / `[\n\n]` |
| `flat_scalars.rs` | スカラ要素フラット列（Integer/Boolean/Null/Name/String 各種） |
| `mixed_types.rs` | スカラ混在配列（5 種混在、Integer/Real、長尺、隣接、負数・ゼロ） |
| `nested.rs` | 2 段ネスト |
| `deep_nested.rs` | 3〜4 段ネスト |
| `whitespace_variants.rs` | TAB/CR/LF/CRLF/FF/NUL/多重 SP |
| `comment_interleaved.rs` | 要素間 `%comment` 透過 |
| `unmatched_eof.rs` | `]` 不在 EOF（position 検証含む） |
| `lexer_error_propagation.rs` | 未終端 hex / literal の `LexerError` 伝播 |
| `unexpected_token.rs` | 配列内 R1 範囲外トークン（DictBegin/Keyword 等） |
| `pdf_sample.rs` | ISO 32000-1 §3.7 例 / MediaBox 相当 |

各ファイル ≤ 200 行（最大 122 行）、全テスト関数に日本語コメント付き。

## 📊 システム図

### 状態マシン / フロー図

\`\`\`mermaid
flowchart TD
    Start([parse_object]) --> NT1[next_token]
    NT1 -->|Comment| NT1
    NT1 -->|Primitive| OkPrim([Ok PdfObject])
    NT1 -->|ArrayBegin| PAB[parse_array_body NEW]:::new
    NT1 -->|Other| ErrUT1([Err UnexpectedToken])
    NT1 -->|None / EOF| ErrEof1([Err UnexpectedEof])
    NT1 -->|None / not EOF| ErrLex1([Err LexerError])

    PAB --> Loop[items = Vec::new<br/>loop next_token]
    Loop -->|Comment| Loop
    Loop -->|ArrayEnd| OkArr([Ok PdfObject::Array items])
    Loop -->|Primitive| Push[items.push] --> Loop
    Loop -->|ArrayBegin| Rec[parse_array_body 再帰] --> Push
    Loop -->|Other| ErrUT2([Err UnexpectedToken])
    Loop -->|None / EOF| ErrEof2([Err UnexpectedEof])
    Loop -->|None / not EOF| ErrLex2([Err LexerError])

    classDef new fill:#ffe4b5,stroke:#d97706,stroke-width:2px
\`\`\`

## 📋 関連 Issue

Refs #407

## 🧪 テスト

### テスト実行コマンド

\`\`\`bash
cd rust && cargo test --workspace --all-targets
\`\`\`

### テスト項目

- [x] 単体テスト (Unit tests) — array_tests 配下 49 ケース + 既存 parser インラインテスト
- [x] 統合テスト (Integration tests) — workspace 全体で 839 passed
- [x] 品質チェック — `cargo build` / `cargo clippy --workspace --all-targets -- -D warnings` / `cargo fmt --all -- --check` all green

### テスト結果

- 単体: 839 passed / 0 failed
- clippy: 警告ゼロ
- fmt: 差分ゼロ

## 🔍 レビューポイント

- **F9 (UnexpectedToken の position = トークン開始位置) の遵守**: `parse_object` / `parse_array_body` の冒頭で `skip_whitespace()` を明示呼び出ししている。これは `Lexer::next_token` 内部の `skip_whitespace` と二重実行になるが、idempotent でありかつ要件 F9 を厳密に満たすために必要。NF4「スカラ経路パフォーマンス劣化なし」の精神に照らして許容範囲と判断。
- **既存テスト破壊的変更（C9）**: `parse_object_returns_unexpected_token_for_array_begin` を `parse_object_returns_unexpected_eof_for_unclosed_array_begin` にリネーム、期待値を `UnexpectedEof` に変更。`b"["` 入力が配列パスに入る挙動の変化を反映。
- **ネスト深さ無制限**: Rust の再帰スタックに任せる設計（spec で accepted）。極端な malformed 入力での stack overflow 可能性は将来 fuzzer で cap 後付けの余地を残す。

## ⚠️ 破壊的変更

- [x] 既存テスト 1 件（`parse_object_returns_unexpected_token_for_array_begin`）の名前・期待値を変更（C9）

公開 API（`parse_object` の戻り値型・エラー型）には変更なし。`b"["` のような未閉鎖配列入力に対するエラー種が `UnexpectedToken { ArrayBegin }` → `UnexpectedEof` に変わる挙動変化はある。

## ✅ チェックリスト

- [x] コードレビューの準備ができている（codex + spec-based-code-review 共に問題なし）
- [x] テストが正常に実行される（839 passed）
- [x] ドキュメントが更新されている（parser.rs モジュール doc コメント、`parse_object` / `parse_array_body` の doc コメント）
- [x] コミットメッセージが適切な形式で書かれている
- [x] PR 本文に `Refs #407` で Issue が記載されている
- [x] セルフレビューを実施した
- [x] 破壊的変更を明記した

🤖 Generated with [Claude Code](https://claude.com/claude-code)