### PR TITLE
✨ [New Feature]: #468 Content Stream の辞書リテラル `<< ... >>` を PdfDictionary として完走させる

### DIFF
--- a/packages/core/src/content-stream/interpreter/__tests__/interpreter.dict-operand.test.ts
+++ b/packages/core/src/content-stream/interpreter/__tests__/interpreter.dict-operand.test.ts
@@ -1,0 +1,108 @@
+import { assert, expect, test } from "vitest";
+import type { PdfObject } from "../../../pdf/index";
+import { ok } from "../../../utils/result/index";
+import { OperandStack } from "../../operand-stack/index";
+import {
+  type OperatorHandler,
+  OperatorRegistry,
+} from "../../operator-registry/index";
+import { ContentStreamInterpreter } from "../index";
+
+const encode = (value: string): Uint8Array => new TextEncoder().encode(value);
+
+function registerOperator(
+  registry: ReturnType<typeof OperatorRegistry.create>,
+  name: string,
+  handler: OperatorHandler,
+): ReturnType<typeof OperatorRegistry.create> {
+  const result = OperatorRegistry.register(registry, name, handler);
+  assert(result.ok);
+  return result.value;
+}
+
+function popAll(stack: ReturnType<typeof OperandStack.create>): PdfObject[] {
+  return Array.from({ length: OperandStack.depth(stack) }, () => {
+    const value = OperandStack.pop(stack);
+    assert(value.some);
+    return value.value;
+  });
+}
+
+test("`<</K /V>> op` operand を含む handler が PdfDictionary を pop できる", () => {
+  const observed: PdfObject[][] = [];
+  const registry = registerOperator(
+    OperatorRegistry.create(),
+    "op",
+    (context) => {
+      observed.push(popAll(context.operandStack));
+      return ok(context);
+    },
+  );
+
+  const result = ContentStreamInterpreter.execute({
+    data: encode("<</K /V>> op"),
+    registry,
+  });
+
+  assert(result.ok);
+  expect(observed).toEqual([
+    [
+      {
+        type: "dictionary",
+        entries: new Map([["K", { type: "name", value: "V" }]]),
+      },
+    ],
+  ]);
+});
+
+// 未登録 operator は operand stack を clear するため、本テストでは「dict が積まれた後に
+// BDC が dict を pop する」までは検証しない。全体完走と UNKNOWN_OPERATOR warning の
+// 発火のみを smoke test として確認する。dict pop の検証は他のテストが担う。
+test("`<</ActualText (x)>> BDC` は未登録 BDC で UNKNOWN_OPERATOR warning を出すが result.ok のまま完走する", () => {
+  const result = ContentStreamInterpreter.execute({
+    data: encode("<</ActualText (x)>> BDC"),
+    registry: OperatorRegistry.create(),
+  });
+
+  assert(result.ok);
+  expect(result.value.warnings).toHaveLength(1);
+  expect(result.value.warnings[0]?.code).toBe("UNKNOWN_OPERATOR");
+  expect(result.value.warnings[0]?.message).toBe("Unknown operator: BDC");
+});
+
+// 辞書→配列の相互再帰経路を入口テストで pin down する。
+test("`<</Subtype /Form /Matrix [1 0 0 1 0 0]>> capture` で 辞書内配列を保持したまま handler が pop できる", () => {
+  const observed: PdfObject[][] = [];
+  const registry = registerOperator(
+    OperatorRegistry.create(),
+    "capture",
+    (context) => {
+      observed.push(popAll(context.operandStack));
+      return ok(context);
+    },
+  );
+
+  const result = ContentStreamInterpreter.execute({
+    data: encode("<</Subtype /Form /Matrix [1 0 0 1 0 0]>> capture"),
+    registry,
+  });
+
+  assert(result.ok);
+  expect(observed).toHaveLength(1);
+  const popped = observed[0];
+  assert(popped !== undefined && popped.length === 1);
+  const dict = popped[0];
+  assert(dict !== undefined && dict.type === "dictionary");
+  expect(dict.entries.get("Subtype")).toEqual({ type: "name", value: "Form" });
+  expect(dict.entries.get("Matrix")).toEqual({
+    type: "array",
+    elements: [
+      { type: "integer", value: 1 },
+      { type: "integer", value: 0 },
+      { type: "integer", value: 0 },
+      { type: "integer", value: 1 },
+      { type: "integer", value: 0 },
+      { type: "integer", value: 0 },
+    ],
+  });
+});

--- a/packages/core/src/content-stream/interpreter/__tests__/interpreter.dispatch.test.ts
+++ b/packages/core/src/content-stream/interpreter/__tests__/interpreter.dispatch.test.ts
@@ -144,11 +144,13 @@ test.each([
   expect(result.error.message).toContain(message);
 });
 
+// 残る 2 ケースは unbalanced delimiter (`]` / `>>` 単独) で、対応する `[` / `<<` が
+// 先行しないため interpreter ループが直接 UNEXPECTED_TOKEN を返す。dict reader 完走パスは
+// `interpreter.dict-operand.test.ts` 側に分離した。
 test.each([
-  { input: "<< /K /V >> op", code: "NOT_IMPLEMENTED" },
   { input: "] op", code: "OBJECT_PARSE_UNEXPECTED_TOKEN" },
   { input: ">> op", code: "OBJECT_PARSE_UNEXPECTED_TOKEN" },
-])("composite tokenはstackを汚染せずErrで中断する: $input", ({
+])("unbalanced delimiter はstackを汚染せずErrで中断する: $input", ({
   input,
   code,
 }) => {

--- a/packages/core/src/content-stream/interpreter/composite-operand/__tests__/array.error.test.ts
+++ b/packages/core/src/content-stream/interpreter/composite-operand/__tests__/array.error.test.ts
@@ -46,17 +46,6 @@ test("`[1 BT 2]` の `BT` を検出すると OBJECT_PARSE_UNEXPECTED_TOKEN を�
   expect(result.error.offset).toBe(positionOf("BT"));
 });
 
-test("`[<< /K /V >>]` の `<<` を検出すると OBJECT_PARSE_UNEXPECTED_TOKEN を返し offset が `<<` の位置と一致する", () => {
-  const stream = "[<< /K /V >>]";
-  const { tokenizer, openToken, positionOf } = setupAfterArrayBegin(stream);
-
-  const result = readArrayOperand(tokenizer, openToken);
-
-  assert(!result.ok);
-  assert(result.error.code === "OBJECT_PARSE_UNEXPECTED_TOKEN");
-  expect(result.error.offset).toBe(positionOf("<<"));
-});
-
 test("`[1 >> 2]` の `>>` を検出すると OBJECT_PARSE_UNEXPECTED_TOKEN を返し offset が `>>` の位置と一致する", () => {
   const stream = "[1 >> 2]";
   const { tokenizer, openToken, positionOf } = setupAfterArrayBegin(stream);

--- a/packages/core/src/content-stream/interpreter/composite-operand/__tests__/array.nested.test.ts
+++ b/packages/core/src/content-stream/interpreter/composite-operand/__tests__/array.nested.test.ts
@@ -121,6 +121,45 @@ test("`[[]]` を読み取り elements[0] が空 PdfArray となる", () => {
   });
 });
 
+test("`[<</K /V>>]` を読み取り 配列要素として PdfDictionary を受理する (array→dict 経路)", () => {
+  const { tokenizer, openToken } = setupAfterArrayBegin("[<</K /V>>]");
+
+  const result = readArrayOperand(tokenizer, openToken);
+
+  assert(result.ok);
+  expect(result.value).toEqual({
+    type: "array",
+    elements: [
+      {
+        type: "dictionary",
+        entries: new Map([["K", { type: "name", value: "V" }]]),
+      },
+    ],
+  });
+});
+
+test("`[1 <</K (x)>> 2]` を読み取り primitive と PdfDictionary の混在を受理する", () => {
+  const { tokenizer, openToken } = setupAfterArrayBegin("[1 <</K (x)>> 2]");
+
+  const result = readArrayOperand(tokenizer, openToken);
+
+  assert(result.ok);
+  const encoded = new TextEncoder().encode("x");
+  expect(result.value).toEqual({
+    type: "array",
+    elements: [
+      { type: "integer", value: 1 },
+      {
+        type: "dictionary",
+        entries: new Map([
+          ["K", { type: "string", value: encoded, encoding: "literal" }],
+        ]),
+      },
+      { type: "integer", value: 2 },
+    ],
+  });
+});
+
 test("ネスト深さ 100 の配列を読み取り成功する (MAX_NESTING_DEPTH 直下)", () => {
   const opens = "[".repeat(100);
   const closes = "]".repeat(100);

--- a/packages/core/src/content-stream/interpreter/composite-operand/__tests__/dict.basic.test.ts
+++ b/packages/core/src/content-stream/interpreter/composite-operand/__tests__/dict.basic.test.ts
@@ -1,0 +1,112 @@
+import { assert, expect, test } from "vitest";
+import type { PdfValue, Token, TokenDictBegin } from "../../../../pdf/index";
+import { TokenType } from "../../../../pdf/index";
+import { ContentStreamTokenizer } from "../../../tokenizer/index";
+import { readDictOperand } from "../index";
+
+const encode = (s: string): Uint8Array => new TextEncoder().encode(s);
+
+/**
+ * stream 文字列を tokenize して最初の `DictBegin` token を取り出し、
+ * その後の呼び出しから読み取りを開始できる状態の tokenizer を返すヘルパ。
+ * `readDictOperand` の呼び出し前提を再現する。
+ */
+function setupAfterDictBegin(stream: string): {
+  tokenizer: ContentStreamTokenizer;
+  openToken: TokenDictBegin;
+} {
+  const tokenizer = new ContentStreamTokenizer(encode(stream));
+  const result = tokenizer.nextToken();
+  assert(result.ok);
+  const token: Token = result.value;
+  assert(token.type === TokenType.DictBegin);
+  return { tokenizer, openToken: token };
+}
+
+test("`<<>>` を読み取り entries が空の PdfDictionary を返す", () => {
+  const { tokenizer, openToken } = setupAfterDictBegin("<<>>");
+
+  const result = readDictOperand(tokenizer, openToken);
+
+  assert(result.ok);
+  expect(result.value).toEqual({ type: "dictionary", entries: new Map() });
+});
+
+test("`<</K /V>>` を読み取り entries.get(`K`) が Name `V` の PdfDictionary を返す", () => {
+  const { tokenizer, openToken } = setupAfterDictBegin("<</K /V>>");
+
+  const result = readDictOperand(tokenizer, openToken);
+
+  assert(result.ok);
+  expect(result.value).toEqual({
+    type: "dictionary",
+    entries: new Map([["K", { type: "name", value: "V" }]]),
+  });
+});
+
+test("`<</A 1 /B 2>>` を読み取り 2 件の entries を含む PdfDictionary を返す", () => {
+  const { tokenizer, openToken } = setupAfterDictBegin("<</A 1 /B 2>>");
+
+  const result = readDictOperand(tokenizer, openToken);
+
+  assert(result.ok);
+  expect(result.value).toEqual({
+    type: "dictionary",
+    entries: new Map<string, PdfValue>([
+      ["A", { type: "integer", value: 1 }],
+      ["B", { type: "integer", value: 2 }],
+    ]),
+  });
+});
+
+test.each<{ label: string; stream: string; expected: PdfValue }>([
+  {
+    label: "Boolean true",
+    stream: "<</K true>>",
+    expected: { type: "boolean", value: true },
+  },
+  {
+    label: "Integer 42",
+    stream: "<</K 42>>",
+    expected: { type: "integer", value: 42 },
+  },
+  {
+    label: "Real 1.5",
+    stream: "<</K 1.5>>",
+    expected: { type: "real", value: 1.5 },
+  },
+  {
+    label: "LiteralString (hello)",
+    stream: "<</K (hello)>>",
+    expected: { type: "string", value: encode("hello"), encoding: "literal" },
+  },
+  {
+    label: "HexString <41>",
+    stream: "<</K <41>>>",
+    expected: {
+      type: "string",
+      value: new Uint8Array([0x41]),
+      encoding: "hex",
+    },
+  },
+  {
+    label: "Name /Inner",
+    stream: "<</K /Inner>>",
+    expected: { type: "name", value: "Inner" },
+  },
+  {
+    label: "Null null",
+    stream: "<</K null>>",
+    expected: { type: "null" },
+  },
+])(
+  "`$stream` を読み取り entries.get(`K`) が $label の PdfValue となる",
+  ({ stream, expected }) => {
+    const { tokenizer, openToken } = setupAfterDictBegin(stream);
+
+    const result = readDictOperand(tokenizer, openToken);
+
+    assert(result.ok);
+    expect(result.value.entries.get("K")).toEqual(expected);
+  },
+);

--- a/packages/core/src/content-stream/interpreter/composite-operand/__tests__/dict.basic.test.ts
+++ b/packages/core/src/content-stream/interpreter/composite-operand/__tests__/dict.basic.test.ts
@@ -99,14 +99,14 @@ test.each<{ label: string; stream: string; expected: PdfValue }>([
     stream: "<</K null>>",
     expected: { type: "null" },
   },
-])(
-  "`$stream` を読み取り entries.get(`K`) が $label の PdfValue となる",
-  ({ stream, expected }) => {
-    const { tokenizer, openToken } = setupAfterDictBegin(stream);
+])("`$stream` を読み取り entries.get(`K`) が $label の PdfValue となる", ({
+  stream,
+  expected,
+}) => {
+  const { tokenizer, openToken } = setupAfterDictBegin(stream);
 
-    const result = readDictOperand(tokenizer, openToken);
+  const result = readDictOperand(tokenizer, openToken);
 
-    assert(result.ok);
-    expect(result.value.entries.get("K")).toEqual(expected);
-  },
-);
+  assert(result.ok);
+  expect(result.value.entries.get("K")).toEqual(expected);
+});

--- a/packages/core/src/content-stream/interpreter/composite-operand/__tests__/dict.duplicate-key.test.ts
+++ b/packages/core/src/content-stream/interpreter/composite-operand/__tests__/dict.duplicate-key.test.ts
@@ -1,0 +1,42 @@
+import { assert, expect, test } from "vitest";
+import type { Token, TokenDictBegin } from "../../../../pdf/index";
+import { TokenType } from "../../../../pdf/index";
+import { ContentStreamTokenizer } from "../../../tokenizer/index";
+import { readDictOperand } from "../index";
+
+const encode = (s: string): Uint8Array => new TextEncoder().encode(s);
+
+function setupAfterDictBegin(stream: string): {
+  tokenizer: ContentStreamTokenizer;
+  openToken: TokenDictBegin;
+} {
+  const tokenizer = new ContentStreamTokenizer(encode(stream));
+  const result = tokenizer.nextToken();
+  assert(result.ok);
+  const token: Token = result.value;
+  assert(token.type === TokenType.DictBegin);
+  return { tokenizer, openToken: token };
+}
+
+// PdfDictionary.entries が Map である以上、同一 key の後勝ち（Map.set 上書き）が成立する。
+// 型が ReadonlyMap 等へ変更されたら本テストが Red になり仕様を pin down できる。
+test("`<</A 1 /A 2>>` を読み取り entries.get(`A`) が PdfInteger 2、entries.size が 1 となる（後勝ち）", () => {
+  const { tokenizer, openToken } = setupAfterDictBegin("<</A 1 /A 2>>");
+
+  const result = readDictOperand(tokenizer, openToken);
+
+  assert(result.ok);
+  expect(result.value.entries.size).toBe(1);
+  expect(result.value.entries.get("A")).toEqual({ type: "integer", value: 2 });
+});
+
+test("`<</A 1 /B 2 /A 3>>` を読み取り entries.get(`A`) が PdfInteger 3、`B` は残り、entries.size が 2 となる", () => {
+  const { tokenizer, openToken } = setupAfterDictBegin("<</A 1 /B 2 /A 3>>");
+
+  const result = readDictOperand(tokenizer, openToken);
+
+  assert(result.ok);
+  expect(result.value.entries.size).toBe(2);
+  expect(result.value.entries.get("A")).toEqual({ type: "integer", value: 3 });
+  expect(result.value.entries.get("B")).toEqual({ type: "integer", value: 2 });
+});

--- a/packages/core/src/content-stream/interpreter/composite-operand/__tests__/dict.error.test.ts
+++ b/packages/core/src/content-stream/interpreter/composite-operand/__tests__/dict.error.test.ts
@@ -61,19 +61,19 @@ test.each<{ label: string; stream: string; badToken: string }>([
     stream: "<<BI /W 1 /H 1 /CS /G /BPC 8 ID @ EI /K 2>>",
     badToken: "BI",
   },
-])(
-  "`$stream` の key 位置 $label を検出すると OBJECT_PARSE_UNEXPECTED_TOKEN を返し offset が `$badToken` の位置と一致する",
-  ({ stream, badToken }) => {
-    const { tokenizer, openToken, positionOf } = setupAfterDictBegin(stream);
+])("`$stream` の key 位置 $label を検出すると OBJECT_PARSE_UNEXPECTED_TOKEN を返し offset が `$badToken` の位置と一致する", ({
+  stream,
+  badToken,
+}) => {
+  const { tokenizer, openToken, positionOf } = setupAfterDictBegin(stream);
 
-    const result = readDictOperand(tokenizer, openToken);
+  const result = readDictOperand(tokenizer, openToken);
 
-    assert(!result.ok);
-    assert(result.error.code === "OBJECT_PARSE_UNEXPECTED_TOKEN");
-    expect(result.error.message).toMatch(/^Dictionary key must be a name, /);
-    expect(result.error.offset).toBe(positionOf(badToken));
-  },
-);
+  assert(!result.ok);
+  assert(result.error.code === "OBJECT_PARSE_UNEXPECTED_TOKEN");
+  expect(result.error.message).toMatch(/^Dictionary key must be a name, /);
+  expect(result.error.offset).toBe(positionOf(badToken));
+});
 
 test.each<{ label: string; stream: string; badToken: string }>([
   { label: "Operator (BT)", stream: "<</K BT>>", badToken: "BT" },
@@ -85,19 +85,21 @@ test.each<{ label: string; stream: string; badToken: string }>([
     badToken: "BI",
   },
   { label: "Operator (endobj)", stream: "<</K endobj>>", badToken: "endobj" },
-])(
-  "`$stream` の value 位置 $label を検出すると OBJECT_PARSE_UNEXPECTED_TOKEN を返し offset が `$badToken` の位置と一致する",
-  ({ stream, badToken }) => {
-    const { tokenizer, openToken, positionOf } = setupAfterDictBegin(stream);
+])("`$stream` の value 位置 $label を検出すると OBJECT_PARSE_UNEXPECTED_TOKEN を返し offset が `$badToken` の位置と一致する", ({
+  stream,
+  badToken,
+}) => {
+  const { tokenizer, openToken, positionOf } = setupAfterDictBegin(stream);
 
-    const result = readDictOperand(tokenizer, openToken);
+  const result = readDictOperand(tokenizer, openToken);
 
-    assert(!result.ok);
-    assert(result.error.code === "OBJECT_PARSE_UNEXPECTED_TOKEN");
-    expect(result.error.message).toMatch(/^Unexpected token in dictionary value: /);
-    expect(result.error.offset).toBe(positionOf(badToken));
-  },
-);
+  assert(!result.ok);
+  assert(result.error.code === "OBJECT_PARSE_UNEXPECTED_TOKEN");
+  expect(result.error.message).toMatch(
+    /^Unexpected token in dictionary value: /,
+  );
+  expect(result.error.offset).toBe(positionOf(badToken));
+});
 
 // 純 dict ネストを 101 段組み立てて MAX_NESTING_DEPTH = 100 の境界を検証する。
 // 上限を超えるのは内側 (101 段目) の `<<` であり、最外ではないことを offset で示す。

--- a/packages/core/src/content-stream/interpreter/composite-operand/__tests__/dict.error.test.ts
+++ b/packages/core/src/content-stream/interpreter/composite-operand/__tests__/dict.error.test.ts
@@ -1,0 +1,140 @@
+import { assert, expect, test } from "vitest";
+import type { Token, TokenDictBegin } from "../../../../pdf/index";
+import { TokenType } from "../../../../pdf/index";
+import { ContentStreamTokenizer } from "../../../tokenizer/index";
+import { readDictOperand } from "../index";
+
+const encode = (s: string): Uint8Array => new TextEncoder().encode(s);
+
+function setupAfterDictBegin(stream: string): {
+  tokenizer: ContentStreamTokenizer;
+  openToken: TokenDictBegin;
+  positionOf: (substr: string) => number;
+} {
+  const tokenizer = new ContentStreamTokenizer(encode(stream));
+  const result = tokenizer.nextToken();
+  assert(result.ok);
+  const token: Token = result.value;
+  assert(token.type === TokenType.DictBegin);
+  return {
+    tokenizer,
+    openToken: token,
+    positionOf: (substr: string) => stream.indexOf(substr),
+  };
+}
+
+test("`<<` 単独で EOF に達すると OBJECT_PARSE_UNTERMINATED を返し offset が `<<` の位置と一致する", () => {
+  const stream = "<<";
+  const { tokenizer, openToken, positionOf } = setupAfterDictBegin(stream);
+
+  const result = readDictOperand(tokenizer, openToken);
+
+  assert(!result.ok);
+  assert(result.error.code === "OBJECT_PARSE_UNTERMINATED");
+  expect(result.error.offset).toBe(positionOf("<<"));
+});
+
+test("`<</K` で value 位置に達する前に EOF となると OBJECT_PARSE_UNTERMINATED を返し offset が `<<` の位置と一致する", () => {
+  const stream = "<</K";
+  const { tokenizer, openToken, positionOf } = setupAfterDictBegin(stream);
+
+  const result = readDictOperand(tokenizer, openToken);
+
+  assert(!result.ok);
+  assert(result.error.code === "OBJECT_PARSE_UNTERMINATED");
+  expect(result.error.offset).toBe(positionOf("<<"));
+});
+
+test.each<{ label: string; stream: string; badToken: string }>([
+  { label: "Integer", stream: "<<1 2>>", badToken: "1" },
+  { label: "Real", stream: "<<1.5 2>>", badToken: "1.5" },
+  { label: "Boolean", stream: "<<true 2>>", badToken: "true" },
+  { label: "Null", stream: "<<null 2>>", badToken: "null" },
+  { label: "LiteralString", stream: "<<(x) 2>>", badToken: "(x)" },
+  { label: "HexString", stream: "<<<41> 2>>", badToken: "<41>" },
+  { label: "Operator", stream: "<<BT 2>>", badToken: "BT" },
+  { label: "ArrayBegin", stream: "<<[ ] 2>>", badToken: "[" },
+  { label: "DictBegin", stream: "<<<</K /V>> 2>>", badToken: "<</K" },
+  { label: "ArrayEnd", stream: "<<] 2>>", badToken: "]" },
+  {
+    label: "InlineImage",
+    stream: "<<BI /W 1 /H 1 /CS /G /BPC 8 ID @ EI /K 2>>",
+    badToken: "BI",
+  },
+])(
+  "`$stream` の key 位置 $label を検出すると OBJECT_PARSE_UNEXPECTED_TOKEN を返し offset が `$badToken` の位置と一致する",
+  ({ stream, badToken }) => {
+    const { tokenizer, openToken, positionOf } = setupAfterDictBegin(stream);
+
+    const result = readDictOperand(tokenizer, openToken);
+
+    assert(!result.ok);
+    assert(result.error.code === "OBJECT_PARSE_UNEXPECTED_TOKEN");
+    expect(result.error.message).toMatch(/^Dictionary key must be a name, /);
+    expect(result.error.offset).toBe(positionOf(badToken));
+  },
+);
+
+test.each<{ label: string; stream: string; badToken: string }>([
+  { label: "Operator (BT)", stream: "<</K BT>>", badToken: "BT" },
+  { label: "ArrayEnd", stream: "<</K ]>>", badToken: "]" },
+  { label: "DictEnd (単独 >>)", stream: "<</K >> /K2 1>>", badToken: ">>" },
+  {
+    label: "InlineImage",
+    stream: "<</K BI /W 1 /H 1 /CS /G /BPC 8 ID @ EI>>",
+    badToken: "BI",
+  },
+  { label: "Operator (endobj)", stream: "<</K endobj>>", badToken: "endobj" },
+])(
+  "`$stream` の value 位置 $label を検出すると OBJECT_PARSE_UNEXPECTED_TOKEN を返し offset が `$badToken` の位置と一致する",
+  ({ stream, badToken }) => {
+    const { tokenizer, openToken, positionOf } = setupAfterDictBegin(stream);
+
+    const result = readDictOperand(tokenizer, openToken);
+
+    assert(!result.ok);
+    assert(result.error.code === "OBJECT_PARSE_UNEXPECTED_TOKEN");
+    expect(result.error.message).toMatch(/^Unexpected token in dictionary value: /);
+    expect(result.error.offset).toBe(positionOf(badToken));
+  },
+);
+
+// 純 dict ネストを 101 段組み立てて MAX_NESTING_DEPTH = 100 の境界を検証する。
+// 上限を超えるのは内側 (101 段目) の `<<` であり、最外ではないことを offset で示す。
+test("`<</K <</K <</K ...>>>>` 形式で 101 段ネストすると NESTING_TOO_DEEP を返し offset が 101 段目の `<<` 位置と一致する", () => {
+  const depth = 101;
+  // 1 段目は最外 `<<` で、2..101 段目は `/K << ` を内側に挟む。
+  // 1 段あたり 5 文字 (`/K << ` のうちトレーリング space を除いて 5 文字)。
+  const inners = "/K <<".repeat(depth - 1);
+  const closes = ">>".repeat(depth);
+  const stream = `<<${inners}${closes}`;
+  const { tokenizer, openToken } = setupAfterDictBegin(stream);
+
+  const result = readDictOperand(tokenizer, openToken);
+
+  assert(!result.ok);
+  assert(result.error.code === "NESTING_TOO_DEEP");
+  // 101 段目の `<<` 位置 = `<<` + `/K << ` × 100 のうち最後の `<<` 開始。
+  // 計算: 最外 `<<` 2 文字 + 100 段分の `/K <<` (各 5 文字) = 2 + 500 = 502 のうち、
+  // 100 段目の `/K <<` 内の `<<` は 2 + 5 × 99 + 3 = 500 から始まる。
+  // → 100 段目を「内側に入る最後の <<」とした場合、その offset は stream.lastIndexOf("<<") で得られる。
+  expect(result.error.offset).toBe(stream.lastIndexOf("<<"));
+});
+
+// array/dict 交互ネストでの共有 depth 増分を pin down する。
+// 構造: 最外 `<<` (depth 1) + `/K [<<` × 50 (各 pair で array→dict と 2 段深くなる)。
+// 50 pair で depth = 1 + 2×50 = 101、101 段目の `<<` が NESTING_TOO_DEEP を発火する。
+test("`<</K [<</K [<</K ...>>]>>]>>` 形式で array/dict 交互 101 段ネストすると NESTING_TOO_DEEP を返す", () => {
+  const pairs = 50;
+  const inners = "/K [<<".repeat(pairs);
+  const closes = ">>]".repeat(pairs);
+  const stream = `<<${inners}${closes}>>`;
+  const { tokenizer, openToken } = setupAfterDictBegin(stream);
+
+  const result = readDictOperand(tokenizer, openToken);
+
+  assert(!result.ok);
+  assert(result.error.code === "NESTING_TOO_DEEP");
+  // 101 段目の token は最後 (50 番目) の pair 内の `<<`、すなわち最終位置の `<<`。
+  expect(result.error.offset).toBe(stream.lastIndexOf("<<"));
+});

--- a/packages/core/src/content-stream/interpreter/composite-operand/__tests__/dict.nested.test.ts
+++ b/packages/core/src/content-stream/interpreter/composite-operand/__tests__/dict.nested.test.ts
@@ -1,0 +1,97 @@
+import { assert, expect, test } from "vitest";
+import type { Token, TokenDictBegin } from "../../../../pdf/index";
+import { TokenType } from "../../../../pdf/index";
+import { ContentStreamTokenizer } from "../../../tokenizer/index";
+import { readDictOperand } from "../index";
+
+const encode = (s: string): Uint8Array => new TextEncoder().encode(s);
+
+function setupAfterDictBegin(stream: string): {
+  tokenizer: ContentStreamTokenizer;
+  openToken: TokenDictBegin;
+} {
+  const tokenizer = new ContentStreamTokenizer(encode(stream));
+  const result = tokenizer.nextToken();
+  assert(result.ok);
+  const token: Token = result.value;
+  assert(token.type === TokenType.DictBegin);
+  return { tokenizer, openToken: token };
+}
+
+test("`<</A [1 2]>>` を読み取り entries.get(`A`) が PdfArray となる (dict→array 経路)", () => {
+  const { tokenizer, openToken } = setupAfterDictBegin("<</A [1 2]>>");
+
+  const result = readDictOperand(tokenizer, openToken);
+
+  assert(result.ok);
+  expect(result.value.entries.get("A")).toEqual({
+    type: "array",
+    elements: [
+      { type: "integer", value: 1 },
+      { type: "integer", value: 2 },
+    ],
+  });
+});
+
+test("`<</A <</B 1>>>>` を読み取り 1 段ネスト辞書を受理する (dict→dict 自己再帰)", () => {
+  const { tokenizer, openToken } = setupAfterDictBegin("<</A <</B 1>>>>");
+
+  const result = readDictOperand(tokenizer, openToken);
+
+  assert(result.ok);
+  expect(result.value).toEqual({
+    type: "dictionary",
+    entries: new Map([
+      [
+        "A",
+        {
+          type: "dictionary",
+          entries: new Map([["B", { type: "integer", value: 1 }]]),
+        },
+      ],
+    ]),
+  });
+});
+
+test("`<</A <</B [1 2]>>>>` を読み取り 辞書→辞書→配列の経路を受理する", () => {
+  const { tokenizer, openToken } = setupAfterDictBegin("<</A <</B [1 2]>>>>");
+
+  const result = readDictOperand(tokenizer, openToken);
+
+  assert(result.ok);
+  const a = result.value.entries.get("A");
+  assert(a !== undefined && a.type === "dictionary");
+  const b = a.entries.get("B");
+  expect(b).toEqual({
+    type: "array",
+    elements: [
+      { type: "integer", value: 1 },
+      { type: "integer", value: 2 },
+    ],
+  });
+});
+
+test("`<</A [<</K 1>>]>>` を読み取り 辞書→配列→辞書の経路を受理する", () => {
+  const { tokenizer, openToken } = setupAfterDictBegin("<</A [<</K 1>>]>>");
+
+  const result = readDictOperand(tokenizer, openToken);
+
+  assert(result.ok);
+  expect(result.value).toEqual({
+    type: "dictionary",
+    entries: new Map([
+      [
+        "A",
+        {
+          type: "array",
+          elements: [
+            {
+              type: "dictionary",
+              entries: new Map([["K", { type: "integer", value: 1 }]]),
+            },
+          ],
+        },
+      ],
+    ]),
+  });
+});

--- a/packages/core/src/content-stream/interpreter/composite-operand/index.ts
+++ b/packages/core/src/content-stream/interpreter/composite-operand/index.ts
@@ -1,8 +1,10 @@
 import type {
   PdfArray,
+  PdfDictionary,
   PdfError,
   PdfValue,
   TokenArrayBegin,
+  TokenDictBegin,
 } from "../../../pdf/index";
 import { Token, TokenType, tokenDisplayString } from "../../../pdf/index";
 import type { Result } from "../../../utils/result/index";
@@ -10,8 +12,9 @@ import { err, ok } from "../../../utils/result/index";
 import type { ContentStreamTokenizer } from "../../tokenizer/index";
 
 /**
- * 配列リテラルのネスト上限。direct-object reader と同値。
+ * 配列・辞書リテラルのネスト上限。direct-object reader と同値。
  * 悪意ある content stream による stack overflow を防ぐ defensive design。
+ * array/dict が相互再帰で共有する単一定数。
  */
 const MAX_NESTING_DEPTH = 100;
 
@@ -20,8 +23,8 @@ const MAX_NESTING_DEPTH = 100;
  *
  * 呼び出し前に `ArrayBegin` token は既に消費済みであること。
  * 内部で `tokenizer.nextToken()` を `ArrayEnd` まで回し、
- * ネスト配列は再帰で処理する。要素は primitive または PdfArray のみ。
- * primitive token に変換できない token（Operator / Dict 開閉 / InlineImage / Keyword 等）は
+ * ネスト配列・辞書は相互再帰で処理する。要素は primitive / PdfArray / PdfDictionary のみ。
+ * primitive token に変換できない token（Operator / InlineImage / Keyword / 不正 delimiter 等）は
  * `OBJECT_PARSE_UNEXPECTED_TOKEN` で拒否する。
  *
  * @param tokenizer - `ArrayBegin` 消費済みの content stream tokenizer
@@ -33,6 +36,26 @@ export function readArrayOperand(
   openToken: TokenArrayBegin,
 ): Result<PdfArray, PdfError> {
   return readArrayInner(tokenizer, openToken, 1);
+}
+
+/**
+ * content stream の辞書リテラル `<< ... >>` を PdfDictionary として組み立てる。
+ *
+ * 呼び出し前に `DictBegin` token は既に消費済みであること。
+ * 内部で `tokenizer.nextToken()` を `DictEnd` まで回し、
+ * key / value pair を `Map<string, PdfValue>` に格納する。
+ * key 位置は `Name` のみ受理、value 位置は primitive / PdfArray / PdfDictionary を受理する。
+ * 同一 key は後勝ち（`Map.set` の上書き挙動）。
+ *
+ * @param tokenizer - `DictBegin` 消費済みの content stream tokenizer
+ * @param openToken - `DictBegin` token（エラー位置報告用、型レベルで `<<` のみ受理）
+ * @returns PdfDictionary、または OBJECT_PARSE_UNTERMINATED / OBJECT_PARSE_UNEXPECTED_TOKEN / NESTING_TOO_DEEP
+ */
+export function readDictOperand(
+  tokenizer: ContentStreamTokenizer,
+  openToken: TokenDictBegin,
+): Result<PdfDictionary, PdfError> {
+  return readDictInner(tokenizer, openToken, 1);
 }
 
 function readArrayInner(
@@ -78,6 +101,15 @@ function readArrayInner(
       continue;
     }
 
+    if (token.type === TokenType.DictBegin) {
+      const nested = readDictInner(tokenizer, token, depth + 1);
+      if (!nested.ok) {
+        return err(nested.error);
+      }
+      elements.push(nested.value);
+      continue;
+    }
+
     const objectResult = Token.toPrimitivePdfValue(token);
     if (!objectResult.ok) {
       return err(objectResult.error);
@@ -91,5 +123,95 @@ function readArrayInner(
     }
 
     elements.push(objectResult.value.value);
+  }
+}
+
+function readDictInner(
+  tokenizer: ContentStreamTokenizer,
+  openToken: TokenDictBegin,
+  depth: number,
+): Result<PdfDictionary, PdfError> {
+  if (depth > MAX_NESTING_DEPTH) {
+    return err({
+      code: "NESTING_TOO_DEEP",
+      message: `Dictionary nesting depth ${depth} exceeds maximum ${MAX_NESTING_DEPTH}`,
+      offset: openToken.offset,
+    });
+  }
+
+  const entries = new Map<string, PdfValue>();
+
+  while (true) {
+    const keyResult = tokenizer.nextToken();
+    if (!keyResult.ok) {
+      return err(keyResult.error);
+    }
+    const keyToken = keyResult.value;
+
+    if (keyToken.type === TokenType.DictEnd) {
+      return ok({ type: "dictionary", entries });
+    }
+
+    if (keyToken.type === TokenType.EOF) {
+      return err({
+        code: "OBJECT_PARSE_UNTERMINATED",
+        message: "Unterminated dictionary operand",
+        offset: openToken.offset,
+      });
+    }
+
+    if (keyToken.type !== TokenType.Name) {
+      return err({
+        code: "OBJECT_PARSE_UNEXPECTED_TOKEN",
+        message: `Dictionary key must be a name, got ${tokenDisplayString(keyToken)}`,
+        offset: keyToken.offset,
+      });
+    }
+
+    const valueResult = tokenizer.nextToken();
+    if (!valueResult.ok) {
+      return err(valueResult.error);
+    }
+    const valueToken = valueResult.value;
+
+    if (valueToken.type === TokenType.EOF) {
+      return err({
+        code: "OBJECT_PARSE_UNTERMINATED",
+        message: "Unterminated dictionary operand",
+        offset: openToken.offset,
+      });
+    }
+
+    if (valueToken.type === TokenType.ArrayBegin) {
+      const nested = readArrayInner(tokenizer, valueToken, depth + 1);
+      if (!nested.ok) {
+        return err(nested.error);
+      }
+      entries.set(keyToken.value, nested.value);
+      continue;
+    }
+
+    if (valueToken.type === TokenType.DictBegin) {
+      const nested = readDictInner(tokenizer, valueToken, depth + 1);
+      if (!nested.ok) {
+        return err(nested.error);
+      }
+      entries.set(keyToken.value, nested.value);
+      continue;
+    }
+
+    const primitive = Token.toPrimitivePdfValue(valueToken);
+    if (!primitive.ok) {
+      return err(primitive.error);
+    }
+    if (!primitive.value.some) {
+      return err({
+        code: "OBJECT_PARSE_UNEXPECTED_TOKEN",
+        message: `Unexpected token in dictionary value: ${tokenDisplayString(valueToken)}`,
+        offset: valueToken.offset,
+      });
+    }
+
+    entries.set(keyToken.value, primitive.value.value);
   }
 }

--- a/packages/core/src/content-stream/interpreter/index.ts
+++ b/packages/core/src/content-stream/interpreter/index.ts
@@ -1,5 +1,9 @@
 import type { PdfWarning } from "../../pdf/errors/warning/index";
-import type { PdfError, TokenArrayBegin } from "../../pdf/index";
+import type {
+  PdfError,
+  TokenArrayBegin,
+  TokenDictBegin,
+} from "../../pdf/index";
 import { Token, TokenType } from "../../pdf/index";
 import type { Result } from "../../utils/result/index";
 import { err, ok } from "../../utils/result/index";
@@ -11,7 +15,7 @@ import {
   OperatorRegistry,
 } from "../operator-registry/index";
 import { ContentStreamTokenizer } from "../tokenizer/index";
-import { readArrayOperand } from "./composite-operand/index";
+import { readArrayOperand, readDictOperand } from "./composite-operand/index";
 
 export type ContentStreamInterpreterExecuteOptions = {
   readonly data: Uint8Array;
@@ -78,11 +82,11 @@ export const ContentStreamInterpreter = {
 /**
  * 1 token を分類して以下のいずれかを実行する:
  * EOF（完了）/ operator dispatch / inline image dispatch / array reader dispatch /
- * 辞書開きの NOT_IMPLEMENTED / 複合 delimiter (`]` `>>`) の UNEXPECTED_TOKEN /
+ * dict reader dispatch / 複合 delimiter (`]` `>>`) の UNEXPECTED_TOKEN /
  * primitive operand の push。
  *
  * @param options.token - 実行対象 token
- * @param options.tokenizer - 配列リテラル `[ ... ]` の読み取りに使う tokenizer（reader へ委譲）
+ * @param options.tokenizer - 配列・辞書リテラルの読み取りに使う tokenizer（reader へ委譲）
  * @param options.registry - operator handler 登録簿
  * @param options.context - 現在 context
  * @param options.warnings - 警告蓄積バッファ
@@ -124,10 +128,10 @@ function executeToken(options: {
   }
 
   if (options.token.type === TokenType.DictBegin) {
-    return err({
-      code: "NOT_IMPLEMENTED",
-      message: `Composite dictionary operand is not supported`,
-      offset: options.token.offset,
+    return dispatchDictOperand({
+      tokenizer: options.tokenizer,
+      openToken: options.token,
+      context: options.context,
     });
   }
 
@@ -212,6 +216,25 @@ function dispatchArrayOperand(options: {
     return err(array.error);
   }
   OperandStack.push(options.context.operandStack, array.value);
+  return ok({ type: "continue", context: options.context });
+}
+
+/**
+ * 辞書リテラル `<< ... >>` を reader に委譲して PdfDictionary を operand stack へ積む。
+ *
+ * @param options - tokenizer・開きトークン・現在 context
+ * @returns 次 step、または reader エラー
+ */
+function dispatchDictOperand(options: {
+  readonly tokenizer: ContentStreamTokenizer;
+  readonly openToken: TokenDictBegin;
+  readonly context: OperatorHandlerContext;
+}): Result<InterpreterStep, PdfError> {
+  const dictionary = readDictOperand(options.tokenizer, options.openToken);
+  if (!dictionary.ok) {
+    return err(dictionary.error);
+  }
+  OperandStack.push(options.context.operandStack, dictionary.value);
   return ok({ type: "continue", context: options.context });
 }
 


### PR DESCRIPTION
## 概要

content stream の辞書リテラル `<< ... >>` を `PdfDictionary` として組み立てて operand stack に push する機能を実装。`readArrayInner` / `readDictInner` を相互再帰で並列定義し、`MAX_NESTING_DEPTH = 100` を共有する。`executeToken` の `DictBegin` 分岐 `NOT_IMPLEMENTED` を `dispatchDictOperand` に差し替え、Issue #331 の `NOT_IMPLEMENTED` 消滅条件も同時に達成する。

## 変更内容

### 🎯 変更の種類

- [x] ✨ 新機能 (New feature)
- [x] 🚨 テスト追加/修正 (Tests)

### 📝 詳細な変更内容

#### 追加された機能・修正

- `readDictOperand(tokenizer, openToken: TokenDictBegin): Result<PdfDictionary, PdfError>` を `composite-operand/index.ts` から公開
- `readDictInner` 実装。key/value 位置で primitive 7 種・`ArrayBegin`・`DictBegin` を受理、`Map.set` の後勝ち挙動でキー重複を解決
- `readArrayInner` の value 位置で `DictBegin` を受理 (array→dict 相互再帰)
- `dispatchDictOperand` 追加、`executeToken` の `DictBegin` 分岐を差し替え

#### 変更されたファイル

- `composite-operand/index.ts` — `readDictOperand` / `readDictInner` 新規、`readArrayInner` 拡張、`MAX_NESTING_DEPTH` 共有
- `interpreter/index.ts` — `dispatchDictOperand` 追加・`DictBegin` 分岐差し替え
- `interpreter/__tests__/interpreter.dispatch.test.ts` — NOT_IMPLEMENTED 行削除、unbalanced delimiter のみ据え置き
- `composite-operand/__tests__/array.nested.test.ts` — array→dict 受理ケース追加
- `composite-operand/__tests__/array.error.test.ts` — `[<< /K /V >>]` 旧拒否ケース削除

#### 追加されたファイル

- `composite-operand/__tests__/dict.basic.test.ts` (10 tests)
- `composite-operand/__tests__/dict.duplicate-key.test.ts` (2 tests)
- `composite-operand/__tests__/dict.error.test.ts` (20 tests、key 位置 11 ケース / value 位置 5 ケース / EOF / nesting 含む)
- `composite-operand/__tests__/dict.nested.test.ts` (4 tests)
- `interpreter/__tests__/interpreter.dict-operand.test.ts` (3 tests)

## 📊 システム図

### token dispatch フロー (executeToken)

```mermaid
flowchart TD
    Token([token]) --> EOF{EOF?}
    EOF -->|yes| Done([done])
    EOF -->|no| Op{Operator?}
    Op -->|yes| DispatchOp[dispatchOperator]
    Op -->|no| Inline{InlineImage?}
    Inline -->|yes| DispatchInline[dispatchInlineImage]
    Inline -->|no| Arr{ArrayBegin?}
    Arr -->|yes| DispatchArr[dispatchArrayOperand]
    Arr -->|no| Dict{DictBegin?}
    Dict -->|yes| DispatchDict[dispatchDictOperand]:::new
    Dict -->|no| Delim{ArrayEnd / DictEnd?}
    Delim -->|yes| Err[UNEXPECTED_TOKEN]
    Delim -->|no| Prim[pushPrimitiveOperand]

    DispatchArr --> ReadArr[readArrayOperand → readArrayInner]
    DispatchDict --> ReadDict[readDictOperand → readDictInner]:::new
    ReadArr -.->|DictBegin in value position| ReadDict
    ReadDict -.->|ArrayBegin in value position| ReadArr
    ReadDict -.->|DictBegin in value position| ReadDict

    classDef new fill:#ffe4b5,stroke:#d97706,stroke-width:2px
```

新規追加 (`[NEW]`): `dispatchDictOperand` / `readDictOperand` / `readDictInner` および array↔dict 相互再帰経路。

## 📋 関連 Issue

- Closes #468
- Closes #331 (`NOT_IMPLEMENTED` が `tokenToPrimitivePdfObject` 経路から消滅)
- 親 Epic: #466

## 🧪 テスト

### テスト実行方法

```bash
pnpm --filter @pdfmod/core test src/content-stream/interpreter
pnpm --filter @pdfmod/core test
pnpm --filter @pdfmod/core build
```

### テスト項目

- [x] 単体テスト (Unit tests) — composite-operand reader と interpreter 入口の両方
- [x] 統合テスト (Integration tests) — interpreter 経由で operand stack に PdfDictionary が積まれることを検証

### テスト結果

- `pnpm --filter @pdfmod/core test`: **2933 tests passed** (N3)
- `pnpm --filter @pdfmod/core build`: **成功** (N4)

主要ケース網羅:
- 正常系: 空辞書 / 1 entry / 複数 entry / primitive 7 種 / dict→array / dict→dict / dict→array→dict / array→dict
- 異常系: EOF (key/value) / 非 Name key (11 種) / 不正 value (5 種) / 純 dict 101 段 NESTING / array/dict 交互 101 段 NESTING
- 重複 key 後勝ち (F7)

## 🔍 レビューポイント

- `readArrayInner` / `readDictInner` の相互再帰部分での depth 共有 (C5)
- `MAX_NESTING_DEPTH = 100` が `composite-operand/index.ts` 内で 1 個のみ (C2)
- EOF メッセージ統一: `"Unterminated array operand"` / `"Unterminated dictionary operand"` (左右対称)
- key/value 位置のエラーメッセージ文言分離 (`Dictionary key must be a name, ...` / `Unexpected token in dictionary value: ...`)
- 既存テスト破壊的更新: `[<< /K /V >>]` UNEXPECTED_TOKEN 削除 / NOT_IMPLEMENTED ケース削除 (対応する OK / 完走ケースを別ファイルに移動)

## ⚠️ 破壊的変更

- [ ] この変更は既存の API に破壊的変更を含みます

ライブラリ公開 API に破壊的変更なし。`readArrayOperand` の挙動拡張 (DictBegin 受理) は前方互換。

## 📚 追加情報

### 設計判断

- `direct-object` 側 (PDF 本体パーサ) は変更せず content-stream に閉じる (C10)
- `Token.toPrimitivePdfValue` は変更なし、`default → ok(none)` の passthrough を流用 (C4)
- 後勝ちは `Map.set` の上書き挙動で自然成立、`dict.duplicate-key.test.ts` で pin down

### 自動レビュー結果

- `/spec-implement` の codex review: review-002 で **問題なし** 確定
- `/spec-based-code-review` 並列 5 エージェント (performance/design/spec-alignment/test-quality/comment-quality): 2 回目で WARNING 0 件、**merge ready**

## ✅ チェックリスト

- [x] コードレビューの準備ができている
- [x] テストが正常に実行される
- [x] ドキュメントが更新されている（implementation-plan の検証コマンドパス修正含む）
- [x] コミットメッセージが適切な形式で書かれている
- [x] 関連する Issue が PR の本文に記載されている
- [x] セルフレビューを実施した
- [x] 破壊的変更なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)