### PR TITLE
✨ [New Feature]: #478 Lexer に token 単位 peek API を導入し parser 側 lookahead バッファを撤去

### DIFF
--- a/rust/crates/core/src/lexer.rs
+++ b/rust/crates/core/src/lexer.rs
@@ -67,7 +67,11 @@ impl<'a> Lexer<'a> {
     /// 論理カーソル位置を返す。バッファに peek 済みトークンがあればその先頭エントリの開始位置を、
     /// バッファ空時は現在のカーソル位置 (`self.pos`) を返す。
     ///
-    /// 「次に `take_token` で取り出されるトークンの開始バイト位置」と等価。
+    /// バッファ非空時のみ「次に `take_token` で取り出されるトークンの開始バイト位置」と等価。
+    /// バッファ空時の `self.pos` は直前のトークン末尾直後を指すため、次のトークン開始位置とは
+    /// 一致しないことがある（`take_token` 内部の `skip_whitespace` で whitespace を消費した
+    /// 後の位置）。次に取り出されるトークンの開始位置が必要な場合は
+    /// [`Self::peek_token_with_pos`] の返す `pos` を使う。
     /// バッファを無視した生のカーソル位置が必要な場合は [`Self::cursor_position`] を使う。
     pub fn position(&self) -> usize {
         self.buffer.front().map(|(_, pos)| *pos).unwrap_or(self.pos)

--- a/rust/crates/core/src/lexer.rs
+++ b/rust/crates/core/src/lexer.rs
@@ -20,6 +20,9 @@ pub mod eol;
 mod hex_string;
 mod literal_string;
 pub mod token;
+mod token_buffer;
+
+use std::collections::VecDeque;
 
 use crate::object::name::PdfName;
 use byte_kind::ByteKind;
@@ -48,17 +51,95 @@ fn hex_value(b: u8) -> u8 {
 pub struct Lexer<'a> {
     input: &'a [u8],
     pos: usize,
+    buffer: VecDeque<(Token, usize)>,
 }
 
 impl<'a> Lexer<'a> {
     /// 入力バイト列を借用して新しい `Lexer` を生成する。`pos` は 0 で初期化される。
     pub fn new(input: &'a [u8]) -> Self {
-        Self { input, pos: 0 }
+        Self {
+            input,
+            pos: 0,
+            buffer: VecDeque::new(),
+        }
     }
 
-    /// 現在の `pos` を返す。
+    /// 論理カーソル位置を返す。バッファに peek 済みトークンがあればその先頭エントリの開始位置を、
+    /// バッファ空時は現在のカーソル位置 (`self.pos`) を返す。
+    ///
+    /// 「次に `take_token` で取り出されるトークンの開始バイト位置」と等価。
+    /// バッファを無視した生のカーソル位置が必要な場合は [`Self::cursor_position`] を使う。
     pub fn position(&self) -> usize {
+        self.buffer.front().map(|(_, pos)| *pos).unwrap_or(self.pos)
+    }
+
+    /// バイト単位のカーソル位置 (`self.pos`) を直接返す。バッファ内のトークンを無視した生の値。
+    ///
+    /// 用途: lookahead 中に lexer が malformed を検知した場合のエラー位置報告など、
+    /// 論理カーソルではなく生バイト位置が必要な場面で使う。
+    /// 通常の論理カーソルが必要な場合は [`Self::position`] を使う。
+    pub fn cursor_position(&self) -> usize {
         self.pos
+    }
+
+    #[cfg(test)]
+    pub(crate) fn buffer_capacity_for_tests(&self) -> usize {
+        self.buffer.capacity()
+    }
+
+    /// 次に消費されるトークンを参照で覗き見る（Comment 透過込み）。
+    ///
+    /// peek した値は次回 `take_token`（および続く `peek_token`）でも同じ値を返す。
+    /// `peek_token_at(0) == peek_token()`（0-indexed の最先頭）。
+    pub fn peek_token(&mut self) -> Option<&Token> {
+        self.peek_token_at(0)
+    }
+
+    /// 0-indexed で `n` 番目に取り出されるトークンを参照で覗き見る（Comment 透過込み）。
+    ///
+    /// `peek_token_at(0) == peek_token()`（0-indexed の最先頭）。
+    /// peek した値は次回 `take_token` / `peek_token` でも同じ値を返す。
+    /// `n` が `usize::MAX` でも panic せず `None` を返す（`n.checked_add(1)` で吸収）。
+    pub fn peek_token_at(&mut self, n: usize) -> Option<&Token> {
+        let required = n.checked_add(1)?;
+        token_buffer::ensure_buffered(self, required)?;
+        self.buffer.get(n).map(|(tok, _)| tok)
+    }
+
+    /// 次のトークンをムーブで取り出す（Comment 透過込み）。
+    ///
+    /// 直前の `peek_token` / `peek_token_at(0)` で得た値（0-indexed の最先頭）と
+    /// 同じトークンを返す。peek した値は次回 `take_token`（および続く `peek_token`）でも
+    /// 同じ値を返す不変条件を保つ。
+    /// バッファ非空ならフロントから、空時は内部で直接 lex を進める（`push_back` を経由しない）。
+    pub fn take_token(&mut self) -> Option<Token> {
+        if let Some((tok, _)) = self.buffer.pop_front() {
+            return Some(tok);
+        }
+        token_buffer::next_non_comment_token(self).map(|(tok, _)| tok)
+    }
+
+    /// 次に消費されるトークンを位置情報付きで覗き見る（Comment 透過込み）。
+    ///
+    /// `peek_token_at(0) == peek_token()` と同じトークンを位置情報 (token 開始バイト位置)
+    /// と共に返す。peek した値は次回 `take_token_with_pos`（および `peek_token`）でも
+    /// 同じ値を返し、`pos` も `take_token_with_pos` が返す値と一致する。
+    pub fn peek_token_with_pos(&mut self) -> Option<(&Token, usize)> {
+        token_buffer::ensure_buffered(self, 1)?;
+        self.buffer.front().map(|(tok, pos)| (tok, *pos))
+    }
+
+    /// 次のトークンを位置情報付きでムーブ取り出す（Comment 透過込み）。
+    ///
+    /// 直前の `peek_token` 系 / `peek_token_with_pos`（`peek_token_at(0) == peek_token()`
+    /// と等価な 0-indexed 最先頭）で得た値があれば、それと同じトークンと `pos` を返す。
+    /// peek した値は次回 `take_token_with_pos` でも同じ値を返す不変条件を保つ。
+    /// バッファ非空ならフロントから、空時は内部で直接 lex を進める（`push_back` を経由しない）。
+    pub fn take_token_with_pos(&mut self) -> Option<(Token, usize)> {
+        if let Some(entry) = self.buffer.pop_front() {
+            return Some(entry);
+        }
+        token_buffer::next_non_comment_token(self)
     }
 
     /// 現在位置のバイトを覗き見る（消費しない）。EOF なら `None`。
@@ -660,3 +741,6 @@ impl<'a> Lexer<'a> {
 
 #[cfg(test)]
 mod tests;
+
+#[cfg(test)]
+mod peek_token_tests;

--- a/rust/crates/core/src/lexer.rs
+++ b/rust/crates/core/src/lexer.rs
@@ -715,17 +715,23 @@ impl<'a> Lexer<'a> {
         if let Some((tok, _)) = self.buffer.pop_front() {
             return Some(tok);
         }
+        self.skip_whitespace();
         self.next_raw_token()
     }
 
     /// 内部 lookahead バッファを無視して入力バイトから直接 1 トークン読み出す low-level API。
     ///
-    /// 公開 [`Self::next_token`] の本体実装。`token_buffer::ensure_buffered` / `next_non_comment_token`
-    /// から「バッファに積むトークンの素材」として呼ばれる経路はこちらを使う必要がある
-    /// （公開 `next_token` を呼ぶと先に buffer から pop されてしまい ensure_buffered のループ
-    /// 不変条件が壊れるため）。
+    /// 公開 [`Self::next_token`] の本体実装。`token_buffer::ensure_buffered` /
+    /// `next_non_comment_token` から「バッファに積むトークンの素材」として呼ばれる経路は
+    /// こちらを使う必要がある（公開 `next_token` を呼ぶと先に buffer から pop されてしまい
+    /// ensure_buffered のループ不変条件が壊れるため）。
+    ///
+    /// **呼び出し前提**: 本 API は冒頭で `skip_whitespace` を呼ばない low-level 設計。
+    /// 必要なら呼び出し側で事前に `skip_whitespace` を実行すること（`next_token` 側と
+    /// `token_buffer::next_non_comment_token` の双方で実施済み）。これにより
+    /// `next_non_comment_token` の `pos` 採取直前にだけ whitespace を消費する形になり、
+    /// `next_raw_token` 内で再スキャンする冗長性が消える。
     pub(super) fn next_raw_token(&mut self) -> Option<Token> {
-        self.skip_whitespace();
         let b = self.peek()?;
         match b {
             b'%' => {

--- a/rust/crates/core/src/lexer.rs
+++ b/rust/crates/core/src/lexer.rs
@@ -694,7 +694,27 @@ impl<'a> Lexer<'a> {
     ///
     /// 注意: `stream` キーワード直後の改行スキップと stream データ本体（`/Length` バイト分）の
     /// 読み出しは本 API のスコープ外。本層は `Token::StreamBegin` を返すまでが責務。
+    ///
+    /// 内部 lookahead バッファとの関係:
+    /// 直前に `peek_token` / `peek_token_at` を呼んで内部バッファにトークンが保留されている場合、
+    /// 本 API はバッファ先頭エントリの `Token` 部分を `pop_front` で返す。これにより
+    /// 「peek した値は次回 `next_token` でも同じ値を返す」契約を満たし、peek 系 API と混在
+    /// しても token が skip/reorder されない。バッファ空時は従来通り入力バイトから lex する。
+    /// 入力バイトから直接 lex したい内部用途には [`Self::next_raw_token`] (private) を使う。
     pub fn next_token(&mut self) -> Option<Token> {
+        if let Some((tok, _)) = self.buffer.pop_front() {
+            return Some(tok);
+        }
+        self.next_raw_token()
+    }
+
+    /// 内部 lookahead バッファを無視して入力バイトから直接 1 トークン読み出す low-level API。
+    ///
+    /// 公開 [`Self::next_token`] の本体実装。`token_buffer::ensure_buffered` / `next_non_comment_token`
+    /// から「バッファに積むトークンの素材」として呼ばれる経路はこちらを使う必要がある
+    /// （公開 `next_token` を呼ぶと先に buffer から pop されてしまい ensure_buffered のループ
+    /// 不変条件が壊れるため）。
+    pub(super) fn next_raw_token(&mut self) -> Option<Token> {
         self.skip_whitespace();
         let b = self.peek()?;
         match b {

--- a/rust/crates/core/src/lexer.rs
+++ b/rust/crates/core/src/lexer.rs
@@ -102,7 +102,11 @@ impl<'a> Lexer<'a> {
     /// 0-indexed で `n` 番目に取り出されるトークンを参照で覗き見る（Comment 透過込み）。
     ///
     /// `peek_token_at(0) == peek_token()`（0-indexed の最先頭）。
-    /// peek した値は次回 `take_token` / `peek_token` でも同じ値を返す。
+    /// peek したトークンは内部バッファに順序を保ったまま保留されるため、`take_token`
+    /// を先頭から繰り返し呼ぶと同じ順序で取り出せる。具体的には `peek_token_at(n)` で
+    /// 観測した値は、先頭から `n` 回 `take_token` を消費した次（つまり `n+1` 回目）の
+    /// `take_token` で同じ値が返る。`n == 0` の場合のみ直後の `take_token` で同じ値が返る
+    /// （`peek_token` と同義）。
     /// `n` が `usize::MAX` でも panic せず `None` を返す（`n.checked_add(1)` で吸収）。
     pub fn peek_token_at(&mut self, n: usize) -> Option<&Token> {
         let required = n.checked_add(1)?;

--- a/rust/crates/core/src/lexer.rs
+++ b/rust/crates/core/src/lexer.rs
@@ -701,6 +701,12 @@ impl<'a> Lexer<'a> {
     /// 「peek した値は次回 `next_token` でも同じ値を返す」契約を満たし、peek 系 API と混在
     /// しても token が skip/reorder されない。バッファ空時は従来通り入力バイトから lex する。
     /// 入力バイトから直接 lex したい内部用途には [`Self::next_raw_token`] (private) を使う。
+    ///
+    /// **Comment 観測上の注意**: `peek_token` / `peek_token_at` は Comment 透過の契約のため、
+    /// peek の過程で読み飛ばされた `Token::Comment` はバッファに保留されず破棄される。
+    /// したがって peek 後に本 API を呼ぶと、peek が透過スキップした Comment はもはや観測
+    /// できない（バッファに残るのは Comment 以外のトークンのみ）。Comment を含む全トークンを
+    /// 順に観測したい場合は、本 API を peek 系と混在させず単独で呼び出すこと。
     pub fn next_token(&mut self) -> Option<Token> {
         if let Some((tok, _)) = self.buffer.pop_front() {
             return Some(tok);

--- a/rust/crates/core/src/lexer/hex_string/tests/robustness.rs
+++ b/rust/crates/core/src/lexer/hex_string/tests/robustness.rs
@@ -32,6 +32,7 @@ fn read_hex_string_does_not_panic_when_pos_is_usize_max() {
     let mut lexer = Lexer {
         input: b"<41>",
         pos: usize::MAX,
+        buffer: std::collections::VecDeque::new(),
     };
     let result = lexer.read_hex_string();
     assert!(result.is_none());

--- a/rust/crates/core/src/lexer/peek_token_tests.rs
+++ b/rust/crates/core/src/lexer/peek_token_tests.rs
@@ -10,6 +10,7 @@ mod comment_transparent;
 mod consecutive_peek_at;
 mod eof_boundary;
 mod malformed_vs_eof;
+mod next_token_drains_buffer;
 mod no_alloc_on_take_only;
 mod peek_then_take_consistency;
 mod position_after_peek;

--- a/rust/crates/core/src/lexer/peek_token_tests.rs
+++ b/rust/crates/core/src/lexer/peek_token_tests.rs
@@ -1,0 +1,21 @@
+//! `Lexer` の token 単位 peek/take API のテスト群。
+//!
+//! 1 シナリオ 1 ファイル構成で、`peek_token` / `peek_token_at` / `take_token` /
+//! `peek_token_with_pos` / `take_token_with_pos` / `cursor_position` の振る舞いを
+//! 検証する。
+
+use super::Lexer;
+
+mod comment_transparent;
+mod consecutive_peek_at;
+mod eof_boundary;
+mod malformed_vs_eof;
+mod no_alloc_on_take_only;
+mod peek_then_take_consistency;
+mod position_after_peek;
+mod skip_ws_and_comments_interaction;
+mod usize_max_safe;
+
+pub(super) fn lexer(input: &[u8]) -> Lexer<'_> {
+    Lexer::new(input)
+}

--- a/rust/crates/core/src/lexer/peek_token_tests/comment_transparent.rs
+++ b/rust/crates/core/src/lexer/peek_token_tests/comment_transparent.rs
@@ -1,0 +1,63 @@
+use crate::lexer::token::{Primitive, Token};
+
+use super::lexer;
+
+#[test]
+fn peek_token_skips_leading_comments_and_returns_following_integer() {
+    // 連続する Comment を透過スキップして直後の Integer を返すことを確認する
+    let mut lex = lexer(b"% a\n% b\n42");
+    assert_eq!(
+        lex.peek_token(),
+        Some(&Token::Primitive(Primitive::Integer(42)))
+    );
+}
+
+#[test]
+fn peek_token_returns_none_for_comments_only_input() {
+    // Comment のみで終端する入力では peek_token が None かつ is_eof()==true を確認する
+    let mut lex = lexer(b"% a\n% b\n");
+    assert_eq!(lex.peek_token(), None);
+    assert!(lex.is_eof());
+}
+
+#[test]
+fn take_token_skips_leading_comments_and_returns_following_integer() {
+    // peek を経由せず直接 take_token を呼んでも Comment が透過スキップされることを確認する
+    let mut lex = lexer(b"% a\n% b\n42");
+    assert_eq!(
+        lex.take_token(),
+        Some(Token::Primitive(Primitive::Integer(42)))
+    );
+}
+
+#[test]
+fn peek_token_at_skips_interleaved_comments_across_indices() {
+    // peek_token_at(0/1/2) が token 間の Comment を透過スキップして Integer(1/2/3) を返すことを確認する
+    // try_parse_indirect_reference 相当の N G R に Comment が挟まる入力パターン
+    let mut lex = lexer(b"1 % between\n 2 % more\n 3");
+    assert_eq!(
+        lex.peek_token_at(0),
+        Some(&Token::Primitive(Primitive::Integer(1)))
+    );
+    assert_eq!(
+        lex.peek_token_at(1),
+        Some(&Token::Primitive(Primitive::Integer(2)))
+    );
+    assert_eq!(
+        lex.peek_token_at(2),
+        Some(&Token::Primitive(Primitive::Integer(3)))
+    );
+    // バッファに保留された値を順次 take_token で取り出せることも確認
+    assert_eq!(
+        lex.take_token(),
+        Some(Token::Primitive(Primitive::Integer(1)))
+    );
+    assert_eq!(
+        lex.take_token(),
+        Some(Token::Primitive(Primitive::Integer(2)))
+    );
+    assert_eq!(
+        lex.take_token(),
+        Some(Token::Primitive(Primitive::Integer(3)))
+    );
+}

--- a/rust/crates/core/src/lexer/peek_token_tests/consecutive_peek_at.rs
+++ b/rust/crates/core/src/lexer/peek_token_tests/consecutive_peek_at.rs
@@ -1,0 +1,42 @@
+use crate::lexer::token::{Primitive, Token};
+
+use super::lexer;
+
+#[test]
+fn peek_token_at_returns_n_th_token_in_input_order() {
+    // peek_token_at(0/1/2) が入力順に Integer(1/2/3) を返すことを確認する
+    let mut lex = lexer(b"1 2 3");
+    assert_eq!(
+        lex.peek_token_at(0),
+        Some(&Token::Primitive(Primitive::Integer(1)))
+    );
+    assert_eq!(
+        lex.peek_token_at(1),
+        Some(&Token::Primitive(Primitive::Integer(2)))
+    );
+    assert_eq!(
+        lex.peek_token_at(2),
+        Some(&Token::Primitive(Primitive::Integer(3)))
+    );
+}
+
+#[test]
+fn take_token_follows_peek_at_order() {
+    // peek_token_at で 0/1/2 を覗いた後、take_token を 3 回呼ぶと同じ順序で取り出せることを確認する
+    let mut lex = lexer(b"1 2 3");
+    let _ = lex.peek_token_at(0);
+    let _ = lex.peek_token_at(1);
+    let _ = lex.peek_token_at(2);
+    assert_eq!(
+        lex.take_token(),
+        Some(Token::Primitive(Primitive::Integer(1)))
+    );
+    assert_eq!(
+        lex.take_token(),
+        Some(Token::Primitive(Primitive::Integer(2)))
+    );
+    assert_eq!(
+        lex.take_token(),
+        Some(Token::Primitive(Primitive::Integer(3)))
+    );
+}

--- a/rust/crates/core/src/lexer/peek_token_tests/eof_boundary.rs
+++ b/rust/crates/core/src/lexer/peek_token_tests/eof_boundary.rs
@@ -1,0 +1,50 @@
+use crate::lexer::token::{Primitive, Token};
+
+use super::lexer;
+
+#[test]
+fn peek_token_at_one_returns_none_at_eof_after_single_token() {
+    // 1 トークンしか含まない入力で peek_token_at(1) が None かつ is_eof()==true、
+    // バッファに保留した peek_token_at(0) は壊れず後続 take_token で取り出せることを確認する
+    let mut lex = lexer(b"42");
+    assert_eq!(
+        lex.peek_token_at(0),
+        Some(&Token::Primitive(Primitive::Integer(42)))
+    );
+    assert_eq!(lex.peek_token_at(1), None);
+    assert!(lex.is_eof());
+    assert_eq!(
+        lex.take_token(),
+        Some(Token::Primitive(Primitive::Integer(42)))
+    );
+}
+
+#[test]
+fn peek_then_take_then_peek_returns_none_at_eof() {
+    // peek -> take で 1 トークン消費後、再度 peek が None かつ is_eof()==true
+    let mut lex = lexer(b"42");
+    let _ = lex.peek_token();
+    let _ = lex.take_token();
+    assert_eq!(lex.peek_token(), None);
+    assert!(lex.is_eof());
+}
+
+#[test]
+fn take_token_drains_all_tokens_then_returns_none() {
+    // 複数トークン入力を順次 take_token で消費し、末尾で None かつ is_eof()==true
+    let mut lex = lexer(b"1 2 3");
+    assert_eq!(
+        lex.take_token(),
+        Some(Token::Primitive(Primitive::Integer(1)))
+    );
+    assert_eq!(
+        lex.take_token(),
+        Some(Token::Primitive(Primitive::Integer(2)))
+    );
+    assert_eq!(
+        lex.take_token(),
+        Some(Token::Primitive(Primitive::Integer(3)))
+    );
+    assert_eq!(lex.take_token(), None);
+    assert!(lex.is_eof());
+}

--- a/rust/crates/core/src/lexer/peek_token_tests/malformed_vs_eof.rs
+++ b/rust/crates/core/src/lexer/peek_token_tests/malformed_vs_eof.rs
@@ -1,0 +1,25 @@
+use super::lexer;
+
+#[test]
+fn peek_token_returns_none_and_is_not_eof_for_lonely_dict_end_marker() {
+    // 単独の `>` は malformed (lexer error) として peek_token() が None かつ is_eof()==false
+    let mut lex = lexer(b">");
+    assert_eq!(lex.peek_token(), None);
+    assert!(!lex.is_eof());
+}
+
+#[test]
+fn peek_token_returns_none_and_is_eof_for_empty_input() {
+    // 空入力では peek_token() が None かつ is_eof()==true
+    let mut lex = lexer(b"");
+    assert_eq!(lex.peek_token(), None);
+    assert!(lex.is_eof());
+}
+
+#[test]
+fn peek_token_returns_none_and_is_not_eof_for_lonely_left_brace() {
+    // 単独の `{` も malformed として peek_token() が None かつ is_eof()==false
+    let mut lex = lexer(b"{");
+    assert_eq!(lex.peek_token(), None);
+    assert!(!lex.is_eof());
+}

--- a/rust/crates/core/src/lexer/peek_token_tests/next_token_drains_buffer.rs
+++ b/rust/crates/core/src/lexer/peek_token_tests/next_token_drains_buffer.rs
@@ -1,0 +1,54 @@
+use crate::lexer::token::{Primitive, Token};
+
+use super::lexer;
+
+#[test]
+fn next_token_returns_buffered_peek_before_advancing_cursor() {
+    // peek_token で buffer に積んだトークンを、続く next_token が先に返却することを確認する
+    // （peek 系 API と next_token を混在させても token が skip/reorder されない契約）
+    let mut lex = lexer(b"1 2");
+    assert_eq!(
+        lex.peek_token(),
+        Some(&Token::Primitive(Primitive::Integer(1)))
+    );
+    assert_eq!(
+        lex.next_token(),
+        Some(Token::Primitive(Primitive::Integer(1)))
+    );
+    assert_eq!(
+        lex.next_token(),
+        Some(Token::Primitive(Primitive::Integer(2)))
+    );
+}
+
+#[test]
+fn next_token_drains_buffer_in_order_after_consecutive_peek_at() {
+    // peek_token_at(0/1/2) でバッファに 3 個積んだ後、next_token を 3 回呼ぶと同じ順序で返ることを確認する
+    let mut lex = lexer(b"1 2 3");
+    let _ = lex.peek_token_at(0);
+    let _ = lex.peek_token_at(1);
+    let _ = lex.peek_token_at(2);
+    assert_eq!(
+        lex.next_token(),
+        Some(Token::Primitive(Primitive::Integer(1)))
+    );
+    assert_eq!(
+        lex.next_token(),
+        Some(Token::Primitive(Primitive::Integer(2)))
+    );
+    assert_eq!(
+        lex.next_token(),
+        Some(Token::Primitive(Primitive::Integer(3)))
+    );
+}
+
+#[test]
+fn next_token_without_prior_peek_reads_directly_from_input() {
+    // peek を経由せず next_token を呼んだ場合は従来通り入力バイトから lex されることを確認する
+    // （バッファ空時の挙動が既存と変わらないことの保証）
+    let mut lex = lexer(b"42");
+    assert_eq!(
+        lex.next_token(),
+        Some(Token::Primitive(Primitive::Integer(42)))
+    );
+}

--- a/rust/crates/core/src/lexer/peek_token_tests/no_alloc_on_take_only.rs
+++ b/rust/crates/core/src/lexer/peek_token_tests/no_alloc_on_take_only.rs
@@ -1,0 +1,21 @@
+use super::lexer;
+
+#[test]
+fn take_token_only_path_keeps_buffer_capacity_zero() {
+    // take_token のみを連続呼び出しした場合、VecDeque の初回割り当てが発生せず capacity==0 のままであることを確認する
+    let mut lex = lexer(b"1 2 3 4 5");
+    for _ in 0..5 {
+        let _ = lex.take_token();
+    }
+    assert_eq!(lex.buffer_capacity_for_tests(), 0);
+}
+
+#[test]
+fn take_token_with_pos_only_path_keeps_buffer_capacity_zero() {
+    // take_token_with_pos のみを連続呼び出しした場合も capacity==0 のままであることを確認する
+    let mut lex = lexer(b"1 2 3");
+    for _ in 0..3 {
+        let _ = lex.take_token_with_pos();
+    }
+    assert_eq!(lex.buffer_capacity_for_tests(), 0);
+}

--- a/rust/crates/core/src/lexer/peek_token_tests/peek_then_take_consistency.rs
+++ b/rust/crates/core/src/lexer/peek_token_tests/peek_then_take_consistency.rs
@@ -1,0 +1,27 @@
+use crate::lexer::token::{Primitive, Token};
+
+use super::lexer;
+
+#[test]
+fn peek_token_then_take_token_returns_same_integer() {
+    // peek_token で参照取得した値が、続く take_token でも同じ値として取り出せることを確認する
+    let mut lex = lexer(b"42");
+    assert_eq!(
+        lex.peek_token(),
+        Some(&Token::Primitive(Primitive::Integer(42)))
+    );
+    assert_eq!(
+        lex.take_token(),
+        Some(Token::Primitive(Primitive::Integer(42)))
+    );
+}
+
+#[test]
+fn take_token_without_prior_peek_returns_first_token() {
+    // peek を経由せず直接 take_token を呼んだ場合に先頭トークンが取得できることを確認する
+    let mut lex = lexer(b"42");
+    assert_eq!(
+        lex.take_token(),
+        Some(Token::Primitive(Primitive::Integer(42)))
+    );
+}

--- a/rust/crates/core/src/lexer/peek_token_tests/position_after_peek.rs
+++ b/rust/crates/core/src/lexer/peek_token_tests/position_after_peek.rs
@@ -1,0 +1,66 @@
+use crate::lexer::token::{Primitive, Token};
+
+use super::lexer;
+
+#[test]
+fn peek_token_with_pos_matches_take_token_with_pos() {
+    // peek_token_with_pos が返す pos と直後の take_token_with_pos が返す pos が一致することを確認する
+    let mut lex = lexer(b"   42");
+    let (peeked_tok, peeked_pos) = lex.peek_token_with_pos().expect("peek should yield");
+    assert_eq!(peeked_tok, &Token::Primitive(Primitive::Integer(42)));
+    let peeked_pos_copy = peeked_pos;
+    let (taken_tok, taken_pos) = lex.take_token_with_pos().expect("take should yield");
+    assert_eq!(taken_tok, Token::Primitive(Primitive::Integer(42)));
+    assert_eq!(taken_pos, peeked_pos_copy);
+}
+
+#[test]
+fn position_after_peek_returns_buffer_head_pos() {
+    // peek 後の lexer.position() がバッファ先頭エントリの pos（カーソルではなく）を返すことを確認する
+    let mut lex = lexer(b"   42 7");
+    let _ = lex.peek_token();
+    // "42" の開始位置は 3
+    assert_eq!(lex.position(), 3);
+}
+
+#[test]
+fn position_returns_cursor_pos_when_buffer_is_empty() {
+    // バッファが空のときは self.pos（カーソル位置）が返ることを確認する
+    let lex = lexer(b"abc");
+    assert_eq!(lex.position(), 0);
+}
+
+#[test]
+fn cursor_position_returns_raw_pos_distinct_from_position_after_peek() {
+    // peek 後に position() がバッファ先頭 pos、cursor_position() が生のカーソル位置を返し
+    // 両者が異なる値であることを直接アサートする（lookahead 中の malformed 報告で使い分け前提）
+    let mut lex = lexer(b"   42 7");
+    let _ = lex.peek_token();
+    // "42" の開始位置は 3、cursor は "42" を読み終えて 5 まで進んでいる
+    assert_eq!(lex.position(), 3);
+    assert_eq!(lex.cursor_position(), 5);
+    assert_ne!(lex.position(), lex.cursor_position());
+}
+
+#[test]
+fn cursor_position_equals_position_when_buffer_is_empty() {
+    // バッファが空のときは position() と cursor_position() が同じ値（self.pos）を返すことを確認する
+    let lex = lexer(b"abc");
+    assert_eq!(lex.position(), lex.cursor_position());
+    assert_eq!(lex.cursor_position(), 0);
+}
+
+#[test]
+fn take_token_with_pos_without_prior_peek_returns_token_start_pos() {
+    // peek を経由せず直接 take_token_with_pos を呼んだ場合、戻り値の pos が
+    // skip_whitespace 後のトークン開始バイト位置と一致することを確認する
+    let mut lex = lexer(b"   42 7");
+    let (tok, pos) = lex.take_token_with_pos().expect("take should yield");
+    assert_eq!(tok, Token::Primitive(Primitive::Integer(42)));
+    // "42" の開始位置は leading 3 spaces をスキップ後の 3
+    assert_eq!(pos, 3);
+    let (tok2, pos2) = lex.take_token_with_pos().expect("take should yield");
+    assert_eq!(tok2, Token::Primitive(Primitive::Integer(7)));
+    // "7" の開始位置は "42" + space で 6
+    assert_eq!(pos2, 6);
+}

--- a/rust/crates/core/src/lexer/peek_token_tests/skip_ws_and_comments_interaction.rs
+++ b/rust/crates/core/src/lexer/peek_token_tests/skip_ws_and_comments_interaction.rs
@@ -1,0 +1,25 @@
+use crate::lexer::token::{Primitive, Token};
+
+use super::lexer;
+
+#[test]
+fn skip_whitespace_and_comments_does_not_destroy_buffered_token() {
+    // peek 後に skip_whitespace_and_comments を呼んでもバッファ内容は破壊されず、
+    // 続く take_token は peek 済みトークンを返すことを確認する
+    let mut lex = lexer(b"42  % trailing comment\n7");
+    let peeked = lex.peek_token().cloned();
+    assert_eq!(peeked, Some(Token::Primitive(Primitive::Integer(42))));
+    lex.skip_whitespace_and_comments();
+    assert_eq!(
+        lex.take_token(),
+        Some(Token::Primitive(Primitive::Integer(42)))
+    );
+}
+
+#[test]
+fn skip_whitespace_and_comments_does_not_panic_when_buffer_holds_token() {
+    // バッファに peek 済みトークンがある状態で skip_whitespace_and_comments を呼んでも panic しないことを確認する
+    let mut lex = lexer(b"42 7");
+    let _ = lex.peek_token();
+    lex.skip_whitespace_and_comments();
+}

--- a/rust/crates/core/src/lexer/peek_token_tests/usize_max_safe.rs
+++ b/rust/crates/core/src/lexer/peek_token_tests/usize_max_safe.rs
@@ -1,0 +1,15 @@
+use super::lexer;
+
+#[test]
+fn peek_token_at_usize_max_returns_none_without_panic() {
+    // n.checked_add(1) のオーバーフロー吸収により peek_token_at(usize::MAX) は panic せず None
+    let mut lex = lexer(b"42");
+    assert_eq!(lex.peek_token_at(usize::MAX), None);
+}
+
+#[test]
+fn peek_token_at_usize_max_minus_one_returns_none_without_panic() {
+    // checked_add 経路で usize::MAX - 1 も panic せず None
+    let mut lex = lexer(b"42");
+    assert_eq!(lex.peek_token_at(usize::MAX - 1), None);
+}

--- a/rust/crates/core/src/lexer/token_buffer.rs
+++ b/rust/crates/core/src/lexer/token_buffer.rs
@@ -27,11 +27,15 @@ pub(super) fn ensure_buffered(lexer: &mut Lexer<'_>, n: usize) -> Option<()> {
 ///
 /// Comment は破棄して継続。EOF または malformed なら `None`。
 /// `pos` は `skip_whitespace` 後の `lexer.pos` を採用する（トークン本体の開始位置）。
+///
+/// 公開 [`Lexer::next_token`] ではなく [`Lexer::next_raw_token`] を呼ぶことで、
+/// バッファ内の peek 済みトークンを誤って pop しないようにする
+/// （ensure_buffered のループ不変条件「`buffer.len() < n` の間ループ」を保つため）。
 pub(super) fn next_non_comment_token(lexer: &mut Lexer<'_>) -> Option<(Token, usize)> {
     loop {
         lexer.skip_whitespace();
         let pos_before = lexer.pos;
-        match lexer.next_token()? {
+        match lexer.next_raw_token()? {
             Token::Comment(_) => continue,
             tok => return Some((tok, pos_before)),
         }

--- a/rust/crates/core/src/lexer/token_buffer.rs
+++ b/rust/crates/core/src/lexer/token_buffer.rs
@@ -1,0 +1,39 @@
+//! `Lexer` 内部の token 単位 lookahead バッファ管理。
+//!
+//! - `ensure_buffered`: 指定数のトークンがバッファに溜まるまで lex を進める（Comment 透過）
+//! - `next_non_comment_token`: Comment を破棄しつつ 1 トークン取得
+//!
+//! 本モジュールは `lexer` の子モジュールとして `pub(super)` 公開。
+//! 公開 peek/take API (`Lexer::peek_token` / `Lexer::take_token` 等) からのみ利用する。
+
+use super::token::Token;
+use super::Lexer;
+
+/// `buffer.len() >= n` になるまで lex を進めてバッファを埋める。
+///
+/// Comment は透過スキップ（バッファに残さない）。EOF または malformed で `n` 個に届かない
+/// 場合は `None`。呼び出し側 (peek_token / peek_token_at) は `None` を受けた後に
+/// [`Lexer::is_eof`] で EOF と malformed を区別する責務を持つ。
+/// 既に `buffer.len() >= n` なら何もせず `Some(())`。
+pub(super) fn ensure_buffered(lexer: &mut Lexer<'_>, n: usize) -> Option<()> {
+    while lexer.buffer.len() < n {
+        let (tok, pos) = next_non_comment_token(lexer)?;
+        lexer.buffer.push_back((tok, pos));
+    }
+    Some(())
+}
+
+/// 次の非 Comment トークンを `(Token, pos)` で取得する。
+///
+/// Comment は破棄して継続。EOF または malformed なら `None`。
+/// `pos` は `skip_whitespace` 後の `lexer.pos` を採用する（トークン本体の開始位置）。
+pub(super) fn next_non_comment_token(lexer: &mut Lexer<'_>) -> Option<(Token, usize)> {
+    loop {
+        lexer.skip_whitespace();
+        let pos_before = lexer.pos;
+        match lexer.next_token()? {
+            Token::Comment(_) => continue,
+            tok => return Some((tok, pos_before)),
+        }
+    }
+}

--- a/rust/crates/core/src/lexer/token_buffer.rs
+++ b/rust/crates/core/src/lexer/token_buffer.rs
@@ -31,6 +31,9 @@ pub(super) fn ensure_buffered(lexer: &mut Lexer<'_>, n: usize) -> Option<()> {
 /// 公開 [`Lexer::next_token`] ではなく [`Lexer::next_raw_token`] を呼ぶことで、
 /// バッファ内の peek 済みトークンを誤って pop しないようにする
 /// （ensure_buffered のループ不変条件「`buffer.len() < n` の間ループ」を保つため）。
+///
+/// `skip_whitespace` は本関数内で 1 度だけ呼ぶ（`next_raw_token` 側は skip 不要前提）。
+/// これによりトークン取得ごとの whitespace スキャンが二重化されない。
 pub(super) fn next_non_comment_token(lexer: &mut Lexer<'_>) -> Option<(Token, usize)> {
     loop {
         lexer.skip_whitespace();

--- a/rust/crates/core/src/parser.rs
+++ b/rust/crates/core/src/parser.rs
@@ -12,19 +12,29 @@
 //! 辞書のキーは `Primitive::Name` のみ受理、値が `Null` のエントリは ISO §7.3.7 準拠で
 //! `PdfDictionary` に登録しない（重複キーで既存値がある場合は削除する）。
 //!
-//! 間接参照は `Integer(N) Integer(G) Keyword("R")` の 3 トークン列を Parser 内の
-//! lookahead バッファ（最大 2 トークン）で検出する。`N >= 0` かつ `0 <= G <= u16::MAX`
-//! のときのみ発火し、`N` を [`PdfObject::Reference`] に格納する。不成立時は呼び出し元で
-//! `N` を [`PdfObject::Integer`] として発行し、先読み済みの `G` や `Token3` はバッファに
-//! 戻してそのまま後続パスで再解釈される（ISO 32000-1 §7.3.10）。
+//! 間接参照は `Integer(N) Integer(G) Keyword("R")` の 3 トークン列を `Lexer` の
+//! token 単位 peek API（`peek_token_at(0/1)` + `take_token`）で検出する。
+//! `N >= 0` かつ `0 <= G <= u16::MAX` のときのみ発火し、`N` を [`PdfObject::Reference`]
+//! に格納する。不成立時は peek 済みトークンが `Lexer` 内部バッファに保留されたまま
+//! `Ok(None)` を返し、呼び出し元は `N` を [`PdfObject::Integer`] として発行する。
+//! 保留中のトークンは次回 `parse_object` 系で透過的に取り出される（ISO 32000-1 §7.3.10）。
 
 pub mod error;
-
-use std::collections::VecDeque;
 
 use crate::byte_offset::ByteOffset;
 use crate::lexer::token::{Primitive, Token};
 use crate::lexer::Lexer;
+
+/// `try_parse_indirect_reference` 内部で peek 結果を借用切れにしてから分岐するための分類タグ。
+///
+/// `Lexer::peek_token_at` の戻り値が握る `&Token` の借用が、後続の `is_eof()` 等の
+/// 不変借用や `take_token()` の可変借用と衝突するため、まず純粋な分類値に変換する。
+#[derive(Debug)]
+enum PeekClass<T> {
+    Match(T),
+    Mismatch,
+    Unavailable,
+}
 use crate::object::dictionary::PdfDictionary;
 use crate::object::generation_number::GenerationNumber;
 use crate::object::indirect_ref::IndirectRef;
@@ -33,36 +43,16 @@ use crate::object::object_number::ObjectNumber;
 use crate::object::pdf_object::PdfObject;
 use crate::parser::error::ParseError;
 
-/// 先読みしたが消費されなかったトークンと、その読み始めバイト位置を保持する内部用構造体。
-///
-/// `try_parse_indirect_reference` で lookahead を失敗判定したときに使われ、
-/// `pos` はバッファから再取得されたトークンの位置情報として
-/// `parse_object` / `parse_array_body` / `parse_dictionary_body` のエラー位置に利用される。
-#[derive(Debug)]
-struct BufferedToken {
-    token: Token,
-    pos: usize,
-}
-
 /// PDF バイト列から [`PdfObject`] を 1 つずつ取り出すパーサ。
 ///
-/// 内部に [`Lexer`] をムーブで保持し、カーソル位置の管理を委譲する。
-/// 加えて、間接参照（`N G R`）の lookahead 用に最大 2 トークンの FIFO
-/// バッファ `buffer: VecDeque<BufferedToken>` を保持する。バッファは
-/// `try_parse_indirect_reference` が R 不在を判定したときにのみ
-/// 一時的に格納され、通常パスでは空のままになる。
-///
-/// [`Primitive`] の所有データは [`PdfObject`] にそのままムーブし、`Vec<u8>`
-/// の clone は行わない。新たな割り当ては `buffer` に最大 2 トークン分の
-/// [`BufferedToken`] が積まれるときに限り発生する（`VecDeque::new()` は
-/// 容量 0 で開始するため、lookahead がバックトラックを起こさない通常パス
-/// では割り当ても発生しない）。
+/// 内部に [`Lexer`] をムーブで保持し、カーソル位置の管理と lookahead バッファを
+/// 委譲する。[`Primitive`] の所有データは [`PdfObject`] にそのままムーブし、
+/// `Vec<u8>` の clone は行わない。
 ///
 /// 任意の入力に対して panic しない契約を持つ（lexer の契約をそのまま継承）。
 #[derive(Debug)]
 pub struct Parser<'a> {
     lexer: Lexer<'a>,
-    buffer: VecDeque<BufferedToken>,
 }
 
 impl<'a> Parser<'a> {
@@ -70,22 +60,16 @@ impl<'a> Parser<'a> {
     pub fn new(input: &'a [u8]) -> Self {
         Self {
             lexer: Lexer::new(input),
-            buffer: VecDeque::new(),
         }
     }
 
     /// 現在の論理カーソル位置をバイトオフセットで返す。
     ///
-    /// lookahead バッファに保留中のトークンがあればその先頭の読み始め位置を、
-    /// なければ内部 [`Lexer`] の `position()` を [`ByteOffset`] にラップして返す。
-    /// パース処理の副作用は伴わない。
+    /// [`Lexer::position`] が返す論理カーソル位置（lookahead バッファに peek 済みの
+    /// トークンがあればその先頭エントリの開始位置、なければ生のカーソル位置）を
+    /// [`ByteOffset`] にラップして返す。パース処理の副作用は伴わない。
     pub fn position(&self) -> ByteOffset {
-        let pos = self
-            .buffer
-            .front()
-            .map(|b| b.pos)
-            .unwrap_or_else(|| self.lexer.position());
-        ByteOffset::new(pos as u64)
+        ByteOffset::new(self.lexer.position() as u64)
     }
 
     /// 次のオブジェクトを 1 つ読み取る。
@@ -102,14 +86,7 @@ impl<'a> Parser<'a> {
     /// lexer が malformed を検知して `None` を返した場合は
     /// [`ParseErrorKind::LexerError`](error::ParseErrorKind::LexerError) を返す。
     pub fn parse_object(&mut self) -> Result<PdfObject, ParseError> {
-        let (token, pos_before) = match self.next_token_with_pos()? {
-            Some(p) => p,
-            None => {
-                return Err(ParseError::unexpected_eof_at(ByteOffset::new(
-                    self.lexer.position() as u64,
-                )));
-            }
-        };
+        let (token, pos_before) = self.take_token_or_error()?;
 
         match token {
             Token::Primitive(Primitive::Integer(n)) => {
@@ -129,8 +106,8 @@ impl<'a> Parser<'a> {
     }
 
     /// `[` を消費済の状態から配列ボディをパースし [`PdfObject::Array`] を返す
-    /// （ISO 32000-1 §7.3.6）。要素間 [`Token::Comment`] は `next_token_with_pos` の
-    /// 中で透過スキップ、[`Token::Primitive`] は所有ムーブで [`PdfObject`] に変換して
+    /// （ISO 32000-1 §7.3.6）。要素間 [`Token::Comment`] は `Lexer::take_token_with_pos`
+    /// の中で透過スキップ、[`Token::Primitive`] は所有ムーブで [`PdfObject`] に変換して
     /// `items` に push、[`Token::ArrayBegin`] はネストとして自身を再帰呼び出しし、
     /// [`Token::DictBegin`] は辞書要素として [`Self::parse_dictionary_body`] を
     /// 再帰呼び出しする。Integer 要素は `try_parse_indirect_reference` を介して
@@ -145,14 +122,7 @@ impl<'a> Parser<'a> {
     fn parse_array_body(&mut self) -> Result<PdfObject, ParseError> {
         let mut items: Vec<PdfObject> = Vec::new();
         loop {
-            let (token, pos_before) = match self.next_token_with_pos()? {
-                Some(p) => p,
-                None => {
-                    return Err(ParseError::unexpected_eof_at(ByteOffset::new(
-                        self.lexer.position() as u64,
-                    )));
-                }
-            };
+            let (token, pos_before) = self.take_token_or_error()?;
             match token {
                 Token::ArrayEnd => return Ok(PdfObject::Array(items)),
                 Token::Primitive(Primitive::Integer(n)) => {
@@ -176,8 +146,8 @@ impl<'a> Parser<'a> {
     }
 
     /// `<<` を消費済の状態から辞書ボディをパースし [`PdfObject::Dictionary`] を返す
-    /// （ISO 32000-1 §7.3.7）。エントリ間 [`Token::Comment`] は `next_token_with_pos`
-    /// の中で透過スキップ、キーは [`Primitive::Name`] のみ受理して所有ムーブで
+    /// （ISO 32000-1 §7.3.7）。エントリ間 [`Token::Comment`] は
+    /// `Lexer::take_token_with_pos` の中で透過スキップ、キーは [`Primitive::Name`] のみ受理して所有ムーブで
     /// [`PdfName`] として保持し、値は [`Self::parse_object`] の再帰呼び出しで取得する。
     /// 値読みが `parse_object` 経由のため、間接参照（ISO 32000-1 §7.3.10）は値位置で
     /// 自動的に [`PdfObject::Reference`] として認識される。
@@ -196,14 +166,7 @@ impl<'a> Parser<'a> {
     fn parse_dictionary_body(&mut self) -> Result<PdfObject, ParseError> {
         let mut dict = PdfDictionary::new();
         loop {
-            let (token, pos_before) = match self.next_token_with_pos()? {
-                Some(p) => p,
-                None => {
-                    return Err(ParseError::unexpected_eof_at(ByteOffset::new(
-                        self.lexer.position() as u64,
-                    )));
-                }
-            };
+            let (token, pos_before) = self.take_token_or_error()?;
             match token {
                 Token::DictEnd => return Ok(PdfObject::Dictionary(dict)),
                 Token::Primitive(Primitive::Name(key)) => {
@@ -224,32 +187,22 @@ impl<'a> Parser<'a> {
         }
     }
 
-    /// バッファが空ならば lexer から次の non-comment トークンと読み始め位置を取得し、
-    /// 非空ならば FIFO で最古のバッファエントリを返す。
-    /// EOF（lexer の `next_token()` が `None` かつ入力末端）は `Ok(None)`、lexer が
-    /// malformed を検知して `None` を返した場合は `Err(ParseError::lexer_error_at(...))`
-    /// を返す。[`Token::Comment`] は透過スキップする（呼び出し元はコメント腕を持たなくてよい）。
+    /// 次のトークンを Comment 透過込みで取り出し、EOF と malformed を区別して
+    /// [`ParseError`] にラップする内部 helper。
     ///
-    /// エラー位置は lexer 呼び出し直前に保存した `pos_before` を用いる。lexer が
-    /// malformed を検知して `None` を返した時点の `lexer.position()` は不定な前進量を
-    /// 含み得るため、トークン開始位置を安定して報告できる `pos_before` を採用する。
-    fn next_token_with_pos(&mut self) -> Result<Option<(Token, usize)>, ParseError> {
-        loop {
-            if let Some(buffered) = self.buffer.pop_front() {
-                return Ok(Some((buffered.token, buffered.pos)));
-            }
-            self.lexer.skip_whitespace();
-            let pos_before = self.lexer.position();
-            match self.lexer.next_token() {
-                Some(Token::Comment(_)) => continue,
-                Some(token) => return Ok(Some((token, pos_before))),
-                None => {
-                    if self.lexer.is_eof() {
-                        return Ok(None);
-                    }
-                    return Err(ParseError::lexer_error_at(ByteOffset::new(
-                        pos_before as u64,
-                    )));
+    /// `Lexer::take_token_with_pos` が `None` を返した時点で、`Lexer` 内部バッファは
+    /// 空であり [`Lexer::cursor_position`] は生のカーソル位置（EOF なら `input.len()`、
+    /// malformed なら巻き戻し済みの不正バイト開始位置）を指す。これをそのまま
+    /// `UnexpectedEof` / `LexerError` のエラー位置として報告する。
+    fn take_token_or_error(&mut self) -> Result<(Token, usize), ParseError> {
+        match self.lexer.take_token_with_pos() {
+            Some(entry) => Ok(entry),
+            None => {
+                let here = ByteOffset::new(self.lexer.cursor_position() as u64);
+                if self.lexer.is_eof() {
+                    Err(ParseError::unexpected_eof_at(here))
+                } else {
+                    Err(ParseError::lexer_error_at(here))
                 }
             }
         }
@@ -263,70 +216,71 @@ impl<'a> Parser<'a> {
     /// - 次トークンが `Integer(G)` かつ `0 <= G <= u16::MAX`
     /// - 次々トークンが `Keyword("R")`
     ///
-    /// 成立時は `Ok(Some(IndirectRef))` を返し、両 lookahead トークンを消費する。
-    /// 不成立時は読んだトークンを `self.buffer` へ FIFO 順で `push_back` し、
-    /// `Ok(None)` を返す（呼び出し元は Integer(N) として処理する）。
+    /// 成立時は `Ok(Some(IndirectRef))` を返し、両 lookahead トークンを `take_token`
+    /// で 2 回消費する。不成立時は peek 済みトークンを [`Lexer`] のバッファに保留した
+    /// まま `Ok(None)` を返す（呼び出し元は Integer(N) として処理し、保留中のトークンは
+    /// 次回 `parse_object` 系で透過的に取り出される）。
     /// `N` は呼び出し元で `Token::Primitive(Primitive::Integer)` として既に成立済み
     /// （i64 範囲外の N は lexer が `Keyword` 化するため、ここには `Integer` のみ届く）。
     ///
     /// lookahead 中に lexer malformed が検出された場合は `Err(LexerError)` を
-    /// fail-fast で伝播する。呼び出し元が握っている `N` の値は捨てられる。
-    /// 「N を一旦返してから次回呼び出しで Err を発火する」逆案は採用しない
-    /// （lookahead を 1 関数で完結させる単純さを優先）。
+    /// fail-fast で伝播する。エラー位置は [`Lexer::cursor_position`]（バッファを無視した
+    /// 生のカーソル位置）を使う。`Lexer::position` だと peek 済みトークンの開始位置が
+    /// 返るため、malformed バイト位置と一致しない。
     fn try_parse_indirect_reference(&mut self, n: i64) -> Result<Option<IndirectRef>, ParseError> {
         if n < 0 {
             return Ok(None);
         }
 
-        let (tok2, pos2) = match self.next_token_with_pos()? {
-            Some(t) => t,
-            None => return Ok(None),
+        let g = match Self::classify_indirect_ref_generation(self.lexer.peek_token_at(0)) {
+            PeekClass::Match(g) => g,
+            PeekClass::Mismatch => return Ok(None),
+            PeekClass::Unavailable => return self.peek_unavailable_to_result(),
         };
-
-        let g = match tok2 {
-            Token::Primitive(Primitive::Integer(g)) => g,
-            other => {
-                self.buffer.push_back(BufferedToken {
-                    token: other,
-                    pos: pos2,
-                });
-                return Ok(None);
-            }
-        };
-
         if !(0..=i64::from(u16::MAX)).contains(&g) {
-            self.buffer.push_back(BufferedToken {
-                token: Token::Primitive(Primitive::Integer(g)),
-                pos: pos2,
-            });
             return Ok(None);
         }
 
-        let (tok3, pos3) = match self.next_token_with_pos()? {
-            Some(t) => t,
-            None => {
-                self.buffer.push_back(BufferedToken {
-                    token: Token::Primitive(Primitive::Integer(g)),
-                    pos: pos2,
-                });
-                return Ok(None);
-            }
-        };
-
-        if matches!(&tok3, Token::Keyword(bytes) if bytes.as_slice() == b"R") {
-            let id = ObjectId::new(ObjectNumber::new(n as u64), GenerationNumber::new(g as u16));
-            return Ok(Some(IndirectRef::new(id)));
+        match Self::classify_indirect_ref_keyword(self.lexer.peek_token_at(1)) {
+            PeekClass::Match(()) => {}
+            PeekClass::Mismatch => return Ok(None),
+            PeekClass::Unavailable => return self.peek_unavailable_to_result(),
         }
 
-        self.buffer.push_back(BufferedToken {
-            token: Token::Primitive(Primitive::Integer(g)),
-            pos: pos2,
-        });
-        self.buffer.push_back(BufferedToken {
-            token: tok3,
-            pos: pos3,
-        });
-        Ok(None)
+        let _ = self.lexer.take_token();
+        let _ = self.lexer.take_token();
+
+        let id = ObjectId::new(ObjectNumber::new(n as u64), GenerationNumber::new(g as u16));
+        Ok(Some(IndirectRef::new(id)))
+    }
+
+    fn classify_indirect_ref_generation(peeked: Option<&Token>) -> PeekClass<i64> {
+        match peeked {
+            Some(Token::Primitive(Primitive::Integer(g))) => PeekClass::Match(*g),
+            Some(_) => PeekClass::Mismatch,
+            None => PeekClass::Unavailable,
+        }
+    }
+
+    fn classify_indirect_ref_keyword(peeked: Option<&Token>) -> PeekClass<()> {
+        match peeked {
+            Some(Token::Keyword(bytes)) if bytes.as_slice() == b"R" => PeekClass::Match(()),
+            Some(_) => PeekClass::Mismatch,
+            None => PeekClass::Unavailable,
+        }
+    }
+
+    /// `peek_token_at` が `None` を返した場合のフォローアップ判定。
+    /// EOF なら `Ok(None)`（呼び出し元は Integer(N) として処理）、malformed なら
+    /// `Err(LexerError)` を `cursor_position` 起点で発火する。
+    fn peek_unavailable_to_result<T>(&self) -> Result<Option<T>, ParseError> {
+        if self.lexer.is_eof() {
+            Ok(None)
+        } else {
+            Err(ParseError::lexer_error_at(ByteOffset::new(
+                self.lexer.cursor_position() as u64,
+            )))
+        }
     }
 
     /// [`Primitive`] を所有ムーブで受け取り、対応する [`PdfObject`] バリアントへ


### PR DESCRIPTION
## 概要

Parser が独自に抱えていた lookahead バッファ (`VecDeque<BufferedToken>` + `push_back` 5 箇所) を撤去し、token 単位の peek/take API を字句層 (`Lexer`) のサービスとして提供する。Comment 透過スキップも字句層に一本化することで、後続フェーズ (xref / trailer / stream parser) で同じ機構を再利用可能にする。

## 変更内容

### 🎯 変更の種類

- [x] ✨ 新機能 (Lexer の公開 API 追加)
- [x] ♻️ リファクタリング (Parser から lookahead バッファ撤去)

### 📝 詳細な変更内容

#### Lexer 側 (`✨` コミット `a0b393a`)

- 6 公開 API 追加（すべて Comment 透過込み）:
  - `peek_token()` — 次に消費されるトークンを参照で覗き見る
  - `peek_token_at(n)` — 0-indexed で n 番目に取り出されるトークンを参照で覗き見る（`usize::MAX` 境界吸収）
  - `take_token()` — 次のトークンをムーブで取り出す
  - `peek_token_with_pos()` / `take_token_with_pos()` — 位置情報付き兄弟 API
  - `cursor_position()` — バッファを無視した生のカーソル位置を返す（lookahead 中の lexer error 報告用）
- `Lexer::position()` の意味論シフト: バッファ非空時はバッファ先頭エントリ pos、空時は生のカーソル位置
- 内部 `VecDeque<(Token, usize)>` ベースの lookahead バッファを Lexer 構造体に保持
- `lexer/token_buffer.rs` (`pub(super)`) に `ensure_buffered` / `next_non_comment_token` を分離
- アロケーション抑制設計: take 系のみのパスでは `push_back` を経由せず直接 lex し、`VecDeque` の初回割り当てを発生させない (NFR-2)
- 新規テスト 10 ファイル / 26 関数を `lexer/peek_token_tests/` 配下に追加

#### Parser 側 (`♻️` コミット `ffebee9`)

- `BufferedToken` / `Parser::buffer` / `Parser::next_token_with_pos` / `use std::collections::VecDeque;` を**完全削除**
- `parse_object` / `parse_array_body` / `parse_dictionary_body` の lookahead 呼び出しを `Lexer::take_token_with_pos` 直接呼び + 共通 helper `take_token_or_error` に集約（EOF/malformed は `cursor_position` で区別）
- `try_parse_indirect_reference` を `peek_token_at(0/1)` + `take_token` × 2 の peek/consume パターンに書き直し、`push_back` 経由のロールバックを完全排除
- 借用ライフタイム衝突回避のため `PeekClass<T>` enum と classify 系内部 helper を追加
- `Parser::position` を `ByteOffset::new(self.lexer.position() as u64)` の薄ラッパに簡素化

### 📊 システム図

#### バッファ状態マシン

```mermaid
flowchart TD
    Empty["EMPTY<br/>buffer.len() == 0<br/>position() = cursor pos"]
    Filled1["FILLED_1<br/>buffer.len() == 1<br/>position() = front.pos"]
    FilledN["FILLED_N (N >= 2)<br/>buffer.len() == N<br/>position() = front.pos"]

    Empty -- "peek_token / peek_token_at(0)<br/>ensure_buffered(1)" --> Filled1
    Empty -- "peek_token_at(n>=1)<br/>ensure_buffered(n+1)" --> FilledN
    Empty -- "take_token (直接 lex 経路)" --> Empty
    Filled1 -- "peek_token / peek_token_at(0)" --> Filled1
    Filled1 -- "peek_token_at(1)<br/>ensure_buffered(2)" --> FilledN
    Filled1 -- "take_token<br/>pop_front" --> Empty
    FilledN -- "take_token<br/>pop_front" --> Filled1
```

#### Parser → Lexer 呼び出しフロー

```mermaid
flowchart LR
    parse_object["Parser::parse_object"]
    take_or_error["Parser::take_token_or_error"]
    try_ref["Parser::try_parse_indirect_reference"]
    lex_take["Lexer::take_token_with_pos"]
    lex_peek["Lexer::peek_token_at(0/1)"]
    lex_take_simple["Lexer::take_token × 2"]
    cursor["Lexer::cursor_position<br/>(malformed 報告用)"]

    parse_object --> take_or_error
    parse_object -- "Integer(N) のとき" --> try_ref
    take_or_error --> lex_take
    take_or_error -- "None かつ EOF/malformed" --> cursor
    try_ref --> lex_peek
    try_ref -- "両方マッチ" --> lex_take_simple
    try_ref -- "lookahead で None かつ !is_eof" --> cursor
```

## 関連Issue

- Issue: #478
- 依存: #409 (マージ済み)
- 親 Epic: #252

Closes #478

## テスト

- `cargo test --package pdfmod-core` — **966 passed** / 0 failed
  - ベースライン 940 passed → +26 新規テスト (`peek_token_tests/`)
- `cargo fmt --check` — 差分なし
- `cargo clippy --all-targets -- -D warnings` — 警告ゼロ
- 既存 `parser/indirect_reference_tests/` 38 関数 / `parser/array_tests/` / `parser/dictionary_tests/` / `parser.rs` インラインテストすべて**無修正でパス**

### AI レビュー結果

| ラウンド | エージェント | CRITICAL | WARNING | INFO |
|---|---|---|---|---|
| review-001 | codex (汎用) | 0 | 0 (2 件指摘→修正済) | — |
| review-002 | codex (汎用) | 0 | 0 | — (問題なし) |
| review-001 (spec-based 5 軸) | performance/design/spec-alignment/test-quality/comment-quality | 0 | 3 | 27 |
| review-002 (spec-based 5 軸) | 上記 5 軸 | 0 | **0** | 8 |

WARNING 3 件はテストカバレッジ（cursor_position 差異検証 / `take_token_with_pos` 直接呼びの pos 検証 / `peek_token_at(n)` + Comment 透過の組合せ）で、追加 4 テストにより全件解消。

## レビューポイント

- `lexer.rs` の 6 公開 API ドキュメントが DoD V-5 文言（「Comment 透過込み」「peek した値は次回 take でも同じ」「`peek_token_at(0) == peek_token()` / 0-indexed」「cursor_position は生 self.pos」）を網羅しているか
- `try_parse_indirect_reference` の `PeekClass<T>` enum 経由が、Rust の借用ライフタイム上必要な対処であることに同意できるか（`peek_token_at` の `Option<&Token>` 借用が match アーム内まで生き、`is_eof()` / `take_token()` と衝突するため）
- malformed 検出時のエラー位置が `Lexer::cursor_position()`（バッファ無視の生 pos）で報告されることが、既存 `lookahead_lexer_error.rs` の `b"1 <48656C"` / `b"1 0 <48656C"` テストを無修正でパスさせるための必須条件であること