### PR TITLE
✨ [New Feature]: #480 bmcHandler を新規実装 (BMC marked content operator handler)

### DIFF
--- a/packages/core/src/content-stream/operators/marked-content/bmc/__tests__/bmc.basic.test.ts
+++ b/packages/core/src/content-stream/operators/marked-content/bmc/__tests__/bmc.basic.test.ts
@@ -1,0 +1,155 @@
+import { assert, expect, test } from "vitest";
+import type {
+  PdfName,
+  PdfObject,
+} from "../../../../../pdf/types/pdf-types/index";
+import { none } from "../../../../../utils/option/index";
+import { GraphicsStateStack } from "../../../../graphics-state/index";
+import type { MarkedContentEntry } from "../../../../marked-content/stack";
+import { MarkedContentStack } from "../../../../marked-content/stack";
+import { OperandStack } from "../../../../operand-stack/index";
+import type { OperatorHandlerContext } from "../../../../operator-registry/index";
+import { bmcHandler } from "../index";
+
+const buildContext = (operands: PdfObject[]): OperatorHandlerContext => {
+  const operandStack = OperandStack.create();
+  for (const operand of operands) {
+    OperandStack.push(operandStack, operand);
+  }
+  return {
+    operandStack,
+    graphicsStateStack: GraphicsStateStack.create(),
+    markedContentStack: MarkedContentStack.create(),
+  };
+};
+
+// markedContentStack を depth=1 の非空状態にして組み立てる（ネスト push 検証用）
+const buildNestedContext = (
+  operands: PdfObject[],
+  seededTag: PdfName,
+): OperatorHandlerContext => {
+  const operandStack = OperandStack.create();
+  for (const operand of operands) {
+    OperandStack.push(operandStack, operand);
+  }
+  const seededEntry: MarkedContentEntry = { tag: seededTag, properties: none };
+  return {
+    operandStack,
+    graphicsStateStack: GraphicsStateStack.create(),
+    markedContentStack: MarkedContentStack.push(
+      MarkedContentStack.create(),
+      seededEntry,
+    ),
+  };
+};
+
+test("name { type: 'name', value: 'Span' } を受理し ok を返す", () => {
+  const ctx = buildContext([{ type: "name", value: "Span" }]);
+
+  const result = bmcHandler(ctx);
+
+  assert(result.ok);
+});
+
+test("成功時に markedContentStack は入力と別参照で返る", () => {
+  const ctx = buildContext([{ type: "name", value: "Span" }]);
+
+  const result = bmcHandler(ctx);
+
+  assert(result.ok);
+  expect(result.value.markedContentStack).not.toBe(ctx.markedContentStack);
+});
+
+test("成功時に markedContentStack の depth が 0 → 1 になる", () => {
+  const ctx = buildContext([{ type: "name", value: "Span" }]);
+
+  const result = bmcHandler(ctx);
+
+  assert(result.ok);
+  expect(MarkedContentStack.depth(result.value.markedContentStack)).toBe(1);
+});
+
+test("成功後も入力 ctx.markedContentStack は非破壊で depth=0 のまま", () => {
+  const ctx = buildContext([{ type: "name", value: "Span" }]);
+
+  const result = bmcHandler(ctx);
+
+  assert(result.ok);
+  expect(MarkedContentStack.depth(ctx.markedContentStack)).toBe(0);
+});
+
+test("push された entry の tag は pop した Name と一致し properties は none", () => {
+  const tag: PdfName = { type: "name", value: "Span" };
+  const ctx = buildContext([tag]);
+
+  const result = bmcHandler(ctx);
+
+  assert(result.ok);
+  const popped = MarkedContentStack.pop(result.value.markedContentStack);
+  assert(popped.some);
+  expect(popped.value.popped.tag).toEqual(tag);
+  expect(popped.value.popped.properties.some).toBe(false);
+});
+
+test("成功時に operandStack は入力と同一参照で返る（in-place mutate）", () => {
+  const ctx = buildContext([{ type: "name", value: "Span" }]);
+
+  const result = bmcHandler(ctx);
+
+  assert(result.ok);
+  expect(result.value.operandStack).toBe(ctx.operandStack);
+});
+
+test("成功時に operand が 1 個消費され operandStack の depth=0 になる", () => {
+  const ctx = buildContext([{ type: "name", value: "Span" }]);
+
+  const result = bmcHandler(ctx);
+
+  assert(result.ok);
+  expect(OperandStack.depth(result.value.operandStack)).toBe(0);
+});
+
+test("余剰 operand があるとき末尾 1 個のみ消費する（depth=3 → depth=2）", () => {
+  const surplus0: PdfObject = { type: "integer", value: 1 };
+  const surplus1: PdfObject = { type: "integer", value: 2 };
+  const ctx = buildContext([
+    surplus0,
+    surplus1,
+    { type: "name", value: "Span" },
+  ]);
+
+  const result = bmcHandler(ctx);
+
+  assert(result.ok);
+  expect(OperandStack.depth(result.value.operandStack)).toBe(2);
+  const top = OperandStack.peek(result.value.operandStack);
+  assert(top.some);
+  expect(top.value).toEqual(surplus1);
+});
+
+test("成功時に graphicsStateStack は入力と同一参照で返る", () => {
+  const ctx = buildContext([{ type: "name", value: "Span" }]);
+
+  const result = bmcHandler(ctx);
+
+  assert(result.ok);
+  expect(result.value.graphicsStateStack).toBe(ctx.graphicsStateStack);
+});
+
+test("既存の非空 stack（depth=1）へネスト push すると depth=2 になる", () => {
+  const seededTag: PdfName = { type: "name", value: "Artifact" };
+  const ctx = buildNestedContext([{ type: "name", value: "Span" }], seededTag);
+
+  const result = bmcHandler(ctx);
+
+  assert(result.ok);
+  expect(MarkedContentStack.depth(result.value.markedContentStack)).toBe(2);
+});
+
+test("name 値が空文字 ('') でも受理する（値域検証なし pin down）", () => {
+  const ctx = buildContext([{ type: "name", value: "" }]);
+
+  const result = bmcHandler(ctx);
+
+  assert(result.ok);
+});

--- a/packages/core/src/content-stream/operators/marked-content/bmc/__tests__/bmc.error.test.ts
+++ b/packages/core/src/content-stream/operators/marked-content/bmc/__tests__/bmc.error.test.ts
@@ -1,0 +1,144 @@
+import { assert, expect, test } from "vitest";
+import type {
+  PdfName,
+  PdfObject,
+} from "../../../../../pdf/types/pdf-types/index";
+import { none } from "../../../../../utils/option/index";
+import { GraphicsStateStack } from "../../../../graphics-state/index";
+import type { MarkedContentEntry } from "../../../../marked-content/stack";
+import { MarkedContentStack } from "../../../../marked-content/stack";
+import { OperandStack } from "../../../../operand-stack/index";
+import type { OperatorHandlerContext } from "../../../../operator-registry/index";
+import { bmcHandler } from "../index";
+
+const buildContext = (operands: PdfObject[]): OperatorHandlerContext => {
+  const operandStack = OperandStack.create();
+  for (const operand of operands) {
+    OperandStack.push(operandStack, operand);
+  }
+  return {
+    operandStack,
+    graphicsStateStack: GraphicsStateStack.create(),
+    markedContentStack: MarkedContentStack.create(),
+  };
+};
+
+// markedContentStack を depth=1 の非空状態にして組み立てる（MISSING 時の不変性検証用）
+const buildSeededContext = (
+  operands: PdfObject[],
+  seededTag: PdfName,
+): OperatorHandlerContext => {
+  const operandStack = OperandStack.create();
+  for (const operand of operands) {
+    OperandStack.push(operandStack, operand);
+  }
+  const seededEntry: MarkedContentEntry = { tag: seededTag, properties: none };
+  return {
+    operandStack,
+    graphicsStateStack: GraphicsStateStack.create(),
+    markedContentStack: MarkedContentStack.push(
+      MarkedContentStack.create(),
+      seededEntry,
+    ),
+  };
+};
+
+const NON_NAME_CASES: ReadonlyArray<[string, PdfObject]> = [
+  ["integer", { type: "integer", value: 42 }],
+  ["real", { type: "real", value: 3.14 }],
+  ["string", { type: "string", value: new Uint8Array(), encoding: "literal" }],
+  ["boolean", { type: "boolean", value: true }],
+  ["null", { type: "null" }],
+  ["array", { type: "array", elements: [] }],
+  ["dictionary", { type: "dictionary", entries: new Map() }],
+  [
+    "indirect-ref",
+    { type: "indirect-ref", objectNumber: 1, generationNumber: 0 },
+  ],
+  [
+    "stream",
+    {
+      type: "stream",
+      dictionary: { type: "dictionary", entries: new Map() },
+      data: new Uint8Array(),
+    },
+  ],
+];
+
+test("operand 0 個のとき MISSING を返す（required:1, actual:0, operatorName:'BMC'）", () => {
+  const ctx = buildContext([]);
+
+  const result = bmcHandler(ctx);
+
+  assert(!result.ok);
+  assert(result.error.code === "OPERATOR_OPERAND_MISSING");
+  expect(result.error.operatorName).toBe("BMC");
+  expect(result.error.required).toBe(1);
+  expect(result.error.actual).toBe(0);
+});
+
+test("MISSING メッセージは \"Operator 'BMC' requires 1 operand(s), got 0\" と完全一致", () => {
+  const ctx = buildContext([]);
+
+  const result = bmcHandler(ctx);
+
+  assert(!result.ok);
+  assert(result.error.code === "OPERATOR_OPERAND_MISSING");
+  expect(result.error.message).toBe(
+    "Operator 'BMC' requires 1 operand(s), got 0",
+  );
+});
+
+test("MISSING 時 markedContentStack は push されず不変（非空 stack で depth=1 のまま）", () => {
+  const ctx = buildSeededContext([], { type: "name", value: "Span" });
+
+  const result = bmcHandler(ctx);
+
+  assert(!result.ok);
+  expect(MarkedContentStack.depth(ctx.markedContentStack)).toBe(1);
+});
+
+test.each<[string, PdfObject]>(
+  NON_NAME_CASES,
+)("top が %s のとき TYPE_MISMATCH を返す（expected:'name', actual=top の type 名）", (type, operand) => {
+  const ctx = buildContext([operand]);
+
+  const result = bmcHandler(ctx);
+
+  assert(!result.ok);
+  assert(result.error.code === "OPERATOR_OPERAND_TYPE_MISMATCH");
+  expect(result.error.expected).toBe("name");
+  expect(result.error.actual).toBe(type);
+});
+
+test("TYPE_MISMATCH の operatorName が 'BMC' でメッセージが完全一致する（top: integer）", () => {
+  const ctx = buildContext([{ type: "integer", value: 42 }]);
+
+  const result = bmcHandler(ctx);
+
+  assert(!result.ok);
+  assert(result.error.code === "OPERATOR_OPERAND_TYPE_MISMATCH");
+  expect(result.error.operatorName).toBe("BMC");
+  expect(result.error.message).toBe(
+    "Operator 'BMC' expected name operand, got integer",
+  );
+});
+
+test("TYPE_MISMATCH 時 markedContentStack は push されず不変（depth 変わらず 0）", () => {
+  const ctx = buildContext([{ type: "integer", value: 42 }]);
+
+  const result = bmcHandler(ctx);
+
+  assert(!result.ok);
+  expect(MarkedContentStack.depth(ctx.markedContentStack)).toBe(0);
+});
+
+test("TYPE_MISMATCH 後に部分消費した operand は復元しない（operandStack depth=1 → depth=0 のまま）", () => {
+  const ctx = buildContext([{ type: "integer", value: 42 }]);
+  expect(OperandStack.depth(ctx.operandStack)).toBe(1);
+
+  const result = bmcHandler(ctx);
+
+  assert(!result.ok);
+  expect(OperandStack.depth(ctx.operandStack)).toBe(0);
+});

--- a/packages/core/src/content-stream/operators/marked-content/bmc/index.ts
+++ b/packages/core/src/content-stream/operators/marked-content/bmc/index.ts
@@ -1,0 +1,72 @@
+import type { PdfError } from "../../../../pdf/errors/index";
+import { PdfName } from "../../../../pdf/types/pdf-types/index";
+import { none } from "../../../../utils/option/index";
+import { err, ok } from "../../../../utils/result/index";
+import type { MarkedContentEntry } from "../../../marked-content/stack/index";
+import { MarkedContentStack } from "../../../marked-content/stack/index";
+import { OperandStack } from "../../../operand-stack/index";
+import type {
+  OperatorHandler,
+  OperatorHandlerContext,
+} from "../../../operator-registry/index";
+
+const OPERATOR_NAME = "BMC";
+const OPERAND_COUNT = 1;
+
+/**
+ * ISO 32000-2:2020 §14.6 `BMC` operator (begin marked-content sequence) のハンドラ。
+ *
+ * operand stack から tag (name) を 1 個 pop し、name 型であれば
+ * `{ tag, properties: none }` を marked content stack へ push した
+ * 新しいコンテキストを返す。
+ *
+ * 検査順序（厳守 / doHandler 準拠）:
+ *   (1) operand pop（none なら `OPERATOR_OPERAND_MISSING`）
+ *   (2) 型検査（PdfName.is が false なら `OPERATOR_OPERAND_TYPE_MISMATCH`）
+ *   (3) 両方通過 → MarkedContentStack.push して markedContentStack を差し替え ok
+ *
+ * - tag の値域（空文字 等）は検証しない。
+ * - 更新するのは markedContentStack のみ。operandStack（pop で in-place 消費済み）・
+ *   graphicsStateStack は入力と同一参照で返す。
+ * - エラー時に部分消費した operand stack は復元しない（既存ハンドラ規約）。
+ *
+ * @param context - 実行コンテキスト
+ * @returns 成功なら更新後コンテキスト、失敗なら PdfError
+ */
+export const bmcHandler: OperatorHandler = (
+  context: OperatorHandlerContext,
+) => {
+  const popped = OperandStack.pop(context.operandStack);
+  if (!popped.some) {
+    const error: PdfError = {
+      code: "OPERATOR_OPERAND_MISSING",
+      message: `Operator '${OPERATOR_NAME}' requires ${OPERAND_COUNT} operand(s), got 0`,
+      operatorName: OPERATOR_NAME,
+      required: OPERAND_COUNT,
+      actual: 0,
+    };
+    return err(error);
+  }
+
+  const operand = popped.value;
+  if (!PdfName.is(operand)) {
+    const error: PdfError = {
+      code: "OPERATOR_OPERAND_TYPE_MISMATCH",
+      message: `Operator '${OPERATOR_NAME}' expected name operand, got ${operand.type}`,
+      operatorName: OPERATOR_NAME,
+      expected: "name",
+      actual: operand.type,
+    };
+    return err(error);
+  }
+
+  const entry: MarkedContentEntry = { tag: operand, properties: none };
+  return ok({
+    operandStack: context.operandStack,
+    graphicsStateStack: context.graphicsStateStack,
+    markedContentStack: MarkedContentStack.push(
+      context.markedContentStack,
+      entry,
+    ),
+  });
+};


### PR DESCRIPTION
## 概要

ISO 32000-2:2020 §14.6 の content stream operator `BMC`（tag 付き begin marked content）の operator handler を新規実装しました。operand stack から tag（`PdfName`）を 1 個 pop し、name 型であれば `{ tag, properties: none }` を marked content stack へ push した新しい `OperatorHandlerContext` を返す純粋関数です。既存 `doHandler` をテンプレートに、検査順序・エラー形状を踏襲しています。

**新規ファイル追加のみ**で既存ファイルの変更はありません。

## 変更内容

### 🎯 変更の種類

- [x] ✨ 新機能 (New feature)
- [x] 🚨 テスト追加/修正 (Tests)

### 📝 詳細な変更内容

#### 追加された機能・修正

- `bmcHandler`: BMC operator handler 本体（`OPERATOR_NAME = "BMC"` / `OPERAND_COUNT = 1`）
  - 検査順序: (1) `OperandStack.pop` が `none` → `OPERATOR_OPERAND_MISSING` / (2) `PdfName.is` が false → `OPERATOR_OPERAND_TYPE_MISMATCH` / (3) 両方通過 → `MarkedContentStack.push` して `markedContentStack` を差し替えた新コンテキストを `ok`
  - 更新は `markedContentStack` のみ。`operandStack`（pop で in-place 消費済み）・`graphicsStateStack` は入力と同一参照で返す
  - エラー形状は `doHandler` と同一（`operatorName: "BMC"`）

#### 変更されたファイル

- `packages/core/src/content-stream/operators/marked-content/bmc/index.ts` [NEW] — `bmcHandler` 本体
- `packages/core/src/content-stream/operators/marked-content/bmc/__tests__/bmc.basic.test.ts` [NEW] — 正常系 11 ケース
- `packages/core/src/content-stream/operators/marked-content/bmc/__tests__/bmc.error.test.ts` [NEW] — 異常系（`test.each` 9 + 個別 6）

#### 削除されたファイル・機能

- なし

## 📊 システム図

### 状態マシン / フロー図

```mermaid
flowchart TD
    Start([入力: OperatorHandlerContext]) --> Pop["OperandStack.pop<br/>(operandStack を in-place で 1 消費)"]:::new
    Pop -->|none| Missing["err: OPERATOR_OPERAND_MISSING<br/>required:1, actual:0"]:::new
    Pop -->|some operand| TypeCheck{"PdfName.is(operand)"}:::new
    TypeCheck -->|false| Mismatch["err: OPERATOR_OPERAND_TYPE_MISMATCH<br/>expected:'name', actual:operand.type"]:::new
    TypeCheck -->|true| Push["MarkedContentStack.push<br/>{ tag: operand, properties: none }<br/>(depth +1・別参照生成)"]:::new
    Push --> Ok["ok: markedContentStack のみ差し替え<br/>operandStack / graphicsStateStack は同一参照"]:::new

    classDef new fill:#ffe4b5,stroke:#d97706,stroke-width:2px
```

### データフロー

```
OperatorHandlerContext (入力)
    │  { operandStack, graphicsStateStack, markedContentStack }
    ▼
OperandStack.pop(context.operandStack)          [NEW]
    │  副作用: operandStack を in-place で 1 消費
    ├─ none ─────────────────────▶ err(OPERATOR_OPERAND_MISSING)
    └─ some(operand)
           ▼
       PdfName.is(operand)                        [NEW]
           ├─ false ─────────────▶ err(OPERATOR_OPERAND_TYPE_MISMATCH)
           └─ true
                  ▼
              MarkedContentStack.push(stack, { tag, properties: none })  [NEW]
                  ▼
              ok({ operandStack: 同一, graphicsStateStack: 同一, markedContentStack: 新参照 })
```

## 📋 関連 Issue

- Refs #480（[Phase 4-J] のサブタスク「bmcHandler 実装 + basic / error テスト」）

## 🧪 テスト

### テスト実行方法

```bash
pnpm --filter @pdfmod/core test
pnpm --filter @pdfmod/core build
pnpm --filter @pdfmod/core typecheck
pnpm run lint
```

### テスト項目

- [x] 単体テスト (Unit tests)
- [x] 手動テスト (Manual testing)

### テスト結果

- `bmc` テスト: 26 pass（basic 11 / error 15）
- コア全体: 240 ファイル 2971 tests pass（リグレッションなし）
- build / typecheck / lint（biome + oxlint）: すべてパス
- codex レビュー: **問題なし**

## 🔍 レビューポイント

- 検査順序（pop → MISSING / 型検査 → TYPE_MISMATCH / 成功 → push → ok）が `doHandler` と一貫しているか
- エラーコードを Issue 本文の指定（`OBJECT_PARSE_UNEXPECTED_OPERAND` 系）ではなく、実在する `OPERATOR_OPERAND_MISSING` / `OPERATOR_OPERAND_TYPE_MISMATCH` に統一した点（requirements.md でユーザー承認済み）
- 不変性: 成功時 `markedContentStack` は新参照・入力非破壊、`operandStack` / `graphicsStateStack` は同一参照。エラー時に部分消費した operand は復元しない（既存 handler 規約）

## ⚠️ 破壊的変更

- [ ] この変更は既存の API に破壊的変更を含みます

新規ファイル追加のみで既存 export・型・挙動は不変。破壊的変更なし。

## 📚 追加情報

### 注意事項

- 本 handler は registry 未登録です（`registerMarkedContentOperators`・re-export hub・interpreter 配線は EMC 実装とセットの後続作業としてスコープ外）。単体では interpreter から呼ばれません。

## ✅ チェックリスト

- [x] コードレビューの準備ができている
- [x] テストが正常に実行される
- [x] コミットメッセージが適切な形式で書かれている
- [x] PR 本文に `Refs #` で Issue が記載されている
- [x] セルフレビューを実施した

🤖 Generated with [Claude Code](https://claude.com/claude-code)