### PR TITLE
♻️ #467 #471 配列 operand 実装と Token primitive companion の分散整理

### DIFF
--- a/packages/core/src/pdf/types/token/boolean/__tests__/boolean.basic.test.ts
+++ b/packages/core/src/pdf/types/token/boolean/__tests__/boolean.basic.test.ts
@@ -1,0 +1,16 @@
+import { assert, expect, test } from "vitest";
+import { ByteOffset } from "../../../byte-offset/index";
+import { TokenType } from "../../index";
+import { TokenBoolean } from "../index";
+
+test("TokenBoolean を PdfBoolean に passthrough する（value は加工せず保持）", () => {
+  const token: TokenBoolean = {
+    type: TokenType.Boolean,
+    value: true,
+    offset: ByteOffset.of(0),
+  };
+  const result = TokenBoolean.toPdfValue(token);
+  assert(result.ok);
+  assert(result.value.some);
+  expect(result.value.value).toEqual({ type: "boolean", value: true });
+});

--- a/packages/core/src/pdf/types/token/boolean/index.ts
+++ b/packages/core/src/pdf/types/token/boolean/index.ts
@@ -1,0 +1,33 @@
+import type { Option } from "../../../../utils/option/index";
+import { some } from "../../../../utils/option/index";
+import type { Result } from "../../../../utils/result/index";
+import { ok } from "../../../../utils/result/index";
+import type { PdfError } from "../../../errors/index";
+import type { ByteOffset } from "../../byte-offset/index";
+import type { PdfBoolean } from "../../pdf-types/index";
+import type { TokenType } from "../index";
+
+/**
+ * Boolean リテラル (`true` / `false`) トークン。
+ */
+export interface TokenBoolean {
+  type: TokenType.Boolean;
+  value: boolean;
+  offset: ByteOffset;
+}
+
+/**
+ * `TokenBoolean` の domain utility を束ねた companion object。
+ * 型と value を同一識別子で公開する declaration merging パターン。
+ */
+export const TokenBoolean = {
+  /**
+   * Boolean token を PdfBoolean へ変換する。常に成功する。
+   *
+   * @param token - 変換対象 token
+   * @returns 変換した PdfBoolean を含む `ok(some(...))`
+   */
+  toPdfValue(token: TokenBoolean): Result<Option<PdfBoolean>, PdfError> {
+    return ok(some({ type: "boolean", value: token.value }));
+  },
+} as const;

--- a/packages/core/src/pdf/types/token/hex-string/__tests__/hex-string.basic.test.ts
+++ b/packages/core/src/pdf/types/token/hex-string/__tests__/hex-string.basic.test.ts
@@ -1,0 +1,65 @@
+import { assert, expect, test } from "vitest";
+import { ByteOffset } from "../../../byte-offset/index";
+import { TokenType } from "../../index";
+import { TokenHexString } from "../index";
+
+test("偶数桁 hex を decode して PdfString(encoding:'hex') を返す", () => {
+  const token: TokenHexString = {
+    type: TokenType.HexString,
+    value: "48656C6C6F",
+    offset: ByteOffset.of(0),
+  };
+  const result = TokenHexString.toPdfValue(token);
+  assert(result.ok);
+  assert(result.value.some);
+  expect(result.value.value).toEqual({
+    type: "string",
+    value: new Uint8Array([0x48, 0x65, 0x6c, 0x6c, 0x6f]),
+    encoding: "hex",
+  });
+});
+
+test("奇数桁 hex は末尾 0 補完で decode される", () => {
+  const token: TokenHexString = {
+    type: TokenType.HexString,
+    value: "414",
+    offset: ByteOffset.of(0),
+  };
+  const result = TokenHexString.toPdfValue(token);
+  assert(result.ok);
+  assert(result.value.some);
+  expect(result.value.value).toEqual({
+    type: "string",
+    value: new Uint8Array([0x41, 0x40]),
+    encoding: "hex",
+  });
+});
+
+test("空文字列を空のバイト列として decode する", () => {
+  const token: TokenHexString = {
+    type: TokenType.HexString,
+    value: "",
+    offset: ByteOffset.of(0),
+  };
+  const result = TokenHexString.toPdfValue(token);
+  assert(result.ok);
+  assert(result.value.some);
+  expect(result.value.value).toEqual({
+    type: "string",
+    value: new Uint8Array([]),
+    encoding: "hex",
+  });
+});
+
+test("非 hex 文字を含むと OBJECT_PARSE_UNEXPECTED_TOKEN と decoded.error を返す", () => {
+  const token: TokenHexString = {
+    type: TokenType.HexString,
+    value: "ZZ",
+    offset: ByteOffset.of(5),
+  };
+  const result = TokenHexString.toPdfValue(token);
+  assert(!result.ok);
+  assert(result.error.code === "OBJECT_PARSE_UNEXPECTED_TOKEN");
+  expect(result.error.message).toBe('Invalid hex digits in hex string: "ZZ"');
+  expect(result.error.offset).toBe(5);
+});

--- a/packages/core/src/pdf/types/token/hex-string/index.ts
+++ b/packages/core/src/pdf/types/token/hex-string/index.ts
@@ -1,0 +1,44 @@
+import { decodeHexString } from "../../../../objects/object-parser/string-decoder/index";
+import type { Option } from "../../../../utils/option/index";
+import { some } from "../../../../utils/option/index";
+import type { Result } from "../../../../utils/result/index";
+import { err, ok } from "../../../../utils/result/index";
+import type { PdfError } from "../../../errors/index";
+import type { ByteOffset } from "../../byte-offset/index";
+import type { PdfString } from "../../pdf-types/index";
+import type { TokenType } from "../index";
+
+/**
+ * 16進文字列 (`<...>`) トークン。
+ */
+export interface TokenHexString {
+  type: TokenType.HexString;
+  value: string;
+  offset: ByteOffset;
+}
+
+/**
+ * `TokenHexString` の domain utility を束ねた companion object。
+ * 型と value を同一識別子で公開する declaration merging パターン。
+ */
+export const TokenHexString = {
+  /**
+   * Hex string token を PdfString(encoding:"hex") へ変換する。
+   * `decodeHexString` の失敗時は `OBJECT_PARSE_UNEXPECTED_TOKEN` で
+   * decode エラーメッセージをそのまま返す。
+   *
+   * @param token - 変換対象 token
+   * @returns 変換した PdfString を含む `ok(some(...))`、または decode 失敗時のエラー
+   */
+  toPdfValue(token: TokenHexString): Result<Option<PdfString>, PdfError> {
+    const decoded = decodeHexString(token.value);
+    if (!decoded.ok) {
+      return err({
+        code: "OBJECT_PARSE_UNEXPECTED_TOKEN",
+        message: decoded.error,
+        offset: token.offset,
+      });
+    }
+    return ok(some({ type: "string", value: decoded.value, encoding: "hex" }));
+  },
+} as const;

--- a/packages/core/src/pdf/types/token/index.ts
+++ b/packages/core/src/pdf/types/token/index.ts
@@ -205,7 +205,9 @@ export const Token = {
 
 /**
  * Token をエラーメッセージなどに埋め込むための文字列表現。
- * Operator は name、Null/EOF は "null"、それ以外は value を文字列化する。
+ * Operator は name、InlineImage は固定文字列 `"BI ... ID ... EI"`
+ * （`data: Uint8Array` を文字列化しても意味がないため）、
+ * Null/EOF は `"null"`、それ以外は value を文字列化する。
  *
  * @param token - 表示対象のトークン
  * @returns 表示用文字列

--- a/packages/core/src/pdf/types/token/index.ts
+++ b/packages/core/src/pdf/types/token/index.ts
@@ -1,14 +1,25 @@
-import {
-  decodeHexString,
-  decodeLiteralString,
-} from "../../../objects/object-parser/string-decoder/index";
 import type { Option } from "../../../utils/option/index";
-import { none, some } from "../../../utils/option/index";
+import { none } from "../../../utils/option/index";
 import type { Result } from "../../../utils/result/index";
-import { err, ok } from "../../../utils/result/index";
+import { ok } from "../../../utils/result/index";
 import type { PdfError } from "../../errors/index";
 import type { ByteOffset } from "../byte-offset/index";
 import type { PdfValue } from "../pdf-types/index";
+import { TokenBoolean } from "./boolean/index";
+import { TokenHexString } from "./hex-string/index";
+import { TokenInteger } from "./integer/index";
+import { TokenLiteralString } from "./literal-string/index";
+import { TokenName } from "./name/index";
+import { TokenNull } from "./null/index";
+import { TokenReal } from "./real/index";
+
+export { TokenBoolean } from "./boolean/index";
+export { TokenHexString } from "./hex-string/index";
+export { TokenInteger } from "./integer/index";
+export { TokenLiteralString } from "./literal-string/index";
+export { TokenName } from "./name/index";
+export { TokenNull } from "./null/index";
+export { TokenReal } from "./real/index";
 
 /**
  * PDFトークンの種別を表す列挙型。
@@ -30,60 +41,6 @@ export enum TokenType {
   Operator = "Operator",
   InlineImage = "InlineImage",
   EOF = "EOF",
-}
-
-/**
- * Boolean リテラル (`true` / `false`) トークン。
- */
-export interface TokenBoolean {
-  type: TokenType.Boolean;
-  value: boolean;
-  offset: ByteOffset;
-}
-
-/**
- * 整数リテラル (`123`, `-7`) トークン。
- */
-export interface TokenInteger {
-  type: TokenType.Integer;
-  value: number;
-  offset: ByteOffset;
-}
-
-/**
- * 実数リテラル (`3.14`, `.5`) トークン。
- */
-export interface TokenReal {
-  type: TokenType.Real;
-  value: number;
-  offset: ByteOffset;
-}
-
-/**
- * リテラル文字列 (`(...)`) トークン。
- */
-export interface TokenLiteralString {
-  type: TokenType.LiteralString;
-  value: string;
-  offset: ByteOffset;
-}
-
-/**
- * 16進文字列 (`<...>`) トークン。
- */
-export interface TokenHexString {
-  type: TokenType.HexString;
-  value: string;
-  offset: ByteOffset;
-}
-
-/**
- * 名前オブジェクト (`/Name`) トークン。
- */
-export interface TokenName {
-  type: TokenType.Name;
-  value: string;
-  offset: ByteOffset;
 }
 
 /**
@@ -119,16 +76,6 @@ export interface TokenDictBegin {
 export interface TokenDictEnd {
   type: TokenType.DictEnd;
   value: ">>";
-  offset: ByteOffset;
-}
-
-/**
- * `null` リテラルトークン。
- * PDF 仕様の `null` オブジェクトを保持するため、value は `null` 固定。
- */
-export interface TokenNull {
-  type: TokenType.Null;
-  value: null;
   offset: ByteOffset;
 }
 
@@ -226,10 +173,10 @@ export const Token = {
    * content stream の primitive token を PdfValue へ変換する。
    *
    * interpreter のメインループと配列リテラル reader の両方から呼ばれる共有純関数。
-   * primitive 7 種（Boolean / Integer / Real / Name / Null / LiteralString / HexString）
-   * のみ `Some(PdfValue)` を返し、それ以外（Operator / Keyword / InlineImage /
-   * Array/Dict 開閉 / EOF）は `None` を返す。複合 delimiter の拒否や operator
-   * dispatch は呼び出し側の責務。
+   * 各 primitive 種別 companion の `toPdfValue` へ dispatch するだけで、変換ロジック
+   * は各 sub-directory に局在化されている。primitive 7 種以外（Operator / Keyword /
+   * InlineImage / Array/Dict 開閉 / EOF）は `None` を返し、複合 delimiter の拒否や
+   * operator dispatch は呼び出し側の責務。
    *
    * @param token - 変換対象 token
    * @returns 変換した PdfValue、対象外 token の None、または変換エラー
@@ -237,92 +184,24 @@ export const Token = {
   toPrimitivePdfValue(token: Token): Result<Option<PdfValue>, PdfError> {
     switch (token.type) {
       case TokenType.Boolean:
-        return ok(some({ type: "boolean", value: token.value }));
+        return TokenBoolean.toPdfValue(token);
       case TokenType.Integer:
-        return integerToPdfValue(token);
+        return TokenInteger.toPdfValue(token);
       case TokenType.Real:
-        return realToPdfValue(token);
-      case TokenType.LiteralString:
-        return literalStringToPdfValue(token);
-      case TokenType.HexString:
-        return hexStringToPdfValue(token);
+        return TokenReal.toPdfValue(token);
       case TokenType.Name:
-        return ok(some({ type: "name", value: token.value }));
+        return TokenName.toPdfValue(token);
       case TokenType.Null:
-        return ok(some({ type: "null" }));
+        return TokenNull.toPdfValue(token);
+      case TokenType.LiteralString:
+        return TokenLiteralString.toPdfValue(token);
+      case TokenType.HexString:
+        return TokenHexString.toPdfValue(token);
       default:
         return ok(none);
     }
   },
 } as const;
-
-function integerToPdfValue(
-  token: TokenInteger,
-): Result<Option<PdfValue>, PdfError> {
-  if (Number.isNaN(token.value)) {
-    return err({
-      code: "OBJECT_PARSE_UNEXPECTED_TOKEN",
-      message: `NaN integer token at offset ${token.offset}`,
-      offset: token.offset,
-    });
-  }
-
-  return ok(some({ type: "integer", value: token.value }));
-}
-
-function realToPdfValue(token: TokenReal): Result<Option<PdfValue>, PdfError> {
-  if (Number.isNaN(token.value)) {
-    return err({
-      code: "OBJECT_PARSE_UNEXPECTED_TOKEN",
-      message: `NaN real token at offset ${token.offset}`,
-      offset: token.offset,
-    });
-  }
-
-  return ok(some({ type: "real", value: token.value }));
-}
-
-function literalStringToPdfValue(
-  token: TokenLiteralString,
-): Result<Option<PdfValue>, PdfError> {
-  const decoded = decodeLiteralString(token.value);
-  if (!decoded.ok) {
-    return err({
-      code: "OBJECT_PARSE_UNEXPECTED_TOKEN",
-      message: decoded.error,
-      offset: token.offset,
-    });
-  }
-
-  return ok(
-    some({
-      type: "string",
-      value: decoded.value,
-      encoding: "literal",
-    }),
-  );
-}
-
-function hexStringToPdfValue(
-  token: TokenHexString,
-): Result<Option<PdfValue>, PdfError> {
-  const decoded = decodeHexString(token.value);
-  if (!decoded.ok) {
-    return err({
-      code: "OBJECT_PARSE_UNEXPECTED_TOKEN",
-      message: decoded.error,
-      offset: token.offset,
-    });
-  }
-
-  return ok(
-    some({
-      type: "string",
-      value: decoded.value,
-      encoding: "hex",
-    }),
-  );
-}
 
 /**
  * Token をエラーメッセージなどに埋め込むための文字列表現。

--- a/packages/core/src/pdf/types/token/integer/__tests__/integer.basic.test.ts
+++ b/packages/core/src/pdf/types/token/integer/__tests__/integer.basic.test.ts
@@ -1,0 +1,64 @@
+import { assert, expect, test } from "vitest";
+import { ByteOffset } from "../../../byte-offset/index";
+import { TokenType } from "../../index";
+import { TokenInteger } from "../index";
+
+test("正の整数の TokenInteger を PdfInteger に変換する", () => {
+  const token: TokenInteger = {
+    type: TokenType.Integer,
+    value: 42,
+    offset: ByteOffset.of(10),
+  };
+  const result = TokenInteger.toPdfValue(token);
+  assert(result.ok);
+  assert(result.value.some);
+  expect(result.value.value).toEqual({ type: "integer", value: 42 });
+});
+
+test("ゼロの TokenInteger を PdfInteger に変換する", () => {
+  const token: TokenInteger = {
+    type: TokenType.Integer,
+    value: 0,
+    offset: ByteOffset.of(0),
+  };
+  const result = TokenInteger.toPdfValue(token);
+  assert(result.ok);
+  assert(result.value.some);
+  expect(result.value.value).toEqual({ type: "integer", value: 0 });
+});
+
+test("負の整数の TokenInteger を PdfInteger に変換する", () => {
+  const token: TokenInteger = {
+    type: TokenType.Integer,
+    value: -7,
+    offset: ByteOffset.of(3),
+  };
+  const result = TokenInteger.toPdfValue(token);
+  assert(result.ok);
+  assert(result.value.some);
+  expect(result.value.value).toEqual({ type: "integer", value: -7 });
+});
+
+test("NaN 整数 token に対し OBJECT_PARSE_UNEXPECTED_TOKEN を返す", () => {
+  const token: TokenInteger = {
+    type: TokenType.Integer,
+    value: NaN,
+    offset: ByteOffset.of(10),
+  };
+  const result = TokenInteger.toPdfValue(token);
+  assert(!result.ok);
+  assert(result.error.code === "OBJECT_PARSE_UNEXPECTED_TOKEN");
+  expect(result.error.message).toBe("NaN integer token at offset 10");
+  expect(result.error.offset).toBe(10);
+});
+
+test("NaN 整数 token のメッセージは offset を動的に展開する", () => {
+  const token: TokenInteger = {
+    type: TokenType.Integer,
+    value: NaN,
+    offset: ByteOffset.of(99),
+  };
+  const result = TokenInteger.toPdfValue(token);
+  assert(!result.ok);
+  expect(result.error.message).toBe("NaN integer token at offset 99");
+});

--- a/packages/core/src/pdf/types/token/integer/index.ts
+++ b/packages/core/src/pdf/types/token/integer/index.ts
@@ -1,0 +1,41 @@
+import type { Option } from "../../../../utils/option/index";
+import { some } from "../../../../utils/option/index";
+import type { Result } from "../../../../utils/result/index";
+import { err, ok } from "../../../../utils/result/index";
+import type { PdfError } from "../../../errors/index";
+import type { ByteOffset } from "../../byte-offset/index";
+import type { PdfInteger } from "../../pdf-types/index";
+import type { TokenType } from "../index";
+
+/**
+ * 整数リテラル (`123`, `-7`) トークン。
+ */
+export interface TokenInteger {
+  type: TokenType.Integer;
+  value: number;
+  offset: ByteOffset;
+}
+
+/**
+ * `TokenInteger` の domain utility を束ねた companion object。
+ * 型と value を同一識別子で公開する declaration merging パターン。
+ */
+export const TokenInteger = {
+  /**
+   * Integer token を PdfInteger へ変換する。
+   * value が NaN の場合は `OBJECT_PARSE_UNEXPECTED_TOKEN` エラーを返す。
+   *
+   * @param token - 変換対象 token
+   * @returns 変換した PdfInteger を含む `ok(some(...))`、または NaN 入力時のエラー
+   */
+  toPdfValue(token: TokenInteger): Result<Option<PdfInteger>, PdfError> {
+    if (Number.isNaN(token.value)) {
+      return err({
+        code: "OBJECT_PARSE_UNEXPECTED_TOKEN",
+        message: `NaN integer token at offset ${token.offset}`,
+        offset: token.offset,
+      });
+    }
+    return ok(some({ type: "integer", value: token.value }));
+  },
+} as const;

--- a/packages/core/src/pdf/types/token/literal-string/__tests__/literal-string.basic.test.ts
+++ b/packages/core/src/pdf/types/token/literal-string/__tests__/literal-string.basic.test.ts
@@ -1,0 +1,67 @@
+import { assert, expect, test } from "vitest";
+import { ByteOffset } from "../../../byte-offset/index";
+import { TokenType } from "../../index";
+import { TokenLiteralString } from "../index";
+
+test("ASCII リテラルを decode して PdfString(encoding:'literal') を返す", () => {
+  const token: TokenLiteralString = {
+    type: TokenType.LiteralString,
+    value: "Hello",
+    offset: ByteOffset.of(0),
+  };
+  const result = TokenLiteralString.toPdfValue(token);
+  assert(result.ok);
+  assert(result.value.some);
+  expect(result.value.value).toEqual({
+    type: "string",
+    value: new Uint8Array([0x48, 0x65, 0x6c, 0x6c, 0x6f]),
+    encoding: "literal",
+  });
+});
+
+test("バックスラッシュを含むリテラルをエスケープ非解釈で素通しする", () => {
+  const token: TokenLiteralString = {
+    type: TokenType.LiteralString,
+    value: "a\\nb",
+    offset: ByteOffset.of(0),
+  };
+  const result = TokenLiteralString.toPdfValue(token);
+  assert(result.ok);
+  assert(result.value.some);
+  expect(result.value.value).toEqual({
+    type: "string",
+    value: new Uint8Array([0x61, 0x5c, 0x6e, 0x62]),
+    encoding: "literal",
+  });
+});
+
+test("空文字列を空のバイト列として decode する", () => {
+  const token: TokenLiteralString = {
+    type: TokenType.LiteralString,
+    value: "",
+    offset: ByteOffset.of(0),
+  };
+  const result = TokenLiteralString.toPdfValue(token);
+  assert(result.ok);
+  assert(result.value.some);
+  expect(result.value.value).toEqual({
+    type: "string",
+    value: new Uint8Array([]),
+    encoding: "literal",
+  });
+});
+
+test("decode 失敗時は OBJECT_PARSE_UNEXPECTED_TOKEN と decoded.error を返す", () => {
+  const token: TokenLiteralString = {
+    type: TokenType.LiteralString,
+    value: "Ā",
+    offset: ByteOffset.of(0),
+  };
+  const result = TokenLiteralString.toPdfValue(token);
+  assert(!result.ok);
+  assert(result.error.code === "OBJECT_PARSE_UNEXPECTED_TOKEN");
+  expect(result.error.message).toBe(
+    "Invalid literal string byte value: 256 at index 0",
+  );
+  expect(result.error.offset).toBe(0);
+});

--- a/packages/core/src/pdf/types/token/literal-string/index.ts
+++ b/packages/core/src/pdf/types/token/literal-string/index.ts
@@ -1,0 +1,46 @@
+import { decodeLiteralString } from "../../../../objects/object-parser/string-decoder/index";
+import type { Option } from "../../../../utils/option/index";
+import { some } from "../../../../utils/option/index";
+import type { Result } from "../../../../utils/result/index";
+import { err, ok } from "../../../../utils/result/index";
+import type { PdfError } from "../../../errors/index";
+import type { ByteOffset } from "../../byte-offset/index";
+import type { PdfString } from "../../pdf-types/index";
+import type { TokenType } from "../index";
+
+/**
+ * リテラル文字列 (`(...)`) トークン。
+ */
+export interface TokenLiteralString {
+  type: TokenType.LiteralString;
+  value: string;
+  offset: ByteOffset;
+}
+
+/**
+ * `TokenLiteralString` の domain utility を束ねた companion object。
+ * 型と value を同一識別子で公開する declaration merging パターン。
+ */
+export const TokenLiteralString = {
+  /**
+   * Literal string token を PdfString(encoding:"literal") へ変換する。
+   * `decodeLiteralString` の失敗時は `OBJECT_PARSE_UNEXPECTED_TOKEN` で
+   * decode エラーメッセージをそのまま返す。
+   *
+   * @param token - 変換対象 token
+   * @returns 変換した PdfString を含む `ok(some(...))`、または decode 失敗時のエラー
+   */
+  toPdfValue(token: TokenLiteralString): Result<Option<PdfString>, PdfError> {
+    const decoded = decodeLiteralString(token.value);
+    if (!decoded.ok) {
+      return err({
+        code: "OBJECT_PARSE_UNEXPECTED_TOKEN",
+        message: decoded.error,
+        offset: token.offset,
+      });
+    }
+    return ok(
+      some({ type: "string", value: decoded.value, encoding: "literal" }),
+    );
+  },
+} as const;

--- a/packages/core/src/pdf/types/token/name/__tests__/name.basic.test.ts
+++ b/packages/core/src/pdf/types/token/name/__tests__/name.basic.test.ts
@@ -1,0 +1,16 @@
+import { assert, expect, test } from "vitest";
+import { ByteOffset } from "../../../byte-offset/index";
+import { TokenType } from "../../index";
+import { TokenName } from "../index";
+
+test("TokenName を PdfName に passthrough する（value は加工せず保持）", () => {
+  const token: TokenName = {
+    type: TokenType.Name,
+    value: "Type",
+    offset: ByteOffset.of(0),
+  };
+  const result = TokenName.toPdfValue(token);
+  assert(result.ok);
+  assert(result.value.some);
+  expect(result.value.value).toEqual({ type: "name", value: "Type" });
+});

--- a/packages/core/src/pdf/types/token/name/index.ts
+++ b/packages/core/src/pdf/types/token/name/index.ts
@@ -1,0 +1,33 @@
+import type { Option } from "../../../../utils/option/index";
+import { some } from "../../../../utils/option/index";
+import type { Result } from "../../../../utils/result/index";
+import { ok } from "../../../../utils/result/index";
+import type { PdfError } from "../../../errors/index";
+import type { ByteOffset } from "../../byte-offset/index";
+import type { PdfName } from "../../pdf-types/index";
+import type { TokenType } from "../index";
+
+/**
+ * 名前オブジェクト (`/Name`) トークン。
+ */
+export interface TokenName {
+  type: TokenType.Name;
+  value: string;
+  offset: ByteOffset;
+}
+
+/**
+ * `TokenName` の domain utility を束ねた companion object。
+ * 型と value を同一識別子で公開する declaration merging パターン。
+ */
+export const TokenName = {
+  /**
+   * Name token を PdfName へ変換する。常に成功する。
+   *
+   * @param token - 変換対象 token
+   * @returns 変換した PdfName を含む `ok(some(...))`
+   */
+  toPdfValue(token: TokenName): Result<Option<PdfName>, PdfError> {
+    return ok(some({ type: "name", value: token.value }));
+  },
+} as const;

--- a/packages/core/src/pdf/types/token/null/__tests__/null.basic.test.ts
+++ b/packages/core/src/pdf/types/token/null/__tests__/null.basic.test.ts
@@ -1,0 +1,16 @@
+import { assert, expect, test } from "vitest";
+import { ByteOffset } from "../../../byte-offset/index";
+import { TokenType } from "../../index";
+import { TokenNull } from "../index";
+
+test("TokenNull を PdfNull に変換する", () => {
+  const token: TokenNull = {
+    type: TokenType.Null,
+    value: null,
+    offset: ByteOffset.of(7),
+  };
+  const result = TokenNull.toPdfValue(token);
+  assert(result.ok);
+  assert(result.value.some);
+  expect(result.value.value).toEqual({ type: "null" });
+});

--- a/packages/core/src/pdf/types/token/null/index.ts
+++ b/packages/core/src/pdf/types/token/null/index.ts
@@ -1,0 +1,34 @@
+import type { Option } from "../../../../utils/option/index";
+import { some } from "../../../../utils/option/index";
+import type { Result } from "../../../../utils/result/index";
+import { ok } from "../../../../utils/result/index";
+import type { PdfError } from "../../../errors/index";
+import type { ByteOffset } from "../../byte-offset/index";
+import type { PdfNull } from "../../pdf-types/index";
+import type { TokenType } from "../index";
+
+/**
+ * `null` リテラルトークン。
+ * PDF 仕様の `null` オブジェクトを保持するため、value は `null` 固定。
+ */
+export interface TokenNull {
+  type: TokenType.Null;
+  value: null;
+  offset: ByteOffset;
+}
+
+/**
+ * `TokenNull` の domain utility を束ねた companion object。
+ * 型と value を同一識別子で公開する declaration merging パターン。
+ */
+export const TokenNull = {
+  /**
+   * Null token を PdfNull へ変換する。常に成功する。
+   *
+   * @param _token - 変換対象 token（値は使用しない）
+   * @returns 変換した PdfNull を含む `ok(some(...))`
+   */
+  toPdfValue(_token: TokenNull): Result<Option<PdfNull>, PdfError> {
+    return ok(some({ type: "null" }));
+  },
+} as const;

--- a/packages/core/src/pdf/types/token/real/__tests__/real.basic.test.ts
+++ b/packages/core/src/pdf/types/token/real/__tests__/real.basic.test.ts
@@ -1,0 +1,77 @@
+import { assert, expect, test } from "vitest";
+import { ByteOffset } from "../../../byte-offset/index";
+import { TokenType } from "../../index";
+import { TokenReal } from "../index";
+
+test("正の小数の TokenReal を PdfReal に変換する", () => {
+  const token: TokenReal = {
+    type: TokenType.Real,
+    value: 3.14,
+    offset: ByteOffset.of(12),
+  };
+  const result = TokenReal.toPdfValue(token);
+  assert(result.ok);
+  assert(result.value.some);
+  expect(result.value.value).toEqual({ type: "real", value: 3.14 });
+});
+
+test("ゼロの TokenReal を PdfReal に変換する", () => {
+  const token: TokenReal = {
+    type: TokenType.Real,
+    value: 0,
+    offset: ByteOffset.of(0),
+  };
+  const result = TokenReal.toPdfValue(token);
+  assert(result.ok);
+  assert(result.value.some);
+  expect(result.value.value).toEqual({ type: "real", value: 0 });
+});
+
+test("負の小数の TokenReal を PdfReal に変換する", () => {
+  const token: TokenReal = {
+    type: TokenType.Real,
+    value: -2.5,
+    offset: ByteOffset.of(8),
+  };
+  const result = TokenReal.toPdfValue(token);
+  assert(result.ok);
+  assert(result.value.some);
+  expect(result.value.value).toEqual({ type: "real", value: -2.5 });
+});
+
+test("Infinity を素通しする（既存挙動の維持・Number.isFinite を呼ばない）", () => {
+  const token: TokenReal = {
+    type: TokenType.Real,
+    value: Infinity,
+    offset: ByteOffset.of(4),
+  };
+  const result = TokenReal.toPdfValue(token);
+  assert(result.ok);
+  assert(result.value.some);
+  expect(result.value.value).toEqual({ type: "real", value: Infinity });
+});
+
+test("-Infinity を素通しする（既存挙動の維持）", () => {
+  const token: TokenReal = {
+    type: TokenType.Real,
+    value: -Infinity,
+    offset: ByteOffset.of(4),
+  };
+  const result = TokenReal.toPdfValue(token);
+  assert(result.ok);
+  assert(result.value.some);
+  expect(result.value.value).toEqual({ type: "real", value: -Infinity });
+});
+
+test("NaN real token に対し OBJECT_PARSE_UNEXPECTED_TOKEN を返す", () => {
+  const token: TokenReal = {
+    type: TokenType.Real,
+    value: NaN,
+    offset: ByteOffset.of(20),
+  };
+  const result = TokenReal.toPdfValue(token);
+  assert(!result.ok);
+  assert(result.error.code === "OBJECT_PARSE_UNEXPECTED_TOKEN");
+  expect(result.error.message).toBe("NaN real token at offset 20");
+  expect(result.error.offset).toBe(20);
+});

--- a/packages/core/src/pdf/types/token/real/index.ts
+++ b/packages/core/src/pdf/types/token/real/index.ts
@@ -1,0 +1,42 @@
+import type { Option } from "../../../../utils/option/index";
+import { some } from "../../../../utils/option/index";
+import type { Result } from "../../../../utils/result/index";
+import { err, ok } from "../../../../utils/result/index";
+import type { PdfError } from "../../../errors/index";
+import type { ByteOffset } from "../../byte-offset/index";
+import type { PdfReal } from "../../pdf-types/index";
+import type { TokenType } from "../index";
+
+/**
+ * 実数リテラル (`3.14`, `.5`) トークン。
+ */
+export interface TokenReal {
+  type: TokenType.Real;
+  value: number;
+  offset: ByteOffset;
+}
+
+/**
+ * `TokenReal` の domain utility を束ねた companion object。
+ * 型と value を同一識別子で公開する declaration merging パターン。
+ */
+export const TokenReal = {
+  /**
+   * Real token を PdfReal へ変換する。
+   * value が NaN の場合は `OBJECT_PARSE_UNEXPECTED_TOKEN` エラーを返す。
+   * `Number.isFinite` は呼ばず `Infinity` / `-Infinity` は素通しする（既存挙動）。
+   *
+   * @param token - 変換対象 token
+   * @returns 変換した PdfReal を含む `ok(some(...))`、または NaN 入力時のエラー
+   */
+  toPdfValue(token: TokenReal): Result<Option<PdfReal>, PdfError> {
+    if (Number.isNaN(token.value)) {
+      return err({
+        code: "OBJECT_PARSE_UNEXPECTED_TOKEN",
+        message: `NaN real token at offset ${token.offset}`,
+        offset: token.offset,
+      });
+    }
+    return ok(some({ type: "real", value: token.value }));
+  },
+} as const;


### PR DESCRIPTION
## 概要

Phase 4-I の配列 operand (`[ ... ]`) 実装（#467）と、関連する Token primitive companion 分散リファクタリング（#471）を 1 PR にまとめる。

## 関連 Issue

- Closes #471（Token 種別ごとの companion 分離）
- Refs #467（[Phase 4-I] 配列 operand を operand stack に積む実装）

## 変更の種類

- ✨ 新機能
- ♻️ リファクタリング
- 📝 ドキュメント

## 詳細な変更内容

### 配列 operand 実装（#467）

- 配列リテラル `[ ... ]` 用の `readArrayOperand` を追加
- `ContentStreamInterpreter` に `ArrayBegin` dispatch を追加
- primitive token を `PdfValue` に変換する共有 converter (`Token.toPrimitivePdfValue`) を追加
- TJ integration テストを stream 直接記述形式に書き換え
- primitive 変換ロジックを `Token` companion に統合し直す
- companion を中間エイリアスなしで直接 export

### Token primitive companion 分散（#471）

`Token` companion に集約されていた primitive 7 種の `PdfValue` 変換ロジックを、各 `TokenXxx` 種別の companion へ分散する。`Token.toPrimitivePdfValue` は薄い dispatcher に保ち、将来 token メソッドが増えても Token companion が肥大化しない構造にする。

- ✨ `TokenBoolean` / `TokenName` / `TokenNull` companion を追加（passthrough 3 種）
- ✨ `TokenInteger` / `TokenReal` / `TokenLiteralString` / `TokenHexString` companion を追加（NaN チェック / decode 経由 4 種）
- ♻️ `Token.toPrimitivePdfValue` を 7 case すべて `TokenXxx.toPdfValue` 呼び出しに統一
- ♻️ 不要となった private helper 4 関数（`integerToPdfValue` / `realToPdfValue` / `literalStringToPdfValue` / `hexStringToPdfValue`）を削除
- 📝 `tokenDisplayString` の docComment に `InlineImage` 分岐を追記（既存記述漏れの是正）

## システム図

```mermaid
flowchart TD
    Caller["interpreter / composite-operand"] -->|Token.toPrimitivePdfValue| Dispatcher{"switch token.type"}
    Dispatcher -->|Boolean| Bool["TokenBoolean.toPdfValue"]
    Dispatcher -->|Integer| Int["TokenInteger.toPdfValue<br/>(NaN チェック)"]
    Dispatcher -->|Real| Real["TokenReal.toPdfValue<br/>(NaN チェック・Infinity 素通し)"]
    Dispatcher -->|Name| Name["TokenName.toPdfValue"]
    Dispatcher -->|Null| Null["TokenNull.toPdfValue"]
    Dispatcher -->|LiteralString| Lit["TokenLiteralString.toPdfValue<br/>(decodeLiteralString)"]
    Dispatcher -->|HexString| Hex["TokenHexString.toPdfValue<br/>(decodeHexString)"]
    Dispatcher -->|それ以外| None["ok(none)"]

    Bool --> PdfValue["PdfValue"]
    Int --> PdfValue
    Real --> PdfValue
    Name --> PdfValue
    Null --> PdfValue
    Lit --> PdfValue
    Hex --> PdfValue

    classDef new fill:#ffe4b5,stroke:#d97706,stroke-width:2px
    class Bool,Int,Real,Name,Null,Lit,Hex new
```

## テスト

- `pnpm -F @pdfmod/core test`: 230 files / 2894 tests passed
- `pnpm -F @pdfmod/core typecheck`: パス
- `pnpm -F @pdfmod/core build`: パス
- `pnpm run lint` (biome + oxlint): 0 errors / 0 warnings
- 既存 28 ファイルのテスト無変更で green（`composite-operand/__tests__/array.error.test.ts:71` の `Token.toPrimitivePdfValue 由来` テスト含む）
- 新規 7 つの companion テストファイルがすべて pass

## レビューポイント

- `Token.toPrimitivePdfValue` の公開シグネチャは無変更（呼び出し側 2 箇所 `interpreter/index.ts:229`, `composite-operand/index.ts:81` は無変更）
- エラーコード `OBJECT_PARSE_UNEXPECTED_TOKEN` とエラーメッセージ（`NaN integer token at offset {N}` 等）は既存と完全一致
- `Number.isFinite` は使用せず、`Infinity` / `-Infinity` の素通し挙動を維持（既存挙動踏襲）
- `null/` ディレクトリ名は予約語ではないため採用。TypeScript / vitest / Node ESM の解決に問題なし
- `direct-object/index.ts:65-126` の重複 NaN チェック・decode 処理は本タスクのスコープ外（exploration-report Section 2.6 参照）

## チェックリスト

- [x] コードレビューの準備完了
- [x] テスト正常実行
- [x] 適切なコミットメッセージ（タイプ + Issue 番号 + 主語）
- [x] Issue 連携キーワード本文記載済み
- [x] セルフレビュー実施
- [x] 破壊的変更なし（公開 API 不変）