### PR TITLE
✨ [New Feature]: #480 emcHandler と registerMarkedContentOperators で BMC/EMC を完成

### DIFF
--- a/packages/core/src/content-stream/interpreter/__tests__/interpreter.marked-content.test.ts
+++ b/packages/core/src/content-stream/interpreter/__tests__/interpreter.marked-content.test.ts
@@ -1,0 +1,113 @@
+import { assert, expect, test } from "vitest";
+import { none } from "../../../utils/option/index";
+import { GraphicsStateStack } from "../../graphics-state/index";
+import type { MarkedContentEntry } from "../../marked-content/stack";
+import { MarkedContentStack } from "../../marked-content/stack";
+import { OperandStack } from "../../operand-stack/index";
+import type { OperatorHandlerContext } from "../../operator-registry/index";
+import { OperatorRegistry } from "../../operator-registry/index";
+import { registerMarkedContentOperators } from "../../operators/marked-content/marked-content-operators/index";
+import { ContentStreamInterpreter } from "../index";
+
+const encode = (value: string): Uint8Array => new TextEncoder().encode(value);
+
+/**
+ * BMC/EMC を登録した registry を生成する。
+ */
+const buildRegistry = (): OperatorRegistry => {
+  const registered = registerMarkedContentOperators(OperatorRegistry.create());
+  assert(registered.ok);
+  return registered.value;
+};
+
+test("`/Span BMC EMC` が ok で完走し warnings 空・末尾 depth 0", () => {
+  const result = ContentStreamInterpreter.execute({
+    data: encode("/Span BMC EMC"),
+    registry: buildRegistry(),
+  });
+
+  assert(result.ok);
+  expect(result.value.warnings).toHaveLength(0);
+  expect(
+    MarkedContentStack.depth(result.value.context.markedContentStack),
+  ).toBe(0);
+});
+
+test("ネスト `/Span BMC /Foo BMC EMC EMC` が LIFO で巻き戻り末尾 depth 0", () => {
+  const result = ContentStreamInterpreter.execute({
+    data: encode("/Span BMC /Foo BMC EMC EMC"),
+    registry: buildRegistry(),
+  });
+
+  assert(result.ok);
+  expect(result.value.warnings).toHaveLength(0);
+  expect(
+    MarkedContentStack.depth(result.value.context.markedContentStack),
+  ).toBe(0);
+});
+
+test("`EMC` 単独で execute が err（OPERATOR_ILLEGAL_STATE）を返す", () => {
+  const result = ContentStreamInterpreter.execute({
+    data: encode("EMC"),
+    registry: buildRegistry(),
+  });
+
+  assert(!result.ok);
+  expect(result.error.code).toBe("OPERATOR_ILLEGAL_STATE");
+});
+
+test("`/Span BMC`（EMC 無し）で末尾 OBJECT_PARSE_UNTERMINATED（depth=1・message pin down）", () => {
+  const result = ContentStreamInterpreter.execute({
+    data: encode("/Span BMC"),
+    registry: buildRegistry(),
+  });
+
+  assert(!result.ok);
+  expect(result.error.code).toBe("OBJECT_PARSE_UNTERMINATED");
+  assert(result.error.code === "OBJECT_PARSE_UNTERMINATED");
+  expect(result.error.message).toBe(
+    "Unterminated marked-content sequence(s): depth=1, last tag=/Span",
+  );
+});
+
+test("ネスト未閉じ `/Span BMC /Foo BMC` で depth=2・last tag=/Foo の OBJECT_PARSE_UNTERMINATED", () => {
+  const result = ContentStreamInterpreter.execute({
+    data: encode("/Span BMC /Foo BMC"),
+    registry: buildRegistry(),
+  });
+
+  assert(!result.ok);
+  expect(result.error.code).toBe("OBJECT_PARSE_UNTERMINATED");
+  assert(result.error.code === "OBJECT_PARSE_UNTERMINATED");
+  expect(result.error.message).toBe(
+    "Unterminated marked-content sequence(s): depth=2, last tag=/Foo",
+  );
+});
+
+test('`data: ""` + 非空 initialContext（depth=1, tag /Span）で OBJECT_PARSE_UNTERMINATED', () => {
+  const seededEntry: MarkedContentEntry = {
+    tag: { type: "name", value: "Span" },
+    properties: none,
+  };
+  const initialContext: OperatorHandlerContext = {
+    operandStack: OperandStack.create(),
+    graphicsStateStack: GraphicsStateStack.create(),
+    markedContentStack: MarkedContentStack.push(
+      MarkedContentStack.create(),
+      seededEntry,
+    ),
+  };
+
+  const result = ContentStreamInterpreter.execute({
+    data: encode(""),
+    registry: OperatorRegistry.create(),
+    initialContext,
+  });
+
+  assert(!result.ok);
+  expect(result.error.code).toBe("OBJECT_PARSE_UNTERMINATED");
+  assert(result.error.code === "OBJECT_PARSE_UNTERMINATED");
+  expect(result.error.message).toBe(
+    "Unterminated marked-content sequence(s): depth=1, last tag=/Span",
+  );
+});

--- a/packages/core/src/content-stream/interpreter/index.ts
+++ b/packages/core/src/content-stream/interpreter/index.ts
@@ -101,6 +101,20 @@ function executeToken(options: {
   readonly warnings: PdfWarning[];
 }): Result<InterpreterStep, PdfError> {
   if (options.token.type === TokenType.EOF) {
+    const unterminated = MarkedContentStack.pop(
+      options.context.markedContentStack,
+    );
+    if (unterminated.some) {
+      const depth = MarkedContentStack.depth(
+        options.context.markedContentStack,
+      );
+      const lastTag = unterminated.value.popped.tag.value;
+      return err({
+        code: "OBJECT_PARSE_UNTERMINATED",
+        message: `Unterminated marked-content sequence(s): depth=${depth}, last tag=/${lastTag}`,
+        offset: options.token.offset,
+      });
+    }
     return ok({ type: "done", result: { context: options.context } });
   }
 

--- a/packages/core/src/content-stream/operators/marked-content/bmc/__tests__/bmc.integration.test.ts
+++ b/packages/core/src/content-stream/operators/marked-content/bmc/__tests__/bmc.integration.test.ts
@@ -1,0 +1,67 @@
+import { assert, expect, test } from "vitest";
+import { ContentStreamInterpreter } from "../../../../interpreter/index";
+import { MarkedContentStack } from "../../../../marked-content/stack";
+import { OperatorRegistry } from "../../../../operator-registry/index";
+import { emcHandler } from "../../emc/index";
+import { bmcHandler } from "../index";
+
+const encode = (value: string): Uint8Array => new TextEncoder().encode(value);
+
+/**
+ * BMC / EMC handler を登録した registry を生成する。
+ * BMC で開いた marked-content を EMC で閉じ、末尾 depth 0 の妥当な stream を
+ * end-to-end で実行するため両 operator を登録する。
+ */
+const buildRegistry = (): OperatorRegistry => {
+  const withBmc = OperatorRegistry.register(
+    OperatorRegistry.create(),
+    "BMC",
+    bmcHandler,
+  );
+  assert(withBmc.ok);
+  const withEmc = OperatorRegistry.register(withBmc.value, "EMC", emcHandler);
+  assert(withEmc.ok);
+  return withEmc.value;
+};
+
+test("BMC で開いた 1 段を EMC で閉じると ok で完走し末尾 depth 0 になる", () => {
+  const registry = buildRegistry();
+  const result = ContentStreamInterpreter.execute({
+    data: encode("/Span BMC EMC"),
+    registry,
+  });
+
+  assert(result.ok);
+  expect(result.value.warnings).toHaveLength(0);
+  expect(
+    MarkedContentStack.depth(result.value.context.markedContentStack),
+  ).toBe(0);
+});
+
+test("BMC が operand の name (/Span) を tag として push する（未閉じ EOF の未閉じ tag で確認）", () => {
+  const registry = buildRegistry();
+  const result = ContentStreamInterpreter.execute({
+    data: encode("/Span BMC"),
+    registry,
+  });
+
+  assert(!result.ok);
+  assert(result.error.code === "OBJECT_PARSE_UNTERMINATED");
+  expect(result.error.message).toBe(
+    "Unterminated marked-content sequence(s): depth=1, last tag=/Span",
+  );
+});
+
+test("ネスト BMC/BMC で 2 段開き、2 段の EMC で閉じると ok で完走し末尾 depth 0 になる", () => {
+  const registry = buildRegistry();
+  const result = ContentStreamInterpreter.execute({
+    data: encode("/Span /Foo BMC BMC EMC EMC"),
+    registry,
+  });
+
+  assert(result.ok);
+  expect(result.value.warnings).toHaveLength(0);
+  expect(
+    MarkedContentStack.depth(result.value.context.markedContentStack),
+  ).toBe(0);
+});

--- a/packages/core/src/content-stream/operators/marked-content/emc/__tests__/emc.basic.test.ts
+++ b/packages/core/src/content-stream/operators/marked-content/emc/__tests__/emc.basic.test.ts
@@ -1,0 +1,120 @@
+import { assert, expect, test } from "vitest";
+import type {
+  PdfName,
+  PdfObject,
+} from "../../../../../pdf/types/pdf-types/index";
+import { none } from "../../../../../utils/option/index";
+import { GraphicsStateStack } from "../../../../graphics-state/index";
+import type { MarkedContentEntry } from "../../../../marked-content/stack/index";
+import { MarkedContentStack } from "../../../../marked-content/stack/index";
+import { OperandStack } from "../../../../operand-stack/index";
+import type { OperatorHandlerContext } from "../../../../operator-registry/index";
+import { emcHandler } from "../index";
+
+/**
+ * EMC handler 呼び出し用の context を生成する。
+ * markedContentStack へ tags を LIFO 順（配列先頭が最外）で push し、
+ * operand stack へ operands を積んだ状態で返す。
+ */
+const buildContext = (
+  tags: readonly PdfName[],
+  operands: readonly PdfObject[] = [],
+): OperatorHandlerContext => {
+  const operandStack = OperandStack.create();
+  for (const operand of operands) {
+    OperandStack.push(operandStack, operand);
+  }
+  let markedContentStack = MarkedContentStack.create();
+  for (const tag of tags) {
+    const entry: MarkedContentEntry = { tag, properties: none };
+    markedContentStack = MarkedContentStack.push(markedContentStack, entry);
+  }
+  return {
+    operandStack,
+    graphicsStateStack: GraphicsStateStack.create(),
+    markedContentStack,
+  };
+};
+
+test("depth=1 の stack を pop すると ok を返す", () => {
+  const ctx = buildContext([{ type: "name", value: "Span" }]);
+
+  const result = emcHandler(ctx);
+
+  assert(result.ok);
+});
+
+test("成功時に markedContentStack の depth が 1 → 0 になる", () => {
+  const ctx = buildContext([{ type: "name", value: "Span" }]);
+
+  const result = emcHandler(ctx);
+
+  assert(result.ok);
+  expect(MarkedContentStack.depth(result.value.markedContentStack)).toBe(0);
+});
+
+test("成功時に markedContentStack は入力と別参照で返る", () => {
+  const ctx = buildContext([{ type: "name", value: "Span" }]);
+
+  const result = emcHandler(ctx);
+
+  assert(result.ok);
+  expect(result.value.markedContentStack).not.toBe(ctx.markedContentStack);
+});
+
+test("成功後も入力 ctx.markedContentStack は非破壊で depth=1 のまま", () => {
+  const ctx = buildContext([{ type: "name", value: "Span" }]);
+
+  const result = emcHandler(ctx);
+
+  assert(result.ok);
+  expect(MarkedContentStack.depth(ctx.markedContentStack)).toBe(1);
+});
+
+test("成功時に operandStack は入力と同一参照で返る", () => {
+  const ctx = buildContext([{ type: "name", value: "Span" }]);
+
+  const result = emcHandler(ctx);
+
+  assert(result.ok);
+  expect(result.value.operandStack).toBe(ctx.operandStack);
+});
+
+test("成功時に graphicsStateStack は入力と同一参照で返る", () => {
+  const ctx = buildContext([{ type: "name", value: "Span" }]);
+
+  const result = emcHandler(ctx);
+
+  assert(result.ok);
+  expect(result.value.graphicsStateStack).toBe(ctx.graphicsStateStack);
+});
+
+test("余剰 operand があっても消費しない（operandStack 同一参照・depth 不変）", () => {
+  const ctx = buildContext(
+    [{ type: "name", value: "Span" }],
+    [
+      { type: "integer", value: 1 },
+      { type: "integer", value: 2 },
+    ],
+  );
+
+  const result = emcHandler(ctx);
+
+  assert(result.ok);
+  expect(result.value.operandStack).toBe(ctx.operandStack);
+  expect(OperandStack.depth(result.value.operandStack)).toBe(2);
+});
+
+test("ネスト（depth=2）を pop すると depth=1 になり残る tag は外側（LIFO）", () => {
+  const outer: PdfName = { type: "name", value: "Outer" };
+  const inner: PdfName = { type: "name", value: "Inner" };
+  const ctx = buildContext([outer, inner]);
+
+  const result = emcHandler(ctx);
+
+  assert(result.ok);
+  expect(MarkedContentStack.depth(result.value.markedContentStack)).toBe(1);
+  const remaining = MarkedContentStack.pop(result.value.markedContentStack);
+  assert(remaining.some);
+  expect(remaining.value.popped.tag).toEqual(outer);
+});

--- a/packages/core/src/content-stream/operators/marked-content/emc/__tests__/emc.unmatched.test.ts
+++ b/packages/core/src/content-stream/operators/marked-content/emc/__tests__/emc.unmatched.test.ts
@@ -1,0 +1,62 @@
+import { assert, expect, test } from "vitest";
+import { GraphicsStateStack } from "../../../../graphics-state/index";
+import { MarkedContentStack } from "../../../../marked-content/stack/index";
+import { OperandStack } from "../../../../operand-stack/index";
+import type { OperatorHandlerContext } from "../../../../operator-registry/index";
+import { emcHandler } from "../index";
+
+/**
+ * 空の marked content stack（depth=0）を持つ context を生成する。
+ */
+const buildEmptyContext = (): OperatorHandlerContext => ({
+  operandStack: OperandStack.create(),
+  graphicsStateStack: GraphicsStateStack.create(),
+  markedContentStack: MarkedContentStack.create(),
+});
+
+test("空 stack（depth=0）で err を返す", () => {
+  const ctx = buildEmptyContext();
+
+  const result = emcHandler(ctx);
+
+  assert(!result.ok);
+});
+
+test("エラー code が OPERATOR_ILLEGAL_STATE", () => {
+  const ctx = buildEmptyContext();
+
+  const result = emcHandler(ctx);
+
+  assert(!result.ok);
+  expect(result.error.code).toBe("OPERATOR_ILLEGAL_STATE");
+});
+
+test("エラー message が完全一致する", () => {
+  const ctx = buildEmptyContext();
+
+  const result = emcHandler(ctx);
+
+  assert(!result.ok);
+  expect(result.error.message).toBe(
+    "EMC: no open marked-content sequence (EMC without BMC/BDC)",
+  );
+});
+
+test("operatorName が EMC", () => {
+  const ctx = buildEmptyContext();
+
+  const result = emcHandler(ctx);
+
+  assert(!result.ok);
+  assert(result.error.code === "OPERATOR_ILLEGAL_STATE");
+  expect(result.error.operatorName).toBe("EMC");
+});
+
+test("失敗時に入力 context の markedContentStack を変更しない（depth=0 のまま）", () => {
+  const ctx = buildEmptyContext();
+
+  const result = emcHandler(ctx);
+
+  assert(!result.ok);
+  expect(MarkedContentStack.depth(ctx.markedContentStack)).toBe(0);
+});

--- a/packages/core/src/content-stream/operators/marked-content/emc/index.ts
+++ b/packages/core/src/content-stream/operators/marked-content/emc/index.ts
@@ -1,0 +1,47 @@
+import type { PdfError } from "../../../../pdf/errors/index";
+import { err, ok } from "../../../../utils/result/index";
+import { MarkedContentStack } from "../../../marked-content/stack/index";
+import type {
+  OperatorHandler,
+  OperatorHandlerContext,
+} from "../../../operator-registry/index";
+
+/** PDF 表記を保持した operator 名（"EMC"）。 */
+const OPERATOR_NAME = "EMC";
+
+/**
+ * ISO 32000-2:2020 §14.6 `EMC` operator (end marked-content sequence) のハンドラ。
+ *
+ * marked content stack の末尾 1 段を pop して閉じる。`bmcHandler` の push の鏡像。
+ *
+ * 検査順序（厳守）:
+ *   (1) MarkedContentStack.pop（none = 開いている sequence 無し → OPERATOR_ILLEGAL_STATE）
+ *   (2) some なら markedContentStack を pop 後 stack へ差し替えて ok
+ *
+ * - operand 数: 0（operand stack を一切 pop / 検証 / clear しない。余剰 operand は非消費）。
+ * - 更新するのは markedContentStack のみ。operandStack / graphicsStateStack は入力と同一参照。
+ * - 開いている marked-content sequence が無い（unmatched EMC）場合は OPERATOR_ILLEGAL_STATE。
+ *   operator handler は byte offset を持たないため offset は付けない。
+ *
+ * @param context - 実行コンテキスト
+ * @returns 更新後コンテキスト、または unmatched EMC 時の PdfError
+ */
+export const emcHandler: OperatorHandler = (
+  context: OperatorHandlerContext,
+) => {
+  const popped = MarkedContentStack.pop(context.markedContentStack);
+  if (!popped.some) {
+    const error: PdfError = {
+      code: "OPERATOR_ILLEGAL_STATE",
+      message: "EMC: no open marked-content sequence (EMC without BMC/BDC)",
+      operatorName: OPERATOR_NAME,
+    };
+    return err(error);
+  }
+
+  return ok({
+    operandStack: context.operandStack,
+    graphicsStateStack: context.graphicsStateStack,
+    markedContentStack: popped.value.stack,
+  });
+};

--- a/packages/core/src/content-stream/operators/marked-content/marked-content-operators/__tests__/marked-content-operators.error.test.ts
+++ b/packages/core/src/content-stream/operators/marked-content/marked-content-operators/__tests__/marked-content-operators.error.test.ts
@@ -1,0 +1,38 @@
+import { afterEach, assert, expect, test, vi } from "vitest";
+import { ok } from "../../../../../utils/result/index";
+import { OperatorRegistry } from "../../../../operator-registry/index";
+import { registerMarkedContentOperators } from "../index";
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+test("BMC の重複登録で fail-fast する（register 呼び出しは BMC で止まる）", () => {
+  const base = OperatorRegistry.create();
+  const seeded = OperatorRegistry.register(base, "BMC", (ctx) => ok(ctx));
+  assert(seeded.ok);
+
+  const spy = vi.spyOn(OperatorRegistry, "register");
+  const result = registerMarkedContentOperators(seeded.value);
+
+  assert(!result.ok);
+  assert(result.error.code === "OPERATOR_ALREADY_REGISTERED");
+  expect(result.error.operatorName).toBe("BMC");
+  const calledNames = spy.mock.calls.map((call) => call[1]);
+  expect(calledNames).toEqual(["BMC"]);
+});
+
+test("EMC の重複登録で fail-fast する（register 呼び出しは BMC 登録後に止まる）", () => {
+  const base = OperatorRegistry.create();
+  const seeded = OperatorRegistry.register(base, "EMC", (ctx) => ok(ctx));
+  assert(seeded.ok);
+
+  const spy = vi.spyOn(OperatorRegistry, "register");
+  const result = registerMarkedContentOperators(seeded.value);
+
+  assert(!result.ok);
+  assert(result.error.code === "OPERATOR_ALREADY_REGISTERED");
+  expect(result.error.operatorName).toBe("EMC");
+  const calledNames = spy.mock.calls.map((call) => call[1]);
+  expect(calledNames).toEqual(["BMC", "EMC"]);
+});

--- a/packages/core/src/content-stream/operators/marked-content/marked-content-operators/__tests__/marked-content-operators.integration.test.ts
+++ b/packages/core/src/content-stream/operators/marked-content/marked-content-operators/__tests__/marked-content-operators.integration.test.ts
@@ -1,0 +1,44 @@
+import { assert, expect, test } from "vitest";
+import { OperatorRegistry } from "../../../../operator-registry/index";
+import { registerMarkedContentOperators } from "../index";
+
+test("registerMarkedContentOperators は ok を返す", () => {
+  const registered = registerMarkedContentOperators(OperatorRegistry.create());
+
+  assert(registered.ok);
+});
+
+test("BMC が登録される", () => {
+  const registered = registerMarkedContentOperators(OperatorRegistry.create());
+
+  assert(registered.ok);
+  expect(OperatorRegistry.has(registered.value, "BMC")).toBe(true);
+});
+
+test("EMC が登録される", () => {
+  const registered = registerMarkedContentOperators(OperatorRegistry.create());
+
+  assert(registered.ok);
+  expect(OperatorRegistry.has(registered.value, "EMC")).toBe(true);
+});
+
+test("BDC は登録されない（未登録の保証）", () => {
+  const registered = registerMarkedContentOperators(OperatorRegistry.create());
+
+  assert(registered.ok);
+  expect(OperatorRegistry.has(registered.value, "BDC")).toBe(false);
+});
+
+test("MP は登録されない", () => {
+  const registered = registerMarkedContentOperators(OperatorRegistry.create());
+
+  assert(registered.ok);
+  expect(OperatorRegistry.has(registered.value, "MP")).toBe(false);
+});
+
+test("DP は登録されない", () => {
+  const registered = registerMarkedContentOperators(OperatorRegistry.create());
+
+  assert(registered.ok);
+  expect(OperatorRegistry.has(registered.value, "DP")).toBe(false);
+});

--- a/packages/core/src/content-stream/operators/marked-content/marked-content-operators/index.ts
+++ b/packages/core/src/content-stream/operators/marked-content/marked-content-operators/index.ts
@@ -1,0 +1,36 @@
+import type { PdfError } from "../../../../pdf/errors/index";
+import type { Result } from "../../../../utils/result/index";
+import { flatMap, ok } from "../../../../utils/result/index";
+import type { OperatorHandler } from "../../../operator-registry/index";
+import { OperatorRegistry } from "../../../operator-registry/index";
+import { bmcHandler } from "../bmc/index";
+import { emcHandler } from "../emc/index";
+
+export { bmcHandler } from "../bmc/index";
+export { emcHandler } from "../emc/index";
+
+// BMC/EMC のみ。BDC/MP/DP は後続 issue で登録する（本 issue では未登録のまま）。
+const MARKED_CONTENT_OPERATORS: ReadonlyArray<
+  readonly [string, OperatorHandler]
+> = [
+  ["BMC", bmcHandler],
+  ["EMC", emcHandler],
+];
+
+/**
+ * Marked-content operator (BMC / EMC) を OperatorRegistry に一括登録するヘルパ。
+ *
+ * fail-fast: いずれかの register が Err を返した時点で reduce 内 flatMap が
+ * 短絡し、後続 operator の register は呼ばれない。
+ *
+ * @param registry - 登録元 registry
+ * @returns 全 operator が登録された新しい registry、または重複登録時の PdfError
+ */
+export const registerMarkedContentOperators = (
+  registry: OperatorRegistry,
+): Result<OperatorRegistry, PdfError> =>
+  MARKED_CONTENT_OPERATORS.reduce<Result<OperatorRegistry, PdfError>>(
+    (acc, [name, handler]) =>
+      flatMap(acc, (r) => OperatorRegistry.register(r, name, handler)),
+    ok(registry),
+  );


### PR DESCRIPTION
## 概要

Phase 4-J の残タスクを消化し、`MarkedContentStack` を扱う **BMC / EMC** operator のペアを完成させる。emcHandler 実装、両者を `OperatorRegistry` に一括登録する `registerMarkedContentOperators`、interpreter レベルの end-to-end 統合テストまでを揃え、Issue #480 の受け入れ基準（ネスト、unmatched EMC、stream 末尾未閉じ）をすべて満たす。

`BDC`（#481）と `MP` / `DP`（#482）は範囲外で、`MARKED_CONTENT_OPERATORS` は BMC / EMC のみを登録する。

## 変更内容

### 🎯 変更の種類

- [x] ✨ 新機能 (New feature)
- [x] 🚨 テスト追加/修正 (Tests)

### 📝 詳細な変更内容

#### 追加された機能・修正

- `emcHandler` を新規実装（`packages/core/src/content-stream/operators/marked-content/emc/index.ts`）
  - `MarkedContentStack.pop` で末尾 1 段を pop、operand stack には触れない
  - 開いていない sequence を閉じようとした unmatched EMC は etHandler と一貫した `OPERATOR_ILLEGAL_STATE` を返す
- `registerMarkedContentOperators` バレル + 一括登録ヘルパーを新規追加（`marked-content-operators/index.ts`）
  - `reduce` 内 `flatMap` で **fail-fast**：いずれかの register が Err を返した時点で短絡し、後続の register は呼ばれない
  - 現状は `BMC` / `EMC` のみ登録。`BDC` / `MP` / `DP` は #481 / #482 で追記
- interpreter レベルの end-to-end 統合テスト（`interpreter.marked-content.test.ts`）
  - 単段 `/Span BMC EMC`、LIFO ネスト `/Span BMC /Foo BMC EMC EMC`
  - `EMC` 単独 → `OPERATOR_ILLEGAL_STATE`
  - 未閉じ EOF → `OBJECT_PARSE_UNTERMINATED`（`depth` と `last tag` を message で pin down）
  - 空 data + 非空 `initialContext` でも同じエラーが返ることを確認
- BMC × EMC 統合テスト（`bmc/__tests__/bmc.integration.test.ts`）
  - `registerMarkedContentOperators` を介さず handler を直接 register した経路もカバー
- `registerMarkedContentOperators` の重複登録エラー / 空 registry での正常系テスト（`marked-content-operators.error.test.ts` / `marked-content-operators.integration.test.ts`）

#### 変更されたファイル

- `packages/core/src/content-stream/operators/marked-content/emc/index.ts`（新規）
- `packages/core/src/content-stream/operators/marked-content/emc/__tests__/emc.basic.test.ts`（新規）
- `packages/core/src/content-stream/operators/marked-content/emc/__tests__/emc.unmatched.test.ts`（新規）
- `packages/core/src/content-stream/operators/marked-content/marked-content-operators/index.ts`（新規）
- `packages/core/src/content-stream/operators/marked-content/marked-content-operators/__tests__/marked-content-operators.integration.test.ts`（新規）
- `packages/core/src/content-stream/operators/marked-content/marked-content-operators/__tests__/marked-content-operators.error.test.ts`（新規）
- `packages/core/src/content-stream/operators/marked-content/bmc/__tests__/bmc.integration.test.ts`（新規）
- `packages/core/src/content-stream/interpreter/__tests__/interpreter.marked-content.test.ts`（新規）

## 📊 システム図

### BMC / EMC 実行時の `markedContentStack` 深さ遷移

```mermaid
flowchart TD
    Start([execute 開始]) --> Empty[depth=0<br/>markedContentStack 空]

    Empty -->|/Span BMC| D1[depth=1<br/>top=/Span]:::new
    Empty -->|EMC 単独| ErrIllegal[OPERATOR_ILLEGAL_STATE]:::err

    D1 -->|EMC| Empty
    D1 -->|/Foo BMC| D2[depth=2<br/>top=/Foo]:::new
    D1 -->|EOF| ErrUnterm1["OBJECT_PARSE_UNTERMINATED<br/>depth=1, last tag=/Span"]:::err

    D2 -->|EMC| D1
    D2 -->|EOF| ErrUnterm2["OBJECT_PARSE_UNTERMINATED<br/>depth=2, last tag=/Foo"]:::err

    classDef new fill:#ffe4b5,stroke:#d97706,stroke-width:2px
    classDef err fill:#fee2e2,stroke:#dc2626,stroke-width:2px
```

### ハンドラ登録経路

```mermaid
flowchart LR
    Reg[OperatorRegistry.create] --> Helper[registerMarkedContentOperators]:::new
    Helper -->|reduce + flatMap<br/>fail-fast| RegBMC[register BMC → bmcHandler]
    RegBMC --> RegEMC[register EMC → emcHandler]:::new
    RegEMC --> Ready[registry 完成]

    Helper -.duplicate.-> Err[Err: 重複登録]:::err

    classDef new fill:#ffe4b5,stroke:#d97706,stroke-width:2px
    classDef err fill:#fee2e2,stroke:#dc2626,stroke-width:2px
```

## 📋 関連 Issue

- Closes #480
- Refs #479 (Epic: Phase 4-J Marked Content Operators)

## 🧪 テスト

### テスト実行方法

\`\`\`bash
pnpm --filter @pdfmod/core test
pnpm --filter @pdfmod/core build
\`\`\`

### テスト項目

- [x] 単体テスト (Unit tests) — emc basic / unmatched, marked-content-operators integration / error
- [x] 統合テスト (Integration tests) — interpreter.marked-content, bmc.integration

### テスト結果

- describe 未使用のフラット構造で追加（testing スキル準拠）
- `OBJECT_PARSE_UNTERMINATED` の message は `Unterminated marked-content sequence(s): depth=N, last tag=/Xxx` として pin down

## 🔍 レビューポイント

- `registerMarkedContentOperators` の `reduce` + `flatMap` による fail-fast 挙動が意図通りか（重複登録時に後続 register が呼ばれないこと）
- 未閉じ EOF エラーメッセージのフォーマット (`depth=N, last tag=/Xxx`) が今後の BDC / MP / DP でも流用しやすい形になっているか
- emcHandler が operand stack に触れないこと、および unmatched EMC を `OPERATOR_ILLEGAL_STATE`（etHandler と同種）で返す方針の妥当性

## ✅ チェックリスト

- [x] コードレビューの準備ができている
- [x] テストが正常に実行される
- [x] コミットメッセージが適切な形式で書かれている
- [x] 関連する Issue が PR の「Development」に Linked されている
- [x] PR 本文に `Closes #` / `Refs #` で Issue が記載されている
- [x] セルフレビューを実施した