### PR TITLE
✨ [New Feature]: #408 parser に辞書パース (<< /K v ... >>) を実装

### DIFF
--- a/rust/crates/core/src/parser.rs
+++ b/rust/crates/core/src/parser.rs
@@ -3,16 +3,21 @@
 //! lexer が返す [`Token`](crate::lexer::token::Token) を ISO 32000-1 §7.3 の
 //! オブジェクトに意味付けして [`PdfObject`] に変換する。本モジュールは
 //! スカラ 7 種（Null / Boolean / Integer / Real / LiteralString / HexString /
-//! Name）と配列（要素はスカラまたは配列）を扱い、辞書・stream・間接参照は対象外。
+//! Name）・配列（ISO §7.3.6）・辞書（ISO §7.3.7、`PdfDictionary` を内包）を扱い、
+//! 配列/辞書は要素/値に配列・辞書を含むネストを再帰的にサポートする。stream・
+//! 間接参照は対象外。
 //!
 //! `LiteralString` と `HexString` は出自情報を落として `PdfObject::String` に統合する
 //! （所有ムーブのため clone は発生しない）。`Token::Comment` は透過的にスキップする。
+//! 辞書のキーは `Primitive::Name` のみ受理、値が `Null` のエントリは ISO §7.3.7 準拠で
+//! `PdfDictionary` に登録しない（重複キーで既存値がある場合は削除する）。
 
 pub mod error;
 
 use crate::byte_offset::ByteOffset;
 use crate::lexer::token::{Primitive, Token};
 use crate::lexer::Lexer;
+use crate::object::dictionary::PdfDictionary;
 use crate::object::pdf_object::PdfObject;
 use crate::parser::error::ParseError;
 
@@ -47,9 +52,10 @@ impl<'a> Parser<'a> {
     /// 次のオブジェクトを 1 つ読み取る。
     ///
     /// スカラ 7 種に加え [`Token::ArrayBegin`] を検出した場合は配列パスに分岐し
-    /// [`PdfObject::Array`] を構築する。[`Token::Comment`] は透過的にスキップする。
-    /// 辞書開始/終了・`obj`/`endobj`/`stream`/`endstream`・キーワード等の対象外
-    /// トークンが来た場合は [`ParseErrorKind::UnexpectedToken`](error::ParseErrorKind::UnexpectedToken)、
+    /// [`PdfObject::Array`] を、[`Token::DictBegin`] を検出した場合は辞書パスに分岐し
+    /// [`PdfObject::Dictionary`] を構築する。[`Token::Comment`] は透過的にスキップする。
+    /// `obj`/`endobj`/`stream`/`endstream`・キーワード等の対象外トークンが来た場合は
+    /// [`ParseErrorKind::UnexpectedToken`](error::ParseErrorKind::UnexpectedToken)、
     /// 入力が尽きていれば [`ParseErrorKind::UnexpectedEof`](error::ParseErrorKind::UnexpectedEof)、
     /// lexer が malformed を検知して `None` を返した場合は
     /// [`ParseErrorKind::LexerError`](error::ParseErrorKind::LexerError) を返す。
@@ -61,6 +67,7 @@ impl<'a> Parser<'a> {
                 Some(Token::Comment(_)) => continue,
                 Some(Token::Primitive(p)) => return Ok(Self::primitive_to_object(p)),
                 Some(Token::ArrayBegin) => return self.parse_array_body(),
+                Some(Token::DictBegin) => return self.parse_dictionary_body(),
                 Some(other) => {
                     return Err(ParseError::unexpected_token_at(
                         ByteOffset::new(pos_before as u64),
@@ -81,8 +88,9 @@ impl<'a> Parser<'a> {
     /// `[` を消費済の状態から配列ボディをパースし [`PdfObject::Array`] を返す
     /// （ISO 32000-1 §7.3.6）。要素間 [`Token::Comment`] は透過スキップ、
     /// [`Token::Primitive`] は所有ムーブで [`PdfObject`] に変換して `items` に
-    /// push、[`Token::ArrayBegin`] はネストとして自身を再帰呼び出しする。
-    /// [`Token::ArrayEnd`] でループを脱出する。対象外トークンは
+    /// push、[`Token::ArrayBegin`] はネストとして自身を再帰呼び出しし、
+    /// [`Token::DictBegin`] は辞書要素として [`Self::parse_dictionary_body`] を
+    /// 再帰呼び出しする。[`Token::ArrayEnd`] でループを脱出する。対象外トークンは
     /// [`ParseErrorKind::UnexpectedToken`](error::ParseErrorKind::UnexpectedToken)、
     /// `]` 不在で入力が尽きた場合は
     /// [`ParseErrorKind::UnexpectedEof`](error::ParseErrorKind::UnexpectedEof)、
@@ -98,6 +106,56 @@ impl<'a> Parser<'a> {
                 Some(Token::ArrayEnd) => return Ok(PdfObject::Array(items)),
                 Some(Token::Primitive(p)) => items.push(Self::primitive_to_object(p)),
                 Some(Token::ArrayBegin) => items.push(self.parse_array_body()?),
+                Some(Token::DictBegin) => items.push(self.parse_dictionary_body()?),
+                Some(other) => {
+                    return Err(ParseError::unexpected_token_at(
+                        ByteOffset::new(pos_before as u64),
+                        Self::token_kind_label(&other),
+                    ));
+                }
+                None => {
+                    let pos = ByteOffset::new(self.lexer.position() as u64);
+                    if self.lexer.is_eof() {
+                        return Err(ParseError::unexpected_eof_at(pos));
+                    }
+                    return Err(ParseError::lexer_error_at(pos));
+                }
+            }
+        }
+    }
+
+    /// `<<` を消費済の状態から辞書ボディをパースし [`PdfObject::Dictionary`] を返す
+    /// （ISO 32000-1 §7.3.7）。エントリ間 [`Token::Comment`] は透過スキップ、
+    /// キーは [`Primitive::Name`] のみ受理して所有ムーブで [`PdfName`] として保持し、
+    /// 値は [`Self::parse_object`] の再帰呼び出しで取得する。
+    /// 値が [`PdfObject::Null`] の場合は ISO §7.3.7 に従い [`PdfDictionary::remove`]
+    /// で既存エントリを削除し未登録状態に正規化する。それ以外は
+    /// [`PdfDictionary::insert`] で登録し、重複キーは `BTreeMap` の自動上書きで
+    /// 「最後の値を採用」となる。[`Token::DictEnd`] でループを脱出する。
+    /// キー位置に Name 以外のトークンが来た場合は
+    /// [`ParseErrorKind::UnexpectedToken`](error::ParseErrorKind::UnexpectedToken)、
+    /// `>>` 不在で入力が尽きた場合は
+    /// [`ParseErrorKind::UnexpectedEof`](error::ParseErrorKind::UnexpectedEof)、
+    /// lexer が malformed を検知して `None` を返した場合は
+    /// [`ParseErrorKind::LexerError`](error::ParseErrorKind::LexerError) を fail-fast で返す。
+    ///
+    /// [`PdfName`]: crate::object::name::PdfName
+    fn parse_dictionary_body(&mut self) -> Result<PdfObject, ParseError> {
+        let mut dict = PdfDictionary::new();
+        loop {
+            self.lexer.skip_whitespace();
+            let pos_before = self.lexer.position();
+            match self.lexer.next_token() {
+                Some(Token::Comment(_)) => continue,
+                Some(Token::DictEnd) => return Ok(PdfObject::Dictionary(dict)),
+                Some(Token::Primitive(Primitive::Name(key))) => {
+                    let value = self.parse_object()?;
+                    if value.is_null() {
+                        let _ = dict.remove(&key);
+                    } else {
+                        let _ = dict.insert(key, value);
+                    }
+                }
                 Some(other) => {
                     return Err(ParseError::unexpected_token_at(
                         ByteOffset::new(pos_before as u64),
@@ -151,6 +209,9 @@ impl<'a> Parser<'a> {
 
 #[cfg(test)]
 mod array_tests;
+
+#[cfg(test)]
+mod dictionary_tests;
 
 #[cfg(test)]
 mod tests {
@@ -404,19 +465,6 @@ mod tests {
             err.kind,
             ParseErrorKind::UnexpectedToken {
                 actual_kind: "ArrayEnd"
-            }
-        );
-    }
-
-    #[test]
-    fn parse_object_returns_unexpected_token_for_dict_begin() {
-        // 入力 b"<<" で UnexpectedToken { actual_kind: "DictBegin" } を返すことを確認する
-        let mut p = parser(b"<<");
-        let err = p.parse_object().expect_err("dict begin must error");
-        assert_eq!(
-            err.kind,
-            ParseErrorKind::UnexpectedToken {
-                actual_kind: "DictBegin"
             }
         );
     }

--- a/rust/crates/core/src/parser/array_tests/unexpected_token.rs
+++ b/rust/crates/core/src/parser/array_tests/unexpected_token.rs
@@ -3,19 +3,6 @@ use super::super::error::ParseErrorKind;
 use super::parser;
 
 #[test]
-fn parse_object_returns_unexpected_token_for_dict_begin_in_array() {
-    // 入力 b"[<<]" で配列要素中の DictBegin が UnexpectedToken { "DictBegin" } で fail-fast されることを確認する
-    let mut p = parser(b"[<<]");
-    let err = p.parse_object().expect_err("dict begin must error");
-    assert_eq!(
-        err.kind,
-        ParseErrorKind::UnexpectedToken {
-            actual_kind: "DictBegin"
-        }
-    );
-}
-
-#[test]
 fn parse_object_returns_unexpected_token_for_dict_end_in_array() {
     // 入力 b"[>>]" で配列要素中の DictEnd が UnexpectedToken { "DictEnd" } で fail-fast されることを確認する
     let mut p = parser(b"[>>]");
@@ -105,18 +92,4 @@ fn parse_object_returns_unexpected_token_for_array_end_only() {
         }
     );
     assert_eq!(err.position, ByteOffset::new(0));
-}
-
-#[test]
-fn parse_object_returns_unexpected_token_for_dict_begin_inside_nested_array() {
-    // 入力 b"[1 <<]" でネスト 1 段内の禁止トークン DictBegin が内側 parse_array_body の Some(other) arm で fail-fast し、position が `<<` の開始位置 (3) に固定されることを確認する
-    let mut p = parser(b"[1 <<]");
-    let err = p.parse_object().expect_err("nested dict begin must error");
-    assert_eq!(
-        err.kind,
-        ParseErrorKind::UnexpectedToken {
-            actual_kind: "DictBegin"
-        }
-    );
-    assert_eq!(err.position, ByteOffset::new(3));
 }

--- a/rust/crates/core/src/parser/dictionary_tests.rs
+++ b/rust/crates/core/src/parser/dictionary_tests.rs
@@ -1,0 +1,30 @@
+mod array_value;
+mod comment_interleaved;
+mod duplicate_key;
+mod empty;
+mod key_type_error;
+mod lexer_error_propagation;
+mod mixed_value_types;
+mod multiple_entries;
+mod nested;
+mod null_value;
+mod pdf_sample;
+mod single_entry;
+mod unmatched_eof;
+mod whitespace_variants;
+
+use super::super::object::dictionary::PdfDictionary;
+use super::super::object::pdf_object::PdfObject;
+use super::Parser;
+
+fn parser(input: &[u8]) -> Parser<'_> {
+    Parser::new(input)
+}
+
+pub(super) fn parse_dict(input: &[u8]) -> PdfDictionary {
+    let mut p = parser(input);
+    match p.parse_object().expect("dictionary should parse") {
+        PdfObject::Dictionary(d) => d,
+        other => panic!("expected Dictionary, got {:?}", other),
+    }
+}

--- a/rust/crates/core/src/parser/dictionary_tests/array_value.rs
+++ b/rust/crates/core/src/parser/dictionary_tests/array_value.rs
@@ -1,0 +1,66 @@
+use super::super::super::object::dictionary::PdfDictionary;
+use super::super::super::object::name::PdfName;
+use super::super::super::object::pdf_object::PdfObject;
+use super::parser;
+
+fn parse_object_at(input: &[u8]) -> PdfObject {
+    // テスト用ヘルパ: 入力をパースして PdfObject を取り出す（top-level が辞書か配列か区別しないケースで使う）
+    let mut p = parser(input);
+    p.parse_object().expect("object should parse")
+}
+
+#[test]
+fn parse_object_returns_dictionary_with_integer_array_value() {
+    // 入力 b"<< /A [1 2 3] >>" で /A の値が 3 要素 Integer 配列になることを確認する
+    let dict = match parse_object_at(b"<< /A [1 2 3] >>") {
+        PdfObject::Dictionary(d) => d,
+        other => panic!("expected Dictionary, got {:?}", other),
+    };
+    assert_eq!(
+        dict.get(&PdfName::from("A")),
+        Some(&PdfObject::Array(vec![
+            PdfObject::Integer(1),
+            PdfObject::Integer(2),
+            PdfObject::Integer(3),
+        ]))
+    );
+}
+
+#[test]
+fn parse_object_returns_dictionary_with_array_containing_dictionary() {
+    // 入力 b"<< /A [<< /K 1 >>] >>" で /A の値が「辞書 1 個の配列」になることを確認する（配列内辞書サポート、UC-1）
+    let dict = match parse_object_at(b"<< /A [<< /K 1 >>] >>") {
+        PdfObject::Dictionary(d) => d,
+        other => panic!("expected Dictionary, got {:?}", other),
+    };
+    let mut inner = PdfDictionary::new();
+    inner.insert(PdfName::from("K"), PdfObject::Integer(1));
+    assert_eq!(
+        dict.get(&PdfName::from("A")),
+        Some(&PdfObject::Array(vec![PdfObject::Dictionary(inner)]))
+    );
+}
+
+#[test]
+fn parse_object_returns_array_with_single_dictionary_element() {
+    // 入力 b"[ << /K 1 >> ]" で配列要素として辞書 1 個を持つ配列を返すことを確認する（配列対称性、UC-1）
+    let mut inner = PdfDictionary::new();
+    inner.insert(PdfName::from("K"), PdfObject::Integer(1));
+    assert_eq!(
+        parse_object_at(b"[ << /K 1 >> ]"),
+        PdfObject::Array(vec![PdfObject::Dictionary(inner)])
+    );
+}
+
+#[test]
+fn parse_object_returns_array_with_two_dictionary_elements() {
+    // 入力 b"[ << /K 1 >> << /K 2 >> ]" で配列要素として辞書 2 個を持つ配列を返すことを確認する
+    let mut d1 = PdfDictionary::new();
+    d1.insert(PdfName::from("K"), PdfObject::Integer(1));
+    let mut d2 = PdfDictionary::new();
+    d2.insert(PdfName::from("K"), PdfObject::Integer(2));
+    assert_eq!(
+        parse_object_at(b"[ << /K 1 >> << /K 2 >> ]"),
+        PdfObject::Array(vec![PdfObject::Dictionary(d1), PdfObject::Dictionary(d2)])
+    );
+}

--- a/rust/crates/core/src/parser/dictionary_tests/comment_interleaved.rs
+++ b/rust/crates/core/src/parser/dictionary_tests/comment_interleaved.rs
@@ -1,0 +1,41 @@
+use super::super::super::object::name::PdfName;
+use super::super::super::object::pdf_object::PdfObject;
+use super::parse_dict;
+
+#[test]
+fn parse_object_skips_comment_immediately_after_open() {
+    // 入力 b"<<%a\n>>" で開き直後コメントが透過スキップされ空辞書を返すことを確認する
+    let dict = parse_dict(b"<<%a\n>>");
+    assert!(dict.is_empty());
+}
+
+#[test]
+fn parse_object_skips_comment_before_key() {
+    // 入力 b"<< %a\n /K 1 >>" でキー前コメントが透過スキップされ /K==Integer(1) を返すことを確認する
+    let dict = parse_dict(b"<< %a\n /K 1 >>");
+    assert_eq!(dict.len(), 1);
+    assert_eq!(dict.get(&PdfName::from("K")), Some(&PdfObject::Integer(1)));
+}
+
+#[test]
+fn parse_object_skips_comment_between_key_and_value() {
+    // 入力 b"<< /K %b\n 1 >>" でキーと値の間のコメントが透過スキップされ /K==Integer(1) を返すことを確認する
+    let dict = parse_dict(b"<< /K %b\n 1 >>");
+    assert_eq!(dict.get(&PdfName::from("K")), Some(&PdfObject::Integer(1)));
+}
+
+#[test]
+fn parse_object_skips_comment_at_end() {
+    // 入力 b"<< /K 1 %c\n >>" で末尾コメントが透過スキップされ /K==Integer(1) を返すことを確認する
+    let dict = parse_dict(b"<< /K 1 %c\n >>");
+    assert_eq!(dict.get(&PdfName::from("K")), Some(&PdfObject::Integer(1)));
+}
+
+#[test]
+fn parse_object_skips_comment_between_entries() {
+    // 入力 b"<< /K 1 %d\n /L 2 >>" でエントリ間コメントが透過スキップされ 2 エントリ辞書を返すことを確認する
+    let dict = parse_dict(b"<< /K 1 %d\n /L 2 >>");
+    assert_eq!(dict.len(), 2);
+    assert_eq!(dict.get(&PdfName::from("K")), Some(&PdfObject::Integer(1)));
+    assert_eq!(dict.get(&PdfName::from("L")), Some(&PdfObject::Integer(2)));
+}

--- a/rust/crates/core/src/parser/dictionary_tests/duplicate_key.rs
+++ b/rust/crates/core/src/parser/dictionary_tests/duplicate_key.rs
@@ -1,0 +1,38 @@
+use super::super::super::object::name::PdfName;
+use super::super::super::object::pdf_object::PdfObject;
+use super::parse_dict;
+
+#[test]
+fn parse_object_dedups_duplicate_key_keeping_latest_value() {
+    // 入力 b"<< /A 1 /A 2 >>" で /A の値が最後の Integer(2) になり len==1 であることを確認する（UC-3 最後勝ち）
+    let dict = parse_dict(b"<< /A 1 /A 2 >>");
+    assert_eq!(dict.len(), 1);
+    assert_eq!(dict.get(&PdfName::from("A")), Some(&PdfObject::Integer(2)));
+}
+
+#[test]
+fn parse_object_dedups_triple_duplicate_key_keeping_latest_value() {
+    // 入力 b"<< /A 1 /A 2 /A 3 >>" で /A の値が最後の Integer(3) になり len==1 であることを確認する
+    let dict = parse_dict(b"<< /A 1 /A 2 /A 3 >>");
+    assert_eq!(dict.len(), 1);
+    assert_eq!(dict.get(&PdfName::from("A")), Some(&PdfObject::Integer(3)));
+}
+
+#[test]
+fn parse_object_dedups_same_value_reinsert_keeping_len_one() {
+    // 入力 b"<< /A 1 /A 1 >>" で /A の値が Integer(1) のまま len==1 になることを確認する（同値再挿入）
+    let dict = parse_dict(b"<< /A 1 /A 1 >>");
+    assert_eq!(dict.len(), 1);
+    assert_eq!(dict.get(&PdfName::from("A")), Some(&PdfObject::Integer(1)));
+}
+
+#[test]
+fn parse_object_dedups_different_variant_reinsert_keeping_latest() {
+    // 入力 b"<< /A 1 /A (str) >>" で /A の値が最後の String(b"str") になり len==1 であることを確認する（異種値再挿入）
+    let dict = parse_dict(b"<< /A 1 /A (str) >>");
+    assert_eq!(dict.len(), 1);
+    assert_eq!(
+        dict.get(&PdfName::from("A")),
+        Some(&PdfObject::String(b"str".to_vec()))
+    );
+}

--- a/rust/crates/core/src/parser/dictionary_tests/empty.rs
+++ b/rust/crates/core/src/parser/dictionary_tests/empty.rs
@@ -1,0 +1,43 @@
+use super::super::super::object::dictionary::PdfDictionary;
+use super::super::super::object::pdf_object::PdfObject;
+use super::parser;
+
+#[test]
+fn parse_object_returns_empty_dictionary_for_double_angle_only() {
+    // 入力 b"<<>>" で区切り文字なしの最短空辞書 Ok(Dictionary(空)) を返すことを確認する
+    let mut p = parser(b"<<>>");
+    assert_eq!(
+        p.parse_object(),
+        Ok(PdfObject::Dictionary(PdfDictionary::new()))
+    );
+}
+
+#[test]
+fn parse_object_returns_empty_dictionary_for_double_angle_with_space() {
+    // 入力 b"<< >>" で内部空白あり空辞書 Ok(Dictionary(空)) を返すことを確認する
+    let mut p = parser(b"<< >>");
+    assert_eq!(
+        p.parse_object(),
+        Ok(PdfObject::Dictionary(PdfDictionary::new()))
+    );
+}
+
+#[test]
+fn parse_object_returns_empty_dictionary_for_mixed_whitespace() {
+    // 境界値: 入力 b"<<\n\t  \n>>" で改行・タブ・空白混在の空辞書を返すことを確認する
+    let mut p = parser(b"<<\n\t  \n>>");
+    assert_eq!(
+        p.parse_object(),
+        Ok(PdfObject::Dictionary(PdfDictionary::new()))
+    );
+}
+
+#[test]
+fn parse_object_returns_empty_dictionary_for_comment_only() {
+    // エッジ: 入力 b"<< %a\n>>" でコメントのみの空辞書を Comment 透過スキップで返すことを確認する
+    let mut p = parser(b"<< %a\n>>");
+    assert_eq!(
+        p.parse_object(),
+        Ok(PdfObject::Dictionary(PdfDictionary::new()))
+    );
+}

--- a/rust/crates/core/src/parser/dictionary_tests/key_type_error.rs
+++ b/rust/crates/core/src/parser/dictionary_tests/key_type_error.rs
@@ -1,0 +1,87 @@
+use super::super::error::ParseErrorKind;
+use super::parser;
+
+fn expect_unexpected_token(input: &[u8], expected_kind: &'static str) {
+    let mut p = parser(input);
+    let err = p.parse_object().expect_err("key type error expected");
+    assert_eq!(
+        err.kind,
+        ParseErrorKind::UnexpectedToken {
+            actual_kind: expected_kind
+        },
+        "input={:?}",
+        input
+    );
+}
+
+#[test]
+fn parse_object_rejects_integer_as_key() {
+    // 入力 b"<< 42 1 >>" でキー位置が Integer の場合 UnexpectedToken { "Primitive" } を返すことを確認する
+    expect_unexpected_token(b"<< 42 1 >>", "Primitive");
+}
+
+#[test]
+fn parse_object_rejects_literal_string_as_key() {
+    // 入力 b"<< (str) 1 >>" でキー位置が LiteralString の場合 UnexpectedToken { "Primitive" } を返すことを確認する
+    expect_unexpected_token(b"<< (str) 1 >>", "Primitive");
+}
+
+#[test]
+fn parse_object_rejects_hex_string_as_key() {
+    // 入力 b"<< <48> 1 >>" でキー位置が HexString の場合 UnexpectedToken { "Primitive" } を返すことを確認する
+    expect_unexpected_token(b"<< <48> 1 >>", "Primitive");
+}
+
+#[test]
+fn parse_object_rejects_boolean_as_key() {
+    // 入力 b"<< true 1 >>" でキー位置が Boolean の場合 UnexpectedToken { "Primitive" } を返すことを確認する
+    expect_unexpected_token(b"<< true 1 >>", "Primitive");
+}
+
+#[test]
+fn parse_object_rejects_null_as_key() {
+    // 入力 b"<< null 1 >>" でキー位置が Null の場合 UnexpectedToken { "Primitive" } を返すことを確認する
+    expect_unexpected_token(b"<< null 1 >>", "Primitive");
+}
+
+#[test]
+fn parse_object_rejects_real_as_key() {
+    // 入力 b"<< 1.5 1 >>" でキー位置が Real の場合 UnexpectedToken { "Primitive" } を返すことを確認する
+    expect_unexpected_token(b"<< 1.5 1 >>", "Primitive");
+}
+
+#[test]
+fn parse_object_rejects_array_begin_as_key() {
+    // 入力 b"<< [1] 1 >>" でキー位置が ArrayBegin の場合 UnexpectedToken { "ArrayBegin" } を返すことを確認する
+    expect_unexpected_token(b"<< [1] 1 >>", "ArrayBegin");
+}
+
+#[test]
+fn parse_object_rejects_array_end_as_key() {
+    // 入力 b"<< ] 1 >>" でキー位置が ArrayEnd の場合 UnexpectedToken { "ArrayEnd" } を返すことを確認する
+    expect_unexpected_token(b"<< ] 1 >>", "ArrayEnd");
+}
+
+#[test]
+fn parse_object_rejects_dict_begin_as_key() {
+    // 入力 b"<< << /X 1 >> 1 >>" で外側辞書のキー位置に内側辞書 (DictBegin) が来た場合 UnexpectedToken { "DictBegin" } を返すことを確認する
+    expect_unexpected_token(b"<< << /X 1 >> 1 >>", "DictBegin");
+}
+
+#[test]
+fn parse_object_rejects_keyword_r_as_key() {
+    // 入力 b"<< R 1 >>" でキー位置が Keyword (R) の場合 UnexpectedToken { "Keyword" } を返すことを確認する
+    expect_unexpected_token(b"<< R 1 >>", "Keyword");
+}
+
+#[test]
+fn parse_object_rejects_obj_begin_as_key() {
+    // 入力 b"<< obj 1 >>" でキー位置が ObjBegin の場合 UnexpectedToken { "ObjBegin" } を返すことを確認する
+    expect_unexpected_token(b"<< obj 1 >>", "ObjBegin");
+}
+
+#[test]
+fn parse_object_rejects_stream_begin_as_key() {
+    // 入力 b"<< stream 1 >>" でキー位置が StreamBegin の場合 UnexpectedToken { "StreamBegin" } を返すことを確認する
+    expect_unexpected_token(b"<< stream 1 >>", "StreamBegin");
+}

--- a/rust/crates/core/src/parser/dictionary_tests/lexer_error_propagation.rs
+++ b/rust/crates/core/src/parser/dictionary_tests/lexer_error_propagation.rs
@@ -1,0 +1,25 @@
+use super::super::super::byte_offset::ByteOffset;
+use super::super::error::ParseErrorKind;
+use super::parser;
+
+#[test]
+fn parse_object_returns_lexer_error_for_unterminated_hex_value() {
+    // 入力 b"<< /A <48" で値位置の未終端 HexString が LexerError として伝播し、position が `<` の開始位置 (6) に固定されることを確認する
+    let mut p = parser(b"<< /A <48");
+    let err = p
+        .parse_object()
+        .expect_err("unterminated hex value must error");
+    assert_eq!(err.kind, ParseErrorKind::LexerError);
+    assert_eq!(err.position, ByteOffset::new(6));
+}
+
+#[test]
+fn parse_object_returns_lexer_error_for_invalid_hex_char_in_value() {
+    // 入力 b"<< /A <4Z> >>" で値位置の不正 16 進文字 (`Z`) が LexerError として伝播し、position が `<` の開始位置 (6) に固定されることを確認する
+    let mut p = parser(b"<< /A <4Z> >>");
+    let err = p
+        .parse_object()
+        .expect_err("invalid hex char in value must error");
+    assert_eq!(err.kind, ParseErrorKind::LexerError);
+    assert_eq!(err.position, ByteOffset::new(6));
+}

--- a/rust/crates/core/src/parser/dictionary_tests/mixed_value_types.rs
+++ b/rust/crates/core/src/parser/dictionary_tests/mixed_value_types.rs
@@ -1,0 +1,35 @@
+use super::super::super::object::dictionary::PdfDictionary;
+use super::super::super::object::name::PdfName;
+use super::super::super::object::pdf_object::PdfObject;
+use super::parse_dict;
+
+#[test]
+fn parse_object_returns_dictionary_with_all_value_types_mixed() {
+    // 入力 1 辞書内に Boolean / Integer / Real / String / Name / Array / Dictionary を混在し、各キーが正しい型を保持することを確認する
+    let dict = parse_dict(b"<< /B true /I 12 /R 0.5 /S (x) /N /V /Arr [1] /Dict << /K 1 >> >>");
+    assert_eq!(dict.len(), 7);
+    assert_eq!(
+        dict.get(&PdfName::from("B")),
+        Some(&PdfObject::Boolean(true))
+    );
+    assert_eq!(dict.get(&PdfName::from("I")), Some(&PdfObject::Integer(12)));
+    assert_eq!(dict.get(&PdfName::from("R")), Some(&PdfObject::Real(0.5)));
+    assert_eq!(
+        dict.get(&PdfName::from("S")),
+        Some(&PdfObject::String(b"x".to_vec()))
+    );
+    assert_eq!(
+        dict.get(&PdfName::from("N")),
+        Some(&PdfObject::Name(PdfName::from("V")))
+    );
+    assert_eq!(
+        dict.get(&PdfName::from("Arr")),
+        Some(&PdfObject::Array(vec![PdfObject::Integer(1)]))
+    );
+    let mut inner = PdfDictionary::new();
+    inner.insert(PdfName::from("K"), PdfObject::Integer(1));
+    assert_eq!(
+        dict.get(&PdfName::from("Dict")),
+        Some(&PdfObject::Dictionary(inner))
+    );
+}

--- a/rust/crates/core/src/parser/dictionary_tests/multiple_entries.rs
+++ b/rust/crates/core/src/parser/dictionary_tests/multiple_entries.rs
@@ -1,0 +1,43 @@
+use super::super::super::object::name::PdfName;
+use super::super::super::object::pdf_object::PdfObject;
+use super::parse_dict;
+
+#[test]
+fn parse_object_returns_dictionary_with_three_entries() {
+    // 入力 b"<< /A 1 /B 2 /C 3 >>" で 3 エントリ辞書 (len==3) を返し各キーに対応する値が一致することを確認する
+    let dict = parse_dict(b"<< /A 1 /B 2 /C 3 >>");
+    assert_eq!(dict.len(), 3);
+    assert_eq!(dict.get(&PdfName::from("A")), Some(&PdfObject::Integer(1)));
+    assert_eq!(dict.get(&PdfName::from("B")), Some(&PdfObject::Integer(2)));
+    assert_eq!(dict.get(&PdfName::from("C")), Some(&PdfObject::Integer(3)));
+}
+
+#[test]
+fn parse_object_returns_dictionary_with_five_entries() {
+    // 入力 b"<< /A 1 /B 2 /C 3 /D 4 /E 5 >>" で 5 エントリ辞書 (len==5) を返すことを確認する（スケール検証）
+    let dict = parse_dict(b"<< /A 1 /B 2 /C 3 /D 4 /E 5 >>");
+    assert_eq!(dict.len(), 5);
+    for (key, value) in [("A", 1), ("B", 2), ("C", 3), ("D", 4), ("E", 5)] {
+        assert_eq!(
+            dict.get(&PdfName::from(key)),
+            Some(&PdfObject::Integer(value))
+        );
+    }
+}
+
+#[test]
+fn parse_object_returns_dictionary_with_one_hundred_entries() {
+    // 境界値: 100 エントリの大量データでも全キーが contains_key で true / len==100 になることを確認する
+    let mut input: Vec<u8> = b"<<".to_vec();
+    for i in 0..100 {
+        input.extend_from_slice(format!(" /K{} {}", i, i).as_bytes());
+    }
+    input.extend_from_slice(b" >>");
+
+    let dict = parse_dict(&input);
+    assert_eq!(dict.len(), 100);
+    for i in 0..100 {
+        let key = PdfName::from(format!("K{}", i).as_str());
+        assert_eq!(dict.get(&key), Some(&PdfObject::Integer(i)));
+    }
+}

--- a/rust/crates/core/src/parser/dictionary_tests/nested.rs
+++ b/rust/crates/core/src/parser/dictionary_tests/nested.rs
@@ -1,0 +1,55 @@
+use super::super::super::object::dictionary::PdfDictionary;
+use super::super::super::object::name::PdfName;
+use super::super::super::object::pdf_object::PdfObject;
+use super::parse_dict;
+
+fn expect_inner_dict<'a>(dict: &'a PdfDictionary, key: &str) -> &'a PdfDictionary {
+    match dict.get(&PdfName::from(key)) {
+        Some(PdfObject::Dictionary(d)) => d,
+        other => panic!("expected nested Dictionary at /{}, got {:?}", key, other),
+    }
+}
+
+#[test]
+fn parse_object_returns_two_level_nested_dictionary() {
+    // 入力 b"<< /Sub << /K 1 >> >>" で 2 段ネスト辞書 /Sub の値が Dictionary(/K==Integer(1)) になることを確認する
+    let dict = parse_dict(b"<< /Sub << /K 1 >> >>");
+    let inner = expect_inner_dict(&dict, "Sub");
+    assert_eq!(inner.len(), 1);
+    assert_eq!(inner.get(&PdfName::from("K")), Some(&PdfObject::Integer(1)));
+}
+
+#[test]
+fn parse_object_returns_three_level_nested_dictionary() {
+    // 入力 b"<< /A << /B << /C 1 >> >> >>" で 3 段ネスト辞書を再帰的にパースし最深 /C==Integer(1) を取得できることを確認する
+    let dict = parse_dict(b"<< /A << /B << /C 1 >> >> >>");
+    let level1 = expect_inner_dict(&dict, "A");
+    let level2 = expect_inner_dict(level1, "B");
+    assert_eq!(level2.len(), 1);
+    assert_eq!(
+        level2.get(&PdfName::from("C")),
+        Some(&PdfObject::Integer(1))
+    );
+}
+
+#[test]
+fn parse_object_returns_two_sibling_nested_dictionaries() {
+    // 入力 b"<< /A << /X 1 >> /B << /Y 2 >> >>" で兄弟ネスト辞書が独立して保持されることを確認する
+    let dict = parse_dict(b"<< /A << /X 1 >> /B << /Y 2 >> >>");
+    assert_eq!(dict.len(), 2);
+    let a = expect_inner_dict(&dict, "A");
+    assert_eq!(a.get(&PdfName::from("X")), Some(&PdfObject::Integer(1)));
+    let b = expect_inner_dict(&dict, "B");
+    assert_eq!(b.get(&PdfName::from("Y")), Some(&PdfObject::Integer(2)));
+}
+
+#[test]
+fn parse_object_returns_five_level_nested_dictionary() {
+    // 入力 b"<< /A << /B << /C << /D << /E 1 >> >> >> >> >>" で 5 段の深ネスト辞書を再帰的にパースできることを確認する
+    let dict = parse_dict(b"<< /A << /B << /C << /D << /E 1 >> >> >> >> >>");
+    let l1 = expect_inner_dict(&dict, "A");
+    let l2 = expect_inner_dict(l1, "B");
+    let l3 = expect_inner_dict(l2, "C");
+    let l4 = expect_inner_dict(l3, "D");
+    assert_eq!(l4.get(&PdfName::from("E")), Some(&PdfObject::Integer(1)));
+}

--- a/rust/crates/core/src/parser/dictionary_tests/null_value.rs
+++ b/rust/crates/core/src/parser/dictionary_tests/null_value.rs
@@ -1,0 +1,37 @@
+use super::super::super::object::name::PdfName;
+use super::super::super::object::pdf_object::PdfObject;
+use super::parse_dict;
+
+#[test]
+fn parse_object_drops_single_null_value_entry() {
+    // 入力 b"<< /A null >>" で /A が登録されず len==0 になることを確認する（UC-3 null 正規化）
+    let dict = parse_dict(b"<< /A null >>");
+    assert!(!dict.contains_key(&PdfName::from("A")));
+    assert_eq!(dict.len(), 0);
+}
+
+#[test]
+fn parse_object_drops_intermediate_null_value_keeping_others() {
+    // 入力 b"<< /A 1 /B null /C 3 >>" で /B が登録されず /A と /C のみ登録、len==2 になることを確認する
+    let dict = parse_dict(b"<< /A 1 /B null /C 3 >>");
+    assert_eq!(dict.len(), 2);
+    assert_eq!(dict.get(&PdfName::from("A")), Some(&PdfObject::Integer(1)));
+    assert!(!dict.contains_key(&PdfName::from("B")));
+    assert_eq!(dict.get(&PdfName::from("C")), Some(&PdfObject::Integer(3)));
+}
+
+#[test]
+fn parse_object_revives_key_overwritten_with_non_null_after_null() {
+    // 入力 b"<< /A null /A 1 >>" で /A の値が Integer(1) として登録され len==1 になることを確認する（null 後の上書きで復活）
+    let dict = parse_dict(b"<< /A null /A 1 >>");
+    assert_eq!(dict.len(), 1);
+    assert_eq!(dict.get(&PdfName::from("A")), Some(&PdfObject::Integer(1)));
+}
+
+#[test]
+fn parse_object_drops_key_when_null_overwrites_existing_value() {
+    // 入力 b"<< /A 1 /A null >>" で /A が null で上書きされて削除され len==0 になることを確認する（重複キーの null 上書き）
+    let dict = parse_dict(b"<< /A 1 /A null >>");
+    assert!(!dict.contains_key(&PdfName::from("A")));
+    assert_eq!(dict.len(), 0);
+}

--- a/rust/crates/core/src/parser/dictionary_tests/pdf_sample.rs
+++ b/rust/crates/core/src/parser/dictionary_tests/pdf_sample.rs
@@ -1,0 +1,88 @@
+use super::super::super::object::name::PdfName;
+use super::super::super::object::pdf_object::PdfObject;
+use super::parse_dict;
+
+const ISO_SAMPLE: &[u8] = b"<< /Type /Example
+/Subtype /DictionaryExample
+/Version 0.01
+/IntegerItem 12
+/StringItem (a string)
+/Subdictionary << /Item1 0.4
+                  /Item2 true
+                  /LastItem (not!)
+               >>
+>>";
+
+#[test]
+fn parse_object_returns_iso_specification_sample_dictionary() {
+    // ISO 32000-1 §7.3.7 仕様例 (UC-2) をパースし、トップレベル 6 エントリ・サブ辞書 3 エントリが各型を正しく保持することを確認する
+    let dict = parse_dict(ISO_SAMPLE);
+    assert_eq!(dict.len(), 6);
+    assert_eq!(
+        dict.get(&PdfName::from("Type")),
+        Some(&PdfObject::Name(PdfName::from("Example")))
+    );
+    assert_eq!(
+        dict.get(&PdfName::from("Subtype")),
+        Some(&PdfObject::Name(PdfName::from("DictionaryExample")))
+    );
+    let version = dict
+        .get(&PdfName::from("Version"))
+        .and_then(PdfObject::as_real)
+        .expect("Version should be Real");
+    assert!((version - 0.01).abs() < 1e-9, "version={}", version);
+    assert_eq!(
+        dict.get(&PdfName::from("IntegerItem")),
+        Some(&PdfObject::Integer(12))
+    );
+    assert_eq!(
+        dict.get(&PdfName::from("StringItem")),
+        Some(&PdfObject::String(b"a string".to_vec()))
+    );
+
+    let sub = match dict.get(&PdfName::from("Subdictionary")) {
+        Some(PdfObject::Dictionary(d)) => d,
+        other => panic!("expected /Subdictionary as Dictionary, got {:?}", other),
+    };
+    assert_eq!(sub.len(), 3);
+    let item1 = sub
+        .get(&PdfName::from("Item1"))
+        .and_then(PdfObject::as_real)
+        .expect("Item1 should be Real");
+    assert!((item1 - 0.4).abs() < 1e-9, "item1={}", item1);
+    assert_eq!(
+        sub.get(&PdfName::from("Item2")),
+        Some(&PdfObject::Boolean(true))
+    );
+    assert_eq!(
+        sub.get(&PdfName::from("LastItem")),
+        Some(&PdfObject::String(b"not!".to_vec()))
+    );
+}
+
+#[test]
+fn parse_object_returns_page_dictionary_with_media_box_array() {
+    // PDF page dict の典型構造 b"<< /Type /Page /MediaBox [0 0 612 792] >>" で /Type==Name("Page") と /MediaBox==Array(4 Integer) を確認する
+    let dict = parse_dict(b"<< /Type /Page /MediaBox [0 0 612 792] >>");
+    assert_eq!(
+        dict.get(&PdfName::from("Type")),
+        Some(&PdfObject::Name(PdfName::from("Page")))
+    );
+    assert_eq!(
+        dict.get(&PdfName::from("MediaBox")),
+        Some(&PdfObject::Array(vec![
+            PdfObject::Integer(0),
+            PdfObject::Integer(0),
+            PdfObject::Integer(612),
+            PdfObject::Integer(792),
+        ]))
+    );
+}
+
+#[test]
+fn parse_object_is_idempotent_for_iso_sample() {
+    // ISO §7.3.7 仕様例を 2 つの独立 Parser で個別にパースした結果が PartialEq で等価になり、Pure Logic 性を満たすことを確認する
+    let result1 = parse_dict(ISO_SAMPLE);
+    let result2 = parse_dict(ISO_SAMPLE);
+    assert_eq!(result1, result2);
+}

--- a/rust/crates/core/src/parser/dictionary_tests/single_entry.rs
+++ b/rust/crates/core/src/parser/dictionary_tests/single_entry.rs
@@ -1,0 +1,94 @@
+use super::super::super::object::name::PdfName;
+use super::super::super::object::pdf_object::PdfObject;
+use super::parse_dict;
+
+#[test]
+fn parse_object_returns_dictionary_with_integer_value() {
+    // 入力 b"<< /K 1 >>" で値が Integer(1) の単一エントリ辞書を返すことを確認する
+    let dict = parse_dict(b"<< /K 1 >>");
+    assert_eq!(dict.len(), 1);
+    assert_eq!(dict.get(&PdfName::from("K")), Some(&PdfObject::Integer(1)));
+}
+
+#[test]
+fn parse_object_returns_dictionary_with_real_value() {
+    // 入力 b"<< /K 1.5 >>" で値が Real(1.5) の単一エントリ辞書を返すことを確認する
+    let dict = parse_dict(b"<< /K 1.5 >>");
+    assert_eq!(dict.get(&PdfName::from("K")), Some(&PdfObject::Real(1.5)));
+}
+
+#[test]
+fn parse_object_returns_dictionary_with_boolean_value() {
+    // 入力 b"<< /K true >>" で値が Boolean(true) の単一エントリ辞書を返すことを確認する
+    let dict = parse_dict(b"<< /K true >>");
+    assert_eq!(
+        dict.get(&PdfName::from("K")),
+        Some(&PdfObject::Boolean(true))
+    );
+}
+
+#[test]
+fn parse_object_returns_dictionary_with_literal_string_value() {
+    // 入力 b"<< /K (str) >>" で値が String(b"str") の単一エントリ辞書を返すことを確認する
+    let dict = parse_dict(b"<< /K (str) >>");
+    assert_eq!(
+        dict.get(&PdfName::from("K")),
+        Some(&PdfObject::String(b"str".to_vec()))
+    );
+}
+
+#[test]
+fn parse_object_returns_dictionary_with_hex_string_value() {
+    // 入力 b"<< /K <48> >>" で値が String(b"H") の単一エントリ辞書を返すことを確認する
+    let dict = parse_dict(b"<< /K <48> >>");
+    assert_eq!(
+        dict.get(&PdfName::from("K")),
+        Some(&PdfObject::String(b"H".to_vec()))
+    );
+}
+
+#[test]
+fn parse_object_returns_dictionary_with_name_value() {
+    // 入力 b"<< /K /V >>" で値が Name("V") の単一エントリ辞書を返すことを確認する
+    let dict = parse_dict(b"<< /K /V >>");
+    assert_eq!(
+        dict.get(&PdfName::from("K")),
+        Some(&PdfObject::Name(PdfName::from("V")))
+    );
+}
+
+#[test]
+fn parse_object_treats_consecutive_names_as_key_value_pair() {
+    // 入力 b"<< /K1 /K2 >>" で /K1 の値が Name("K2") として解釈され dict.len()==1 / dict.get(/K1)==Some(&Name("K2")) になることを確認する（仕様準拠の副次挙動）
+    let dict = parse_dict(b"<< /K1 /K2 >>");
+    assert_eq!(dict.len(), 1);
+    assert_eq!(
+        dict.get(&PdfName::from("K1")),
+        Some(&PdfObject::Name(PdfName::from("K2")))
+    );
+}
+
+#[test]
+fn parse_object_returns_dictionary_with_array_value() {
+    // 入力 b"<< /K [1 2] >>" で値が Array([Integer(1), Integer(2)]) の単一エントリ辞書を返すことを確認する
+    let dict = parse_dict(b"<< /K [1 2] >>");
+    assert_eq!(
+        dict.get(&PdfName::from("K")),
+        Some(&PdfObject::Array(vec![
+            PdfObject::Integer(1),
+            PdfObject::Integer(2),
+        ]))
+    );
+}
+
+#[test]
+fn parse_object_returns_dictionary_with_nested_dictionary_value() {
+    // 入力 b"<< /K << /X 1 >> >>" でネスト辞書値（内側 /X==Integer(1)）を返すことを確認する
+    let dict = parse_dict(b"<< /K << /X 1 >> >>");
+    let inner = match dict.get(&PdfName::from("K")) {
+        Some(PdfObject::Dictionary(d)) => d,
+        other => panic!("expected nested Dictionary, got {:?}", other),
+    };
+    assert_eq!(inner.len(), 1);
+    assert_eq!(inner.get(&PdfName::from("X")), Some(&PdfObject::Integer(1)));
+}

--- a/rust/crates/core/src/parser/dictionary_tests/unmatched_eof.rs
+++ b/rust/crates/core/src/parser/dictionary_tests/unmatched_eof.rs
@@ -1,0 +1,64 @@
+use super::super::super::byte_offset::ByteOffset;
+use super::super::error::ParseErrorKind;
+use super::parser;
+
+#[test]
+fn parse_object_returns_unexpected_eof_for_open_dict_only() {
+    // 入力 b"<<" で `<<` 直後 EOF が UnexpectedEof, position=2 で返ることを確認する
+    let mut p = parser(b"<<");
+    let err = p.parse_object().expect_err("unclosed dict must error");
+    assert_eq!(err.kind, ParseErrorKind::UnexpectedEof);
+    assert_eq!(err.position, ByteOffset::new(2));
+}
+
+#[test]
+fn parse_object_returns_unexpected_eof_for_open_dict_then_key_only() {
+    // 入力 b"<< /A" でキーだけで EOF となった場合、値読み中の parse_object() 経由で UnexpectedEof が伝播することを確認する
+    let mut p = parser(b"<< /A");
+    let err = p.parse_object().expect_err("key without value must error");
+    assert_eq!(err.kind, ParseErrorKind::UnexpectedEof);
+}
+
+#[test]
+fn parse_object_returns_unexpected_eof_for_complete_entry_then_eof() {
+    // 入力 b"<< /A 1" で値読了後 `>>` 不在 EOF が UnexpectedEof で返ることを確認する
+    let mut p = parser(b"<< /A 1");
+    let err = p.parse_object().expect_err("eof after value must error");
+    assert_eq!(err.kind, ParseErrorKind::UnexpectedEof);
+}
+
+#[test]
+fn parse_object_returns_unexpected_eof_for_second_key_only_then_eof() {
+    // 入力 b"<< /A 1 /B" で 2 つ目キーの値読み中 EOF が UnexpectedEof で返ることを確認する
+    let mut p = parser(b"<< /A 1 /B");
+    let err = p
+        .parse_object()
+        .expect_err("second key without value must error");
+    assert_eq!(err.kind, ParseErrorKind::UnexpectedEof);
+}
+
+#[test]
+fn parse_object_returns_unexpected_eof_for_two_complete_entries_then_eof() {
+    // 入力 b"<< /A 1 /B 2" で 2 エントリ読了後 `>>` 不在 EOF が UnexpectedEof で返ることを確認する
+    let mut p = parser(b"<< /A 1 /B 2");
+    let err = p
+        .parse_object()
+        .expect_err("eof after two entries must error");
+    assert_eq!(err.kind, ParseErrorKind::UnexpectedEof);
+}
+
+#[test]
+fn parse_object_returns_unexpected_token_dict_end_when_value_missing() {
+    // 入力 b"<< /A >>" でキー /A の値位置に `>>` が来た場合、値読み中の parse_object() 経由で
+    // UnexpectedToken { actual_kind: "DictEnd" } が返ることを確認する（仕様準拠の副次挙動）
+    let mut p = parser(b"<< /A >>");
+    let err = p
+        .parse_object()
+        .expect_err("missing value before `>>` must error");
+    assert_eq!(
+        err.kind,
+        ParseErrorKind::UnexpectedToken {
+            actual_kind: "DictEnd"
+        }
+    );
+}

--- a/rust/crates/core/src/parser/dictionary_tests/whitespace_variants.rs
+++ b/rust/crates/core/src/parser/dictionary_tests/whitespace_variants.rs
@@ -1,0 +1,47 @@
+use super::super::super::object::dictionary::PdfDictionary;
+use super::super::super::object::name::PdfName;
+use super::super::super::object::pdf_object::PdfObject;
+use super::parse_dict;
+
+fn assert_single_int_entry(dict: &PdfDictionary, key: &str, value: i64) {
+    assert_eq!(dict.len(), 1);
+    assert_eq!(
+        dict.get(&PdfName::from(key)),
+        Some(&PdfObject::Integer(value))
+    );
+}
+
+#[test]
+fn parse_object_returns_dictionary_with_tab_between_key_and_value() {
+    // 入力 b"<< /K\t1 >>" でキーと値の間が TAB のみでも正しく要素境界として認識されることを確認する
+    let dict = parse_dict(b"<< /K\t1 >>");
+    assert_single_int_entry(&dict, "K", 1);
+}
+
+#[test]
+fn parse_object_returns_dictionary_with_crlf_between_key_and_value() {
+    // 入力 b"<< /K\r\n1 >>" でキーと値の間が CRLF のみでも正しく要素境界として認識されることを確認する
+    let dict = parse_dict(b"<< /K\r\n1 >>");
+    assert_single_int_entry(&dict, "K", 1);
+}
+
+#[test]
+fn parse_object_returns_dictionary_with_nul_between_key_and_value() {
+    // 入力 b"<< /K\x001 >>" でキーと値の間が NUL のみ（PDF 仕様上 whitespace）でも正しく要素境界として認識されることを確認する
+    let dict = parse_dict(b"<< /K\x001 >>");
+    assert_single_int_entry(&dict, "K", 1);
+}
+
+#[test]
+fn parse_object_returns_dictionary_with_form_feed_around_entry() {
+    // 入力 b"<<\x0c/K 1\x0c>>" でエントリ前後が FF (Form Feed) でも正しく境界として認識されることを確認する
+    let dict = parse_dict(b"<<\x0c/K 1\x0c>>");
+    assert_single_int_entry(&dict, "K", 1);
+}
+
+#[test]
+fn parse_object_returns_dictionary_with_multiple_spaces() {
+    // 境界値: 入力 b"<<   /K   1   >>" で多重 SP がエントリの前後に挿入されていても正しくパースできることを確認する
+    let dict = parse_dict(b"<<   /K   1   >>");
+    assert_single_int_entry(&dict, "K", 1);
+}


### PR DESCRIPTION
## 概要

`Parser::parse_object` に PDF 辞書オブジェクト `<< /Key value ... >>`（ISO 32000-1 §7.3.7）の受理パスを追加し、`PdfObject::Dictionary(PdfDictionary)` を返せるようにします。これにより後続の stream / xref / 間接参照モジュールが辞書を前提に組み立てられます。

## 変更内容

### 🎯 変更の種類

- [x] ✨ 新機能 (New feature)
- [x] 🚨 テスト追加/修正 (Tests)
- [x] 🗑️ 削除 (Removal) — 受理に変わった既存テスト 3 件

### 📝 詳細な変更内容

#### 追加された機能

- `parse_dictionary_body` を private method として追加（`parser.rs`）
  - エントリ間 `Token::Comment` 透過スキップ
  - キーは `Primitive::Name` のみ受理（他は `UnexpectedToken { actual_kind }` で fail-fast）
  - 値は `parse_object` の再帰呼び出しで取得
  - 値が `PdfObject::Null` の場合は `PdfDictionary::remove` で正規化（UC-3、ISO §7.3.7 準拠）
  - 重複キーは `BTreeMap::insert` の自動上書きで「最後の値を採用」（UC-3）
  - `>>` 不在 EOF / lexer error をそれぞれ `UnexpectedEof` / `LexerError` で fail-fast
- `parse_object` の dispatch に `Some(Token::DictBegin) => return self.parse_dictionary_body()` 分岐を追加
- `parse_array_body` に `Some(Token::DictBegin) => items.push(self.parse_dictionary_body()?)` 分岐を追加し配列内辞書 `[ << /K 1 >> ]` を受理（UC-1、配列対称性）

#### 変更されたファイル

- `rust/crates/core/src/parser.rs`
  - `use crate::object::dictionary::PdfDictionary` 追加
  - ファイル冒頭 `//!` doc コメントを辞書受理後の状態に更新
  - `parse_object` / `parse_array_body` の doc コメント更新（辞書バリアント / 配列内辞書を反映）
  - `parse_dictionary_body` 新設（5 アーム構造で `parse_array_body` と対称）
  - `#[cfg(test)] mod dictionary_tests;` 宣言追加
- `rust/crates/core/src/parser/array_tests/unexpected_token.rs`
  - 既存テスト 2 件（`_dict_begin_in_array` / `_dict_begin_inside_nested_array`）を削除

#### 削除されたテスト（受理に変わったため）

- `parser.rs::tests::parse_object_returns_unexpected_token_for_dict_begin`
- `parser/array_tests/unexpected_token.rs::parse_object_returns_unexpected_token_for_dict_begin_in_array`
- `parser/array_tests/unexpected_token.rs::parse_object_returns_unexpected_token_for_dict_begin_inside_nested_array`

代替カバレッジ:
- `dictionary_tests/empty.rs::parse_object_returns_empty_dictionary_for_double_angle_only` で `<<>>` の受理を検証
- `dictionary_tests/array_value.rs::parse_object_returns_array_with_single_dictionary_element` 他で配列内辞書を検証

#### 新規テストファイル（14 ファイル、計 66 テスト）

`parser/dictionary_tests/` 配下に観点別物理分割:

| ファイル | 役割 | 件数 |
|---------|------|-----|
| `empty.rs` | 空辞書 4 種 | 4 |
| `single_entry.rs` | 1 エントリ × 8 値型 + Name 連続副次挙動 | 9 |
| `multiple_entries.rs` | 複数エントリ（3 / 5 / 100 件） | 3 |
| `nested.rs` | ネスト辞書（2 / 3 / 兄弟 / 5 段） | 4 |
| `array_value.rs` | 配列値 + 配列内辞書（UC-1 対称性） | 4 |
| `mixed_value_types.rs` | 全型混在 | 1 |
| `duplicate_key.rs` | 重複キー（UC-3 最後勝ち） | 4 |
| `null_value.rs` | null 値正規化（UC-3） | 4 |
| `comment_interleaved.rs` | コメント位置の組合せ | 5 |
| `unmatched_eof.rs` | `>>` 不在 EOF / 値欠落 | 6 |
| `key_type_error.rs` | キー型違反（actual_kind 網羅） | 12 |
| `lexer_error_propagation.rs` | 値内 lexer エラー伝播 | 2 |
| `pdf_sample.rs` | ISO §7.3.7 仕様例 + page dict + べき等性 | 3 |
| `whitespace_variants.rs` | TAB / CRLF / NUL / FF / 多重 SP | 5 |

共通ヘルパ `parse_dict` は `dictionary_tests.rs` モジュールルートに集約。

## 📊 システム図

### parse_object ディスパッチ

```mermaid
flowchart TD
    Start([parse_object]) --> SkipWS[skip_whitespace]
    SkipWS --> NextToken[lexer.next_token]
    NextToken --> Branch{token?}
    Branch -->|Comment| SkipWS
    Branch -->|Primitive| ScalarObj[primitive_to_object]
    Branch -->|ArrayBegin| ArrayBody[parse_array_body]
    Branch -->|DictBegin| DictBody[parse_dictionary_body]:::new
    Branch -->|other| UnexpToken[UnexpectedToken]
    Branch -->|None+EOF| UnexpEof[UnexpectedEof]
    Branch -->|None| LexErr[LexerError]
    ScalarObj --> End([Result])
    ArrayBody --> End
    DictBody --> End
    UnexpToken --> End
    UnexpEof --> End
    LexErr --> End

    classDef new fill:#ffe4b5,stroke:#d97706,stroke-width:2px
```

### parse_dictionary_body 状態遷移

```mermaid
flowchart TD
    Init([<< 消費済]) --> AwaitKey[AWAITING_KEY<br/>skip_whitespace<br/>next_token]
    AwaitKey -->|Comment| AwaitKey
    AwaitKey -->|DictEnd| ReturnOk([Ok Dictionary])
    AwaitKey -->|Name k| AwaitValue[parse_object 再帰]
    AwaitKey -->|other| UnexpToken([UnexpectedToken])
    AwaitKey -->|None+EOF| UnexpEof([UnexpectedEof])
    AwaitKey -->|None| LexErr([LexerError])
    AwaitValue -->|Err| Propagate([Err 伝播])
    AwaitValue -->|Null| Remove[dict.remove k]:::new
    AwaitValue -->|other| Insert[dict.insert k v]
    Remove --> AwaitKey
    Insert --> AwaitKey

    classDef new fill:#ffe4b5,stroke:#d97706,stroke-width:2px
```

### データフロー

```
入力バイト列 (&[u8])
    ↓
┌────────────────────┐
│      Lexer         │ skip_whitespace / next_token / position / is_eof
└─────────┬──────────┘
          ↓ Token stream
┌────────────────────┐
│ Parser::parse_object│ DictBegin → parse_dictionary_body  [NEW]
└─────────┬──────────┘
          ↓
┌────────────────────┐
│ parse_dictionary_  │ Name(key) → parse_object()? (再帰)
│ body         [NEW] │  ├─ Primitive  → primitive_to_object
│                    │  ├─ ArrayBegin → parse_array_body
│                    │  └─ DictBegin  → parse_dictionary_body (再帰)
└─────────┬──────────┘
          ↓ (key, value) pairs
┌────────────────────┐
│ Null フィルタ [NEW]│ value.is_null() ?
└────┬───────────────┘
     ├── true  → dict.remove(&key)  （UC-3、重複キー時の旧値も消去）
     └── false → dict.insert(key, value)  （重複キーは BTreeMap が自動上書き）
                   ↓
        PdfObject::Dictionary(PdfDictionary)
```

## 関連 Issue

Closes #408

## テスト

- `cargo test`: **902 件全緑**
- `cargo test --package pdfmod-core parser::dictionary_tests`: **66 件全緑**
- `cargo fmt`: 整形完了
- `cargo clippy --all-targets -- -D warnings`: 警告ゼロ
- `git grep "parse_object_returns_unexpected_token_for_dict_begin"`: 残存ゼロ（削除 3 件完了）

### Definition of Done

- [x] `Parser::parse_object()` が `<<>>` / `<< /K v ... >>` を `Ok(PdfObject::Dictionary(_))` として返す（UC-1）
- [x] ISO §7.3.7 仕様例が 1 回の `parse_object()` で完全に取り出せる（UC-2）
- [x] 重複キーは最後の値、`null` 値は未登録という正規化が動作（UC-3）
- [x] 配列内辞書 `[ << /K 1 >> ]` を受理（UC-1）
- [x] キー型違反 / `>>` 不在 EOF / 値内 lexer エラーが `ParseError` で fail-fast し panic しない
- [x] 既存テスト 3 件削除
- [x] 既存機能にリグレッションなし

## レビューポイント

- **配列内辞書 `[ << /K 1 >> ]` の受理は仕様変更**を含みます（既存テスト 2 件を削除）。配列パスとの対称性確保のため UC-1 で確定しています
- **`null` 値正規化を本 Issue で適用**: `<< /A null >>` は `dict.remove(&key)` で未登録化（ISO §7.3.7 準拠）
- **`<< /A >>` の挙動**: 値読み中の `parse_object()` 再帰で `>>` が `UnexpectedToken { "DictEnd" }` として返る副次挙動。`parse_array_body` の `]` 不在パターンと完全対称で挙動として一貫しており、`unmatched_eof.rs` で明示テスト化
- **`parse_array_body` と `parse_dictionary_body` の構造重複は意図的**: 「並べて読める」「変更時に独立して触れる」価値を優先（implementation-plan のリスクセクションで明示）
- **再帰深度制限（DoS 対策）は本 Issue 対象外**: 配列パスと同性質のため後続 Issue へ委ねます