### PR TITLE
✨ [New Feature]: #480 OperatorHandlerContext に markedContentStack を統合し全 handler で透過

### DIFF
--- a/packages/core/src/content-stream/inline-image/handler/__tests__/handler.basic.test.ts
+++ b/packages/core/src/content-stream/inline-image/handler/__tests__/handler.basic.test.ts
@@ -7,6 +7,7 @@ import type {
 import { TokenType } from "../../../../pdf/index";
 import { ByteOffset } from "../../../../pdf/types/byte-offset/index";
 import { GraphicsStateStack } from "../../../graphics-state/index";
+import { MarkedContentStack } from "../../../marked-content/stack";
 import { OperandStack } from "../../../operand-stack/index";
 import type { OperatorHandlerContext } from "../../../operator-registry/index";
 import type { InlineImageDict } from "../../inline-image-dict/index";
@@ -45,6 +46,7 @@ const buildInlineImageToken = (
 const buildContext = (): OperatorHandlerContext => ({
   operandStack: OperandStack.create(),
   graphicsStateStack: GraphicsStateStack.create(),
+  markedContentStack: MarkedContentStack.create(),
 });
 
 test("完全名のみで揃った dict を受理する", () => {

--- a/packages/core/src/content-stream/inline-image/handler/__tests__/handler.error.test.ts
+++ b/packages/core/src/content-stream/inline-image/handler/__tests__/handler.error.test.ts
@@ -11,6 +11,7 @@ import type {
 import { TokenType } from "../../../../pdf/index";
 import { ByteOffset } from "../../../../pdf/types/byte-offset/index";
 import { GraphicsStateStack } from "../../../graphics-state/index";
+import { MarkedContentStack } from "../../../marked-content/stack";
 import { OperandStack } from "../../../operand-stack/index";
 import type { OperatorHandlerContext } from "../../../operator-registry/index";
 import type { InlineImageDict } from "../../inline-image-dict/index";
@@ -48,6 +49,7 @@ const buildToken = (entries: InlineImageDict): TokenInlineImage => ({
 const buildContext = (): OperatorHandlerContext => ({
   operandStack: OperandStack.create(),
   graphicsStateStack: GraphicsStateStack.create(),
+  markedContentStack: MarkedContentStack.create(),
 });
 
 test("Width 欠落で err.code/missingKey/offset/message を載せる（err 生成と offset 伝搬の統合）", () => {

--- a/packages/core/src/content-stream/inline-image/handler/__tests__/handler.image-mask.test.ts
+++ b/packages/core/src/content-stream/inline-image/handler/__tests__/handler.image-mask.test.ts
@@ -7,6 +7,7 @@ import type {
 import { TokenType } from "../../../../pdf/index";
 import { ByteOffset } from "../../../../pdf/types/byte-offset/index";
 import { GraphicsStateStack } from "../../../graphics-state/index";
+import { MarkedContentStack } from "../../../marked-content/stack";
 import { OperandStack } from "../../../operand-stack/index";
 import type { OperatorHandlerContext } from "../../../operator-registry/index";
 import type { InlineImageDict } from "../../inline-image-dict/index";
@@ -42,6 +43,7 @@ const buildToken = (entries: InlineImageDict): TokenInlineImage => ({
 const buildContext = (): OperatorHandlerContext => ({
   operandStack: OperandStack.create(),
   graphicsStateStack: GraphicsStateStack.create(),
+  markedContentStack: MarkedContentStack.create(),
 });
 
 test("/ImageMask true + ColorSpace なしで成功する（stencil mask 例外の統合）", () => {

--- a/packages/core/src/content-stream/inline-image/handler/index.ts
+++ b/packages/core/src/content-stream/inline-image/handler/index.ts
@@ -60,5 +60,6 @@ export const inlineImageHandler = (
   return ok({
     operandStack: context.operandStack,
     graphicsStateStack: context.graphicsStateStack,
+    markedContentStack: context.markedContentStack,
   });
 };

--- a/packages/core/src/content-stream/interpreter/__tests__/interpreter.inline-image.test.ts
+++ b/packages/core/src/content-stream/interpreter/__tests__/interpreter.inline-image.test.ts
@@ -2,6 +2,7 @@ import { assert, expect, test } from "vitest";
 import type { PdfObject } from "../../../pdf/types/pdf-types/index";
 import { ok } from "../../../utils/result/index";
 import { GraphicsStateStack } from "../../graphics-state/index";
+import { MarkedContentStack } from "../../marked-content/stack";
 import { OperandStack } from "../../operand-stack/index";
 import {
   type OperatorHandler,
@@ -38,6 +39,7 @@ test("inline image の前後で operand stack / graphics state stack は同一�
   const initialContext = {
     operandStack: OperandStack.create(),
     graphicsStateStack: GraphicsStateStack.create(),
+    markedContentStack: MarkedContentStack.create(),
   };
   const before = GraphicsStateStack.current(initialContext.graphicsStateStack);
 

--- a/packages/core/src/content-stream/interpreter/__tests__/interpreter.marked-content-stack.test.ts
+++ b/packages/core/src/content-stream/interpreter/__tests__/interpreter.marked-content-stack.test.ts
@@ -1,0 +1,59 @@
+import { assert, expect, test } from "vitest";
+import { GraphicsStateStack } from "../../graphics-state/index";
+import { MarkedContentStack } from "../../marked-content/stack";
+import { OperandStack } from "../../operand-stack/index";
+import { OperatorRegistry } from "../../operator-registry/index";
+import { ContentStreamInterpreter } from "../index";
+
+const encode = (value: string): Uint8Array => new TextEncoder().encode(value);
+
+test("初期contextのmarkedContentStackは深さ0の空stackである", () => {
+  // initialContext 未指定で execute すると createInitialContext が空 stack を生成する
+  const result = ContentStreamInterpreter.execute({
+    data: encode(""),
+    registry: OperatorRegistry.create(),
+  });
+
+  assert(result.ok);
+  expect(
+    MarkedContentStack.depth(result.value.context.markedContentStack),
+  ).toBe(0);
+});
+
+test("executeを2回呼ぶと返されるmarkedContentStackは別インスタンスである", () => {
+  // createInitialContext が factory を毎回呼ぶ間接検証
+  const r1 = ContentStreamInterpreter.execute({
+    data: encode(""),
+    registry: OperatorRegistry.create(),
+  });
+  const r2 = ContentStreamInterpreter.execute({
+    data: encode(""),
+    registry: OperatorRegistry.create(),
+  });
+
+  assert(r1.ok);
+  assert(r2.ok);
+  expect(r1.value.context.markedContentStack).not.toBe(
+    r2.value.context.markedContentStack,
+  );
+});
+
+test("外部注入したinitialContext.markedContentStackはそのまま透過して返る", () => {
+  // initialContext !== undefined 分岐の既存挙動（呼び出し側の stack を尊重）を pin down
+  const initialContext = {
+    operandStack: OperandStack.create(),
+    graphicsStateStack: GraphicsStateStack.create(),
+    markedContentStack: MarkedContentStack.create(),
+  };
+
+  const result = ContentStreamInterpreter.execute({
+    data: encode(""),
+    registry: OperatorRegistry.create(),
+    initialContext,
+  });
+
+  assert(result.ok);
+  expect(result.value.context.markedContentStack).toBe(
+    initialContext.markedContentStack,
+  );
+});

--- a/packages/core/src/content-stream/interpreter/index.ts
+++ b/packages/core/src/content-stream/interpreter/index.ts
@@ -9,6 +9,7 @@ import type { Result } from "../../utils/result/index";
 import { err, ok } from "../../utils/result/index";
 import { GraphicsStateStack } from "../graphics-state/index";
 import { inlineImageHandler } from "../inline-image/handler/index";
+import { MarkedContentStack } from "../marked-content/stack";
 import { OperandStack } from "../operand-stack/index";
 import {
   type OperatorHandlerContext,
@@ -277,5 +278,6 @@ function createInitialContext(
   return {
     operandStack: OperandStack.create(),
     graphicsStateStack: GraphicsStateStack.create(),
+    markedContentStack: MarkedContentStack.create(),
   };
 }

--- a/packages/core/src/content-stream/marked-content/stack/__tests__/stack.basic.test.ts
+++ b/packages/core/src/content-stream/marked-content/stack/__tests__/stack.basic.test.ts
@@ -1,4 +1,4 @@
-import { expect, test } from "vitest";
+import { assert, expect, test } from "vitest";
 import type {
   PdfDictionary,
   PdfName,
@@ -57,9 +57,7 @@ test("LIFO順でpopが直近pushしたentryを返す", () => {
     some: true,
     value: { stack: expect.any(Object), popped: bmcArtifact },
   });
-  if (!first.some) {
-    throw new Error("expected some");
-  }
+  assert(first.some);
   const second = MarkedContentStack.pop(first.value.stack);
   expect(second).toEqual({
     some: true,
@@ -71,9 +69,7 @@ test("popは元stackをmutateせず別参照のstackを返す", () => {
   // pop 後も元 stack の depth が変わらず、別参照の stack を返す
   const prev = MarkedContentStack.push(MarkedContentStack.create(), bmcSpan);
   const result = MarkedContentStack.pop(prev);
-  if (!result.some) {
-    throw new Error("expected some");
-  }
+  assert(result.some);
   expect(result.value.stack).not.toBe(prev);
   expect(MarkedContentStack.depth(prev)).toBe(1);
 });
@@ -83,8 +79,6 @@ test("BDC entry(propertiesがsome)もpushしてpopで同じ参照が返る", () 
   // pop で同じ entry 参照が返ること
   const stack = MarkedContentStack.push(MarkedContentStack.create(), bdcSpan);
   const result = MarkedContentStack.pop(stack);
-  if (!result.some) {
-    throw new Error("expected some");
-  }
+  assert(result.some);
   expect(result.value.popped).toBe(bdcSpan);
 });

--- a/packages/core/src/content-stream/marked-content/stack/__tests__/stack.basic.test.ts
+++ b/packages/core/src/content-stream/marked-content/stack/__tests__/stack.basic.test.ts
@@ -22,6 +22,15 @@ test("createは深さ0の空stackを返す", () => {
   expect(MarkedContentStack.depth(stack)).toBe(0);
 });
 
+test("createは呼び出しごとに別インスタンスの空stackを返す", () => {
+  // create() は共有定数ではなく呼び出しごとに独立した stack を返す factory 契約
+  const a = MarkedContentStack.create();
+  const b = MarkedContentStack.create();
+  expect(a).not.toBe(b);
+  expect(MarkedContentStack.depth(a)).toBe(0);
+  expect(MarkedContentStack.depth(b)).toBe(0);
+});
+
 test("pushは深さを1増やした新stackを返す", () => {
   // BMC entry を 1 つ push したら depth が 0 → 1 に増加する
   const stack = MarkedContentStack.push(MarkedContentStack.create(), bmcSpan);

--- a/packages/core/src/content-stream/operator-registry/index.ts
+++ b/packages/core/src/content-stream/operator-registry/index.ts
@@ -5,6 +5,7 @@ import { none, some } from "../../utils/option/index";
 import type { Result } from "../../utils/result/index";
 import { err, ok } from "../../utils/result/index";
 import type { GraphicsStateStack } from "../graphics-state/stack";
+import type { MarkedContentStack } from "../marked-content/stack";
 import type { OperandStack } from "../operand-stack/index";
 
 declare const OperatorRegistryBrand: unique symbol;
@@ -17,6 +18,8 @@ export type OperatorHandlerContext = {
   readonly operandStack: OperandStack;
   /** 現在の graphics state stack */
   readonly graphicsStateStack: GraphicsStateStack;
+  /** BMC/BDC/EMC 由来の marked content stack (ISO 32000-2:2020 §14.6) */
+  readonly markedContentStack: MarkedContentStack;
 };
 
 /**

--- a/packages/core/src/content-stream/operators/color/cmyk/__tests__/fill.basic.test.ts
+++ b/packages/core/src/content-stream/operators/color/cmyk/__tests__/fill.basic.test.ts
@@ -11,6 +11,7 @@ import {
   Matrix,
 } from "../../../../graphics-state/index";
 import { PathSegment } from "../../../../graphics-state/path-segment/index";
+import { MarkedContentStack } from "../../../../marked-content/stack";
 import { OperandStack } from "../../../../operand-stack/index";
 import type { OperatorHandlerContext } from "../../../../operator-registry/index";
 import { kHandler } from "../fill";
@@ -23,7 +24,11 @@ const buildContext = (operands: PdfObject[]): OperatorHandlerContext => {
     OperandStack.push(operandStack, operand);
   }
   const graphicsStateStack = GraphicsStateStack.create();
-  return { operandStack, graphicsStateStack };
+  return {
+    operandStack,
+    graphicsStateStack,
+    markedContentStack: MarkedContentStack.create(),
+  };
 };
 
 const real = (value: number): PdfObject => ({ type: "real", value });
@@ -82,7 +87,11 @@ test("初期 strokeColor=rgb(0.7, 0.8, 0.9) を seed しても k 実行後 strok
     seeded,
   );
 
-  const result = kHandler({ operandStack, graphicsStateStack });
+  const result = kHandler({
+    operandStack,
+    graphicsStateStack,
+    markedContentStack: MarkedContentStack.create(),
+  });
 
   assert(result.ok);
   const current = GraphicsStateStack.current(result.value.graphicsStateStack);
@@ -163,7 +172,11 @@ test("成功時 非デフォルトの ctm / lineWidth / lineCap / lineJoin / mit
     seeded,
   );
 
-  const result = kHandler({ operandStack, graphicsStateStack });
+  const result = kHandler({
+    operandStack,
+    graphicsStateStack,
+    markedContentStack: MarkedContentStack.create(),
+  });
 
   assert(result.ok);
   const after = GraphicsStateStack.current(result.value.graphicsStateStack);

--- a/packages/core/src/content-stream/operators/color/cmyk/__tests__/fill.error.test.ts
+++ b/packages/core/src/content-stream/operators/color/cmyk/__tests__/fill.error.test.ts
@@ -1,6 +1,7 @@
 import { assert, expect, test } from "vitest";
 import type { PdfObject } from "../../../../../pdf/types/pdf-types/index";
 import { GraphicsStateStack } from "../../../../graphics-state/index";
+import { MarkedContentStack } from "../../../../marked-content/stack";
 import { OperandStack } from "../../../../operand-stack/index";
 import type { OperatorHandlerContext } from "../../../../operator-registry/index";
 import { kHandler } from "../fill";
@@ -13,7 +14,11 @@ const buildContext = (operands: PdfObject[]): OperatorHandlerContext => {
     OperandStack.push(operandStack, operand);
   }
   const graphicsStateStack = GraphicsStateStack.create();
-  return { operandStack, graphicsStateStack };
+  return {
+    operandStack,
+    graphicsStateStack,
+    markedContentStack: MarkedContentStack.create(),
+  };
 };
 
 const real = (value: number): PdfObject => ({ type: "real", value });

--- a/packages/core/src/content-stream/operators/color/cmyk/__tests__/stroke.basic.test.ts
+++ b/packages/core/src/content-stream/operators/color/cmyk/__tests__/stroke.basic.test.ts
@@ -11,6 +11,7 @@ import {
   Matrix,
 } from "../../../../graphics-state/index";
 import { PathSegment } from "../../../../graphics-state/path-segment/index";
+import { MarkedContentStack } from "../../../../marked-content/stack";
 import { OperandStack } from "../../../../operand-stack/index";
 import type { OperatorHandlerContext } from "../../../../operator-registry/index";
 import { KHandler } from "../stroke";
@@ -23,7 +24,11 @@ const buildContext = (operands: PdfObject[]): OperatorHandlerContext => {
     OperandStack.push(operandStack, operand);
   }
   const graphicsStateStack = GraphicsStateStack.create();
-  return { operandStack, graphicsStateStack };
+  return {
+    operandStack,
+    graphicsStateStack,
+    markedContentStack: MarkedContentStack.create(),
+  };
 };
 
 const real = (value: number): PdfObject => ({ type: "real", value });
@@ -82,7 +87,11 @@ test("初期 fillColor=rgb(0.7, 0.8, 0.9) を seed しても K 実行後 fill �
     seeded,
   );
 
-  const result = KHandler({ operandStack, graphicsStateStack });
+  const result = KHandler({
+    operandStack,
+    graphicsStateStack,
+    markedContentStack: MarkedContentStack.create(),
+  });
 
   assert(result.ok);
   const current = GraphicsStateStack.current(result.value.graphicsStateStack);
@@ -163,7 +172,11 @@ test("成功時 非デフォルトの ctm / lineWidth / lineCap / lineJoin / mit
     seeded,
   );
 
-  const result = KHandler({ operandStack, graphicsStateStack });
+  const result = KHandler({
+    operandStack,
+    graphicsStateStack,
+    markedContentStack: MarkedContentStack.create(),
+  });
 
   assert(result.ok);
   const after = GraphicsStateStack.current(result.value.graphicsStateStack);

--- a/packages/core/src/content-stream/operators/color/cmyk/__tests__/stroke.error.test.ts
+++ b/packages/core/src/content-stream/operators/color/cmyk/__tests__/stroke.error.test.ts
@@ -1,6 +1,7 @@
 import { assert, expect, test } from "vitest";
 import type { PdfObject } from "../../../../../pdf/types/pdf-types/index";
 import { GraphicsStateStack } from "../../../../graphics-state/index";
+import { MarkedContentStack } from "../../../../marked-content/stack";
 import { OperandStack } from "../../../../operand-stack/index";
 import type { OperatorHandlerContext } from "../../../../operator-registry/index";
 import { KHandler } from "../stroke";
@@ -13,7 +14,11 @@ const buildContext = (operands: PdfObject[]): OperatorHandlerContext => {
     OperandStack.push(operandStack, operand);
   }
   const graphicsStateStack = GraphicsStateStack.create();
-  return { operandStack, graphicsStateStack };
+  return {
+    operandStack,
+    graphicsStateStack,
+    markedContentStack: MarkedContentStack.create(),
+  };
 };
 
 const real = (value: number): PdfObject => ({ type: "real", value });

--- a/packages/core/src/content-stream/operators/color/cmyk/fill.ts
+++ b/packages/core/src/content-stream/operators/color/cmyk/fill.ts
@@ -80,5 +80,6 @@ export const kHandler: OperatorHandler = (context: OperatorHandlerContext) => {
   return ok({
     operandStack: context.operandStack,
     graphicsStateStack,
+    markedContentStack: context.markedContentStack,
   });
 };

--- a/packages/core/src/content-stream/operators/color/cmyk/stroke.ts
+++ b/packages/core/src/content-stream/operators/color/cmyk/stroke.ts
@@ -80,5 +80,6 @@ export const KHandler: OperatorHandler = (context: OperatorHandlerContext) => {
   return ok({
     operandStack: context.operandStack,
     graphicsStateStack,
+    markedContentStack: context.markedContentStack,
   });
 };

--- a/packages/core/src/content-stream/operators/color/gray/__tests__/fill.basic.test.ts
+++ b/packages/core/src/content-stream/operators/color/gray/__tests__/fill.basic.test.ts
@@ -6,6 +6,7 @@ import {
   GraphicsState,
   GraphicsStateStack,
 } from "../../../../graphics-state/index";
+import { MarkedContentStack } from "../../../../marked-content/stack";
 import { OperandStack } from "../../../../operand-stack/index";
 import type { OperatorHandlerContext } from "../../../../operator-registry/index";
 import { gHandler } from "../fill";
@@ -16,7 +17,11 @@ const buildContext = (operands: PdfObject[]): OperatorHandlerContext => {
     OperandStack.push(operandStack, operand);
   }
   const graphicsStateStack = GraphicsStateStack.create();
-  return { operandStack, graphicsStateStack };
+  return {
+    operandStack,
+    graphicsStateStack,
+    markedContentStack: MarkedContentStack.create(),
+  };
 };
 
 const real = (value: number): PdfObject => ({ type: "real", value });
@@ -46,7 +51,11 @@ test("初期 fillColorSpace=deviceRGB/fillColor=rgb の状態から `0.5 g` で 
     rgbState,
   );
 
-  const result = gHandler({ operandStack, graphicsStateStack });
+  const result = gHandler({
+    operandStack,
+    graphicsStateStack,
+    markedContentStack: MarkedContentStack.create(),
+  });
 
   assert(result.ok);
   const current = GraphicsStateStack.current(result.value.graphicsStateStack);

--- a/packages/core/src/content-stream/operators/color/gray/__tests__/stroke.basic.test.ts
+++ b/packages/core/src/content-stream/operators/color/gray/__tests__/stroke.basic.test.ts
@@ -6,6 +6,7 @@ import {
   GraphicsState,
   GraphicsStateStack,
 } from "../../../../graphics-state/index";
+import { MarkedContentStack } from "../../../../marked-content/stack";
 import { OperandStack } from "../../../../operand-stack/index";
 import type { OperatorHandlerContext } from "../../../../operator-registry/index";
 import { GHandler } from "../stroke";
@@ -16,7 +17,11 @@ const buildContext = (operands: PdfObject[]): OperatorHandlerContext => {
     OperandStack.push(operandStack, operand);
   }
   const graphicsStateStack = GraphicsStateStack.create();
-  return { operandStack, graphicsStateStack };
+  return {
+    operandStack,
+    graphicsStateStack,
+    markedContentStack: MarkedContentStack.create(),
+  };
 };
 
 const real = (value: number): PdfObject => ({ type: "real", value });
@@ -46,7 +51,11 @@ test("初期 strokeColorSpace=deviceRGB/strokeColor=rgb の状態から `0.5 G` 
     rgbState,
   );
 
-  const result = GHandler({ operandStack, graphicsStateStack });
+  const result = GHandler({
+    operandStack,
+    graphicsStateStack,
+    markedContentStack: MarkedContentStack.create(),
+  });
 
   assert(result.ok);
   const current = GraphicsStateStack.current(result.value.graphicsStateStack);

--- a/packages/core/src/content-stream/operators/color/gray/fill.ts
+++ b/packages/core/src/content-stream/operators/color/gray/fill.ts
@@ -83,5 +83,6 @@ export const gHandler: OperatorHandler = (context: OperatorHandlerContext) => {
   return ok({
     operandStack: context.operandStack,
     graphicsStateStack,
+    markedContentStack: context.markedContentStack,
   });
 };

--- a/packages/core/src/content-stream/operators/color/gray/stroke.ts
+++ b/packages/core/src/content-stream/operators/color/gray/stroke.ts
@@ -82,5 +82,6 @@ export const GHandler: OperatorHandler = (context: OperatorHandlerContext) => {
   return ok({
     operandStack: context.operandStack,
     graphicsStateStack,
+    markedContentStack: context.markedContentStack,
   });
 };

--- a/packages/core/src/content-stream/operators/color/rgb/__tests__/fill.basic.test.ts
+++ b/packages/core/src/content-stream/operators/color/rgb/__tests__/fill.basic.test.ts
@@ -6,6 +6,7 @@ import {
   GraphicsState,
   GraphicsStateStack,
 } from "../../../../graphics-state/index";
+import { MarkedContentStack } from "../../../../marked-content/stack";
 import { OperandStack } from "../../../../operand-stack/index";
 import type { OperatorHandlerContext } from "../../../../operator-registry/index";
 import { rgHandler } from "../fill";
@@ -16,7 +17,11 @@ const buildContext = (operands: PdfObject[]): OperatorHandlerContext => {
     OperandStack.push(operandStack, operand);
   }
   const graphicsStateStack = GraphicsStateStack.create();
-  return { operandStack, graphicsStateStack };
+  return {
+    operandStack,
+    graphicsStateStack,
+    markedContentStack: MarkedContentStack.create(),
+  };
 };
 
 const real = (value: number): PdfObject => ({ type: "real", value });
@@ -81,7 +86,11 @@ test("初期 strokeColor=rgb(0.5, 0.5, 0.5) の状態でも rg 実行後 strokeC
     seeded,
   );
 
-  const result = rgHandler({ operandStack, graphicsStateStack });
+  const result = rgHandler({
+    operandStack,
+    graphicsStateStack,
+    markedContentStack: MarkedContentStack.create(),
+  });
 
   assert(result.ok);
   const current = GraphicsStateStack.current(result.value.graphicsStateStack);

--- a/packages/core/src/content-stream/operators/color/rgb/__tests__/fill.error.test.ts
+++ b/packages/core/src/content-stream/operators/color/rgb/__tests__/fill.error.test.ts
@@ -1,6 +1,7 @@
 import { assert, expect, test } from "vitest";
 import type { PdfObject } from "../../../../../pdf/types/pdf-types/index";
 import { GraphicsStateStack } from "../../../../graphics-state/index";
+import { MarkedContentStack } from "../../../../marked-content/stack";
 import { OperandStack } from "../../../../operand-stack/index";
 import type { OperatorHandlerContext } from "../../../../operator-registry/index";
 import { rgHandler } from "../fill";
@@ -11,7 +12,11 @@ const buildContext = (operands: PdfObject[]): OperatorHandlerContext => {
     OperandStack.push(operandStack, operand);
   }
   const graphicsStateStack = GraphicsStateStack.create();
-  return { operandStack, graphicsStateStack };
+  return {
+    operandStack,
+    graphicsStateStack,
+    markedContentStack: MarkedContentStack.create(),
+  };
 };
 
 const real = (value: number): PdfObject => ({ type: "real", value });

--- a/packages/core/src/content-stream/operators/color/rgb/__tests__/stroke.basic.test.ts
+++ b/packages/core/src/content-stream/operators/color/rgb/__tests__/stroke.basic.test.ts
@@ -6,6 +6,7 @@ import {
   GraphicsState,
   GraphicsStateStack,
 } from "../../../../graphics-state/index";
+import { MarkedContentStack } from "../../../../marked-content/stack";
 import { OperandStack } from "../../../../operand-stack/index";
 import type { OperatorHandlerContext } from "../../../../operator-registry/index";
 import { RGHandler } from "../stroke";
@@ -16,7 +17,11 @@ const buildContext = (operands: PdfObject[]): OperatorHandlerContext => {
     OperandStack.push(operandStack, operand);
   }
   const graphicsStateStack = GraphicsStateStack.create();
-  return { operandStack, graphicsStateStack };
+  return {
+    operandStack,
+    graphicsStateStack,
+    markedContentStack: MarkedContentStack.create(),
+  };
 };
 
 const real = (value: number): PdfObject => ({ type: "real", value });
@@ -81,7 +86,11 @@ test("初期 fillColor=rgb(0.5, 0.5, 0.5) の状態でも RG 実行後 fillColor
     seeded,
   );
 
-  const result = RGHandler({ operandStack, graphicsStateStack });
+  const result = RGHandler({
+    operandStack,
+    graphicsStateStack,
+    markedContentStack: MarkedContentStack.create(),
+  });
 
   assert(result.ok);
   const current = GraphicsStateStack.current(result.value.graphicsStateStack);

--- a/packages/core/src/content-stream/operators/color/rgb/__tests__/stroke.error.test.ts
+++ b/packages/core/src/content-stream/operators/color/rgb/__tests__/stroke.error.test.ts
@@ -1,6 +1,7 @@
 import { assert, expect, test } from "vitest";
 import type { PdfObject } from "../../../../../pdf/types/pdf-types/index";
 import { GraphicsStateStack } from "../../../../graphics-state/index";
+import { MarkedContentStack } from "../../../../marked-content/stack";
 import { OperandStack } from "../../../../operand-stack/index";
 import type { OperatorHandlerContext } from "../../../../operator-registry/index";
 import { RGHandler } from "../stroke";
@@ -11,7 +12,11 @@ const buildContext = (operands: PdfObject[]): OperatorHandlerContext => {
     OperandStack.push(operandStack, operand);
   }
   const graphicsStateStack = GraphicsStateStack.create();
-  return { operandStack, graphicsStateStack };
+  return {
+    operandStack,
+    graphicsStateStack,
+    markedContentStack: MarkedContentStack.create(),
+  };
 };
 
 const real = (value: number): PdfObject => ({ type: "real", value });

--- a/packages/core/src/content-stream/operators/color/rgb/fill.ts
+++ b/packages/core/src/content-stream/operators/color/rgb/fill.ts
@@ -80,5 +80,6 @@ export const rgHandler: OperatorHandler = (context: OperatorHandlerContext) => {
   return ok({
     operandStack: context.operandStack,
     graphicsStateStack,
+    markedContentStack: context.markedContentStack,
   });
 };

--- a/packages/core/src/content-stream/operators/color/rgb/stroke.ts
+++ b/packages/core/src/content-stream/operators/color/rgb/stroke.ts
@@ -80,5 +80,6 @@ export const RGHandler: OperatorHandler = (context: OperatorHandlerContext) => {
   return ok({
     operandStack: context.operandStack,
     graphicsStateStack,
+    markedContentStack: context.markedContentStack,
   });
 };

--- a/packages/core/src/content-stream/operators/graphics-state/cm/__tests__/cm.basic.test.ts
+++ b/packages/core/src/content-stream/operators/graphics-state/cm/__tests__/cm.basic.test.ts
@@ -1,6 +1,7 @@
 import { assert, expect, test } from "vitest";
 import type { PdfObject } from "../../../../../pdf/types/pdf-types/index";
 import { GraphicsStateStack, Matrix } from "../../../../graphics-state/index";
+import { MarkedContentStack } from "../../../../marked-content/stack";
 import { OperandStack } from "../../../../operand-stack/index";
 import type { OperatorHandlerContext } from "../../../../operator-registry/index";
 import { cmHandler } from "../../cm";
@@ -11,7 +12,11 @@ const buildContext = (operands: PdfObject[]): OperatorHandlerContext => {
     OperandStack.push(operandStack, operand);
   }
   const graphicsStateStack = GraphicsStateStack.create();
-  return { operandStack, graphicsStateStack };
+  return {
+    operandStack,
+    graphicsStateStack,
+    markedContentStack: MarkedContentStack.create(),
+  };
 };
 
 const real = (value: number): PdfObject => ({ type: "real", value });
@@ -115,6 +120,7 @@ test("左乗算検証 (非可換): CTM が S(2,3) の状態で T(5,7) を cm 適
   const result = cmHandler({
     operandStack,
     graphicsStateStack: stackWithS,
+    markedContentStack: MarkedContentStack.create(),
   });
 
   assert(result.ok);
@@ -151,6 +157,7 @@ test("平行移動の合成: CTM が T(10,20) の状態で T(5,7) を cm 適用�
   const result = cmHandler({
     operandStack,
     graphicsStateStack: stackWithT1,
+    markedContentStack: MarkedContentStack.create(),
   });
 
   assert(result.ok);

--- a/packages/core/src/content-stream/operators/graphics-state/cm/index.ts
+++ b/packages/core/src/content-stream/operators/graphics-state/cm/index.ts
@@ -77,5 +77,6 @@ export const cmHandler: OperatorHandler = (context: OperatorHandlerContext) => {
   return ok({
     operandStack: context.operandStack,
     graphicsStateStack,
+    markedContentStack: context.markedContentStack,
   });
 };

--- a/packages/core/src/content-stream/operators/graphics-state/graphics-state-operators/__tests__/graphics-state-operators.integration.test.ts
+++ b/packages/core/src/content-stream/operators/graphics-state/graphics-state-operators/__tests__/graphics-state-operators.integration.test.ts
@@ -6,6 +6,7 @@ import {
   Matrix,
 } from "../../../../graphics-state/index";
 import { ContentStreamInterpreter } from "../../../../interpreter/index";
+import { MarkedContentStack } from "../../../../marked-content/stack";
 import {
   type OperatorHandler,
   OperatorRegistry,
@@ -18,12 +19,14 @@ const qHandler: OperatorHandler = (context) =>
   ok({
     ...context,
     graphicsStateStack: GraphicsStateStack.save(context.graphicsStateStack),
+    markedContentStack: MarkedContentStack.create(),
   });
 
 const qRestoreHandler: OperatorHandler = (context) =>
   ok({
     ...context,
     graphicsStateStack: GraphicsStateStack.restore(context.graphicsStateStack),
+    markedContentStack: MarkedContentStack.create(),
   });
 
 test("barrel 経由で `1 0 0 1 100 200 cm 2 w` を実行すると CTM と lineWidth が更新される", () => {

--- a/packages/core/src/content-stream/operators/graphics-state/graphics-state-operators/__tests__/graphics-state-operators.integration.test.ts
+++ b/packages/core/src/content-stream/operators/graphics-state/graphics-state-operators/__tests__/graphics-state-operators.integration.test.ts
@@ -6,7 +6,6 @@ import {
   Matrix,
 } from "../../../../graphics-state/index";
 import { ContentStreamInterpreter } from "../../../../interpreter/index";
-import { MarkedContentStack } from "../../../../marked-content/stack";
 import {
   type OperatorHandler,
   OperatorRegistry,
@@ -19,14 +18,12 @@ const qHandler: OperatorHandler = (context) =>
   ok({
     ...context,
     graphicsStateStack: GraphicsStateStack.save(context.graphicsStateStack),
-    markedContentStack: MarkedContentStack.create(),
   });
 
 const qRestoreHandler: OperatorHandler = (context) =>
   ok({
     ...context,
     graphicsStateStack: GraphicsStateStack.restore(context.graphicsStateStack),
-    markedContentStack: MarkedContentStack.create(),
   });
 
 test("barrel 経由で `1 0 0 1 100 200 cm 2 w` を実行すると CTM と lineWidth が更新される", () => {

--- a/packages/core/src/content-stream/operators/graphics-state/line-cap-handler/__tests__/line-cap-handler.basic.test.ts
+++ b/packages/core/src/content-stream/operators/graphics-state/line-cap-handler/__tests__/line-cap-handler.basic.test.ts
@@ -1,6 +1,7 @@
 import { assert, expect, test } from "vitest";
 import type { PdfObject } from "../../../../../pdf/types/pdf-types/index";
 import { GraphicsStateStack, LineCap } from "../../../../graphics-state/index";
+import { MarkedContentStack } from "../../../../marked-content/stack";
 import { OperandStack } from "../../../../operand-stack/index";
 import type { OperatorHandlerContext } from "../../../../operator-registry/index";
 import { lineCapHandler } from "../../line-cap-handler";
@@ -11,7 +12,11 @@ const buildContext = (operands: PdfObject[]): OperatorHandlerContext => {
     OperandStack.push(operandStack, operand);
   }
   const graphicsStateStack = GraphicsStateStack.create();
-  return { operandStack, graphicsStateStack };
+  return {
+    operandStack,
+    graphicsStateStack,
+    markedContentStack: MarkedContentStack.create(),
+  };
 };
 
 test.each([

--- a/packages/core/src/content-stream/operators/graphics-state/line-cap-handler/index.ts
+++ b/packages/core/src/content-stream/operators/graphics-state/line-cap-handler/index.ts
@@ -79,5 +79,6 @@ export const lineCapHandler: OperatorHandler = (
   return ok({
     operandStack: context.operandStack,
     graphicsStateStack,
+    markedContentStack: context.markedContentStack,
   });
 };

--- a/packages/core/src/content-stream/operators/graphics-state/line-join-handler/__tests__/line-join-handler.basic.test.ts
+++ b/packages/core/src/content-stream/operators/graphics-state/line-join-handler/__tests__/line-join-handler.basic.test.ts
@@ -1,6 +1,7 @@
 import { assert, expect, test } from "vitest";
 import type { PdfObject } from "../../../../../pdf/types/pdf-types/index";
 import { GraphicsStateStack, LineJoin } from "../../../../graphics-state/index";
+import { MarkedContentStack } from "../../../../marked-content/stack";
 import { OperandStack } from "../../../../operand-stack/index";
 import type { OperatorHandlerContext } from "../../../../operator-registry/index";
 import { lineJoinHandler } from "../../line-join-handler";
@@ -11,7 +12,11 @@ const buildContext = (operands: PdfObject[]): OperatorHandlerContext => {
     OperandStack.push(operandStack, operand);
   }
   const graphicsStateStack = GraphicsStateStack.create();
-  return { operandStack, graphicsStateStack };
+  return {
+    operandStack,
+    graphicsStateStack,
+    markedContentStack: MarkedContentStack.create(),
+  };
 };
 
 test.each([

--- a/packages/core/src/content-stream/operators/graphics-state/line-join-handler/index.ts
+++ b/packages/core/src/content-stream/operators/graphics-state/line-join-handler/index.ts
@@ -79,5 +79,6 @@ export const lineJoinHandler: OperatorHandler = (
   return ok({
     operandStack: context.operandStack,
     graphicsStateStack,
+    markedContentStack: context.markedContentStack,
   });
 };

--- a/packages/core/src/content-stream/operators/graphics-state/line-width-handler/__tests__/line-width-handler.basic.test.ts
+++ b/packages/core/src/content-stream/operators/graphics-state/line-width-handler/__tests__/line-width-handler.basic.test.ts
@@ -1,6 +1,7 @@
 import { assert, expect, test } from "vitest";
 import type { PdfObject } from "../../../../../pdf/types/pdf-types/index";
 import { GraphicsStateStack } from "../../../../graphics-state/index";
+import { MarkedContentStack } from "../../../../marked-content/stack";
 import { OperandStack } from "../../../../operand-stack/index";
 import type { OperatorHandlerContext } from "../../../../operator-registry/index";
 import { lineWidthHandler } from "../../line-width-handler";
@@ -11,7 +12,11 @@ const buildContext = (operands: PdfObject[]): OperatorHandlerContext => {
     OperandStack.push(operandStack, operand);
   }
   const graphicsStateStack = GraphicsStateStack.create();
-  return { operandStack, graphicsStateStack };
+  return {
+    operandStack,
+    graphicsStateStack,
+    markedContentStack: MarkedContentStack.create(),
+  };
 };
 
 test("integer operand 5 で current lineWidth が 5 に更新される", () => {

--- a/packages/core/src/content-stream/operators/graphics-state/line-width-handler/index.ts
+++ b/packages/core/src/content-stream/operators/graphics-state/line-width-handler/index.ts
@@ -61,5 +61,6 @@ export const lineWidthHandler: OperatorHandler = (
   return ok({
     operandStack: context.operandStack,
     graphicsStateStack,
+    markedContentStack: context.markedContentStack,
   });
 };

--- a/packages/core/src/content-stream/operators/graphics-state/miter-limit-handler/__tests__/miter-limit-handler.basic.test.ts
+++ b/packages/core/src/content-stream/operators/graphics-state/miter-limit-handler/__tests__/miter-limit-handler.basic.test.ts
@@ -1,6 +1,7 @@
 import { assert, expect, test } from "vitest";
 import type { PdfObject } from "../../../../../pdf/types/pdf-types/index";
 import { GraphicsStateStack } from "../../../../graphics-state/index";
+import { MarkedContentStack } from "../../../../marked-content/stack";
 import { OperandStack } from "../../../../operand-stack/index";
 import type { OperatorHandlerContext } from "../../../../operator-registry/index";
 import { miterLimitHandler } from "../../miter-limit-handler";
@@ -11,7 +12,11 @@ const buildContext = (operands: PdfObject[]): OperatorHandlerContext => {
     OperandStack.push(operandStack, operand);
   }
   const graphicsStateStack = GraphicsStateStack.create();
-  return { operandStack, graphicsStateStack };
+  return {
+    operandStack,
+    graphicsStateStack,
+    markedContentStack: MarkedContentStack.create(),
+  };
 };
 
 test("integer operand 5 で current miterLimit が 5 に更新される", () => {

--- a/packages/core/src/content-stream/operators/graphics-state/miter-limit-handler/index.ts
+++ b/packages/core/src/content-stream/operators/graphics-state/miter-limit-handler/index.ts
@@ -61,5 +61,6 @@ export const miterLimitHandler: OperatorHandler = (
   return ok({
     operandStack: context.operandStack,
     graphicsStateStack,
+    markedContentStack: context.markedContentStack,
   });
 };

--- a/packages/core/src/content-stream/operators/path/c/__tests__/c.basic.test.ts
+++ b/packages/core/src/content-stream/operators/path/c/__tests__/c.basic.test.ts
@@ -6,6 +6,7 @@ import {
   GraphicsStateStack,
 } from "../../../../graphics-state/index";
 import { PathSegment } from "../../../../graphics-state/path-segment";
+import { MarkedContentStack } from "../../../../marked-content/stack";
 import { OperandStack } from "../../../../operand-stack/index";
 import type { OperatorHandlerContext } from "../../../../operator-registry/index";
 import { mHandler } from "../../m/index";
@@ -17,7 +18,11 @@ const buildContext = (operands: PdfObject[]): OperatorHandlerContext => {
     OperandStack.push(operandStack, operand);
   }
   const graphicsStateStack = GraphicsStateStack.create();
-  return { operandStack, graphicsStateStack };
+  return {
+    operandStack,
+    graphicsStateStack,
+    markedContentStack: MarkedContentStack.create(),
+  };
 };
 
 const buildContextWithCurrentPoint = (
@@ -39,7 +44,11 @@ const buildContextWithCurrentPoint = (
     GraphicsStateStack.create(),
     seededState,
   );
-  return { operandStack, graphicsStateStack };
+  return {
+    operandStack,
+    graphicsStateStack,
+    markedContentStack: MarkedContentStack.create(),
+  };
 };
 
 const real = (value: number): PdfObject => ({ type: "real", value });
@@ -96,6 +105,7 @@ test("既存 currentPath を持つ state から開始した場合、元 segment 
   const result = cHandler({
     operandStack,
     graphicsStateStack: stackWithSeed,
+    markedContentStack: MarkedContentStack.create(),
   });
 
   assert(result.ok);
@@ -130,6 +140,7 @@ test("`mHandler(10,20)` 実行後 `cHandler(30,40,50,60,70,80)` を実行する�
   const result = cHandler({
     operandStack,
     graphicsStateStack: mResult.value.graphicsStateStack,
+    markedContentStack: MarkedContentStack.create(),
   });
 
   assert(result.ok);
@@ -166,6 +177,7 @@ test("連続 `c → c` で 2 つの CurveTo が append され、前 CurveTo は�
   const secondResult = cHandler({
     operandStack,
     graphicsStateStack: firstResult.value.graphicsStateStack,
+    markedContentStack: MarkedContentStack.create(),
   });
 
   assert(secondResult.ok);

--- a/packages/core/src/content-stream/operators/path/c/index.ts
+++ b/packages/core/src/content-stream/operators/path/c/index.ts
@@ -92,5 +92,6 @@ export const cHandler: OperatorHandler = (context: OperatorHandlerContext) => {
   return ok({
     operandStack: context.operandStack,
     graphicsStateStack,
+    markedContentStack: context.markedContentStack,
   });
 };

--- a/packages/core/src/content-stream/operators/path/fill-stroke/__tests__/fill-stroke.basic.test.ts
+++ b/packages/core/src/content-stream/operators/path/fill-stroke/__tests__/fill-stroke.basic.test.ts
@@ -9,6 +9,7 @@ import {
   Matrix,
 } from "../../../../graphics-state/index";
 import { PathSegment } from "../../../../graphics-state/path-segment";
+import { MarkedContentStack } from "../../../../marked-content/stack";
 import { OperandStack } from "../../../../operand-stack/index";
 import type { OperatorHandlerContext } from "../../../../operator-registry/index";
 import { fillStrokeHandler } from "../index";
@@ -21,7 +22,11 @@ const buildContext = (operands: PdfObject[]): OperatorHandlerContext => {
     OperandStack.push(operandStack, operand);
   }
   const graphicsStateStack = GraphicsStateStack.create();
-  return { operandStack, graphicsStateStack };
+  return {
+    operandStack,
+    graphicsStateStack,
+    markedContentStack: MarkedContentStack.create(),
+  };
 };
 
 const buildContextWithSegments = (
@@ -42,7 +47,11 @@ const buildContextWithSegments = (
     GraphicsStateStack.create(),
     seededState,
   );
-  return { operandStack, graphicsStateStack };
+  return {
+    operandStack,
+    graphicsStateStack,
+    markedContentStack: MarkedContentStack.create(),
+  };
 };
 
 const buildContextWithGraphicsState = (
@@ -57,7 +66,11 @@ const buildContextWithGraphicsState = (
     GraphicsStateStack.create(),
     state,
   );
-  return { operandStack, graphicsStateStack };
+  return {
+    operandStack,
+    graphicsStateStack,
+    markedContentStack: MarkedContentStack.create(),
+  };
 };
 
 test("空 path に対して `B` は no-op で segments が空のまま保たれる", () => {
@@ -281,6 +294,7 @@ test("`q` 済み (saved state あり) 状態で `B` を実行しても saved sta
   const ctx: OperatorHandlerContext = {
     operandStack: OperandStack.create(),
     graphicsStateStack: seededStack,
+    markedContentStack: MarkedContentStack.create(),
   };
 
   const result = fillStrokeHandler(ctx);

--- a/packages/core/src/content-stream/operators/path/fill-stroke/index.ts
+++ b/packages/core/src/content-stream/operators/path/fill-stroke/index.ts
@@ -46,6 +46,7 @@ export const fillStrokeHandler: OperatorHandler = (
     return ok({
       operandStack: context.operandStack,
       graphicsStateStack: context.graphicsStateStack,
+      markedContentStack: context.markedContentStack,
     });
   }
   const next = GraphicsState.update(current, {
@@ -58,5 +59,6 @@ export const fillStrokeHandler: OperatorHandler = (
   return ok({
     operandStack: context.operandStack,
     graphicsStateStack,
+    markedContentStack: context.markedContentStack,
   });
 };

--- a/packages/core/src/content-stream/operators/path/fill/__tests__/fill.basic.test.ts
+++ b/packages/core/src/content-stream/operators/path/fill/__tests__/fill.basic.test.ts
@@ -9,6 +9,7 @@ import {
   Matrix,
 } from "../../../../graphics-state/index";
 import { PathSegment } from "../../../../graphics-state/path-segment";
+import { MarkedContentStack } from "../../../../marked-content/stack";
 import { OperandStack } from "../../../../operand-stack/index";
 import type { OperatorHandlerContext } from "../../../../operator-registry/index";
 import { fillHandler } from "../index";
@@ -21,7 +22,11 @@ const buildContext = (operands: PdfObject[]): OperatorHandlerContext => {
     OperandStack.push(operandStack, operand);
   }
   const graphicsStateStack = GraphicsStateStack.create();
-  return { operandStack, graphicsStateStack };
+  return {
+    operandStack,
+    graphicsStateStack,
+    markedContentStack: MarkedContentStack.create(),
+  };
 };
 
 const buildContextWithSegments = (
@@ -42,7 +47,11 @@ const buildContextWithSegments = (
     GraphicsStateStack.create(),
     seededState,
   );
-  return { operandStack, graphicsStateStack };
+  return {
+    operandStack,
+    graphicsStateStack,
+    markedContentStack: MarkedContentStack.create(),
+  };
 };
 
 const buildContextWithGraphicsState = (
@@ -57,7 +66,11 @@ const buildContextWithGraphicsState = (
     GraphicsStateStack.create(),
     state,
   );
-  return { operandStack, graphicsStateStack };
+  return {
+    operandStack,
+    graphicsStateStack,
+    markedContentStack: MarkedContentStack.create(),
+  };
 };
 
 test("空 path に対して `f` は no-op で segments が空のまま保たれる", () => {
@@ -281,6 +294,7 @@ test("`q` 済み (saved state あり) 状態で `f` を実行しても saved sta
   const ctx: OperatorHandlerContext = {
     operandStack: OperandStack.create(),
     graphicsStateStack: seededStack,
+    markedContentStack: MarkedContentStack.create(),
   };
 
   const result = fillHandler(ctx);

--- a/packages/core/src/content-stream/operators/path/fill/index.ts
+++ b/packages/core/src/content-stream/operators/path/fill/index.ts
@@ -41,6 +41,7 @@ export const fillHandler: OperatorHandler = (
     return ok({
       operandStack: context.operandStack,
       graphicsStateStack: context.graphicsStateStack,
+      markedContentStack: context.markedContentStack,
     });
   }
   const next = GraphicsState.update(current, {
@@ -53,5 +54,6 @@ export const fillHandler: OperatorHandler = (
   return ok({
     operandStack: context.operandStack,
     graphicsStateStack,
+    markedContentStack: context.markedContentStack,
   });
 };

--- a/packages/core/src/content-stream/operators/path/h/__tests__/h.basic.test.ts
+++ b/packages/core/src/content-stream/operators/path/h/__tests__/h.basic.test.ts
@@ -6,6 +6,7 @@ import {
   GraphicsStateStack,
 } from "../../../../graphics-state/index";
 import { PathSegment } from "../../../../graphics-state/path-segment";
+import { MarkedContentStack } from "../../../../marked-content/stack";
 import { OperandStack } from "../../../../operand-stack/index";
 import type { OperatorHandlerContext } from "../../../../operator-registry/index";
 import { hHandler } from "../index";
@@ -18,7 +19,11 @@ const buildContext = (operands: PdfObject[]): OperatorHandlerContext => {
     OperandStack.push(operandStack, operand);
   }
   const graphicsStateStack = GraphicsStateStack.create();
-  return { operandStack, graphicsStateStack };
+  return {
+    operandStack,
+    graphicsStateStack,
+    markedContentStack: MarkedContentStack.create(),
+  };
 };
 
 const buildContextWithSegments = (
@@ -39,7 +44,11 @@ const buildContextWithSegments = (
     GraphicsStateStack.create(),
     seededState,
   );
-  return { operandStack, graphicsStateStack };
+  return {
+    operandStack,
+    graphicsStateStack,
+    markedContentStack: MarkedContentStack.create(),
+  };
 };
 
 test("空 path に対して `h` は no-op で segments が空のまま保たれる", () => {

--- a/packages/core/src/content-stream/operators/path/h/index.ts
+++ b/packages/core/src/content-stream/operators/path/h/index.ts
@@ -35,6 +35,7 @@ export const hHandler: OperatorHandler = (context: OperatorHandlerContext) => {
     return ok({
       operandStack: context.operandStack,
       graphicsStateStack: context.graphicsStateStack,
+      markedContentStack: context.markedContentStack,
     });
   }
   const nextPath = CurrentPath.append(current.currentPath, PathSegment.close());
@@ -46,5 +47,6 @@ export const hHandler: OperatorHandler = (context: OperatorHandlerContext) => {
   return ok({
     operandStack: context.operandStack,
     graphicsStateStack,
+    markedContentStack: context.markedContentStack,
   });
 };

--- a/packages/core/src/content-stream/operators/path/l/__tests__/l.basic.test.ts
+++ b/packages/core/src/content-stream/operators/path/l/__tests__/l.basic.test.ts
@@ -6,6 +6,7 @@ import {
   GraphicsStateStack,
 } from "../../../../graphics-state/index";
 import { PathSegment } from "../../../../graphics-state/path-segment";
+import { MarkedContentStack } from "../../../../marked-content/stack";
 import { OperandStack } from "../../../../operand-stack/index";
 import type { OperatorHandlerContext } from "../../../../operator-registry/index";
 import { mHandler } from "../../m/index";
@@ -17,7 +18,11 @@ const buildContext = (operands: PdfObject[]): OperatorHandlerContext => {
     OperandStack.push(operandStack, operand);
   }
   const graphicsStateStack = GraphicsStateStack.create();
-  return { operandStack, graphicsStateStack };
+  return {
+    operandStack,
+    graphicsStateStack,
+    markedContentStack: MarkedContentStack.create(),
+  };
 };
 
 const buildContextWithCurrentPoint = (
@@ -39,7 +44,11 @@ const buildContextWithCurrentPoint = (
     GraphicsStateStack.create(),
     seededState,
   );
-  return { operandStack, graphicsStateStack };
+  return {
+    operandStack,
+    graphicsStateStack,
+    markedContentStack: MarkedContentStack.create(),
+  };
 };
 
 const real = (value: number): PdfObject => ({ type: "real", value });
@@ -82,6 +91,7 @@ test("既存 currentPath を持つ state から開始した場合、元 segment 
   const result = lHandler({
     operandStack,
     graphicsStateStack: stackWithSeed,
+    markedContentStack: MarkedContentStack.create(),
   });
 
   assert(result.ok);
@@ -109,6 +119,7 @@ test("`mHandler(10,20)` 実行後 `lHandler(30,40)` を実行すると [MoveTo, 
   const result = lHandler({
     operandStack,
     graphicsStateStack: mResult.value.graphicsStateStack,
+    markedContentStack: MarkedContentStack.create(),
   });
 
   assert(result.ok);
@@ -131,6 +142,7 @@ test("連続 `l → l` で 2 つの LineTo が append され、前 LineTo は上
   const secondResult = lHandler({
     operandStack,
     graphicsStateStack: firstResult.value.graphicsStateStack,
+    markedContentStack: MarkedContentStack.create(),
   });
 
   assert(secondResult.ok);

--- a/packages/core/src/content-stream/operators/path/l/index.ts
+++ b/packages/core/src/content-stream/operators/path/l/index.ts
@@ -91,5 +91,6 @@ export const lHandler: OperatorHandler = (context: OperatorHandlerContext) => {
   return ok({
     operandStack: context.operandStack,
     graphicsStateStack,
+    markedContentStack: context.markedContentStack,
   });
 };

--- a/packages/core/src/content-stream/operators/path/m/__tests__/m.basic.test.ts
+++ b/packages/core/src/content-stream/operators/path/m/__tests__/m.basic.test.ts
@@ -6,6 +6,7 @@ import {
   GraphicsStateStack,
 } from "../../../../graphics-state/index";
 import { PathSegment } from "../../../../graphics-state/path-segment";
+import { MarkedContentStack } from "../../../../marked-content/stack";
 import { OperandStack } from "../../../../operand-stack/index";
 import type { OperatorHandlerContext } from "../../../../operator-registry/index";
 import { mHandler } from "../index";
@@ -16,7 +17,11 @@ const buildContext = (operands: PdfObject[]): OperatorHandlerContext => {
     OperandStack.push(operandStack, operand);
   }
   const graphicsStateStack = GraphicsStateStack.create();
-  return { operandStack, graphicsStateStack };
+  return {
+    operandStack,
+    graphicsStateStack,
+    markedContentStack: MarkedContentStack.create(),
+  };
 };
 
 const real = (value: number): PdfObject => ({ type: "real", value });
@@ -56,6 +61,7 @@ test("既存 currentPath を持つ state から開始した場合、元 segment 
   const result = mHandler({
     operandStack,
     graphicsStateStack: stackWithSeed,
+    markedContentStack: MarkedContentStack.create(),
   });
 
   assert(result.ok);
@@ -83,6 +89,7 @@ test("連続した `m` で前の MoveTo が上書きされる (ISO 32000-1:2008 
   const secondResult = mHandler({
     operandStack,
     graphicsStateStack: firstResult.value.graphicsStateStack,
+    markedContentStack: MarkedContentStack.create(),
   });
 
   assert(secondResult.ok);
@@ -110,7 +117,11 @@ test("`m → l → m` のとき直前 lineTo があるため 2 番目の m は�
     OperandStack.push(operandStack, operand);
   }
 
-  const result = mHandler({ operandStack, graphicsStateStack: stack });
+  const result = mHandler({
+    operandStack,
+    graphicsStateStack: stack,
+    markedContentStack: MarkedContentStack.create(),
+  });
 
   assert(result.ok);
   const current = GraphicsStateStack.current(result.value.graphicsStateStack);

--- a/packages/core/src/content-stream/operators/path/m/index.ts
+++ b/packages/core/src/content-stream/operators/path/m/index.ts
@@ -82,5 +82,6 @@ export const mHandler: OperatorHandler = (context: OperatorHandlerContext) => {
   return ok({
     operandStack: context.operandStack,
     graphicsStateStack,
+    markedContentStack: context.markedContentStack,
   });
 };

--- a/packages/core/src/content-stream/operators/path/re/__tests__/re.basic.test.ts
+++ b/packages/core/src/content-stream/operators/path/re/__tests__/re.basic.test.ts
@@ -6,6 +6,7 @@ import {
   GraphicsStateStack,
 } from "../../../../graphics-state/index";
 import { PathSegment } from "../../../../graphics-state/path-segment";
+import { MarkedContentStack } from "../../../../marked-content/stack";
 import { OperandStack } from "../../../../operand-stack/index";
 import type { OperatorHandlerContext } from "../../../../operator-registry/index";
 import { reHandler } from "../index";
@@ -19,7 +20,11 @@ const buildContext = (operands: PdfObject[]): OperatorHandlerContext => {
     OperandStack.push(operandStack, operand);
   }
   const graphicsStateStack = GraphicsStateStack.create();
-  return { operandStack, graphicsStateStack };
+  return {
+    operandStack,
+    graphicsStateStack,
+    markedContentStack: MarkedContentStack.create(),
+  };
 };
 
 const buildContextWithSegments = (
@@ -40,7 +45,11 @@ const buildContextWithSegments = (
     GraphicsStateStack.create(),
     seededState,
   );
-  return { operandStack, graphicsStateStack };
+  return {
+    operandStack,
+    graphicsStateStack,
+    markedContentStack: MarkedContentStack.create(),
+  };
 };
 
 test("`100 100 200 150 re` で PathSegment.rect(100,100,200,150) が空 currentPath に append される", () => {

--- a/packages/core/src/content-stream/operators/path/re/index.ts
+++ b/packages/core/src/content-stream/operators/path/re/index.ts
@@ -85,5 +85,6 @@ export const reHandler: OperatorHandler = (context: OperatorHandlerContext) => {
   return ok({
     operandStack: context.operandStack,
     graphicsStateStack,
+    markedContentStack: context.markedContentStack,
   });
 };

--- a/packages/core/src/content-stream/operators/path/stroke/__tests__/stroke.basic.test.ts
+++ b/packages/core/src/content-stream/operators/path/stroke/__tests__/stroke.basic.test.ts
@@ -9,6 +9,7 @@ import {
   Matrix,
 } from "../../../../graphics-state/index";
 import { PathSegment } from "../../../../graphics-state/path-segment";
+import { MarkedContentStack } from "../../../../marked-content/stack";
 import { OperandStack } from "../../../../operand-stack/index";
 import type { OperatorHandlerContext } from "../../../../operator-registry/index";
 import { strokeHandler } from "../index";
@@ -21,7 +22,11 @@ const buildContext = (operands: PdfObject[]): OperatorHandlerContext => {
     OperandStack.push(operandStack, operand);
   }
   const graphicsStateStack = GraphicsStateStack.create();
-  return { operandStack, graphicsStateStack };
+  return {
+    operandStack,
+    graphicsStateStack,
+    markedContentStack: MarkedContentStack.create(),
+  };
 };
 
 const buildContextWithSegments = (
@@ -42,7 +47,11 @@ const buildContextWithSegments = (
     GraphicsStateStack.create(),
     seededState,
   );
-  return { operandStack, graphicsStateStack };
+  return {
+    operandStack,
+    graphicsStateStack,
+    markedContentStack: MarkedContentStack.create(),
+  };
 };
 
 const buildContextWithGraphicsState = (
@@ -57,7 +66,11 @@ const buildContextWithGraphicsState = (
     GraphicsStateStack.create(),
     state,
   );
-  return { operandStack, graphicsStateStack };
+  return {
+    operandStack,
+    graphicsStateStack,
+    markedContentStack: MarkedContentStack.create(),
+  };
 };
 
 test("空 path に対して `S` は no-op で segments が空のまま保たれる", () => {

--- a/packages/core/src/content-stream/operators/path/stroke/index.ts
+++ b/packages/core/src/content-stream/operators/path/stroke/index.ts
@@ -40,6 +40,7 @@ export const strokeHandler: OperatorHandler = (
     return ok({
       operandStack: context.operandStack,
       graphicsStateStack: context.graphicsStateStack,
+      markedContentStack: context.markedContentStack,
     });
   }
   const next = GraphicsState.update(current, {
@@ -52,5 +53,6 @@ export const strokeHandler: OperatorHandler = (
   return ok({
     operandStack: context.operandStack,
     graphicsStateStack,
+    markedContentStack: context.markedContentStack,
   });
 };

--- a/packages/core/src/content-stream/operators/text/apostrophe/__tests__/apostrophe.basic.test.ts
+++ b/packages/core/src/content-stream/operators/text/apostrophe/__tests__/apostrophe.basic.test.ts
@@ -7,6 +7,7 @@ import {
   TextObject,
   TextState,
 } from "../../../../graphics-state/index";
+import { MarkedContentStack } from "../../../../marked-content/stack";
 import { OperandStack } from "../../../../operand-stack/index";
 import type { OperatorHandlerContext } from "../../../../operator-registry/index";
 import { apostropheHandler } from "../index";
@@ -31,7 +32,11 @@ const buildActiveContext = (
     GraphicsStateStack.create(),
     activeState,
   );
-  return { operandStack, graphicsStateStack };
+  return {
+    operandStack,
+    graphicsStateStack,
+    markedContentStack: MarkedContentStack.create(),
+  };
 };
 
 // active かつ任意の Tm / Tlm を持つ TextObject を生で組むヘルパ（dirty state 構築用）。

--- a/packages/core/src/content-stream/operators/text/apostrophe/__tests__/apostrophe.error.test.ts
+++ b/packages/core/src/content-stream/operators/text/apostrophe/__tests__/apostrophe.error.test.ts
@@ -7,6 +7,7 @@ import {
   TextObject,
   TextState,
 } from "../../../../graphics-state/index";
+import { MarkedContentStack } from "../../../../marked-content/stack";
 import { OperandStack } from "../../../../operand-stack/index";
 import type { OperatorHandlerContext } from "../../../../operator-registry/index";
 import { apostropheHandler } from "../index";
@@ -28,7 +29,11 @@ const buildActiveContext = (
     GraphicsStateStack.create(),
     activeState,
   );
-  return { operandStack, graphicsStateStack };
+  return {
+    operandStack,
+    graphicsStateStack,
+    markedContentStack: MarkedContentStack.create(),
+  };
 };
 
 // active=false (BT 未発行) の context を組み立てる。
@@ -40,7 +45,11 @@ const buildInactiveContext = (
     OperandStack.push(operandStack, operand);
   }
   const graphicsStateStack = GraphicsStateStack.create();
-  return { operandStack, graphicsStateStack };
+  return {
+    operandStack,
+    graphicsStateStack,
+    markedContentStack: MarkedContentStack.create(),
+  };
 };
 
 // inactive かつ非 identity の matrix / 非 default の leading を持つ context。
@@ -61,7 +70,11 @@ const buildInactiveNonIdentityContext = (): OperatorHandlerContext => {
     GraphicsStateStack.create(),
     state,
   );
-  return { operandStack, graphicsStateStack };
+  return {
+    operandStack,
+    graphicsStateStack,
+    markedContentStack: MarkedContentStack.create(),
+  };
 };
 
 const literalString = (bytes: number[]): PdfObject => ({

--- a/packages/core/src/content-stream/operators/text/apostrophe/index.ts
+++ b/packages/core/src/content-stream/operators/text/apostrophe/index.ts
@@ -87,5 +87,6 @@ export const apostropheHandler: OperatorHandler = (
   return ok({
     operandStack: context.operandStack,
     graphicsStateStack,
+    markedContentStack: context.markedContentStack,
   });
 };

--- a/packages/core/src/content-stream/operators/text/bt/__tests__/bt.basic.test.ts
+++ b/packages/core/src/content-stream/operators/text/bt/__tests__/bt.basic.test.ts
@@ -5,6 +5,7 @@ import {
   Matrix,
   TextObject,
 } from "../../../../graphics-state/index";
+import { MarkedContentStack } from "../../../../marked-content/stack";
 import { OperandStack } from "../../../../operand-stack/index";
 import type { OperatorHandlerContext } from "../../../../operator-registry/index";
 import { btHandler } from "../index";
@@ -18,7 +19,11 @@ const buildContext = (operands: PdfObject[] = []): OperatorHandlerContext => {
     OperandStack.push(operandStack, operand);
   }
   const graphicsStateStack = GraphicsStateStack.create();
-  return { operandStack, graphicsStateStack };
+  return {
+    operandStack,
+    graphicsStateStack,
+    markedContentStack: MarkedContentStack.create(),
+  };
 };
 
 test("初期 inactive 状態で BT を実行すると textObject.active が true へ遷移する", () => {

--- a/packages/core/src/content-stream/operators/text/bt/__tests__/bt.error.test.ts
+++ b/packages/core/src/content-stream/operators/text/bt/__tests__/bt.error.test.ts
@@ -5,6 +5,7 @@ import {
   GraphicsStateStack,
   TextObject,
 } from "../../../../graphics-state/index";
+import { MarkedContentStack } from "../../../../marked-content/stack";
 import { OperandStack } from "../../../../operand-stack/index";
 import type { OperatorHandlerContext } from "../../../../operator-registry/index";
 import { btHandler } from "../index";
@@ -27,7 +28,11 @@ const buildActiveContext = (
     GraphicsStateStack.create(),
     activeState,
   );
-  return { operandStack, graphicsStateStack };
+  return {
+    operandStack,
+    graphicsStateStack,
+    markedContentStack: MarkedContentStack.create(),
+  };
 };
 
 test("active=true の状態で BT を実行すると OPERATOR_ILLEGAL_STATE を返す", () => {

--- a/packages/core/src/content-stream/operators/text/bt/index.ts
+++ b/packages/core/src/content-stream/operators/text/bt/index.ts
@@ -50,5 +50,6 @@ export const btHandler: OperatorHandler = (context: OperatorHandlerContext) => {
   return ok({
     operandStack: context.operandStack,
     graphicsStateStack,
+    markedContentStack: context.markedContentStack,
   });
 };

--- a/packages/core/src/content-stream/operators/text/et/__tests__/et.basic.test.ts
+++ b/packages/core/src/content-stream/operators/text/et/__tests__/et.basic.test.ts
@@ -5,6 +5,7 @@ import {
   Matrix,
   TextObject,
 } from "../../../../graphics-state/index";
+import { MarkedContentStack } from "../../../../marked-content/stack";
 import { OperandStack } from "../../../../operand-stack/index";
 import type { OperatorHandlerContext } from "../../../../operator-registry/index";
 import { etHandler } from "../index";
@@ -19,7 +20,11 @@ const buildActiveContext = (): OperatorHandlerContext => {
     GraphicsStateStack.create(),
     activeState,
   );
-  return { operandStack, graphicsStateStack };
+  return {
+    operandStack,
+    graphicsStateStack,
+    markedContentStack: MarkedContentStack.create(),
+  };
 };
 
 test("active な state で ET を実行すると textObject.active が false へ遷移する", () => {

--- a/packages/core/src/content-stream/operators/text/et/__tests__/et.error.test.ts
+++ b/packages/core/src/content-stream/operators/text/et/__tests__/et.error.test.ts
@@ -5,6 +5,7 @@ import {
   Matrix,
   TextObject,
 } from "../../../../graphics-state/index";
+import { MarkedContentStack } from "../../../../marked-content/stack";
 import { OperandStack } from "../../../../operand-stack/index";
 import type { OperatorHandlerContext } from "../../../../operator-registry/index";
 import { etHandler } from "../index";
@@ -13,7 +14,11 @@ import { etHandler } from "../index";
 const buildContext = (): OperatorHandlerContext => {
   const operandStack = OperandStack.create();
   const graphicsStateStack = GraphicsStateStack.create();
-  return { operandStack, graphicsStateStack };
+  return {
+    operandStack,
+    graphicsStateStack,
+    markedContentStack: MarkedContentStack.create(),
+  };
 };
 
 // inactive (active=false) かつ matrix が非 identity の textObject を持つ context。
@@ -33,7 +38,11 @@ const buildInactiveNonIdentityContext = (): OperatorHandlerContext => {
     GraphicsStateStack.create(),
     state,
   );
-  return { operandStack, graphicsStateStack };
+  return {
+    operandStack,
+    graphicsStateStack,
+    markedContentStack: MarkedContentStack.create(),
+  };
 };
 
 test("inactive な state で ET を実行すると OPERATOR_ILLEGAL_STATE を返す", () => {

--- a/packages/core/src/content-stream/operators/text/et/__tests__/et.integration.test.ts
+++ b/packages/core/src/content-stream/operators/text/et/__tests__/et.integration.test.ts
@@ -4,6 +4,7 @@ import {
   Matrix,
   TextObject,
 } from "../../../../graphics-state/index";
+import { MarkedContentStack } from "../../../../marked-content/stack";
 import { OperandStack } from "../../../../operand-stack/index";
 import type { OperatorHandlerContext } from "../../../../operator-registry/index";
 import { btHandler } from "../../bt/index";
@@ -13,7 +14,11 @@ import { etHandler } from "../index";
 const buildContext = (): OperatorHandlerContext => {
   const operandStack = OperandStack.create();
   const graphicsStateStack = GraphicsStateStack.create();
-  return { operandStack, graphicsStateStack };
+  return {
+    operandStack,
+    graphicsStateStack,
+    markedContentStack: MarkedContentStack.create(),
+  };
 };
 
 test("BT → ET を連続適用すると textObject.active が false へ復帰する", () => {

--- a/packages/core/src/content-stream/operators/text/et/index.ts
+++ b/packages/core/src/content-stream/operators/text/et/index.ts
@@ -50,5 +50,6 @@ export const etHandler: OperatorHandler = (context: OperatorHandlerContext) => {
   return ok({
     operandStack: context.operandStack,
     graphicsStateStack,
+    markedContentStack: context.markedContentStack,
   });
 };

--- a/packages/core/src/content-stream/operators/text/quote/__tests__/quote.basic.test.ts
+++ b/packages/core/src/content-stream/operators/text/quote/__tests__/quote.basic.test.ts
@@ -7,6 +7,7 @@ import {
   TextObject,
   TextState,
 } from "../../../../graphics-state/index";
+import { MarkedContentStack } from "../../../../marked-content/stack";
 import { OperandStack } from "../../../../operand-stack/index";
 import type { OperatorHandlerContext } from "../../../../operator-registry/index";
 import { quoteHandler } from "../index";
@@ -30,7 +31,11 @@ const buildActiveContext = (
     GraphicsStateStack.create(),
     activeState,
   );
-  return { operandStack, graphicsStateStack };
+  return {
+    operandStack,
+    graphicsStateStack,
+    markedContentStack: MarkedContentStack.create(),
+  };
 };
 
 // active かつ任意の Tm / Tlm を持つ TextObject を生で組むヘルパ（dirty state 構築用）。

--- a/packages/core/src/content-stream/operators/text/quote/__tests__/quote.error.test.ts
+++ b/packages/core/src/content-stream/operators/text/quote/__tests__/quote.error.test.ts
@@ -7,6 +7,7 @@ import {
   TextObject,
   TextState,
 } from "../../../../graphics-state/index";
+import { MarkedContentStack } from "../../../../marked-content/stack";
 import { OperandStack } from "../../../../operand-stack/index";
 import type { OperatorHandlerContext } from "../../../../operator-registry/index";
 import { quoteHandler } from "../index";
@@ -28,7 +29,11 @@ const buildActiveContext = (
     GraphicsStateStack.create(),
     activeState,
   );
-  return { operandStack, graphicsStateStack };
+  return {
+    operandStack,
+    graphicsStateStack,
+    markedContentStack: MarkedContentStack.create(),
+  };
 };
 
 // active=false (BT 未発行) の context を組み立てる。
@@ -40,7 +45,11 @@ const buildInactiveContext = (
     OperandStack.push(operandStack, operand);
   }
   const graphicsStateStack = GraphicsStateStack.create();
-  return { operandStack, graphicsStateStack };
+  return {
+    operandStack,
+    graphicsStateStack,
+    markedContentStack: MarkedContentStack.create(),
+  };
 };
 
 // inactive かつ非 identity の matrix / 非 default の leading を持つ context。
@@ -61,7 +70,11 @@ const buildInactiveNonIdentityContext = (): OperatorHandlerContext => {
     GraphicsStateStack.create(),
     state,
   );
-  return { operandStack, graphicsStateStack };
+  return {
+    operandStack,
+    graphicsStateStack,
+    markedContentStack: MarkedContentStack.create(),
+  };
 };
 
 const literalString = (bytes: number[]): PdfObject => ({

--- a/packages/core/src/content-stream/operators/text/quote/index.ts
+++ b/packages/core/src/content-stream/operators/text/quote/index.ts
@@ -160,5 +160,6 @@ export const quoteHandler: OperatorHandler = (
   return ok({
     operandStack: context.operandStack,
     graphicsStateStack,
+    markedContentStack: context.markedContentStack,
   });
 };

--- a/packages/core/src/content-stream/operators/text/t-star/__tests__/t-star.basic.test.ts
+++ b/packages/core/src/content-stream/operators/text/t-star/__tests__/t-star.basic.test.ts
@@ -7,6 +7,7 @@ import {
   TextObject,
   TextState,
 } from "../../../../graphics-state/index";
+import { MarkedContentStack } from "../../../../marked-content/stack";
 import { OperandStack } from "../../../../operand-stack/index";
 import type { OperatorHandlerContext } from "../../../../operator-registry/index";
 import { tStarHandler } from "../index";
@@ -30,7 +31,11 @@ const buildActiveContext = (
     GraphicsStateStack.create(),
     activeState,
   );
-  return { operandStack, graphicsStateStack };
+  return {
+    operandStack,
+    graphicsStateStack,
+    markedContentStack: MarkedContentStack.create(),
+  };
 };
 
 // active かつ任意の Tm / Tlm を持つ TextObject を生で組むヘルパ（dirty state 構築用）。

--- a/packages/core/src/content-stream/operators/text/t-star/__tests__/t-star.error.test.ts
+++ b/packages/core/src/content-stream/operators/text/t-star/__tests__/t-star.error.test.ts
@@ -7,6 +7,7 @@ import {
   TextObject,
   TextState,
 } from "../../../../graphics-state/index";
+import { MarkedContentStack } from "../../../../marked-content/stack";
 import { OperandStack } from "../../../../operand-stack/index";
 import type { OperatorHandlerContext } from "../../../../operator-registry/index";
 import { tStarHandler } from "../index";
@@ -21,7 +22,11 @@ const buildInactiveContext = (
     OperandStack.push(operandStack, operand);
   }
   const graphicsStateStack = GraphicsStateStack.create();
-  return { operandStack, graphicsStateStack };
+  return {
+    operandStack,
+    graphicsStateStack,
+    markedContentStack: MarkedContentStack.create(),
+  };
 };
 
 const int = (value: number): PdfObject => ({ type: "integer", value });
@@ -45,7 +50,11 @@ const buildInactiveNonIdentityContext = (): OperatorHandlerContext => {
     GraphicsStateStack.create(),
     state,
   );
-  return { operandStack, graphicsStateStack };
+  return {
+    operandStack,
+    graphicsStateStack,
+    markedContentStack: MarkedContentStack.create(),
+  };
 };
 
 test("inactive な state で T* を実行すると OPERATOR_ILLEGAL_STATE を返す", () => {

--- a/packages/core/src/content-stream/operators/text/t-star/index.ts
+++ b/packages/core/src/content-stream/operators/text/t-star/index.ts
@@ -59,5 +59,6 @@ export const tStarHandler: OperatorHandler = (
   return ok({
     operandStack: context.operandStack,
     graphicsStateStack,
+    markedContentStack: context.markedContentStack,
   });
 };

--- a/packages/core/src/content-stream/operators/text/tc/__tests__/tc.basic.test.ts
+++ b/packages/core/src/content-stream/operators/text/tc/__tests__/tc.basic.test.ts
@@ -5,6 +5,7 @@ import {
   GraphicsStateStack,
   TextState,
 } from "../../../../graphics-state/index";
+import { MarkedContentStack } from "../../../../marked-content/stack";
 import { OperandStack } from "../../../../operand-stack/index";
 import type { OperatorHandlerContext } from "../../../../operator-registry/index";
 import { tcHandler } from "../index";
@@ -15,7 +16,11 @@ const buildContext = (operands: PdfObject[]): OperatorHandlerContext => {
     OperandStack.push(operandStack, operand);
   }
   const graphicsStateStack = GraphicsStateStack.create();
-  return { operandStack, graphicsStateStack };
+  return {
+    operandStack,
+    graphicsStateStack,
+    markedContentStack: MarkedContentStack.create(),
+  };
 };
 
 test("'2 Tc' で charSpace が 2 に更新される", () => {
@@ -34,6 +39,7 @@ test("非0 の charSpace に '0 Tc' を適用すると 0 にリセットされ�
   const reset = tcHandler({
     operandStack: buildContext([{ type: "integer", value: 0 }]).operandStack,
     graphicsStateStack: first.value.graphicsStateStack,
+    markedContentStack: MarkedContentStack.create(),
   });
 
   assert(reset.ok);
@@ -73,6 +79,7 @@ test("charSpace 更新時、非デフォルト値の他フィールドは保持�
   const result = tcHandler({
     operandStack: buildContext([{ type: "integer", value: 3 }]).operandStack,
     graphicsStateStack,
+    markedContentStack: MarkedContentStack.create(),
   });
 
   assert(result.ok);

--- a/packages/core/src/content-stream/operators/text/tc/__tests__/tc.error.test.ts
+++ b/packages/core/src/content-stream/operators/text/tc/__tests__/tc.error.test.ts
@@ -1,6 +1,7 @@
 import { assert, expect, test } from "vitest";
 import type { PdfObject } from "../../../../../pdf/types/pdf-types/index";
 import { GraphicsStateStack } from "../../../../graphics-state/index";
+import { MarkedContentStack } from "../../../../marked-content/stack";
 import { OperandStack } from "../../../../operand-stack/index";
 import type { OperatorHandlerContext } from "../../../../operator-registry/index";
 import { tcHandler } from "../index";
@@ -11,7 +12,11 @@ const buildContext = (operands: PdfObject[]): OperatorHandlerContext => {
     OperandStack.push(operandStack, operand);
   }
   const graphicsStateStack = GraphicsStateStack.create();
-  return { operandStack, graphicsStateStack };
+  return {
+    operandStack,
+    graphicsStateStack,
+    markedContentStack: MarkedContentStack.create(),
+  };
 };
 
 test("operand が 0 個のとき OPERATOR_OPERAND_MISSING を返す", () => {

--- a/packages/core/src/content-stream/operators/text/tc/index.ts
+++ b/packages/core/src/content-stream/operators/text/tc/index.ts
@@ -65,5 +65,6 @@ export const tcHandler: OperatorHandler = (context: OperatorHandlerContext) => {
   return ok({
     operandStack: context.operandStack,
     graphicsStateStack,
+    markedContentStack: context.markedContentStack,
   });
 };

--- a/packages/core/src/content-stream/operators/text/td-leading/__tests__/td-leading.basic.test.ts
+++ b/packages/core/src/content-stream/operators/text/td-leading/__tests__/td-leading.basic.test.ts
@@ -6,6 +6,7 @@ import {
   Matrix,
   TextObject,
 } from "../../../../graphics-state/index";
+import { MarkedContentStack } from "../../../../marked-content/stack";
 import { OperandStack } from "../../../../operand-stack/index";
 import type { OperatorHandlerContext } from "../../../../operator-registry/index";
 import { tdLeadingHandler } from "../index";
@@ -27,7 +28,11 @@ const buildActiveContext = (
     GraphicsStateStack.create(),
     activeState,
   );
-  return { operandStack, graphicsStateStack };
+  return {
+    operandStack,
+    graphicsStateStack,
+    markedContentStack: MarkedContentStack.create(),
+  };
 };
 
 const int = (value: number): PdfObject => ({ type: "integer", value });

--- a/packages/core/src/content-stream/operators/text/td-leading/__tests__/td-leading.error.test.ts
+++ b/packages/core/src/content-stream/operators/text/td-leading/__tests__/td-leading.error.test.ts
@@ -5,6 +5,7 @@ import {
   GraphicsStateStack,
   TextObject,
 } from "../../../../graphics-state/index";
+import { MarkedContentStack } from "../../../../marked-content/stack";
 import { OperandStack } from "../../../../operand-stack/index";
 import type { OperatorHandlerContext } from "../../../../operator-registry/index";
 import { tdLeadingHandler } from "../index";
@@ -23,7 +24,11 @@ const buildActiveContext = (operands: PdfObject[]): OperatorHandlerContext => {
     GraphicsStateStack.create(),
     activeState,
   );
-  return { operandStack, graphicsStateStack };
+  return {
+    operandStack,
+    graphicsStateStack,
+    markedContentStack: MarkedContentStack.create(),
+  };
 };
 
 // inactive な context（active=false ガードテスト用。GraphicsStateStack.create() 既定）。
@@ -34,7 +39,11 @@ const buildInactiveContext = (
   for (const operand of operands) {
     OperandStack.push(operandStack, operand);
   }
-  return { operandStack, graphicsStateStack: GraphicsStateStack.create() };
+  return {
+    operandStack,
+    graphicsStateStack: GraphicsStateStack.create(),
+    markedContentStack: MarkedContentStack.create(),
+  };
 };
 
 const int = (value: number): PdfObject => ({ type: "integer", value });

--- a/packages/core/src/content-stream/operators/text/td-leading/index.ts
+++ b/packages/core/src/content-stream/operators/text/td-leading/index.ts
@@ -124,5 +124,6 @@ export const tdLeadingHandler: OperatorHandler = (
   return ok({
     operandStack: context.operandStack,
     graphicsStateStack,
+    markedContentStack: context.markedContentStack,
   });
 };

--- a/packages/core/src/content-stream/operators/text/td/__tests__/td.basic.test.ts
+++ b/packages/core/src/content-stream/operators/text/td/__tests__/td.basic.test.ts
@@ -6,6 +6,7 @@ import {
   Matrix,
   TextObject,
 } from "../../../../graphics-state/index";
+import { MarkedContentStack } from "../../../../marked-content/stack";
 import { OperandStack } from "../../../../operand-stack/index";
 import type { OperatorHandlerContext } from "../../../../operator-registry/index";
 import { tdHandler } from "../index";
@@ -27,7 +28,11 @@ const buildActiveContext = (
     GraphicsStateStack.create(),
     activeState,
   );
-  return { operandStack, graphicsStateStack };
+  return {
+    operandStack,
+    graphicsStateStack,
+    markedContentStack: MarkedContentStack.create(),
+  };
 };
 
 const int = (value: number): PdfObject => ({ type: "integer", value });

--- a/packages/core/src/content-stream/operators/text/td/__tests__/td.error.test.ts
+++ b/packages/core/src/content-stream/operators/text/td/__tests__/td.error.test.ts
@@ -5,6 +5,7 @@ import {
   GraphicsStateStack,
   TextObject,
 } from "../../../../graphics-state/index";
+import { MarkedContentStack } from "../../../../marked-content/stack";
 import { OperandStack } from "../../../../operand-stack/index";
 import type { OperatorHandlerContext } from "../../../../operator-registry/index";
 import { tdHandler } from "../index";
@@ -23,7 +24,11 @@ const buildActiveContext = (operands: PdfObject[]): OperatorHandlerContext => {
     GraphicsStateStack.create(),
     activeState,
   );
-  return { operandStack, graphicsStateStack };
+  return {
+    operandStack,
+    graphicsStateStack,
+    markedContentStack: MarkedContentStack.create(),
+  };
 };
 
 // inactive な context（active=false ガードテスト用。GraphicsStateStack.create() 既定）。
@@ -34,7 +39,11 @@ const buildInactiveContext = (
   for (const operand of operands) {
     OperandStack.push(operandStack, operand);
   }
-  return { operandStack, graphicsStateStack: GraphicsStateStack.create() };
+  return {
+    operandStack,
+    graphicsStateStack: GraphicsStateStack.create(),
+    markedContentStack: MarkedContentStack.create(),
+  };
 };
 
 const int = (value: number): PdfObject => ({ type: "integer", value });

--- a/packages/core/src/content-stream/operators/text/td/index.ts
+++ b/packages/core/src/content-stream/operators/text/td/index.ts
@@ -113,5 +113,6 @@ export const tdHandler: OperatorHandler = (context: OperatorHandlerContext) => {
   return ok({
     operandStack: context.operandStack,
     graphicsStateStack,
+    markedContentStack: context.markedContentStack,
   });
 };

--- a/packages/core/src/content-stream/operators/text/tf/__tests__/tf.basic.test.ts
+++ b/packages/core/src/content-stream/operators/text/tf/__tests__/tf.basic.test.ts
@@ -1,6 +1,7 @@
 import { assert, expect, test } from "vitest";
 import type { PdfObject } from "../../../../../pdf/types/pdf-types/index";
 import { GraphicsStateStack } from "../../../../graphics-state/index";
+import { MarkedContentStack } from "../../../../marked-content/stack";
 import { OperandStack } from "../../../../operand-stack/index";
 import type { OperatorHandlerContext } from "../../../../operator-registry/index";
 import { tfHandler } from "../index";
@@ -11,7 +12,11 @@ const buildContext = (operands: PdfObject[]): OperatorHandlerContext => {
     OperandStack.push(operandStack, operand);
   }
   const graphicsStateStack = GraphicsStateStack.create();
-  return { operandStack, graphicsStateStack };
+  return {
+    operandStack,
+    graphicsStateStack,
+    markedContentStack: MarkedContentStack.create(),
+  };
 };
 
 test("/F1 12 Tf で fontName=some('F1'), fontSize=12 に更新される", () => {

--- a/packages/core/src/content-stream/operators/text/tf/__tests__/tf.error.test.ts
+++ b/packages/core/src/content-stream/operators/text/tf/__tests__/tf.error.test.ts
@@ -1,6 +1,7 @@
 import { assert, expect, test } from "vitest";
 import type { PdfObject } from "../../../../../pdf/types/pdf-types/index";
 import { GraphicsStateStack } from "../../../../graphics-state/index";
+import { MarkedContentStack } from "../../../../marked-content/stack";
 import { OperandStack } from "../../../../operand-stack/index";
 import type { OperatorHandlerContext } from "../../../../operator-registry/index";
 import { tfHandler } from "../index";
@@ -11,7 +12,11 @@ const buildContext = (operands: PdfObject[]): OperatorHandlerContext => {
     OperandStack.push(operandStack, operand);
   }
   const graphicsStateStack = GraphicsStateStack.create();
-  return { operandStack, graphicsStateStack };
+  return {
+    operandStack,
+    graphicsStateStack,
+    markedContentStack: MarkedContentStack.create(),
+  };
 };
 
 test("operand 0 個では MISSING（required:2, actual:0）を返す", () => {

--- a/packages/core/src/content-stream/operators/text/tf/index.ts
+++ b/packages/core/src/content-stream/operators/text/tf/index.ts
@@ -94,5 +94,6 @@ export const tfHandler: OperatorHandler = (context: OperatorHandlerContext) => {
   return ok({
     operandStack: context.operandStack,
     graphicsStateStack,
+    markedContentStack: context.markedContentStack,
   });
 };

--- a/packages/core/src/content-stream/operators/text/tj-array/__tests__/tj-array.basic.test.ts
+++ b/packages/core/src/content-stream/operators/text/tj-array/__tests__/tj-array.basic.test.ts
@@ -9,6 +9,7 @@ import {
   TextObject,
   TextState,
 } from "../../../../graphics-state/index";
+import { MarkedContentStack } from "../../../../marked-content/stack";
 import { OperandStack } from "../../../../operand-stack/index";
 import type { OperatorHandlerContext } from "../../../../operator-registry/index";
 import { tjArrayHandler } from "../index";
@@ -41,7 +42,11 @@ const buildActiveContext = (
     GraphicsStateStack.create(),
     activeState,
   );
-  return { operandStack, graphicsStateStack };
+  return {
+    operandStack,
+    graphicsStateStack,
+    markedContentStack: MarkedContentStack.create(),
+  };
 };
 
 // "[(H) 40 (ello)] TJ" で textMatrix が水平方向に translate され、textLineMatrix は据え置きされる。

--- a/packages/core/src/content-stream/operators/text/tj-array/__tests__/tj-array.error.test.ts
+++ b/packages/core/src/content-stream/operators/text/tj-array/__tests__/tj-array.error.test.ts
@@ -9,6 +9,7 @@ import {
   TextObject,
   TextState,
 } from "../../../../graphics-state/index";
+import { MarkedContentStack } from "../../../../marked-content/stack";
 import { OperandStack } from "../../../../operand-stack/index";
 import type { OperatorHandlerContext } from "../../../../operator-registry/index";
 import { tjArrayHandler } from "../index";
@@ -40,7 +41,11 @@ const buildActiveContext = (
     GraphicsStateStack.create(),
     activeState,
   );
-  return { operandStack, graphicsStateStack };
+  return {
+    operandStack,
+    graphicsStateStack,
+    markedContentStack: MarkedContentStack.create(),
+  };
 };
 
 const buildInactiveContext = (
@@ -51,7 +56,11 @@ const buildInactiveContext = (
     OperandStack.push(operandStack, operand);
   }
   // textObject は initial（active === false）のまま。
-  return { operandStack, graphicsStateStack: GraphicsStateStack.create() };
+  return {
+    operandStack,
+    graphicsStateStack: GraphicsStateStack.create(),
+    markedContentStack: MarkedContentStack.create(),
+  };
 };
 
 // inactive 状態では OPERATOR_ILLEGAL_STATE を返し、stack は両方 (operand / graphics state) 不変。

--- a/packages/core/src/content-stream/operators/text/tj-array/index.ts
+++ b/packages/core/src/content-stream/operators/text/tj-array/index.ts
@@ -113,6 +113,7 @@ export const tjArrayHandler: OperatorHandler = (
     return ok({
       operandStack: context.operandStack,
       graphicsStateStack: context.graphicsStateStack,
+      markedContentStack: context.markedContentStack,
     });
   }
 
@@ -124,5 +125,6 @@ export const tjArrayHandler: OperatorHandler = (
   return ok({
     operandStack: context.operandStack,
     graphicsStateStack,
+    markedContentStack: context.markedContentStack,
   });
 };

--- a/packages/core/src/content-stream/operators/text/tj/__tests__/tj.basic.test.ts
+++ b/packages/core/src/content-stream/operators/text/tj/__tests__/tj.basic.test.ts
@@ -5,6 +5,7 @@ import {
   GraphicsStateStack,
   TextObject,
 } from "../../../../graphics-state/index";
+import { MarkedContentStack } from "../../../../marked-content/stack";
 import { OperandStack } from "../../../../operand-stack/index";
 import type { OperatorHandlerContext } from "../../../../operator-registry/index";
 import { tjHandler } from "../index";
@@ -24,7 +25,11 @@ const buildActiveContext = (operands: PdfObject[]): OperatorHandlerContext => {
     GraphicsStateStack.create(),
     activeState,
   );
-  return { operandStack, graphicsStateStack };
+  return {
+    operandStack,
+    graphicsStateStack,
+    markedContentStack: MarkedContentStack.create(),
+  };
 };
 
 const literalString = (bytes: number[]): PdfObject => ({

--- a/packages/core/src/content-stream/operators/text/tj/__tests__/tj.error.test.ts
+++ b/packages/core/src/content-stream/operators/text/tj/__tests__/tj.error.test.ts
@@ -5,6 +5,7 @@ import {
   GraphicsStateStack,
   TextObject,
 } from "../../../../graphics-state/index";
+import { MarkedContentStack } from "../../../../marked-content/stack";
 import { OperandStack } from "../../../../operand-stack/index";
 import type { OperatorHandlerContext } from "../../../../operator-registry/index";
 import { tjHandler } from "../index";
@@ -19,7 +20,11 @@ const buildInactiveContext = (
     OperandStack.push(operandStack, operand);
   }
   const graphicsStateStack = GraphicsStateStack.create();
-  return { operandStack, graphicsStateStack };
+  return {
+    operandStack,
+    graphicsStateStack,
+    markedContentStack: MarkedContentStack.create(),
+  };
 };
 
 // active な text object を持つ最小コンテキストを組むビルダ（pop / 型検査用）。
@@ -35,7 +40,11 @@ const buildActiveContext = (operands: PdfObject[]): OperatorHandlerContext => {
     GraphicsStateStack.create(),
     activeState,
   );
-  return { operandStack, graphicsStateStack };
+  return {
+    operandStack,
+    graphicsStateStack,
+    markedContentStack: MarkedContentStack.create(),
+  };
 };
 
 const literalString = (bytes: number[]): PdfObject => ({

--- a/packages/core/src/content-stream/operators/text/tj/index.ts
+++ b/packages/core/src/content-stream/operators/text/tj/index.ts
@@ -71,5 +71,6 @@ export const tjHandler: OperatorHandler = (context: OperatorHandlerContext) => {
   return ok({
     operandStack: context.operandStack,
     graphicsStateStack: context.graphicsStateStack,
+    markedContentStack: context.markedContentStack,
   });
 };

--- a/packages/core/src/content-stream/operators/text/tl/__tests__/tl.basic.test.ts
+++ b/packages/core/src/content-stream/operators/text/tl/__tests__/tl.basic.test.ts
@@ -5,6 +5,7 @@ import {
   GraphicsStateStack,
   TextState,
 } from "../../../../graphics-state/index";
+import { MarkedContentStack } from "../../../../marked-content/stack";
 import { OperandStack } from "../../../../operand-stack/index";
 import type { OperatorHandlerContext } from "../../../../operator-registry/index";
 import { tlHandler } from "../index";
@@ -15,7 +16,11 @@ const buildContext = (operands: PdfObject[]): OperatorHandlerContext => {
     OperandStack.push(operandStack, operand);
   }
   const graphicsStateStack = GraphicsStateStack.create();
-  return { operandStack, graphicsStateStack };
+  return {
+    operandStack,
+    graphicsStateStack,
+    markedContentStack: MarkedContentStack.create(),
+  };
 };
 
 test("'14 TL' で leading が 14 に更新される", () => {
@@ -34,6 +39,7 @@ test("非0 の leading に '0 TL' を適用すると 0 にリセットされる"
   const reset = tlHandler({
     operandStack: buildContext([{ type: "integer", value: 0 }]).operandStack,
     graphicsStateStack: first.value.graphicsStateStack,
+    markedContentStack: MarkedContentStack.create(),
   });
 
   assert(reset.ok);
@@ -73,6 +79,7 @@ test("leading 更新時、非デフォルト値の他フィールドは保持さ
   const result = tlHandler({
     operandStack: buildContext([{ type: "integer", value: 3 }]).operandStack,
     graphicsStateStack,
+    markedContentStack: MarkedContentStack.create(),
   });
 
   assert(result.ok);

--- a/packages/core/src/content-stream/operators/text/tl/__tests__/tl.error.test.ts
+++ b/packages/core/src/content-stream/operators/text/tl/__tests__/tl.error.test.ts
@@ -1,6 +1,7 @@
 import { assert, expect, test } from "vitest";
 import type { PdfObject } from "../../../../../pdf/types/pdf-types/index";
 import { GraphicsStateStack } from "../../../../graphics-state/index";
+import { MarkedContentStack } from "../../../../marked-content/stack";
 import { OperandStack } from "../../../../operand-stack/index";
 import type { OperatorHandlerContext } from "../../../../operator-registry/index";
 import { tlHandler } from "../index";
@@ -11,7 +12,11 @@ const buildContext = (operands: PdfObject[]): OperatorHandlerContext => {
     OperandStack.push(operandStack, operand);
   }
   const graphicsStateStack = GraphicsStateStack.create();
-  return { operandStack, graphicsStateStack };
+  return {
+    operandStack,
+    graphicsStateStack,
+    markedContentStack: MarkedContentStack.create(),
+  };
 };
 
 test("operand が 0 個のとき OPERATOR_OPERAND_MISSING を返す", () => {

--- a/packages/core/src/content-stream/operators/text/tl/index.ts
+++ b/packages/core/src/content-stream/operators/text/tl/index.ts
@@ -66,5 +66,6 @@ export const tlHandler: OperatorHandler = (context: OperatorHandlerContext) => {
   return ok({
     operandStack: context.operandStack,
     graphicsStateStack,
+    markedContentStack: context.markedContentStack,
   });
 };

--- a/packages/core/src/content-stream/operators/text/tm/__tests__/tm.basic.test.ts
+++ b/packages/core/src/content-stream/operators/text/tm/__tests__/tm.basic.test.ts
@@ -6,6 +6,7 @@ import {
   Matrix,
   TextObject,
 } from "../../../../graphics-state/index";
+import { MarkedContentStack } from "../../../../marked-content/stack";
 import { OperandStack } from "../../../../operand-stack/index";
 import type { OperatorHandlerContext } from "../../../../operator-registry/index";
 import { tmHandler } from "../index";
@@ -27,7 +28,11 @@ const buildActiveContext = (
     GraphicsStateStack.create(),
     activeState,
   );
-  return { operandStack, graphicsStateStack };
+  return {
+    operandStack,
+    graphicsStateStack,
+    markedContentStack: MarkedContentStack.create(),
+  };
 };
 
 const int = (value: number): PdfObject => ({ type: "integer", value });

--- a/packages/core/src/content-stream/operators/text/tm/__tests__/tm.error.test.ts
+++ b/packages/core/src/content-stream/operators/text/tm/__tests__/tm.error.test.ts
@@ -5,6 +5,7 @@ import {
   GraphicsStateStack,
   TextObject,
 } from "../../../../graphics-state/index";
+import { MarkedContentStack } from "../../../../marked-content/stack";
 import { OperandStack } from "../../../../operand-stack/index";
 import type { OperatorHandlerContext } from "../../../../operator-registry/index";
 import { tmHandler } from "../index";
@@ -23,7 +24,11 @@ const buildActiveContext = (operands: PdfObject[]): OperatorHandlerContext => {
     GraphicsStateStack.create(),
     activeState,
   );
-  return { operandStack, graphicsStateStack };
+  return {
+    operandStack,
+    graphicsStateStack,
+    markedContentStack: MarkedContentStack.create(),
+  };
 };
 
 // inactive な context（active=false ガードテスト用。GraphicsStateStack.create() 既定）。
@@ -34,7 +39,11 @@ const buildInactiveContext = (
   for (const operand of operands) {
     OperandStack.push(operandStack, operand);
   }
-  return { operandStack, graphicsStateStack: GraphicsStateStack.create() };
+  return {
+    operandStack,
+    graphicsStateStack: GraphicsStateStack.create(),
+    markedContentStack: MarkedContentStack.create(),
+  };
 };
 
 const int = (value: number): PdfObject => ({ type: "integer", value });

--- a/packages/core/src/content-stream/operators/text/tm/index.ts
+++ b/packages/core/src/content-stream/operators/text/tm/index.ts
@@ -102,5 +102,6 @@ export const tmHandler: OperatorHandler = (context: OperatorHandlerContext) => {
   return ok({
     operandStack: context.operandStack,
     graphicsStateStack,
+    markedContentStack: context.markedContentStack,
   });
 };

--- a/packages/core/src/content-stream/operators/text/tr/__tests__/tr.basic.test.ts
+++ b/packages/core/src/content-stream/operators/text/tr/__tests__/tr.basic.test.ts
@@ -6,6 +6,7 @@ import {
   TextRenderingMode,
   TextState,
 } from "../../../../graphics-state/index";
+import { MarkedContentStack } from "../../../../marked-content/stack";
 import { OperandStack } from "../../../../operand-stack/index";
 import type { OperatorHandlerContext } from "../../../../operator-registry/index";
 import { trHandler } from "../index";
@@ -16,7 +17,11 @@ const buildContext = (operands: PdfObject[]): OperatorHandlerContext => {
     OperandStack.push(operandStack, operand);
   }
   const graphicsStateStack = GraphicsStateStack.create();
-  return { operandStack, graphicsStateStack };
+  return {
+    operandStack,
+    graphicsStateStack,
+    markedContentStack: MarkedContentStack.create(),
+  };
 };
 
 test.each([
@@ -49,6 +54,7 @@ test("renderingMode 更新時、非デフォルト値の他フィールドは保
   const result = trHandler({
     operandStack: buildContext([{ type: "integer", value: 2 }]).operandStack,
     graphicsStateStack,
+    markedContentStack: MarkedContentStack.create(),
   });
 
   assert(result.ok);

--- a/packages/core/src/content-stream/operators/text/tr/__tests__/tr.error.test.ts
+++ b/packages/core/src/content-stream/operators/text/tr/__tests__/tr.error.test.ts
@@ -6,6 +6,7 @@ import {
   TextRenderingMode,
   TextState,
 } from "../../../../graphics-state/index";
+import { MarkedContentStack } from "../../../../marked-content/stack";
 import { OperandStack } from "../../../../operand-stack/index";
 import type { OperatorHandlerContext } from "../../../../operator-registry/index";
 import { trHandler } from "../index";
@@ -16,7 +17,11 @@ const buildContext = (operands: PdfObject[]): OperatorHandlerContext => {
     OperandStack.push(operandStack, operand);
   }
   const graphicsStateStack = GraphicsStateStack.create();
-  return { operandStack, graphicsStateStack };
+  return {
+    operandStack,
+    graphicsStateStack,
+    markedContentStack: MarkedContentStack.create(),
+  };
 };
 
 test("operand が 0 個のとき OPERATOR_OPERAND_MISSING を返す", () => {
@@ -140,7 +145,11 @@ const seedFillStroke = (): OperatorHandlerContext => {
     stack,
     GraphicsState.update(current, { textState }),
   );
-  return { operandStack: OperandStack.create(), graphicsStateStack };
+  return {
+    operandStack: OperandStack.create(),
+    graphicsStateStack,
+    markedContentStack: MarkedContentStack.create(),
+  };
 };
 
 test.each<[string, PdfObject, string]>([

--- a/packages/core/src/content-stream/operators/text/tr/index.ts
+++ b/packages/core/src/content-stream/operators/text/tr/index.ts
@@ -80,5 +80,6 @@ export const trHandler: OperatorHandler = (context: OperatorHandlerContext) => {
   return ok({
     operandStack: context.operandStack,
     graphicsStateStack,
+    markedContentStack: context.markedContentStack,
   });
 };

--- a/packages/core/src/content-stream/operators/text/ts/__tests__/ts.basic.test.ts
+++ b/packages/core/src/content-stream/operators/text/ts/__tests__/ts.basic.test.ts
@@ -5,6 +5,7 @@ import {
   GraphicsStateStack,
   TextState,
 } from "../../../../graphics-state/index";
+import { MarkedContentStack } from "../../../../marked-content/stack";
 import { OperandStack } from "../../../../operand-stack/index";
 import type { OperatorHandlerContext } from "../../../../operator-registry/index";
 import { tsHandler } from "../index";
@@ -15,7 +16,11 @@ const buildContext = (operands: PdfObject[]): OperatorHandlerContext => {
     OperandStack.push(operandStack, operand);
   }
   const graphicsStateStack = GraphicsStateStack.create();
-  return { operandStack, graphicsStateStack };
+  return {
+    operandStack,
+    graphicsStateStack,
+    markedContentStack: MarkedContentStack.create(),
+  };
 };
 
 test("正値 '3 Ts' で rise が 3 に更新される", () => {
@@ -43,6 +48,7 @@ test("非0 の rise に '0 Ts' を適用すると 0 にリセットされる", (
   const reset = tsHandler({
     operandStack: buildContext([{ type: "integer", value: 0 }]).operandStack,
     graphicsStateStack: first.value.graphicsStateStack,
+    markedContentStack: MarkedContentStack.create(),
   });
 
   assert(reset.ok);
@@ -90,6 +96,7 @@ test("rise 更新時、非デフォルト値の他フィールドは保持され
   const result = tsHandler({
     operandStack: buildContext([{ type: "integer", value: 3 }]).operandStack,
     graphicsStateStack,
+    markedContentStack: MarkedContentStack.create(),
   });
 
   assert(result.ok);

--- a/packages/core/src/content-stream/operators/text/ts/__tests__/ts.error.test.ts
+++ b/packages/core/src/content-stream/operators/text/ts/__tests__/ts.error.test.ts
@@ -1,6 +1,7 @@
 import { assert, expect, test } from "vitest";
 import type { PdfObject } from "../../../../../pdf/types/pdf-types/index";
 import { GraphicsStateStack } from "../../../../graphics-state/index";
+import { MarkedContentStack } from "../../../../marked-content/stack";
 import { OperandStack } from "../../../../operand-stack/index";
 import type { OperatorHandlerContext } from "../../../../operator-registry/index";
 import { tsHandler } from "../index";
@@ -11,7 +12,11 @@ const buildContext = (operands: PdfObject[]): OperatorHandlerContext => {
     OperandStack.push(operandStack, operand);
   }
   const graphicsStateStack = GraphicsStateStack.create();
-  return { operandStack, graphicsStateStack };
+  return {
+    operandStack,
+    graphicsStateStack,
+    markedContentStack: MarkedContentStack.create(),
+  };
 };
 
 test("operand が 0 個のとき OPERATOR_OPERAND_MISSING を返す", () => {

--- a/packages/core/src/content-stream/operators/text/ts/index.ts
+++ b/packages/core/src/content-stream/operators/text/ts/index.ts
@@ -68,5 +68,6 @@ export const tsHandler: OperatorHandler = (context: OperatorHandlerContext) => {
   return ok({
     operandStack: context.operandStack,
     graphicsStateStack,
+    markedContentStack: context.markedContentStack,
   });
 };

--- a/packages/core/src/content-stream/operators/text/tw/__tests__/tw.basic.test.ts
+++ b/packages/core/src/content-stream/operators/text/tw/__tests__/tw.basic.test.ts
@@ -5,6 +5,7 @@ import {
   GraphicsStateStack,
   TextState,
 } from "../../../../graphics-state/index";
+import { MarkedContentStack } from "../../../../marked-content/stack";
 import { OperandStack } from "../../../../operand-stack/index";
 import type { OperatorHandlerContext } from "../../../../operator-registry/index";
 import { twHandler } from "../index";
@@ -15,7 +16,11 @@ const buildContext = (operands: PdfObject[]): OperatorHandlerContext => {
     OperandStack.push(operandStack, operand);
   }
   const graphicsStateStack = GraphicsStateStack.create();
-  return { operandStack, graphicsStateStack };
+  return {
+    operandStack,
+    graphicsStateStack,
+    markedContentStack: MarkedContentStack.create(),
+  };
 };
 
 test("'5 Tw' で wordSpace が 5 に更新される", () => {
@@ -34,6 +39,7 @@ test("非0 の wordSpace に '0 Tw' を適用すると 0 にリセットされ�
   const reset = twHandler({
     operandStack: buildContext([{ type: "integer", value: 0 }]).operandStack,
     graphicsStateStack: first.value.graphicsStateStack,
+    markedContentStack: MarkedContentStack.create(),
   });
 
   assert(reset.ok);
@@ -73,6 +79,7 @@ test("wordSpace 更新時、非デフォルト値の他フィールドは保持�
   const result = twHandler({
     operandStack: buildContext([{ type: "integer", value: 5 }]).operandStack,
     graphicsStateStack,
+    markedContentStack: MarkedContentStack.create(),
   });
 
   assert(result.ok);

--- a/packages/core/src/content-stream/operators/text/tw/__tests__/tw.error.test.ts
+++ b/packages/core/src/content-stream/operators/text/tw/__tests__/tw.error.test.ts
@@ -1,6 +1,7 @@
 import { assert, expect, test } from "vitest";
 import type { PdfObject } from "../../../../../pdf/types/pdf-types/index";
 import { GraphicsStateStack } from "../../../../graphics-state/index";
+import { MarkedContentStack } from "../../../../marked-content/stack";
 import { OperandStack } from "../../../../operand-stack/index";
 import type { OperatorHandlerContext } from "../../../../operator-registry/index";
 import { twHandler } from "../index";
@@ -11,7 +12,11 @@ const buildContext = (operands: PdfObject[]): OperatorHandlerContext => {
     OperandStack.push(operandStack, operand);
   }
   const graphicsStateStack = GraphicsStateStack.create();
-  return { operandStack, graphicsStateStack };
+  return {
+    operandStack,
+    graphicsStateStack,
+    markedContentStack: MarkedContentStack.create(),
+  };
 };
 
 test("operand が 0 個のとき OPERATOR_OPERAND_MISSING を返す", () => {

--- a/packages/core/src/content-stream/operators/text/tw/index.ts
+++ b/packages/core/src/content-stream/operators/text/tw/index.ts
@@ -65,5 +65,6 @@ export const twHandler: OperatorHandler = (context: OperatorHandlerContext) => {
   return ok({
     operandStack: context.operandStack,
     graphicsStateStack,
+    markedContentStack: context.markedContentStack,
   });
 };

--- a/packages/core/src/content-stream/operators/text/tz/__tests__/tz.basic.test.ts
+++ b/packages/core/src/content-stream/operators/text/tz/__tests__/tz.basic.test.ts
@@ -5,6 +5,7 @@ import {
   GraphicsStateStack,
   TextState,
 } from "../../../../graphics-state/index";
+import { MarkedContentStack } from "../../../../marked-content/stack";
 import { OperandStack } from "../../../../operand-stack/index";
 import type { OperatorHandlerContext } from "../../../../operator-registry/index";
 import { tzHandler } from "../index";
@@ -15,7 +16,11 @@ const buildContext = (operands: PdfObject[]): OperatorHandlerContext => {
     OperandStack.push(operandStack, operand);
   }
   const graphicsStateStack = GraphicsStateStack.create();
-  return { operandStack, graphicsStateStack };
+  return {
+    operandStack,
+    graphicsStateStack,
+    markedContentStack: MarkedContentStack.create(),
+  };
 };
 
 test("'150 Tz' で horizontalScaling が 150 に更新される", () => {
@@ -76,6 +81,7 @@ test("horizontalScaling 更新時、非デフォルト値の他フィールド�
   const result = tzHandler({
     operandStack: buildContext([{ type: "integer", value: 150 }]).operandStack,
     graphicsStateStack,
+    markedContentStack: MarkedContentStack.create(),
   });
 
   assert(result.ok);

--- a/packages/core/src/content-stream/operators/text/tz/__tests__/tz.error.test.ts
+++ b/packages/core/src/content-stream/operators/text/tz/__tests__/tz.error.test.ts
@@ -1,6 +1,7 @@
 import { assert, expect, test } from "vitest";
 import type { PdfObject } from "../../../../../pdf/types/pdf-types/index";
 import { GraphicsStateStack } from "../../../../graphics-state/index";
+import { MarkedContentStack } from "../../../../marked-content/stack";
 import { OperandStack } from "../../../../operand-stack/index";
 import type { OperatorHandlerContext } from "../../../../operator-registry/index";
 import { tzHandler } from "../index";
@@ -11,7 +12,11 @@ const buildContext = (operands: PdfObject[]): OperatorHandlerContext => {
     OperandStack.push(operandStack, operand);
   }
   const graphicsStateStack = GraphicsStateStack.create();
-  return { operandStack, graphicsStateStack };
+  return {
+    operandStack,
+    graphicsStateStack,
+    markedContentStack: MarkedContentStack.create(),
+  };
 };
 
 test("operand が 0 個のとき OPERATOR_OPERAND_MISSING を返す", () => {

--- a/packages/core/src/content-stream/operators/text/tz/index.ts
+++ b/packages/core/src/content-stream/operators/text/tz/index.ts
@@ -67,5 +67,6 @@ export const tzHandler: OperatorHandler = (context: OperatorHandlerContext) => {
   return ok({
     operandStack: context.operandStack,
     graphicsStateStack,
+    markedContentStack: context.markedContentStack,
   });
 };

--- a/packages/core/src/content-stream/operators/xobject/do/__tests__/do.basic.test.ts
+++ b/packages/core/src/content-stream/operators/xobject/do/__tests__/do.basic.test.ts
@@ -5,6 +5,7 @@ import {
   GraphicsStateStack,
   TextObject,
 } from "../../../../graphics-state/index";
+import { MarkedContentStack } from "../../../../marked-content/stack";
 import { OperandStack } from "../../../../operand-stack/index";
 import type { OperatorHandlerContext } from "../../../../operator-registry/index";
 import { doHandler } from "../index";
@@ -16,7 +17,11 @@ const buildContext = (operands: PdfObject[]): OperatorHandlerContext => {
     OperandStack.push(operandStack, operand);
   }
   const graphicsStateStack = GraphicsStateStack.create();
-  return { operandStack, graphicsStateStack };
+  return {
+    operandStack,
+    graphicsStateStack,
+    markedContentStack: MarkedContentStack.create(),
+  };
 };
 
 // active な textObject（BT 後相当）に差し替えてビルド
@@ -32,7 +37,11 @@ const buildActiveContext = (operands: PdfObject[]): OperatorHandlerContext => {
     GraphicsStateStack.create(),
     activeState,
   );
-  return { operandStack, graphicsStateStack };
+  return {
+    operandStack,
+    graphicsStateStack,
+    markedContentStack: MarkedContentStack.create(),
+  };
 };
 
 test("name { type: 'name', value: 'Im1' } を受理し ok を返す", () => {

--- a/packages/core/src/content-stream/operators/xobject/do/__tests__/do.error.test.ts
+++ b/packages/core/src/content-stream/operators/xobject/do/__tests__/do.error.test.ts
@@ -1,6 +1,7 @@
 import { assert, expect, test } from "vitest";
 import type { PdfObject } from "../../../../../pdf/types/pdf-types/index";
 import { GraphicsStateStack } from "../../../../graphics-state/index";
+import { MarkedContentStack } from "../../../../marked-content/stack";
 import { OperandStack } from "../../../../operand-stack/index";
 import type { OperatorHandlerContext } from "../../../../operator-registry/index";
 import { doHandler } from "../index";
@@ -11,7 +12,11 @@ const buildContext = (operands: PdfObject[]): OperatorHandlerContext => {
     OperandStack.push(operandStack, operand);
   }
   const graphicsStateStack = GraphicsStateStack.create();
-  return { operandStack, graphicsStateStack };
+  return {
+    operandStack,
+    graphicsStateStack,
+    markedContentStack: MarkedContentStack.create(),
+  };
 };
 
 const NON_NAME_CASES: ReadonlyArray<[string, PdfObject]> = [

--- a/packages/core/src/content-stream/operators/xobject/do/index.ts
+++ b/packages/core/src/content-stream/operators/xobject/do/index.ts
@@ -59,5 +59,6 @@ export const doHandler: OperatorHandler = (context: OperatorHandlerContext) => {
   return ok({
     operandStack: context.operandStack,
     graphicsStateStack: context.graphicsStateStack,
+    markedContentStack: context.markedContentStack,
   });
 };

--- a/packages/core/src/content-stream/operators/xobject/xobject-operators/__tests__/xobject-operators.integration.test.ts
+++ b/packages/core/src/content-stream/operators/xobject/xobject-operators/__tests__/xobject-operators.integration.test.ts
@@ -3,7 +3,6 @@ import { flatMap, ok } from "../../../../../utils/result/index";
 import { GraphicsStateStack } from "../../../../graphics-state/index";
 import type { ContentStreamInterpreterResult } from "../../../../interpreter/index";
 import { ContentStreamInterpreter } from "../../../../interpreter/index";
-import { MarkedContentStack } from "../../../../marked-content/stack";
 import { OperandStack } from "../../../../operand-stack/index";
 import type {
   OperatorHandler,
@@ -23,14 +22,12 @@ const qHandler: OperatorHandler = (context) =>
   ok({
     ...context,
     graphicsStateStack: GraphicsStateStack.save(context.graphicsStateStack),
-    markedContentStack: MarkedContentStack.create(),
   });
 
 const qRestoreHandler: OperatorHandler = (context) =>
   ok({
     ...context,
     graphicsStateStack: GraphicsStateStack.restore(context.graphicsStateStack),
-    markedContentStack: MarkedContentStack.create(),
   });
 
 // XObject + text-state + graphics-state (cm/w/J/j/M) + inline q/Q を併用登録した registry を作るヘルパ。

--- a/packages/core/src/content-stream/operators/xobject/xobject-operators/__tests__/xobject-operators.integration.test.ts
+++ b/packages/core/src/content-stream/operators/xobject/xobject-operators/__tests__/xobject-operators.integration.test.ts
@@ -3,6 +3,7 @@ import { flatMap, ok } from "../../../../../utils/result/index";
 import { GraphicsStateStack } from "../../../../graphics-state/index";
 import type { ContentStreamInterpreterResult } from "../../../../interpreter/index";
 import { ContentStreamInterpreter } from "../../../../interpreter/index";
+import { MarkedContentStack } from "../../../../marked-content/stack";
 import { OperandStack } from "../../../../operand-stack/index";
 import type {
   OperatorHandler,
@@ -22,12 +23,14 @@ const qHandler: OperatorHandler = (context) =>
   ok({
     ...context,
     graphicsStateStack: GraphicsStateStack.save(context.graphicsStateStack),
+    markedContentStack: MarkedContentStack.create(),
   });
 
 const qRestoreHandler: OperatorHandler = (context) =>
   ok({
     ...context,
     graphicsStateStack: GraphicsStateStack.restore(context.graphicsStateStack),
+    markedContentStack: MarkedContentStack.create(),
   });
 
 // XObject + text-state + graphics-state (cm/w/J/j/M) + inline q/Q を併用登録した registry を作るヘルパ。

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -14,6 +14,8 @@ export type {
   ContentStreamInterpreterResult,
 } from "./content-stream/interpreter/index";
 export { ContentStreamInterpreter } from "./content-stream/interpreter/index";
+export type { MarkedContentEntry } from "./content-stream/marked-content/index";
+export { MarkedContentStack } from "./content-stream/marked-content/index";
 export { OperandStack } from "./content-stream/operand-stack/index";
 export type {
   OperatorHandler,


### PR DESCRIPTION
## 概要

content stream の marked content 階層 (`MarkedContentStack`) を `OperatorHandlerContext` に統合する。前 PR #491 で導入した `MarkedContentStack` を context の必須フィールドとして配線し、`createInitialContext` で空 stack を生成、既存の全 operator handler がこの stack を透過的に引き継ぐようにする。

BMC / BDC / EMC の各 handler 実装は後続 PR で扱うため、本 PR は **context への統合と全 handler の透過配線** までをスコープとする。

## 変更内容

### 🎯 変更の種類

- [x] ✨ 新機能 (New feature)
- [x] ♻️ リファクタリング (Refactoring)
- [x] 🚨 テスト追加/修正 (Tests)

### 📝 詳細な変更内容

#### 追加された機能・修正

- `OperatorHandlerContext` に `markedContentStack: MarkedContentStack` を必須フィールドとして追加 (`operator-registry/index.ts`)
- `ContentStreamInterpreter.createInitialContext` で `MarkedContentStack.create()` を生成し初期 context に含める (`interpreter/index.ts`)
- color (gray/rgb/cmyk) / graphics-state (cm・line 系) / path (m/l/c/h/re/fill/stroke/fill-stroke) / text (Tj/TJ/BT/ET ほか) / xobject (Do) / inline-image の全 handler が返す context に `markedContentStack` を透過的に引き継ぐよう更新
- 新規テスト: 初期 context の空 stack・execute ごとの別インスタンス・外部注入 stack の透過を検証 (`interpreter.marked-content-stack.test.ts`)、`MarkedContentStack.create()` の factory 契約を検証 (`stack.basic.test.ts`)
- テストルール(条件分岐禁止)準拠のため、既存 stack テストの Option ナローイングを `if (!x.some) throw` から `assert(x.some)` へ置換

#### 変更されたファイル

- `packages/core/src/content-stream/operator-registry/index.ts` — 型に `markedContentStack` 追加
- `packages/core/src/content-stream/interpreter/index.ts` — `createInitialContext` で空 stack 生成
- 各 operator handler の `index.ts` / `fill.ts` / `stroke.ts` — context に `markedContentStack` を透過
- 各 handler の `__tests__` — 型必須化に追従し context を同期

## 📊 システム図

```mermaid
flowchart TD
    Execute[ContentStreamInterpreter.execute] --> Init["createInitialContext"]
    Init -->|"markedContentStack: MarkedContentStack.create()"| Ctx[OperatorHandlerContext]
    Ctx --> Handler["各 operator handler"]
    Handler -->|"markedContentStack を透過して次 context へ"| Ctx

    style Init fill:#ffe4b5,stroke:#d97706,stroke-width:2px
    style Ctx fill:#ffe4b5,stroke:#d97706,stroke-width:2px
```

## 📋 関連 Issue

- Refs #480

BMC / EMC handler 実装は本 PR のスコープ外のため `Closes` ではなく参照のみとする。

## 🧪 テスト

### テスト実行方法

```bash
pnpm --filter @pdfmod/core test
```

### テスト項目

- [x] 単体テスト (Unit tests)
- [x] 統合テスト (Integration tests)

### テスト結果

- `pnpm --filter @pdfmod/core test` — 238 ファイル / 2945 件パス
- `tsc --noEmit` — エラーなし
- `pnpm lint` (biome + oxlint) — 0 warnings / 0 errors

## 🔍 レビューポイント

- `markedContentStack` を必須フィールドにしたことで、全 handler・全 handler テストへ機械的な追従が広範に及んでいる点（透過漏れがないか）
- `stack.basic.test.ts` の `if throw` → `assert` 置換がテストの意図を変えていないか

## ⚠️ 破壊的変更

- [x] この変更は既存の API に破壊的変更を含みます

### 破壊的変更の詳細

`OperatorHandlerContext` に必須フィールド `markedContentStack` を追加したため、この型を直接組み立てる呼び出し側は `markedContentStack` の指定が必要になる。リポジトリ内の該当箇所（handler テスト等）は本 PR で追従済み。