### PR TITLE
✨ [New Feature]: #480 MarkedContentStack を新規実装 (BMC/BDC/EMC 階層管理)

### DIFF
--- a/packages/core/src/content-stream/marked-content/index.ts
+++ b/packages/core/src/content-stream/marked-content/index.ts
@@ -1,2 +1,2 @@
-export { MarkedContentStack } from "./stack";
 export type { MarkedContentEntry } from "./stack";
+export { MarkedContentStack } from "./stack";

--- a/packages/core/src/content-stream/marked-content/index.ts
+++ b/packages/core/src/content-stream/marked-content/index.ts
@@ -1,0 +1,2 @@
+export { MarkedContentStack } from "./stack";
+export type { MarkedContentEntry } from "./stack";

--- a/packages/core/src/content-stream/marked-content/stack/__tests__/stack.basic.test.ts
+++ b/packages/core/src/content-stream/marked-content/stack/__tests__/stack.basic.test.ts
@@ -1,0 +1,81 @@
+import { expect, test } from "vitest";
+import type {
+  PdfDictionary,
+  PdfName,
+} from "../../../../pdf/types/pdf-types/index";
+import { none, some } from "../../../../utils/option/index";
+import { MarkedContentStack, type MarkedContentEntry } from "../../index";
+
+const spanTag: PdfName = { type: "name", value: "Span" };
+const artifactTag: PdfName = { type: "name", value: "Artifact" };
+const emptyDict: PdfDictionary = { type: "dictionary", entries: new Map() };
+const bmcSpan: MarkedContentEntry = { tag: spanTag, properties: none };
+const bmcArtifact: MarkedContentEntry = { tag: artifactTag, properties: none };
+const bdcSpan: MarkedContentEntry = {
+  tag: spanTag,
+  properties: some(emptyDict),
+};
+
+test("createは深さ0の空stackを返す", () => {
+  // create() 直後の stack は深さ 0 (entry が積まれていない初期状態)
+  const stack = MarkedContentStack.create();
+  expect(MarkedContentStack.depth(stack)).toBe(0);
+});
+
+test("pushは深さを1増やした新stackを返す", () => {
+  // BMC entry を 1 つ push したら depth が 0 → 1 に増加する
+  const stack = MarkedContentStack.push(MarkedContentStack.create(), bmcSpan);
+  expect(MarkedContentStack.depth(stack)).toBe(1);
+});
+
+test("pushは元stackをmutateせず別参照を返す", () => {
+  // push は元 stack を変更せず、別参照の stack を返す不変更新であること
+  const prev = MarkedContentStack.create();
+  const next = MarkedContentStack.push(prev, bmcSpan);
+  expect(next).not.toBe(prev);
+  expect(MarkedContentStack.depth(prev)).toBe(0);
+});
+
+test("LIFO順でpopが直近pushしたentryを返す", () => {
+  // push(span) → push(artifact) で depth = 2 を確認した上で
+  // pop は LIFO で最後に push した artifact から取り出す
+  const s1 = MarkedContentStack.push(MarkedContentStack.create(), bmcSpan);
+  const s2 = MarkedContentStack.push(s1, bmcArtifact);
+  expect(MarkedContentStack.depth(s2)).toBe(2);
+
+  const first = MarkedContentStack.pop(s2);
+  expect(first).toEqual({
+    some: true,
+    value: { stack: expect.any(Object), popped: bmcArtifact },
+  });
+  if (!first.some) {
+    throw new Error("expected some");
+  }
+  const second = MarkedContentStack.pop(first.value.stack);
+  expect(second).toEqual({
+    some: true,
+    value: { stack: expect.any(Object), popped: bmcSpan },
+  });
+});
+
+test("popは元stackをmutateせず別参照のstackを返す", () => {
+  // pop 後も元 stack の depth が変わらず、別参照の stack を返す
+  const prev = MarkedContentStack.push(MarkedContentStack.create(), bmcSpan);
+  const result = MarkedContentStack.pop(prev);
+  if (!result.some) {
+    throw new Error("expected some");
+  }
+  expect(result.value.stack).not.toBe(prev);
+  expect(MarkedContentStack.depth(prev)).toBe(1);
+});
+
+test("BDC entry(propertiesがsome)もpushしてpopで同じ参照が返る", () => {
+  // BDC 由来 entry (properties が some) も配列に不変参照として保持され、
+  // pop で同じ entry 参照が返ること
+  const stack = MarkedContentStack.push(MarkedContentStack.create(), bdcSpan);
+  const result = MarkedContentStack.pop(stack);
+  if (!result.some) {
+    throw new Error("expected some");
+  }
+  expect(result.value.popped).toBe(bdcSpan);
+});

--- a/packages/core/src/content-stream/marked-content/stack/__tests__/stack.basic.test.ts
+++ b/packages/core/src/content-stream/marked-content/stack/__tests__/stack.basic.test.ts
@@ -4,7 +4,7 @@ import type {
   PdfName,
 } from "../../../../pdf/types/pdf-types/index";
 import { none, some } from "../../../../utils/option/index";
-import { MarkedContentStack, type MarkedContentEntry } from "../../index";
+import { type MarkedContentEntry, MarkedContentStack } from "../../index";
 
 const spanTag: PdfName = { type: "name", value: "Span" };
 const artifactTag: PdfName = { type: "name", value: "Artifact" };

--- a/packages/core/src/content-stream/marked-content/stack/__tests__/stack.pop-empty.test.ts
+++ b/packages/core/src/content-stream/marked-content/stack/__tests__/stack.pop-empty.test.ts
@@ -1,0 +1,13 @@
+import { expect, test } from "vitest";
+import { MarkedContentStack } from "../index";
+
+test("空stackのpopはnoneを返す", () => {
+  // 空 stack に対する pop は throw せず Option の none を返す
+  const stack = MarkedContentStack.create();
+  expect(MarkedContentStack.pop(stack)).toEqual({ some: false });
+});
+
+test("空stackのdepthは0", () => {
+  // create() 直後の境界値: depth は 0
+  expect(MarkedContentStack.depth(MarkedContentStack.create())).toBe(0);
+});

--- a/packages/core/src/content-stream/marked-content/stack/index.ts
+++ b/packages/core/src/content-stream/marked-content/stack/index.ts
@@ -1,0 +1,101 @@
+// ISO 32000-2:2020 §14.6 Marked content
+
+import type {
+  PdfDictionary,
+  PdfName,
+} from "../../../pdf/types/pdf-types/index";
+import type { Brand } from "../../../utils/brand/index";
+import type { Option } from "../../../utils/option/index";
+import { none, some } from "../../../utils/option/index";
+
+/**
+ * Marked content stack の各エントリ。
+ * BMC operator 由来は `properties: none`、BDC operator 由来は dict もしくは name reference を保持する。
+ */
+export type MarkedContentEntry = {
+  readonly tag: PdfName;
+  readonly properties: Option<PdfDictionary | PdfName>;
+};
+
+declare const MarkedContentStackBrand: unique symbol;
+
+type MarkedContentStackFields = {
+  readonly current: ReadonlyArray<MarkedContentEntry>;
+};
+
+/**
+ * BMC / BDC / EMC operator で管理される marked content の LIFO スタック。
+ * 内部表現 `{ current: ReadonlyArray<MarkedContentEntry> }` を Brand 型で包み、
+ * 素のオブジェクトリテラルが代入されることを防ぐ。
+ *
+ * 注: `current` フィールドは型システム上はモジュール外からも参照可能だが、
+ * 規約上 private 扱いとし、外部から直接アクセス・変更してはならない。
+ * 状態変更が必要な操作は元 stack を mutate せず、新しい stack を返す。
+ */
+export type MarkedContentStack = Brand<
+  MarkedContentStackFields,
+  typeof MarkedContentStackBrand
+>;
+
+export const MarkedContentStack = {
+  /**
+   * 空の marked content スタックを生成する。
+   *
+   * @returns 要素 0 件の `MarkedContentStack`
+   */
+  create(): MarkedContentStack {
+    return {
+      current: [] as ReadonlyArray<MarkedContentEntry>,
+    } as unknown as MarkedContentStack;
+  },
+
+  /**
+   * `entry` を末尾に積んだ新しい stack を返す。
+   * 元 `stack` は変更されず、内部 `current` 配列も新規生成する
+   * (`[...stack.current, entry]` で別配列参照)。
+   *
+   * @param stack - 元のスタック（変更されない）
+   * @param entry - 積む {@link MarkedContentEntry}
+   * @returns entry を追加した新規 `MarkedContentStack`
+   */
+  push(
+    stack: MarkedContentStack,
+    entry: MarkedContentEntry,
+  ): MarkedContentStack {
+    return {
+      current: [...stack.current, entry],
+    } as unknown as MarkedContentStack;
+  },
+
+  /**
+   * 末尾の entry を取り出した新しい stack と取り出した entry を返す。
+   * 元 `stack` は変更されず、`slice(0, lastIndex)` で新規配列を生成する。
+   *
+   * @param stack - 対象スタック（変更されない）
+   * @returns 空なら `none`、それ以外は `some({ stack, popped })`
+   */
+  pop(
+    stack: MarkedContentStack,
+  ): Option<{ stack: MarkedContentStack; popped: MarkedContentEntry }> {
+    const length = stack.current.length;
+    if (length === 0) {
+      return none;
+    }
+    const lastIndex = length - 1;
+    const popped = stack.current[lastIndex] as MarkedContentEntry;
+    const next = {
+      current: stack.current.slice(0, lastIndex),
+    } as unknown as MarkedContentStack;
+    return some({ stack: next, popped });
+  },
+
+  /**
+   * 現在の深さ（積まれている entry 数）を返す。
+   *
+   * @param stack - 対象スタック
+   * @returns 深さ（空なら 0）
+   */
+  depth(stack: MarkedContentStack): number {
+    return stack.current.length;
+  },
+} as const;


### PR DESCRIPTION
## 概要

PDF content stream の `BMC` / `BDC` / `EMC` operator が必要とする「マーク付きコンテンツ階層」を保持する **不変 stack データ構造** と要素型 `MarkedContentEntry` を新規実装する。本 PR は **データ構造の提供のみ** で、handler / context / interpreter 統合は後続タスクで扱う（[#480](https://github.com/DIO0550/pdfmod/issues/480) Phase 4-J のタスク 1 つ目）。

参照規格: ISO 32000-2:2020 §14.6 Marked content。

## 変更内容

### 🎯 変更の種類

- [x] ✨ 新機能 (New feature)

### 📝 詳細な変更内容

#### 追加された機能・修正

- `MarkedContentEntry` 型 (`tag: PdfName` + `properties: Option<PdfDictionary | PdfName>`)
- `MarkedContentStack` Brand 型 + companion (`create` / `push` / `pop` / `depth`)
- `push` は `[...stack.current, entry]` で新規配列を生成 (元 stack を mutate しない)
- `pop` は `slice(0, lastIndex)` で新規配列を生成し、`Option<{stack, popped}>` を返す
- 空 stack の `pop` は throw せず `none` を返す (`OperandStack.pop` と同方針)
- `marked-content/index.ts` を re-export hub として新設

#### 変更されたファイル

- `packages/core/src/content-stream/marked-content/index.ts` (新規・re-export hub)
- `packages/core/src/content-stream/marked-content/stack/index.ts` (新規・本体実装)
- `packages/core/src/content-stream/marked-content/stack/__tests__/stack.basic.test.ts` (新規・6 ケース)
- `packages/core/src/content-stream/marked-content/stack/__tests__/stack.pop-empty.test.ts` (新規・2 ケース)

#### 削除されたファイル・機能

- なし

## 📊 システム図

### 状態マシン図 (stack 状態遷移)

```mermaid
flowchart TD
    Start([create]):::new --> Empty[EMPTY<br/>depth=0<br/>current=]:::new
    Empty -->|pop| EmptyNone[none を返す<br/>遷移なし]:::new
    Empty -->|push entry| NonEmpty[NON_EMPTY<br/>depth=N N≥1<br/>current=e1...eN]:::new
    NonEmpty -->|push entry| NonEmpty2[NON_EMPTY'<br/>depth=N+1]:::new
    NonEmpty -->|pop depth=1| Empty
    NonEmpty -->|pop depth≥2| NonEmpty
    EmptyNone --> Empty

    classDef new fill:#ffe4b5,stroke:#d97706,stroke-width:2px
```

不変性インバリアント:
- `push(s, e)` は `s !== returned` かつ `s.current !== returned.current`
- `pop(s)` は `s !== returned.stack` かつ `s.current !== returned.stack.current`
- 元 stack の `current` 配列は一切 mutate されない

### データフロー (将来統合の文脈)

```mermaid
flowchart TD
    Interp[Content Stream Interpreter<br/>後続タスク]
    Interp -->|tokenized BMC/BDC/EMC| Handler[bmcHandler / bdcHandler / emcHandler<br/>後続タスク]
    Handler -->|MarkedContentEntry| Stack[MarkedContentStack companion<br/>本 PR のスコープ]:::new
    Stack -->|popped + stack'| Handler
    Stack -.->|保持| Entry[MarkedContentEntry<br/>tag: PdfName<br/>properties: Option]:::new
    Entry -.->|依存| Deps[PdfName / PdfDictionary<br/>Option / Brand]

    classDef new fill:#ffe4b5,stroke:#d97706,stroke-width:2px
```

## 📋 関連 Issue

- Refs #480

## 🧪 テスト

### テスト実行方法

\`\`\`bash
pnpm --filter @pdfmod/core test
pnpm --filter @pdfmod/core build
\`\`\`

### テスト項目

- [x] 単体テスト (Unit tests)

### テスト結果

- `stack.basic.test.ts`: 6 ケース全てパス
  - createは深さ0の空stackを返す
  - pushは深さを1増やした新stackを返す
  - pushは元stackをmutateせず別参照を返す
  - LIFO順でpopが直近pushしたentryを返す
  - popは元stackをmutateせず別参照のstackを返す
  - BDC entry(propertiesがsome)もpushしてpopで同じ参照が返る
- `stack.pop-empty.test.ts`: 2 ケース全てパス
  - 空stackのpopはnoneを返す
  - 空stackのdepthは0
- 全体: 2941 件パス (regression なし)
- build: 成功 (型エラーなし)

## 🔍 レビューポイント

- 既存 `GraphicsStateStack` の Brand + companion + `as unknown as` キャストパターンを踏襲しているか
- `current` の double-readonly (`readonly current: ReadonlyArray<...>`) が `CurrentPath` 方式と一致しているか
- 空 stack の `pop` が `none` を返す挙動 (`OperandStack.pop` と同方針)
- basic.test は hub 経由 import で hub の export 漏れも検出できる構成、pop-empty.test は stack 本体直参照で 2 ルートを最小ファイル数で担保している

## ⚠️ 破壊的変更

- [ ] 該当なし (新規ファイル追加のみで既存ファイルは無変更)

## 📚 追加情報

### 参考資料

- ISO 32000-2:2020 §14.6 Marked content
- `.plugin-workspace/.specs/073-marked-content-stack/implementation-plan.md`

### 注意事項

- `packages/core/src/index.ts` には **本 PR では追加していない**。後続の handler 統合タスクで `MarkedContentStack` / `MarkedContentEntry` を追加する
- handler / context / interpreter 統合 (`OperatorHandlerContext.markedContentStack` / `bmcHandler` / `bdcHandler` / `emcHandler` / `registerMarkedContentOperators` / `ContentStreamInterpreter` の末尾未閉じチェック) は後続タスク

## ✅ チェックリスト

- [x] コードレビューの準備ができている
- [x] テストが正常に実行される
- [x] コミットメッセージが適切な形式で書かれている
- [x] 関連 Issue を PR 本文に `Refs #480` で記載
- [x] セルフレビューを実施した
- [x] 破壊的変更なし