### PR TITLE
♻️ [Refactoring]: #475 readDictInner を readDictKey / readDictValue へ責務分離

### DIFF
--- a/packages/core/src/content-stream/inline-image/inline-image-dict/__tests__/inline-image-dict.required-keys.test.ts
+++ b/packages/core/src/content-stream/inline-image/inline-image-dict/__tests__/inline-image-dict.required-keys.test.ts
@@ -5,6 +5,7 @@ import {
   type TokenInlineImageDictEntry,
   TokenType,
 } from "../../../../pdf/index";
+import { some } from "../../../../utils/option/index";
 import { InlineImageDict, type InlineImageRequiredKey } from "../index";
 
 const integerToken = (value: number): Token => ({
@@ -62,10 +63,7 @@ test("BitsPerComponent は imageMask=true で optional、imageMask=false で必�
   const normal = InlineImageDict.findMissingRequiredKey(dict, false);
 
   expect(stencil.some).toBe(false);
-  expect(normal.some).toBe(true);
-  if (normal.some) {
-    expect(normal.value).toBe("BitsPerComponent");
-  }
+  expect(normal).toStrictEqual(some("BitsPerComponent"));
 });
 
 test("imageMask=true で ColorSpace が dict に余分に含まれても none を返す（現実装の既存挙動）", () => {
@@ -92,10 +90,7 @@ test.each<[InlineImageRequiredKey]>([
 
   const result = InlineImageDict.findMissingRequiredKey(dict, false);
 
-  expect(result.some).toBe(true);
-  if (result.some) {
-    expect(result.value).toBe(missingKey);
-  }
+  expect(result).toStrictEqual(some(missingKey));
 });
 
 test("imageMask=false で Width と Height が両方欠落のとき some('Width') を返す（先頭優先）", () => {
@@ -107,10 +102,7 @@ test("imageMask=false で Width と Height が両方欠落のとき some('Width'
 
   const result = InlineImageDict.findMissingRequiredKey(dict, false);
 
-  expect(result.some).toBe(true);
-  if (result.some) {
-    expect(result.value).toBe("Width");
-  }
+  expect(result).toStrictEqual(some("Width"));
 });
 
 test("imageMask=false で Height のみ欠落のとき some('Height') を返す", () => {
@@ -123,10 +115,7 @@ test("imageMask=false で Height のみ欠落のとき some('Height') を返す"
 
   const result = InlineImageDict.findMissingRequiredKey(dict, false);
 
-  expect(result.some).toBe(true);
-  if (result.some) {
-    expect(result.value).toBe("Height");
-  }
+  expect(result).toStrictEqual(some("Height"));
 });
 
 test("imageMask=false で BitsPerComponent のみ欠落のとき some('BitsPerComponent') を返す", () => {
@@ -139,10 +128,7 @@ test("imageMask=false で BitsPerComponent のみ欠落のとき some('BitsPerCo
 
   const result = InlineImageDict.findMissingRequiredKey(dict, false);
 
-  expect(result.some).toBe(true);
-  if (result.some) {
-    expect(result.value).toBe("BitsPerComponent");
-  }
+  expect(result).toStrictEqual(some("BitsPerComponent"));
 });
 
 test("imageMask=true で Width が欠落のとき some('Width') を返す", () => {
@@ -151,10 +137,7 @@ test("imageMask=true で Width が欠落のとき some('Width') を返す", () =
 
   const result = InlineImageDict.findMissingRequiredKey(dict, true);
 
-  expect(result.some).toBe(true);
-  if (result.some) {
-    expect(result.value).toBe("Width");
-  }
+  expect(result).toStrictEqual(some("Width"));
 });
 
 test("imageMask=true で Height が欠落のとき some('Height') を返す", () => {
@@ -163,30 +146,21 @@ test("imageMask=true で Height が欠落のとき some('Height') を返す", ()
 
   const result = InlineImageDict.findMissingRequiredKey(dict, true);
 
-  expect(result.some).toBe(true);
-  if (result.some) {
-    expect(result.value).toBe("Height");
-  }
+  expect(result).toStrictEqual(some("Height"));
 });
 
 test("空 dict × imageMask=false で some('Width') を返す（先頭の必須キーから検査）", () => {
   // 空入力でも検査順 1 番目の Width を返す
   const result = InlineImageDict.findMissingRequiredKey([], false);
 
-  expect(result.some).toBe(true);
-  if (result.some) {
-    expect(result.value).toBe("Width");
-  }
+  expect(result).toStrictEqual(some("Width"));
 });
 
 test("空 dict × imageMask=true で some('Width') を返す", () => {
   // stencil 経路でも先頭は Width
   const result = InlineImageDict.findMissingRequiredKey([], true);
 
-  expect(result.some).toBe(true);
-  if (result.some) {
-    expect(result.value).toBe("Width");
-  }
+  expect(result).toStrictEqual(some("Width"));
 });
 
 test("略号のまま入力（normalize 未経由）すると some('Width') を返す（呼び出し前提の pin down）", () => {
@@ -201,10 +175,7 @@ test("略号のまま入力（normalize 未経由）すると some('Width') を�
 
   const result = InlineImageDict.findMissingRequiredKey(dict, false);
 
-  expect(result.some).toBe(true);
-  if (result.some) {
-    expect(result.value).toBe("Width");
-  }
+  expect(result).toStrictEqual(some("Width"));
 });
 
 test("normalize 連鎖: 全略号 dict は完全名展開後に必須キー揃いと判定される", () => {

--- a/packages/core/src/content-stream/inline-image/inline-image-dict/index.ts
+++ b/packages/core/src/content-stream/inline-image/inline-image-dict/index.ts
@@ -222,6 +222,7 @@ export const InlineImageDict = {
    * - value 配列が空、value[0] が Boolean 以外、Boolean(false) のときはすべて false。
    *
    * @param dict 既に `normalize` を経由した dict を想定するが、未経由でも安全に false を返す
+   * @returns `/ImageMask` の最初の entry が `TokenBoolean(true)` のときのみ true、それ以外は false
    */
   isImageMaskTrue: (dict: InlineImageDict): boolean => {
     const entry = findFirstEntry(dict, "ImageMask");
@@ -279,6 +280,9 @@ export const InlineImageDict = {
    *   - Name 以外（Integer / Boolean / Array / Dict / Null / Real / String 等）は素通し
    *   - Name token は table に hit すれば新 token で置換（`offset` 継承）、miss すれば素通し
    *   - Array / Dict 系 token に対する **再帰展開はしない**（Table 89 は 1 階層の Name のみが対象）
+   *
+   * @param dict 完全名キーへ `normalize` 済みの inline-image dict
+   * @returns 値側略号を完全名へ展開した新 dict（4 階層参照同一性ルールで非置換部は同一参照）
    */
   expandValueAbbrevs: (dict: InlineImageDict): InlineImageDict => {
     return dict.map((entry) => {

--- a/packages/core/src/content-stream/interpreter/composite-operand/index.ts
+++ b/packages/core/src/content-stream/interpreter/composite-operand/index.ts
@@ -5,8 +5,11 @@ import type {
   PdfValue,
   TokenArrayBegin,
   TokenDictBegin,
+  TokenName,
 } from "../../../pdf/index";
 import { Token, TokenType, tokenDisplayString } from "../../../pdf/index";
+import type { Option } from "../../../utils/option/index";
+import { none, some } from "../../../utils/option/index";
 import type { Result } from "../../../utils/result/index";
 import { err, ok } from "../../../utils/result/index";
 import type { ContentStreamTokenizer } from "../../tokenizer/index";
@@ -58,6 +61,15 @@ export function readDictOperand(
   return readDictInner(tokenizer, openToken, 1);
 }
 
+/**
+ * 配列リテラルの本体ループ。`readArrayOperand` から depth=1 で呼び出される他、
+ * `readDictInner` / 自分自身から `depth + 1` で再帰呼び出しされる。
+ *
+ * @param tokenizer - `ArrayBegin` 消費済みの content stream tokenizer
+ * @param openToken - `ArrayBegin` token（エラー位置報告用）
+ * @param depth - 現在のネスト深度（先頭呼び出しは 1）
+ * @returns PdfArray、または OBJECT_PARSE_UNTERMINATED / OBJECT_PARSE_UNEXPECTED_TOKEN / NESTING_TOO_DEEP
+ */
 function readArrayInner(
   tokenizer: ContentStreamTokenizer,
   openToken: TokenArrayBegin,
@@ -126,6 +138,18 @@ function readArrayInner(
   }
 }
 
+/**
+ * 辞書リテラルの本体ループ。`readDictOperand` から depth=1 で呼び出される他、
+ * `readDictValue` / `readArrayInner` から `depth + 1` で再帰呼び出しされる。
+ *
+ * while 本体は `readDictKey` → `readDictValue` → `entries.set` の 3 ステップに圧縮されており、
+ * key/value 各位置のパース責務はヘルパに委譲する。
+ *
+ * @param tokenizer - `DictBegin` 消費済みの content stream tokenizer
+ * @param openToken - `DictBegin` token（エラー位置報告用）
+ * @param depth - 現在のネスト深度（先頭呼び出しは 1）
+ * @returns PdfDictionary、または OBJECT_PARSE_UNTERMINATED / OBJECT_PARSE_UNEXPECTED_TOKEN / NESTING_TOO_DEEP
+ */
 function readDictInner(
   tokenizer: ContentStreamTokenizer,
   openToken: TokenDictBegin,
@@ -142,76 +166,127 @@ function readDictInner(
   const entries = new Map<string, PdfValue>();
 
   while (true) {
-    const keyResult = tokenizer.nextToken();
+    const keyResult = readDictKey(tokenizer, openToken);
     if (!keyResult.ok) {
       return err(keyResult.error);
     }
-    const keyToken = keyResult.value;
-
-    if (keyToken.type === TokenType.DictEnd) {
+    if (!keyResult.value.some) {
       return ok({ type: "dictionary", entries });
     }
+    const keyToken = keyResult.value.value;
 
-    if (keyToken.type === TokenType.EOF) {
-      return err({
-        code: "OBJECT_PARSE_UNTERMINATED",
-        message: "Unterminated dictionary operand",
-        offset: openToken.offset,
-      });
-    }
-
-    if (keyToken.type !== TokenType.Name) {
-      return err({
-        code: "OBJECT_PARSE_UNEXPECTED_TOKEN",
-        message: `Dictionary key must be a name, got ${tokenDisplayString(keyToken)}`,
-        offset: keyToken.offset,
-      });
-    }
-
-    const valueResult = tokenizer.nextToken();
+    const valueResult = readDictValue(tokenizer, openToken, depth);
     if (!valueResult.ok) {
       return err(valueResult.error);
     }
-    const valueToken = valueResult.value;
 
-    if (valueToken.type === TokenType.EOF) {
-      return err({
-        code: "OBJECT_PARSE_UNTERMINATED",
-        message: "Unterminated dictionary operand",
-        offset: openToken.offset,
-      });
-    }
-
-    if (valueToken.type === TokenType.ArrayBegin) {
-      const nested = readArrayInner(tokenizer, valueToken, depth + 1);
-      if (!nested.ok) {
-        return err(nested.error);
-      }
-      entries.set(keyToken.value, nested.value);
-      continue;
-    }
-
-    if (valueToken.type === TokenType.DictBegin) {
-      const nested = readDictInner(tokenizer, valueToken, depth + 1);
-      if (!nested.ok) {
-        return err(nested.error);
-      }
-      entries.set(keyToken.value, nested.value);
-      continue;
-    }
-
-    const primitive = Token.toPrimitivePdfValue(valueToken);
-    if (!primitive.ok) {
-      return err(primitive.error);
-    }
-    if (!primitive.value.some) {
-      return err({
-        code: "OBJECT_PARSE_UNEXPECTED_TOKEN",
-        message: `Unexpected token in dictionary value: ${tokenDisplayString(valueToken)}`,
-        offset: valueToken.offset,
-      });
-    }
-
-    entries.set(keyToken.value, primitive.value.value);
+    entries.set(keyToken.value, valueResult.value);
   }
+}
+
+/**
+ * 辞書の key 位置から 1 token 読み取り、ループ終了 / key / エラーの 3 状態を返す。
+ *
+ * `Result<Option<TokenName>, PdfError>` の三状態:
+ * - `ok(some(token))`: 正常な key トークン（`TokenName` へ narrowing 済み）
+ * - `ok(none)`: `DictEnd` を観測。`readDictInner` のループ終了サイン
+ * - `err(...)`: tokenizer 自体のエラー / EOF / Name 以外の token
+ *
+ * EOF は openToken.offset を、key 位置の不正は keyToken.offset を返す。
+ *
+ * @param tokenizer - `DictBegin` 消費済みの content stream tokenizer
+ * @param openToken - `DictBegin` token（OBJECT_PARSE_UNTERMINATED の offset 報告用）
+ * @returns 正常 key / 終了サイン / エラーの三状態
+ */
+function readDictKey(
+  tokenizer: ContentStreamTokenizer,
+  openToken: TokenDictBegin,
+): Result<Option<TokenName>, PdfError> {
+  const tokenResult = tokenizer.nextToken();
+  if (!tokenResult.ok) {
+    return err(tokenResult.error);
+  }
+  const keyToken = tokenResult.value;
+
+  if (keyToken.type === TokenType.DictEnd) {
+    return ok(none);
+  }
+
+  if (keyToken.type === TokenType.EOF) {
+    return err({
+      code: "OBJECT_PARSE_UNTERMINATED",
+      message: "Unterminated dictionary operand",
+      offset: openToken.offset,
+    });
+  }
+
+  if (keyToken.type !== TokenType.Name) {
+    return err({
+      code: "OBJECT_PARSE_UNEXPECTED_TOKEN",
+      message: `Dictionary key must be a name, got ${tokenDisplayString(keyToken)}`,
+      offset: keyToken.offset,
+    });
+  }
+
+  return ok(some(keyToken));
+}
+
+/**
+ * 辞書の value 位置から 1 token 読み取り、対応する `PdfValue` を返す。
+ *
+ * value 位置の分岐:
+ * - `EOF`        → `err(OBJECT_PARSE_UNTERMINATED, openToken.offset)`
+ * - `ArrayBegin` → `readArrayInner(tokenizer, token, depth + 1)` へ相互再帰
+ * - `DictBegin`  → `readDictInner(tokenizer, token, depth + 1)` へ自己再帰
+ * - その他       → `Token.toPrimitivePdfValue(token)` を呼び、
+ *                  `ok(none)` の場合は `err(OBJECT_PARSE_UNEXPECTED_TOKEN, token.offset)`
+ *
+ * tokenizer 自体のエラーは透過。`OBJECT_PARSE_UNEXPECTED_TOKEN` の offset は
+ * 該当 valueToken.offset を維持する。
+ *
+ * @param tokenizer - `DictBegin` 消費済みの content stream tokenizer
+ * @param openToken - `DictBegin` token（OBJECT_PARSE_UNTERMINATED の offset 報告用）
+ * @param depth - 現在のネスト深度。ネスト再帰では depth + 1 を渡す
+ * @returns PdfValue、または OBJECT_PARSE_UNTERMINATED / OBJECT_PARSE_UNEXPECTED_TOKEN / NESTING_TOO_DEEP
+ */
+function readDictValue(
+  tokenizer: ContentStreamTokenizer,
+  openToken: TokenDictBegin,
+  depth: number,
+): Result<PdfValue, PdfError> {
+  const tokenResult = tokenizer.nextToken();
+  if (!tokenResult.ok) {
+    return err(tokenResult.error);
+  }
+  const valueToken = tokenResult.value;
+
+  if (valueToken.type === TokenType.EOF) {
+    return err({
+      code: "OBJECT_PARSE_UNTERMINATED",
+      message: "Unterminated dictionary operand",
+      offset: openToken.offset,
+    });
+  }
+
+  if (valueToken.type === TokenType.ArrayBegin) {
+    return readArrayInner(tokenizer, valueToken, depth + 1);
+  }
+
+  if (valueToken.type === TokenType.DictBegin) {
+    return readDictInner(tokenizer, valueToken, depth + 1);
+  }
+
+  const primitive = Token.toPrimitivePdfValue(valueToken);
+  if (!primitive.ok) {
+    return err(primitive.error);
+  }
+  if (!primitive.value.some) {
+    return err({
+      code: "OBJECT_PARSE_UNEXPECTED_TOKEN",
+      message: `Unexpected token in dictionary value: ${tokenDisplayString(valueToken)}`,
+      offset: valueToken.offset,
+    });
+  }
+
+  return ok(primitive.value.value);
 }

--- a/packages/core/src/ext/string-array/__tests__/string-array.basic.test.ts
+++ b/packages/core/src/ext/string-array/__tests__/string-array.basic.test.ts
@@ -115,12 +115,8 @@ test("allMissing: 複数欠落のとき requiredKeys 順の配列を返す", () 
 // 戻り値型: firstMissing が返す some の中身は string 型であること
 test("firstMissing: some の中身が string 型である", () => {
   const result = StringArrayEx.firstMissing(["Width"], ["Width", "Height"]);
-  expect(result.some).toBe(true);
-  if (result.some) {
-    // value が文字列であることをランタイムで pin down する
-    expect(typeof result.value).toBe("string");
-    expect(result.value).toBe("Height");
-  }
+  // 構造一致で some("Height") を pin down（value の型は TypeScript で string に narrowing 済み）
+  expect(result).toStrictEqual(some("Height"));
 });
 
 // 戻り値型: firstMissing が none を返すときは utils/option の singleton と参照一致すること


### PR DESCRIPTION
## 概要

`packages/core/src/content-stream/interpreter/composite-operand/index.ts` の `readDictInner` 本体（約 90 行）を `readDictKey` / `readDictValue` の 2 ヘルパへ責務分離し、while 本体を「key 読む → value 読む → entries に格納」の 3 ステップ構造へ圧縮するリファクタです。挙動（公開 API シグネチャ・成功戻り値・エラーコード / メッセージ / offset）は完全不変。

## 変更内容

### 🎯 変更の種類

- [x] ♻️ リファクタリング (Refactoring)
- [x] 🚨 テスト追加/修正 (Tests) — pre-push hook 要件を満たすため既存違反を修正
- [x] 📖 ドキュメント更新 (Documentation) — JSDoc tag 追補

### 📝 詳細な変更内容

#### 追加された機能・修正

- `readDictKey(tokenizer, openToken): Result<Option<TokenName>, PdfError>`
  - 三状態 (`ok(some(name))` / `ok(none)` = DictEnd / `err(...)`) で key 位置の責務を表現
  - `TokenName` への narrowing をヘルパ境界で 1 回だけ実施
- `readDictValue(tokenizer, openToken, depth): Result<PdfValue, PdfError>`
  - `EOF / ArrayBegin / DictBegin / primitive` の 4 分岐で value 位置を表現
  - 相互再帰 `depth + 1` 伝播もここに集約
- `readDictInner` の while 本体を 3 ステップへ圧縮（depth ガード・`entries` 初期化は不変）

#### 変更されたファイル

- `packages/core/src/content-stream/interpreter/composite-operand/index.ts` (+132, −57)
  - `readArrayInner` / `readDictInner` に JSDoc を追加（hook 要件、ロジック無変更）
- `packages/core/src/content-stream/inline-image/inline-image-dict/__tests__/inline-image-dict.required-keys.test.ts`
  - `if (result.some) { expect(result.value).toBe(...) }` を `expect(result).toStrictEqual(some(...))` へ書き換え（pre-push hook の条件分岐禁止検査対応）
- `packages/core/src/ext/string-array/__tests__/string-array.basic.test.ts`
  - 同上
- `packages/core/src/content-stream/inline-image/inline-image-dict/index.ts`
  - `isImageMaskTrue` / `expandValueAbbrevs` に `@param` / `@returns` を追記（pre-push hook の JSDoc 検査対応）

#### 削除されたファイル・機能

- なし

## 📊 システム図

### 状態マシン / フロー図

```mermaid
flowchart TD
    Start([readDictInner 入口]) --> Depth{depth > MAX?}
    Depth -->|yes| ErrNest[err NESTING_TOO_DEEP]
    Depth -->|no| Loop[while loop 開始]

    Loop --> Key["readDictKey(tokenizer, openToken)<br/>[NEW]"]:::new
    Key -->|err| ReturnErr[return err]
    Key -->|ok(none) = DictEnd| ReturnOk[return ok dictionary]
    Key -->|ok(some(name))| Value["readDictValue(tokenizer, openToken, depth)<br/>[NEW]"]:::new

    Value -->|err| ReturnErr
    Value -->|ok(v)| Set["entries.set(name.value, v)"]
    Set --> Loop

    classDef new fill:#ffe4b5,stroke:#d97706,stroke-width:2px
```

### データフロー

```
readDictOperand                              [PUBLIC, 不変]
        │
        │ readDictInner(tokenizer, openToken, depth=1)
        ▼
readDictInner                                [PRIVATE, 3 ステップ構造へ圧縮]
   ┌────┴────┐
   │ while   │
   └────┬────┘
        │
        ├─▶ readDictKey()         [NEW PRIVATE]  Result<Option<TokenName>, PdfError>
        │      ├─ DictEnd → ok(none)            (ループ終了サイン)
        │      ├─ EOF     → err UNTERMINATED    (offset = openToken.offset)
        │      ├─ Name    → ok(some(name))
        │      └─ other   → err UNEXPECTED_TOKEN (offset = keyToken.offset)
        │
        ├─▶ readDictValue()       [NEW PRIVATE]  Result<PdfValue, PdfError>
        │      ├─ EOF        → err UNTERMINATED  (offset = openToken.offset)
        │      ├─ ArrayBegin → readArrayInner(depth + 1)
        │      ├─ DictBegin  → readDictInner(depth + 1)  (自己再帰)
        │      └─ other     → Token.toPrimitivePdfValue()
        │                       ├─ ok(some(v)) → ok(v)
        │                       └─ ok(none)    → err UNEXPECTED_TOKEN (offset = valueToken.offset)
        │
        └─▶ entries.set(name.value, value)     (Map<string, PdfValue>)
```

## 📋 関連 Issue

- Closes #475

## 🧪 テスト

### テスト実行方法

```bash
pnpm --filter @pdfmod/core test src/content-stream/interpreter   # 86 件（dict / array / interpreter 統合）
pnpm --filter @pdfmod/core test                                  # 2933 件（core 全体）
pnpm --filter @pdfmod/core typecheck
pnpm --filter @pdfmod/core build
pnpm lint                                                        # biome + oxlint
```

### テスト項目

- [x] 単体テスト (Unit tests)
- [x] 統合テスト (Integration tests) — interpreter.dict-operand / interpreter.dispatch / interpreter.inline-image
- [ ] E2E テスト (End-to-end tests)
- [x] 手動テスト (Manual testing) — git diff によるエラー文言 / コード / offset の完全不変確認

### テスト結果

| ゲート | 結果 |
|---|---|
| `pnpm --filter @pdfmod/core test src/content-stream/interpreter` | 86 passed |
| `pnpm --filter @pdfmod/core test` | 2933 passed |
| `pnpm --filter @pdfmod/core typecheck` | passed |
| `pnpm --filter @pdfmod/core build` | passed |
| `pnpm lint` (biome + oxlint) | 0 warnings / 0 errors |
| Codex CLI レビュー | 問題なし |

新規テストは追加していません（C-5: 挙動完全不変リファクタのため既存 86 件で回帰確認）。

## 🔍 レビューポイント

- **挙動完全不変**: `readDictOperand` シグネチャ・成功戻り値・エラーコード / メッセージ / offset がリファクタ前後で完全に一致していること（`OBJECT_PARSE_UNTERMINATED` は `openToken.offset`、`OBJECT_PARSE_UNEXPECTED_TOKEN` は対象 token の offset を保持）。
- **3 ステップ構造の可読性**: `readDictInner` の while 本体が `readDictKey → readDictValue → entries.set` に圧縮され、各分岐がヘルパ境界に閉じ込められていること。
- **`readArrayInner` との並列対称性**: 並列の状態マシンとして読めるようになっていること（array 側の対称リファクタは別 Issue として将来 `readArrayElement` 命名で導入予定）。
- **pre-push hook 起因の同梱変更**: テストルール（条件分岐禁止）と JSDoc 検査の既存違反 3 ファイルを同 PR に含めています。これらはスコープ外でしたが、push を通すための最小修正です。

## ⚠️ 破壊的変更

- [ ] この変更は既存の API に破壊的変更を含みます

破壊的変更なし。`readDictOperand` の公開 API は完全不変。

## ✅ チェックリスト

- [x] コードレビューの準備ができている
- [x] テストが正常に実行される
- [x] ドキュメントが更新されている（JSDoc 追記）
- [x] コミットメッセージが適切な形式で書かれている（絵文字付きタイプ、Issue 連携）
- [x] 関連する Issue が PR の「Development」に Linked されている（Closes #475）
- [x] PR 本文に `Closes #` で Issue が記載されている
- [x] セルフレビューを実施した（Codex CLI による問題なし判定含む）
- [x] 破壊的変更がある場合は明記されている（該当なし）