### PR TITLE
✨ [New Feature]: #410 間接オブジェクト（N G obj … endobj）のパースを実装

### DIFF
--- a/rust/crates/core/src/object.rs
+++ b/rust/crates/core/src/object.rs
@@ -9,6 +9,7 @@
 
 pub mod dictionary;
 pub mod generation_number;
+pub mod indirect_object;
 pub mod indirect_ref;
 pub mod name;
 pub mod object_id;

--- a/rust/crates/core/src/object/indirect_object.rs
+++ b/rust/crates/core/src/object/indirect_object.rs
@@ -1,0 +1,244 @@
+//! PDF の間接オブジェクト定義（`N G obj … endobj`）を表す `IndirectObject` を定義するモジュール。
+//!
+//! ヘッダの `ObjectId`（オブジェクト番号 + 世代番号）と `obj`〜`endobj` 間の
+//! 単一 `PdfObject`（content）を組にした値ラッパ。オブジェクト解決（Epic R2）が
+//! ファイル内オフセットから読み出した 1 定義の受け皿となる。生成は無検証
+//! （infallible）で、番号の妥当性検証は xref レイヤに委譲する（ISO 32000-1 §7.3.10）。
+
+use crate::object::object_id::ObjectId;
+use crate::object::pdf_object::PdfObject;
+
+/// PDF の間接オブジェクト定義（`N G obj … endobj`）。`ObjectId` と content の
+/// `PdfObject` を内包する値ラッパ。
+///
+/// content の `PdfObject` がヒープ保持バリアント（String/Array/Dictionary/…）と
+/// `Real(f64)` を含むため、derive は `Debug, Clone, PartialEq` のみ
+/// （`Copy`/`Eq`/`Hash`/`Ord` は付けない。`pdf_object.rs` の derive 制約を継承）。
+/// 同型テンプレートは `stream.rs` の `PdfStream`（非 Copy・2 フィールド・ヒープ保持・
+/// 同一 derive・参照返しアクセサ）。`IndirectRef` は単一フィールド・`Copy` 付きで構造が遠い。
+#[derive(Debug, Clone, PartialEq)]
+pub struct IndirectObject {
+    id: ObjectId,
+    object: PdfObject,
+}
+
+impl IndirectObject {
+    /// `ObjectId` と content `PdfObject` から `IndirectObject` を生成する。
+    ///
+    /// 無検証（infallible）。`object` は所有ムーブで受け取り clone しない。
+    pub fn new(id: ObjectId, object: PdfObject) -> IndirectObject {
+        IndirectObject { id, object }
+    }
+
+    /// ヘッダの `ObjectId` を `Copy` で取り出す。
+    pub fn id(&self) -> ObjectId {
+        self.id
+    }
+
+    /// content の `PdfObject` を参照で取り出す（ヒープ保持のため clone を避ける）。
+    pub fn object(&self) -> &PdfObject {
+        &self.object
+    }
+
+    /// `self` を消費して `ObjectId` と content の `PdfObject` を所有権ごと分解する。
+    ///
+    /// 後続の R2 リゾルバが content（`PdfObject`）をムーブで所有取得する用途を想定
+    /// （格納済み値のムーブ返しで追加コピーなし・clone なし）。参照取得で足りる場合は
+    /// `id()` / `object()` を使う（姉妹型 `PdfStream::into_parts` と同方針）。
+    pub fn into_parts(self) -> (ObjectId, PdfObject) {
+        (self.id, self.object)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::object::dictionary::PdfDictionary;
+    use crate::object::generation_number::GenerationNumber;
+    use crate::object::indirect_ref::IndirectRef;
+    use crate::object::name::PdfName;
+    use crate::object::object_number::ObjectNumber;
+
+    /// `(n, g)` から `ObjectId` を組み立てるテスト用小ヘルパ。
+    fn oid(n: u64, g: u16) -> ObjectId {
+        ObjectId::new(ObjectNumber::new(n), GenerationNumber::new(g))
+    }
+
+    /// 代表 `(n,g)` + Integer content を `new` に包み `id()`/`object()` で取り出すと入力と一致する（ラウンドトリップ・無損失）。
+    #[test]
+    fn new_then_accessors_roundtrip() {
+        let io = IndirectObject::new(oid(1, 0), PdfObject::Integer(42));
+        assert_eq!(io.id(), oid(1, 0));
+        assert_eq!(io.object(), &PdfObject::Integer(42));
+    }
+
+    /// `id()` は `Copy` 値返しのため複数回呼んでも元の `IndirectObject` を使い続けられ、両呼び出しが等価。
+    #[test]
+    fn id_returns_copy_and_stays_usable() {
+        let io = IndirectObject::new(oid(7, 3), PdfObject::Boolean(true));
+        let first = io.id();
+        let second = io.id();
+        assert_eq!(first, second);
+        assert_eq!(io.object(), &PdfObject::Boolean(true));
+    }
+
+    /// `object()` は参照返しで、内包 content と `==` で一致する（借用経路で内容へ到達できる）。
+    #[test]
+    fn object_returns_reference_to_content() {
+        let io = IndirectObject::new(oid(2, 0), PdfObject::Integer(9));
+        let reference: &PdfObject = io.object();
+        assert_eq!(reference, &PdfObject::Integer(9));
+    }
+
+    /// `into_parts()` で `(id, object)` を所有取り出し（消費・ムーブ）すると、構築時の入力と一致する（無損失ムーブ・clone なし）。
+    #[test]
+    fn into_parts_decomposes_ownership() {
+        let io = IndirectObject::new(oid(12, 0), PdfObject::String(b"body".to_vec()));
+        let (id, object) = io.into_parts();
+        assert_eq!(id, oid(12, 0));
+        assert_eq!(object, PdfObject::String(b"body".to_vec()));
+    }
+
+    /// `clone()` の複製が元と `==` 等価かつ元も引き続き使用可能（深いコピー・独立性）。
+    #[test]
+    fn clone_preserves_content_and_keeps_original_usable() {
+        let original = IndirectObject::new(oid(5, 1), PdfObject::Integer(100));
+        let cloned = original.clone();
+        assert_eq!(cloned, original);
+        assert_eq!(original.object(), &PdfObject::Integer(100));
+    }
+
+    /// 同 id・同 content の 2 値は `==` で等価（`PartialEq` が両フィールドに委譲）。
+    #[test]
+    fn same_id_and_content_are_equal() {
+        let a = IndirectObject::new(oid(3, 0), PdfObject::Integer(1));
+        let b = IndirectObject::new(oid(3, 0), PdfObject::Integer(1));
+        assert_eq!(a, b);
+    }
+
+    /// generation・content が同一で object_number のみ異なる 2 値は `!=` 非等価（object_number 軸の差異が反映される）。
+    #[test]
+    fn not_equal_when_object_number_differs() {
+        let a = IndirectObject::new(oid(3, 0), PdfObject::Integer(1));
+        let b = IndirectObject::new(oid(4, 0), PdfObject::Integer(1));
+        assert_ne!(a, b);
+    }
+
+    /// object_number・content が同一で generation のみ異なる 2 値は `!=` 非等価（generation 軸の差異が反映される）。
+    #[test]
+    fn not_equal_when_generation_differs() {
+        let a = IndirectObject::new(oid(3, 0), PdfObject::Integer(1));
+        let b = IndirectObject::new(oid(3, 1), PdfObject::Integer(1));
+        assert_ne!(a, b);
+    }
+
+    /// 同 id で content が `Integer(1)` vs `Integer(2)` の 2 値は `!=` 非等価（content 軸の差異が反映される）。
+    #[test]
+    fn not_equal_when_content_differs() {
+        let a = IndirectObject::new(oid(3, 0), PdfObject::Integer(1));
+        let b = IndirectObject::new(oid(3, 0), PdfObject::Integer(2));
+        assert_ne!(a, b);
+    }
+
+    /// 同 id で content が `Real(f64::NAN)` の 2 値は `!=` 非等価（`NaN != NaN` の伝播。`Eq` 非実装の帰結）。
+    #[test]
+    fn nan_content_propagates_to_inequality() {
+        let a = IndirectObject::new(oid(3, 0), PdfObject::Real(f64::NAN));
+        let b = IndirectObject::new(oid(3, 0), PdfObject::Real(f64::NAN));
+        assert_ne!(a, b);
+    }
+
+    /// `Debug` 出力に型名 `IndirectObject` を含む。
+    #[test]
+    fn debug_format_contains_type_name() {
+        let io = IndirectObject::new(oid(1, 0), PdfObject::Null);
+        assert!(format!("{:?}", io).contains("IndirectObject"));
+    }
+
+    /// 最小境界 `ObjectId(0, 0)` を無検証で受理し、番号/世代がともに 0 でラウンドトリップが成立する。
+    #[test]
+    fn accepts_min_boundary_object_id() {
+        let io = IndirectObject::new(oid(0, 0), PdfObject::Null);
+        assert_eq!(io.id().object_number().value(), 0);
+        assert_eq!(io.id().generation_number().value(), 0);
+        assert_eq!(io.object(), &PdfObject::Null);
+    }
+
+    /// 最大境界 `ObjectId(u64::MAX, u16::MAX)` を無検証で受理し、番号/世代がともに MAX でラウンドトリップが成立する。
+    #[test]
+    fn accepts_max_boundary_object_id() {
+        let io = IndirectObject::new(oid(u64::MAX, u16::MAX), PdfObject::Null);
+        assert_eq!(io.id().object_number().value(), u64::MAX);
+        assert_eq!(io.id().generation_number().value(), u16::MAX);
+    }
+
+    /// content `Null` を無損失で保持し `object()` が `&Null` を返す。
+    #[test]
+    fn content_preserves_null() {
+        let io = IndirectObject::new(oid(1, 0), PdfObject::Null);
+        assert_eq!(io.object(), &PdfObject::Null);
+    }
+
+    /// content `Boolean(true)` を無損失で保持し `object()` が `&Boolean(true)` を返す。
+    #[test]
+    fn content_preserves_boolean() {
+        let io = IndirectObject::new(oid(1, 0), PdfObject::Boolean(true));
+        assert_eq!(io.object(), &PdfObject::Boolean(true));
+    }
+
+    /// content `Integer(-7)` を無損失で保持し `object()` が `&Integer(-7)` を返す。
+    #[test]
+    fn content_preserves_integer() {
+        let io = IndirectObject::new(oid(1, 0), PdfObject::Integer(-7));
+        assert_eq!(io.object(), &PdfObject::Integer(-7));
+    }
+
+    /// content `Real(2.5)` を無損失で保持し `object()` が `&Real(2.5)` を返す。
+    #[test]
+    fn content_preserves_real() {
+        let io = IndirectObject::new(oid(1, 0), PdfObject::Real(2.5));
+        assert_eq!(io.object(), &PdfObject::Real(2.5));
+    }
+
+    /// content `String(b"abc")` を無損失で保持し `object()` が同一バイト列の `&String` を返す。
+    #[test]
+    fn content_preserves_string() {
+        let io = IndirectObject::new(oid(1, 0), PdfObject::String(b"abc".to_vec()));
+        assert_eq!(io.object(), &PdfObject::String(b"abc".to_vec()));
+    }
+
+    /// content `Name("Page")` を無損失で保持し `object()` が同名の `&Name` を返す。
+    #[test]
+    fn content_preserves_name() {
+        let io = IndirectObject::new(oid(1, 0), PdfObject::Name(PdfName::from("Page")));
+        assert_eq!(io.object(), &PdfObject::Name(PdfName::from("Page")));
+    }
+
+    /// content `Array[Integer(1), Integer(2)]` を無損失で保持し `object()` が同一配列の `&Array` を返す。
+    #[test]
+    fn content_preserves_array() {
+        let items = vec![PdfObject::Integer(1), PdfObject::Integer(2)];
+        let io = IndirectObject::new(oid(1, 0), PdfObject::Array(items.clone()));
+        assert_eq!(io.object(), &PdfObject::Array(items));
+    }
+
+    /// content `Dictionary{/Type→Name("Page")}` を無損失で保持し `object()` が同一辞書の `&Dictionary` を返す。
+    #[test]
+    fn content_preserves_dictionary() {
+        let mut dict = PdfDictionary::new();
+        dict.insert(
+            PdfName::from("Type"),
+            PdfObject::Name(PdfName::from("Page")),
+        );
+        let io = IndirectObject::new(oid(1, 0), PdfObject::Dictionary(dict.clone()));
+        assert_eq!(io.object(), &PdfObject::Dictionary(dict));
+    }
+
+    /// content `Reference(15, 0)` を無損失で保持し `object()` が同一参照の `&Reference` を返す。
+    #[test]
+    fn content_preserves_reference() {
+        let reference = IndirectRef::new(oid(15, 0));
+        let io = IndirectObject::new(oid(1, 0), PdfObject::Reference(reference));
+        assert_eq!(io.object(), &PdfObject::Reference(reference));
+    }
+}

--- a/rust/crates/core/src/parser.rs
+++ b/rust/crates/core/src/parser.rs
@@ -37,6 +37,7 @@ enum PeekClass<T> {
 }
 use crate::object::dictionary::PdfDictionary;
 use crate::object::generation_number::GenerationNumber;
+use crate::object::indirect_object::IndirectObject;
 use crate::object::indirect_ref::IndirectRef;
 use crate::object::object_id::ObjectId;
 use crate::object::object_number::ObjectNumber;
@@ -102,6 +103,91 @@ impl<'a> Parser<'a> {
                 ByteOffset::new(pos_before as u64),
                 Self::token_kind_label(&other),
             )),
+        }
+    }
+
+    /// 間接オブジェクト定義 `N G obj <content> endobj` を 1 つ読み取り
+    /// [`IndirectObject`] を返す（ISO 32000-1 §7.3.10）。
+    ///
+    /// 消費型の専用エントリ。ヘッダ `Integer(N) Integer(G) ObjBegin` を順に消費し
+    /// （`N >= 0` / `0 <= G <= u16::MAX` を範囲検証）、content を [`Self::parse_object`]
+    /// で 1 回読み、最後に `endobj`（[`Token::ObjEnd`]）を要求する。ヘッダ/`endobj`
+    /// 位置が期待形でなければ
+    /// [`ParseErrorKind::UnexpectedToken`](error::ParseErrorKind::UnexpectedToken)、
+    /// 入力が尽きれば
+    /// [`ParseErrorKind::UnexpectedEof`](error::ParseErrorKind::UnexpectedEof)、
+    /// lexer が malformed を検知した場合は
+    /// [`ParseErrorKind::LexerError`](error::ParseErrorKind::LexerError) を返す。
+    /// 番号の妥当性検証（`N >= 1` 等）は xref レイヤに委譲する。
+    pub fn parse_indirect_object(&mut self) -> Result<IndirectObject, ParseError> {
+        let object_number = self.take_object_number()?;
+        let generation = self.take_generation_number()?;
+        self.expect_token(&Token::ObjBegin)?;
+        let object = self.parse_object()?;
+        self.expect_token(&Token::ObjEnd)?;
+        let id = ObjectId::new(
+            ObjectNumber::new(object_number),
+            GenerationNumber::new(generation),
+        );
+        Ok(IndirectObject::new(id, object))
+    }
+
+    /// ヘッダ先頭の N を消費する。`Integer(N)` かつ `N >= 0` のみ受理し `u64` へ変換する。
+    ///
+    /// 非 Integer / 範囲外（`N < 0`）は
+    /// [`ParseErrorKind::UnexpectedToken`](error::ParseErrorKind::UnexpectedToken)
+    /// （範囲外でも token 自体は有効な `Primitive` のため `actual_kind` は "Primitive"）、
+    /// EOF / malformed は [`Self::take_token_or_error`] 経由で区別して返す。範囲検証後にのみ
+    /// `n as u64` を行うため panic しない（`N >= 0` により非負 i64 → u64 は常に安全）。
+    fn take_object_number(&mut self) -> Result<u64, ParseError> {
+        let (token, pos_before) = self.take_token_or_error()?;
+        match token {
+            Token::Primitive(Primitive::Integer(n)) if n >= 0 => Ok(n as u64),
+            other => Err(ParseError::unexpected_token_at(
+                ByteOffset::new(pos_before as u64),
+                Self::token_kind_label(&other),
+            )),
+        }
+    }
+
+    /// ヘッダ 2 番目の G を消費する。`Integer(G)` かつ `0 <= G <= u16::MAX` のみ受理し `u16` へ変換する。
+    ///
+    /// 非 Integer / 範囲外は
+    /// [`ParseErrorKind::UnexpectedToken`](error::ParseErrorKind::UnexpectedToken)
+    /// （範囲外でも token 自体は有効な `Primitive` のため `actual_kind` は "Primitive"）、
+    /// EOF / malformed は [`Self::take_token_or_error`] 経由で区別して返す。範囲検証後にのみ
+    /// `g as u16` を行うため panic しない。
+    fn take_generation_number(&mut self) -> Result<u16, ParseError> {
+        let (token, pos_before) = self.take_token_or_error()?;
+        match token {
+            Token::Primitive(Primitive::Integer(g)) if (0..=i64::from(u16::MAX)).contains(&g) => {
+                Ok(g as u16)
+            }
+            other => Err(ParseError::unexpected_token_at(
+                ByteOffset::new(pos_before as u64),
+                Self::token_kind_label(&other),
+            )),
+        }
+    }
+
+    /// 取得済みトークンが `expected` と等価であることを要求して消費する。
+    ///
+    /// `obj`（[`Token::ObjBegin`]）/ `endobj`（[`Token::ObjEnd`]）要求を 1 本化した
+    /// 汎用 helper。両ステップは骨格が同一（`take_token_or_error` → unit トークン判定 →
+    /// 不一致で `token_kind_label` + `unexpected_token_at`）のため DRY 化する。`expected` は
+    /// unit variant を想定し、取得済みトークンとの `==`（`Token: PartialEq`）で等価判定する。
+    /// 不一致は
+    /// [`ParseErrorKind::UnexpectedToken`](error::ParseErrorKind::UnexpectedToken)、
+    /// EOF / malformed は [`Self::take_token_or_error`] 経由で区別して返す。
+    fn expect_token(&mut self, expected: &Token) -> Result<(), ParseError> {
+        let (token, pos_before) = self.take_token_or_error()?;
+        if &token == expected {
+            Ok(())
+        } else {
+            Err(ParseError::unexpected_token_at(
+                ByteOffset::new(pos_before as u64),
+                Self::token_kind_label(&token),
+            ))
         }
     }
 
@@ -322,6 +408,9 @@ mod array_tests;
 
 #[cfg(test)]
 mod dictionary_tests;
+
+#[cfg(test)]
+mod indirect_object_tests;
 
 #[cfg(test)]
 mod indirect_reference_tests;

--- a/rust/crates/core/src/parser/indirect_object_tests.rs
+++ b/rust/crates/core/src/parser/indirect_object_tests.rs
@@ -1,0 +1,36 @@
+mod basic;
+mod boundary;
+mod comment_interleaved;
+mod eof_boundary;
+mod header_invalid;
+mod lexer_error;
+mod missing_endobj;
+mod pdf_sample;
+
+use super::Parser;
+use crate::object::generation_number::GenerationNumber;
+use crate::object::indirect_object::IndirectObject;
+use crate::object::indirect_ref::IndirectRef;
+use crate::object::object_id::ObjectId;
+use crate::object::object_number::ObjectNumber;
+use crate::object::pdf_object::PdfObject;
+
+fn parser(input: &[u8]) -> Parser<'_> {
+    Parser::new(input)
+}
+
+/// `(n, g, object)` から期待値 `IndirectObject` を組み立てる小ヘルパ。
+fn indirect_object(n: u64, g: u16, object: PdfObject) -> IndirectObject {
+    IndirectObject::new(
+        ObjectId::new(ObjectNumber::new(n), GenerationNumber::new(g)),
+        object,
+    )
+}
+
+/// `(n, g)` から content 用の `PdfObject::Reference` を組み立てる小ヘルパ。
+fn reference(n: u64, g: u16) -> PdfObject {
+    PdfObject::Reference(IndirectRef::new(ObjectId::new(
+        ObjectNumber::new(n),
+        GenerationNumber::new(g),
+    )))
+}

--- a/rust/crates/core/src/parser/indirect_object_tests/basic.rs
+++ b/rust/crates/core/src/parser/indirect_object_tests/basic.rs
@@ -1,0 +1,139 @@
+use super::super::super::object::dictionary::PdfDictionary;
+use super::super::super::object::name::PdfName;
+use super::super::super::object::pdf_object::PdfObject;
+use super::{indirect_object, parser, reference};
+
+#[test]
+fn parse_indirect_object_returns_integer_content() {
+    // 最小成立ケース: b"1 0 obj 42 endobj" が IndirectObject(id=(1,0), Integer(42)) を返す
+    let mut p = parser(b"1 0 obj 42 endobj");
+    assert_eq!(
+        p.parse_indirect_object(),
+        Ok(indirect_object(1, 0, PdfObject::Integer(42)))
+    );
+}
+
+#[test]
+fn parse_indirect_object_returns_boolean_content() {
+    // Boolean content: b"3 0 obj true endobj" が Boolean(true) を content に持つ
+    let mut p = parser(b"3 0 obj true endobj");
+    assert_eq!(
+        p.parse_indirect_object(),
+        Ok(indirect_object(3, 0, PdfObject::Boolean(true)))
+    );
+}
+
+#[test]
+fn parse_indirect_object_returns_null_content() {
+    // Null content: b"3 0 obj null endobj" が Null を content に持つ
+    let mut p = parser(b"3 0 obj null endobj");
+    assert_eq!(
+        p.parse_indirect_object(),
+        Ok(indirect_object(3, 0, PdfObject::Null))
+    );
+}
+
+#[test]
+fn parse_indirect_object_returns_real_content() {
+    // Real content: b"9 0 obj 2.5 endobj" が Real(2.5) を content に持つ（scalar 7 種のうち Real）
+    let mut p = parser(b"9 0 obj 2.5 endobj");
+    assert_eq!(
+        p.parse_indirect_object(),
+        Ok(indirect_object(9, 0, PdfObject::Real(2.5)))
+    );
+}
+
+#[test]
+fn parse_indirect_object_returns_string_content() {
+    // String content: b"10 0 obj (abc) endobj" がリテラル文字列 String(b"abc") を content に持つ
+    let mut p = parser(b"10 0 obj (abc) endobj");
+    assert_eq!(
+        p.parse_indirect_object(),
+        Ok(indirect_object(10, 0, PdfObject::String(b"abc".to_vec())))
+    );
+}
+
+#[test]
+fn parse_indirect_object_returns_name_content() {
+    // Name content: b"4 0 obj /Page endobj" が Name("Page") を content に持つ
+    let mut p = parser(b"4 0 obj /Page endobj");
+    assert_eq!(
+        p.parse_indirect_object(),
+        Ok(indirect_object(
+            4,
+            0,
+            PdfObject::Name(PdfName::from("Page"))
+        ))
+    );
+}
+
+#[test]
+fn parse_indirect_object_returns_array_content() {
+    // 配列 content: b"5 0 obj [1 2 3] endobj" が Array[Integer(1),Integer(2),Integer(3)] を content に持つ
+    let mut p = parser(b"5 0 obj [1 2 3] endobj");
+    let expected = PdfObject::Array(vec![
+        PdfObject::Integer(1),
+        PdfObject::Integer(2),
+        PdfObject::Integer(3),
+    ]);
+    assert_eq!(
+        p.parse_indirect_object(),
+        Ok(indirect_object(5, 0, expected))
+    );
+}
+
+#[test]
+fn parse_indirect_object_returns_dictionary_content() {
+    // 辞書 content: b"12 0 obj << /Type /Page >> endobj" が Dictionary を content に持ち id==(12,0)
+    let mut p = parser(b"12 0 obj << /Type /Page >> endobj");
+    let mut dict = PdfDictionary::new();
+    dict.insert(
+        PdfName::from("Type"),
+        PdfObject::Name(PdfName::from("Page")),
+    );
+    assert_eq!(
+        p.parse_indirect_object(),
+        Ok(indirect_object(12, 0, PdfObject::Dictionary(dict)))
+    );
+}
+
+#[test]
+fn parse_indirect_object_returns_reference_content() {
+    // 参照 content: b"6 0 obj 15 0 R endobj" が content として間接参照 Reference(15,0) を持つ
+    let mut p = parser(b"6 0 obj 15 0 R endobj");
+    assert_eq!(
+        p.parse_indirect_object(),
+        Ok(indirect_object(6, 0, reference(15, 0)))
+    );
+}
+
+#[test]
+fn parse_indirect_object_returns_nested_dictionary_content() {
+    // ネスト content: b"7 0 obj << /Kids [ << /X 1 >> ] >> endobj" がネスト構造（辞書内配列内辞書）を保持する
+    let mut p = parser(b"7 0 obj << /Kids [ << /X 1 >> ] >> endobj");
+    let mut inner = PdfDictionary::new();
+    inner.insert(PdfName::from("X"), PdfObject::Integer(1));
+    let mut outer = PdfDictionary::new();
+    outer.insert(
+        PdfName::from("Kids"),
+        PdfObject::Array(vec![PdfObject::Dictionary(inner)]),
+    );
+    assert_eq!(
+        p.parse_indirect_object(),
+        Ok(indirect_object(7, 0, PdfObject::Dictionary(outer)))
+    );
+}
+
+#[test]
+fn parse_indirect_object_twice_does_not_overconsume() {
+    // 連続 2 定義: 同一 Parser で 2 回呼び、1 定義ずつ読んで後続を過剰消費しないことを確認する
+    let mut p = parser(b"1 0 obj 42 endobj 2 0 obj true endobj");
+    assert_eq!(
+        p.parse_indirect_object(),
+        Ok(indirect_object(1, 0, PdfObject::Integer(42)))
+    );
+    assert_eq!(
+        p.parse_indirect_object(),
+        Ok(indirect_object(2, 0, PdfObject::Boolean(true)))
+    );
+}

--- a/rust/crates/core/src/parser/indirect_object_tests/boundary.rs
+++ b/rust/crates/core/src/parser/indirect_object_tests/boundary.rs
@@ -1,0 +1,32 @@
+use super::super::super::object::pdf_object::PdfObject;
+use super::{indirect_object, parser};
+
+#[test]
+fn parse_indirect_object_accepts_object_number_zero() {
+    // 境界: N=0（最小オブジェクト番号）を寛容方針で受理し、object_number が 0 になる
+    let mut p = parser(b"0 0 obj true endobj");
+    let result = p
+        .parse_indirect_object()
+        .expect("object number 0 should be accepted");
+    assert_eq!(result.id().object_number().value(), 0);
+}
+
+#[test]
+fn parse_indirect_object_accepts_generation_zero() {
+    // 境界: G=0（最小世代）を寛容方針で受理し、generation_number が 0 になる
+    let mut p = parser(b"7 0 obj true endobj");
+    let result = p
+        .parse_indirect_object()
+        .expect("generation 0 should be accepted");
+    assert_eq!(result.id().generation_number().value(), 0);
+}
+
+#[test]
+fn parse_indirect_object_accepts_generation_u16_max() {
+    // 境界: G=u16::MAX(65535) を受理境界として受理する
+    let mut p = parser(b"5 65535 obj true endobj");
+    assert_eq!(
+        p.parse_indirect_object(),
+        Ok(indirect_object(5, 65535, PdfObject::Boolean(true)))
+    );
+}

--- a/rust/crates/core/src/parser/indirect_object_tests/comment_interleaved.rs
+++ b/rust/crates/core/src/parser/indirect_object_tests/comment_interleaved.rs
@@ -1,0 +1,42 @@
+use super::super::super::object::pdf_object::PdfObject;
+use super::{indirect_object, parser};
+
+#[test]
+fn parse_indirect_object_skips_comment_between_n_and_g() {
+    // コメント透過(N-G 間): b"1 % c\n0 obj 42 endobj" の N と G の間のコメントがスキップされる
+    let mut p = parser(b"1 % c\n0 obj 42 endobj");
+    assert_eq!(
+        p.parse_indirect_object(),
+        Ok(indirect_object(1, 0, PdfObject::Integer(42)))
+    );
+}
+
+#[test]
+fn parse_indirect_object_skips_comment_between_g_and_obj() {
+    // コメント透過(G-obj 間): b"1 0 % c\nobj 42 endobj" の G と obj の間のコメントがスキップされる
+    let mut p = parser(b"1 0 % c\nobj 42 endobj");
+    assert_eq!(
+        p.parse_indirect_object(),
+        Ok(indirect_object(1, 0, PdfObject::Integer(42)))
+    );
+}
+
+#[test]
+fn parse_indirect_object_skips_comment_between_obj_and_content() {
+    // コメント透過(obj-content 間): b"1 0 obj % c\n42 endobj" の obj と content の間のコメントがスキップされる
+    let mut p = parser(b"1 0 obj % c\n42 endobj");
+    assert_eq!(
+        p.parse_indirect_object(),
+        Ok(indirect_object(1, 0, PdfObject::Integer(42)))
+    );
+}
+
+#[test]
+fn parse_indirect_object_skips_comment_between_content_and_endobj() {
+    // コメント透過(content-endobj 間): b"1 0 obj 42 % c\nendobj" の content と endobj の間のコメントがスキップされる
+    let mut p = parser(b"1 0 obj 42 % c\nendobj");
+    assert_eq!(
+        p.parse_indirect_object(),
+        Ok(indirect_object(1, 0, PdfObject::Integer(42)))
+    );
+}

--- a/rust/crates/core/src/parser/indirect_object_tests/eof_boundary.rs
+++ b/rust/crates/core/src/parser/indirect_object_tests/eof_boundary.rs
@@ -1,0 +1,43 @@
+use super::super::super::byte_offset::ByteOffset;
+use super::super::error::ParseError;
+use super::parser;
+
+#[test]
+fn parse_indirect_object_empty_input_returns_unexpected_eof() {
+    // ヘッダ途中 EOF(空入力): b"" は N 取得位置で即入力終端となり UnexpectedEof を位置 0 で返す（panic しない）
+    let mut p = parser(b"");
+    assert_eq!(
+        p.parse_indirect_object(),
+        Err(ParseError::unexpected_eof_at(ByteOffset::new(0)))
+    );
+}
+
+#[test]
+fn parse_indirect_object_object_number_only_returns_unexpected_eof() {
+    // ヘッダ途中 EOF(N のみ): b"1" は G 取得位置で入力が尽き UnexpectedEof を位置 1 で返す（panic しない）
+    let mut p = parser(b"1");
+    assert_eq!(
+        p.parse_indirect_object(),
+        Err(ParseError::unexpected_eof_at(ByteOffset::new(1)))
+    );
+}
+
+#[test]
+fn parse_indirect_object_number_and_generation_only_returns_unexpected_eof() {
+    // ヘッダ途中 EOF(N G のみ): b"1 0" は obj 要求位置で入力が尽き UnexpectedEof を位置 3 で返す（panic しない）
+    let mut p = parser(b"1 0");
+    assert_eq!(
+        p.parse_indirect_object(),
+        Err(ParseError::unexpected_eof_at(ByteOffset::new(3)))
+    );
+}
+
+#[test]
+fn parse_indirect_object_header_without_content_returns_unexpected_eof() {
+    // ヘッダ途中 EOF(N G obj のみ): b"1 0 obj" は content 読取位置で入力が尽き UnexpectedEof を位置 7 で返す（panic しない）
+    let mut p = parser(b"1 0 obj");
+    assert_eq!(
+        p.parse_indirect_object(),
+        Err(ParseError::unexpected_eof_at(ByteOffset::new(7)))
+    );
+}

--- a/rust/crates/core/src/parser/indirect_object_tests/header_invalid.rs
+++ b/rust/crates/core/src/parser/indirect_object_tests/header_invalid.rs
@@ -1,0 +1,68 @@
+use super::super::super::byte_offset::ByteOffset;
+use super::super::error::ParseError;
+use super::parser;
+
+#[test]
+fn parse_indirect_object_missing_generation_returns_unexpected_obj_begin() {
+    // ヘッダ不正(G欠落): b"12 obj" は 2 番目に obj が来て UnexpectedToken{"ObjBegin"} を obj 位置(3)で返す
+    let mut p = parser(b"12 obj");
+    assert_eq!(
+        p.parse_indirect_object(),
+        Err(ParseError::unexpected_token_at(
+            ByteOffset::new(3),
+            "ObjBegin"
+        ))
+    );
+}
+
+#[test]
+fn parse_indirect_object_non_obj_keyword_returns_unexpected_keyword() {
+    // ヘッダ不正(obj でない): b"12 0 x" は 3 番目が Keyword で UnexpectedToken{"Keyword"} を x 位置(5)で返す
+    let mut p = parser(b"12 0 x");
+    assert_eq!(
+        p.parse_indirect_object(),
+        Err(ParseError::unexpected_token_at(
+            ByteOffset::new(5),
+            "Keyword"
+        ))
+    );
+}
+
+#[test]
+fn parse_indirect_object_negative_object_number_returns_unexpected_primitive() {
+    // ヘッダ不正(N<0): b"-1 0 obj" はオブジェクト番号が負で UnexpectedToken{"Primitive"} を位置 0 で返す
+    let mut p = parser(b"-1 0 obj");
+    assert_eq!(
+        p.parse_indirect_object(),
+        Err(ParseError::unexpected_token_at(
+            ByteOffset::new(0),
+            "Primitive"
+        ))
+    );
+}
+
+#[test]
+fn parse_indirect_object_negative_generation_returns_unexpected_primitive() {
+    // ヘッダ不正(G<0): b"12 -1 obj" は世代番号が負で UnexpectedToken{"Primitive"} を -1 位置(3)で返す
+    let mut p = parser(b"12 -1 obj");
+    assert_eq!(
+        p.parse_indirect_object(),
+        Err(ParseError::unexpected_token_at(
+            ByteOffset::new(3),
+            "Primitive"
+        ))
+    );
+}
+
+#[test]
+fn parse_indirect_object_generation_over_u16_max_returns_unexpected_primitive() {
+    // ヘッダ不正(G>u16::MAX): b"12 65536 obj" は世代番号が範囲外で UnexpectedToken{"Primitive"} を 65536 位置(3)で返す
+    let mut p = parser(b"12 65536 obj");
+    assert_eq!(
+        p.parse_indirect_object(),
+        Err(ParseError::unexpected_token_at(
+            ByteOffset::new(3),
+            "Primitive"
+        ))
+    );
+}

--- a/rust/crates/core/src/parser/indirect_object_tests/lexer_error.rs
+++ b/rust/crates/core/src/parser/indirect_object_tests/lexer_error.rs
@@ -1,0 +1,33 @@
+use super::super::super::byte_offset::ByteOffset;
+use super::super::error::ParseError;
+use super::parser;
+
+#[test]
+fn parse_indirect_object_lexer_error_at_generation_position() {
+    // lexer malformed(G 位置): b"1 <48656C" は世代取得位置の未終端 hex で LexerError を位置 2 で返す
+    let mut p = parser(b"1 <48656C");
+    assert_eq!(
+        p.parse_indirect_object(),
+        Err(ParseError::lexer_error_at(ByteOffset::new(2)))
+    );
+}
+
+#[test]
+fn parse_indirect_object_lexer_error_at_obj_position() {
+    // lexer malformed(obj 位置): b"1 0 <48656C" は obj 要求位置の未終端 hex で LexerError を位置 4 で返す
+    let mut p = parser(b"1 0 <48656C");
+    assert_eq!(
+        p.parse_indirect_object(),
+        Err(ParseError::lexer_error_at(ByteOffset::new(4)))
+    );
+}
+
+#[test]
+fn parse_indirect_object_lexer_error_at_content_position() {
+    // lexer malformed(content 位置): b"1 0 obj <48656C" は content 位置の未終端 hex で LexerError を位置 8 で返す
+    let mut p = parser(b"1 0 obj <48656C");
+    assert_eq!(
+        p.parse_indirect_object(),
+        Err(ParseError::lexer_error_at(ByteOffset::new(8)))
+    );
+}

--- a/rust/crates/core/src/parser/indirect_object_tests/missing_endobj.rs
+++ b/rust/crates/core/src/parser/indirect_object_tests/missing_endobj.rs
@@ -1,0 +1,54 @@
+use super::super::super::byte_offset::ByteOffset;
+use super::super::error::{ParseError, ParseErrorKind};
+use super::parser;
+
+#[test]
+fn parse_indirect_object_missing_endobj_at_eof_returns_unexpected_eof() {
+    // endobj 欠落(content 後 EOF): b"1 0 obj 42" は content 読取後に入力が尽きて UnexpectedEof を末尾(10)で返す
+    let mut p = parser(b"1 0 obj 42");
+    assert_eq!(
+        p.parse_indirect_object(),
+        Err(ParseError::unexpected_eof_at(ByteOffset::new(10)))
+    );
+}
+
+#[test]
+fn parse_indirect_object_non_endobj_token_returns_unexpected_token() {
+    // endobj 位置に別トークン: b"1 0 obj 42 [1]" は content 後に配列開始が来て UnexpectedToken{"ArrayBegin"} を [ 位置(11)で返す
+    let mut p = parser(b"1 0 obj 42 [1]");
+    assert_eq!(
+        p.parse_indirect_object(),
+        Err(ParseError::unexpected_token_at(
+            ByteOffset::new(11),
+            "ArrayBegin"
+        ))
+    );
+}
+
+#[test]
+fn parse_indirect_object_empty_content_returns_unexpected_obj_end() {
+    // 空 content: b"12 0 obj endobj" は obj 直後に endobj が来て content 読みの parse_object が UnexpectedToken{"ObjEnd"} を endobj 位置(9)で返す
+    let mut p = parser(b"12 0 obj endobj");
+    assert_eq!(
+        p.parse_indirect_object(),
+        Err(ParseError::unexpected_token_at(
+            ByteOffset::new(9),
+            "ObjEnd"
+        ))
+    );
+}
+
+#[test]
+fn parse_indirect_object_stream_content_fails_stably_at_stream_begin() {
+    // stream は対象外(安定失敗): 辞書を content 読取後 endobj 位置に stream(スコープ外)が来て UnexpectedToken{"StreamBegin"} を返す
+    let mut p = parser(b"1 0 obj << /Length 0 >> stream\nendstream endobj");
+    assert!(matches!(
+        p.parse_indirect_object(),
+        Err(ParseError {
+            kind: ParseErrorKind::UnexpectedToken {
+                actual_kind: "StreamBegin"
+            },
+            ..
+        })
+    ));
+}

--- a/rust/crates/core/src/parser/indirect_object_tests/pdf_sample.rs
+++ b/rust/crates/core/src/parser/indirect_object_tests/pdf_sample.rs
@@ -1,0 +1,53 @@
+use super::super::super::object::name::PdfName;
+use super::super::super::object::pdf_object::PdfObject;
+use super::{parser, reference};
+
+/// ISO 32000-1 §7.3.10 の Page 定義サンプル（辞書・参照混在 content）。
+const PAGE_SAMPLE: &[u8] = b"12 0 obj << /Type /Page /Contents 15 0 R >> endobj";
+
+#[test]
+fn parse_page_sample_extracts_object_id() {
+    // Page サンプルをパースし id() == ObjectId(12,0) が抽出されることを確認する
+    let mut p = parser(PAGE_SAMPLE);
+    let io = p.parse_indirect_object().expect("page sample should parse");
+    assert_eq!(io.id().object_number().value(), 12);
+    assert_eq!(io.id().generation_number().value(), 0);
+}
+
+#[test]
+fn parse_page_sample_content_is_dictionary() {
+    // Page サンプルの content 種別が PdfObject::Dictionary であることを確認する
+    let mut p = parser(PAGE_SAMPLE);
+    let io = p.parse_indirect_object().expect("page sample should parse");
+    assert!(matches!(io.object(), PdfObject::Dictionary(_)));
+}
+
+#[test]
+fn parse_page_sample_contents_entry_is_reference() {
+    // Page サンプルの辞書内 /Contents が Reference(15,0) として認識されることを確認する
+    let mut p = parser(PAGE_SAMPLE);
+    let io = p.parse_indirect_object().expect("page sample should parse");
+    let dict = match io.object() {
+        PdfObject::Dictionary(d) => d,
+        other => panic!("expected Dictionary, got {:?}", other),
+    };
+    assert_eq!(
+        dict.get(&PdfName::from("Contents")),
+        Some(&reference(15, 0))
+    );
+}
+
+#[test]
+fn parse_page_sample_type_entry_is_name() {
+    // Page サンプルの辞書内 /Type が Name("Page") で、参照認識の副作用を受けないことを確認する
+    let mut p = parser(PAGE_SAMPLE);
+    let io = p.parse_indirect_object().expect("page sample should parse");
+    let dict = match io.object() {
+        PdfObject::Dictionary(d) => d,
+        other => panic!("expected Dictionary, got {:?}", other),
+    };
+    assert_eq!(
+        dict.get(&PdfName::from("Type")),
+        Some(&PdfObject::Name(PdfName::from("Page")))
+    );
+}


### PR DESCRIPTION
## 概要

Phase R1 / #410。`N G obj <content> endobj` 形式の間接オブジェクト定義を 1 つ読み取り、`ObjectId` と content の `PdfObject` を組にした `IndirectObject` を返すパーサ入口 `Parser::parse_indirect_object` を実装します（ISO 32000-1 §7.3.10）。オブジェクト解決（Epic R2）がファイル内オフセットから 1 定義を読み出す際の入口になります。

## 🎯 変更の種類

- [x] ✨ 新機能 (New feature)
- [x] 🚨 テスト追加 (Tests)

## 📝 詳細な変更内容

### 追加された機能

- **object 層**: 値ラッパ `IndirectObject`（`new` / `id()` / `object()` / `into_parts()`）を新設。生成は無検証（infallible）で、番号の妥当性検証は xref レイヤに委譲。
- **parser 層**: 消費型エントリ `parse_indirect_object` を追加。ヘッダ `N G obj` → content 1 回 → `endobj` の順に読み取る。
  - `take_object_number` … `Integer(N)` かつ `N >= 0` のみ受理し `u64` へ変換
  - `take_generation_number` … `Integer(G)` かつ `0 <= G <= u16::MAX` のみ受理し `u16` へ変換
  - `expect_token` … `obj` / `endobj` 要求を 1 本化した汎用 helper（DRY）
- **エラー区別**: 不正ヘッダ・`endobj` 位置不一致 → `UnexpectedToken`、入力終端 → `UnexpectedEof`、lexer malformed → `LexerError`。番号の妥当性検証（`N >= 1` 等）は xref レイヤに委譲。

### 変更されたファイル

- `rust/crates/core/src/object.rs` … `indirect_object` モジュール宣言を追加
- `rust/crates/core/src/object/indirect_object.rs` … `IndirectObject`（新規）
- `rust/crates/core/src/parser.rs` … `parse_indirect_object` ほか 3 helper と `indirect_object_tests` モジュール宣言（+89 行）
- `rust/crates/core/src/parser/indirect_object_tests/**` … テスト 8 サブモジュール（新規）

## 📊 システム図

```mermaid
flowchart TD
    Start([parse_indirect_object]) --> N["take_object_number<br/>Integer N ≥ 0 → u64"]
    N --> G["take_generation_number<br/>0 ≤ G ≤ u16::MAX → u16"]
    G --> Obj["expect_token: obj"]
    Obj --> Content["parse_object<br/>content を 1 回読取"]
    Content --> EndTok["expect_token: endobj"]
    EndTok --> Ok(["Ok(IndirectObject id, content)"]):::new

    N -.->|非Integer/範囲外| ErrTok["UnexpectedToken"]
    G -.->|非Integer/範囲外| ErrTok
    Obj -.->|不一致| ErrTok
    EndTok -.->|不一致| ErrTok
    N -.->|入力終端| ErrEof["UnexpectedEof"]
    N -.->|malformed| ErrLex["LexerError"]

    classDef new fill:#ffe4b5,stroke:#d97706,stroke-width:2px
```

## 📋 関連 Issue

- Closes #410
- Refs #252（親 Epic）, #258（ObjectId）, #409（間接参照のパース）

## 🧪 テスト

```bash
cargo test -p pdfmod-core
cargo clippy -p pdfmod-core --all-targets -- -D warnings
```

### テスト結果

- `cargo test -p pdfmod-core` … **1029 passed / 0 failed / 0 ignored**
- `cargo clippy --all-targets -- -D warnings` … 指摘なし（clean）
- 新規 `indirect_object_tests` … **38 テスト全通過**

| サブモジュール | 件数 | 観点 |
|:-|:-:|:-|
| basic | 11 | スカラ 7 種 / 配列 / 辞書 / 参照 / ネスト / 連続 2 定義の非過剰消費 |
| boundary | 3 | 番号境界（N=0・G=0・G=u16::MAX） |
| comment_interleaved | 4 | ヘッダ/content 各所のコメント透過 |
| eof_boundary | 4 | ヘッダ各段での入力終端（panic しない） |
| header_invalid | 5 | G 欠落・非 obj・N<0・G<0・G>u16::MAX |
| lexer_error | 3 | G / obj / content 各位置での lexer malformed |
| missing_endobj | 4 | endobj 欠落・別トークン・空 content・stream スコープ外 |
| pdf_sample | 4 | ISO §7.3.10 Page サンプル |

## 🔍 レビューポイント

- **範囲検証の方針**: ヘッダは `N >= 0` / `0 <= G <= u16::MAX` のみで受理し、`N >= 1` 等の妥当性検証は xref レイヤに委譲する寛容方針としています。この責務分担が妥当か。
- **stream はスコープ外**: 辞書 content 読取後の `endobj` 位置に `stream` が来ると `UnexpectedToken{StreamBegin}` で安定失敗する設計です（R2 以降で対応予定）。
- **エラー位置（ByteOffset）**: 各失敗段で返す `ByteOffset` が期待どおりか（テストで固定値検証済み）。

## ✅ チェックリスト

- [x] テストが正常に実行される（1029 passed）
- [x] コミットメッセージが適切な形式で書かれている
- [x] セルフレビューを実施した
- [x] 破壊的変更なし（新規 API の追加のみ）