### PR TITLE
✨ [New Feature]: #411 stream オブジェクト (<< /Length N >> stream ... endstream) のパースを実装

### DIFF
--- a/rust/crates/core/src/lexer/cursor.rs
+++ b/rust/crates/core/src/lexer/cursor.rs
@@ -30,4 +30,54 @@ impl<'a> Lexer<'a> {
         self.pos = self.pos.checked_add(1)?;
         Some(byte)
     }
+
+    /// 現在位置から `len` バイトを raw slice として取り出し、`pos` を `pos + len` に進める。
+    ///
+    /// ストリームデータのように「Length バイトを丸ごと切り出す」用途で使う低レベル API。
+    ///
+    /// # 契約
+    /// - 呼び出し前に `peek_token` / `peek_token_at` などの lookahead を経由していないこと。
+    ///   lookahead により内部バッファにトークンが保留されていると、`pos` はバイト
+    ///   ストリーム上の「次の生バイト位置」と食い違い、切り出す範囲が壊れる。
+    /// - 呼び出し側でバッファをフラッシュ（`take_token` 等で消費）してから呼ぶ責務を持つ。
+    ///
+    /// # 戻り値
+    /// - `Some(slice)` — `input[pos..pos+len]` を返し、内部 `pos` を `pos + len` に進める
+    /// - `None` — `pos + len` が入力範囲を超える場合（`checked_add` オーバーフロー含む）。`pos` は不変
+    ///
+    /// # panic
+    /// panic しない契約（`checked_add` / `slice::get` の `Option` 経由でオーバーフロー吸収）。
+    pub(crate) fn take_bytes(&mut self, len: usize) -> Option<&'a [u8]> {
+        let end = self.pos.checked_add(len)?;
+        let slice = self.input.get(self.pos..end)?;
+        self.pos = end;
+        Some(slice)
+    }
+
+    /// 入力バイト列全体への参照を返す（`EolKind::at(input, pos)` に渡す用途）。
+    ///
+    /// # 契約
+    /// - 参照を保持したまま `take_token` / `take_bytes` などの内部状態変更 API を呼ばないこと
+    ///   （Rust の借用チェックで拒否される想定）。
+    /// - 呼び出し前に `peek_token` などで lookahead バッファが埋まっていないこと。
+    pub(crate) fn input(&self) -> &'a [u8] {
+        self.input
+    }
+
+    /// 現在の `pos` を `n` バイト進める（生バイトを消費するときに使う）。
+    ///
+    /// 既存の [`Self::advance`] は 1 バイト単位で「消費バイトを返す」API。
+    /// 本 API は複数バイトを「戻り値なしで」スキップする用途のため名前を分けている。
+    ///
+    /// # 契約
+    /// - [`Self::take_bytes`] と同様、lookahead バッファが空の状態で呼ぶこと。
+    /// - `pos + n` が入力範囲を超える場合は `None` を返し、`pos` は進めない。
+    pub(crate) fn skip_bytes(&mut self, n: usize) -> Option<()> {
+        let end = self.pos.checked_add(n)?;
+        if end > self.input.len() {
+            return None;
+        }
+        self.pos = end;
+        Some(())
+    }
 }

--- a/rust/crates/core/src/lexer/cursor.rs
+++ b/rust/crates/core/src/lexer/cursor.rs
@@ -48,6 +48,10 @@ impl<'a> Lexer<'a> {
     /// # panic
     /// panic しない契約（`checked_add` / `slice::get` の `Option` 経由でオーバーフロー吸収）。
     pub(crate) fn take_bytes(&mut self, len: usize) -> Option<&'a [u8]> {
+        debug_assert!(
+            self.buffer.is_empty(),
+            "take_bytes called with non-empty lookahead buffer; flush via take_token first"
+        );
         let end = self.pos.checked_add(len)?;
         let slice = self.input.get(self.pos..end)?;
         self.pos = end;
@@ -73,6 +77,10 @@ impl<'a> Lexer<'a> {
     /// - [`Self::take_bytes`] と同様、lookahead バッファが空の状態で呼ぶこと。
     /// - `pos + n` が入力範囲を超える場合は `None` を返し、`pos` は進めない。
     pub(crate) fn skip_bytes(&mut self, n: usize) -> Option<()> {
+        debug_assert!(
+            self.buffer.is_empty(),
+            "skip_bytes called with non-empty lookahead buffer; flush via take_token first"
+        );
         let end = self.pos.checked_add(n)?;
         if end > self.input.len() {
             return None;

--- a/rust/crates/core/src/lexer/hex_string/tests/guard.rs
+++ b/rust/crates/core/src/lexer/hex_string/tests/guard.rs
@@ -42,7 +42,7 @@ fn read_hex_string_returns_none_for_every_leading_whitespace_byte() {
 #[test]
 fn read_hex_string_returns_none_for_leading_delimiters_other_than_open_angle() {
     // delimiter 10 種から '<' を除いた 9 種で None・pos == 0 を確認する
-    for d in [b'(', b')', b'>', b'[', b']', b'{', b'}', b'/', b'%'] {
+    for d in *b"()>[]{}/%" {
         let input = [d];
         let mut lexer = Lexer::new(&input);
         assert_eq!(lexer.read_hex_string(), None, "delimiter {:?}", d as char);

--- a/rust/crates/core/src/lexer/literal_string/tests/guard.rs
+++ b/rust/crates/core/src/lexer/literal_string/tests/guard.rs
@@ -39,7 +39,7 @@ fn read_literal_string_returns_none_for_every_leading_whitespace_byte() {
 #[test]
 fn read_literal_string_returns_none_for_every_non_open_paren_delimiter_byte() {
     // delimiter 10 種から '(' を除いた 9 種で None・pos == 0 を確認する
-    for d in [b')', b'<', b'>', b'[', b']', b'{', b'}', b'/', b'%'] {
+    for d in *b")<>[]{}/%" {
         let input = [d];
         let mut lexer = Lexer::new(&input);
         assert_eq!(

--- a/rust/crates/core/src/lexer/tests.rs
+++ b/rust/crates/core/src/lexer/tests.rs
@@ -14,3 +14,4 @@ mod lexer_read_real_edge;
 mod lexer_skip_comment;
 mod lexer_skip_whitespace;
 mod lexer_skip_ws_and_comments;
+mod lexer_take_bytes;

--- a/rust/crates/core/src/lexer/tests/lexer_read_integer.rs
+++ b/rust/crates/core/src/lexer/tests/lexer_read_integer.rs
@@ -124,7 +124,7 @@ fn read_integer_returns_none_for_plus_then_whitespace() {
 #[test]
 fn read_integer_returns_none_for_sign_then_every_delimiter_byte() {
     // 符号 ∈ {+, -} × delimiter 10 種の全 20 組で None・pos 0 に巻き戻されることを確認する
-    let signs = [b'+', b'-'];
+    let signs = *b"+-";
     let delimiter_bytes = [0x28, 0x29, 0x3C, 0x3E, 0x5B, 0x5D, 0x7B, 0x7D, 0x2F, 0x25];
     for s in signs {
         for d in delimiter_bytes {
@@ -147,7 +147,7 @@ fn read_integer_returns_none_for_sign_then_every_delimiter_byte() {
 #[test]
 fn read_integer_returns_none_for_sign_then_every_whitespace_byte() {
     // 符号 ∈ {+, -} × whitespace 6 種の全 12 組で None・pos 0 に巻き戻されることを確認する
-    let signs = [b'+', b'-'];
+    let signs = *b"+-";
     let whitespace_bytes = [0x00, 0x09, 0x0A, 0x0C, 0x0D, 0x20];
     for s in signs {
         for w in whitespace_bytes {

--- a/rust/crates/core/src/lexer/tests/lexer_read_real_basic.rs
+++ b/rust/crates/core/src/lexer/tests/lexer_read_real_basic.rs
@@ -328,7 +328,7 @@ fn read_real_returns_none_at_eof() {
 #[test]
 fn read_real_returns_none_for_non_digit_non_dot_non_sign_regular_byte() {
     // 先頭が 'x' / 'a' / 'A' 等の regular byte で None・pos 0 を確認する
-    for byte in [b'x', b'a', b'A'] {
+    for byte in *b"xaA" {
         let input = [byte, b'1', b'2'];
         let mut lexer = Lexer::new(&input);
         assert_eq!(
@@ -423,7 +423,7 @@ fn read_real_returns_none_for_every_leading_delimiter_byte() {
 #[test]
 fn read_real_returns_none_for_sign_then_every_whitespace_byte() {
     // 符号 ∈ {+, -} × whitespace 6 種の全 12 組で None・pos 0 を確認する
-    let signs = [b'+', b'-'];
+    let signs = *b"+-";
     let whitespace_bytes = [0x00, 0x09, 0x0A, 0x0C, 0x0D, 0x20];
     for s in signs {
         for w in whitespace_bytes {
@@ -446,7 +446,7 @@ fn read_real_returns_none_for_sign_then_every_whitespace_byte() {
 #[test]
 fn read_real_returns_none_for_sign_then_every_delimiter_byte() {
     // 符号 ∈ {+, -} × delimiter 10 種の全 20 組で None・pos 0 を確認する
-    let signs = [b'+', b'-'];
+    let signs = *b"+-";
     let delimiter_bytes = [0x28, 0x29, 0x3C, 0x3E, 0x5B, 0x5D, 0x7B, 0x7D, 0x2F, 0x25];
     for s in signs {
         for d in delimiter_bytes {

--- a/rust/crates/core/src/lexer/tests/lexer_take_bytes.rs
+++ b/rust/crates/core/src/lexer/tests/lexer_take_bytes.rs
@@ -1,0 +1,93 @@
+use super::super::Lexer;
+
+#[test]
+fn take_bytes_returns_slice_when_within_bounds() {
+    // 入力範囲内で len バイトの slice を返し、pos が len 分進むことを確認する
+    let mut lexer = Lexer::new(b"abcdef");
+    assert_eq!(lexer.take_bytes(3), Some(&b"abc"[..]));
+    assert_eq!(lexer.cursor_position(), 3);
+}
+
+#[test]
+fn take_bytes_returns_none_when_out_of_bounds() {
+    // 入力範囲を超える len を渡すと None を返し、pos は変わらないことを確認する
+    let mut lexer = Lexer::new(b"abc");
+    assert_eq!(lexer.take_bytes(5), None);
+    assert_eq!(lexer.cursor_position(), 0);
+}
+
+#[test]
+fn take_bytes_zero_length_returns_empty_slice() {
+    // len=0 で空 slice を返し、pos が変わらないことを確認する
+    let mut lexer = Lexer::new(b"abc");
+    assert_eq!(lexer.take_bytes(0), Some(&b""[..]));
+    assert_eq!(lexer.cursor_position(), 0);
+}
+
+#[test]
+fn take_bytes_advances_position_correctly() {
+    // 連続呼び出しで pos が期待どおり進むことを確認する（三角測量）
+    let mut lexer = Lexer::new(b"abcdefgh");
+    assert_eq!(lexer.take_bytes(2), Some(&b"ab"[..]));
+    assert_eq!(lexer.cursor_position(), 2);
+    assert_eq!(lexer.take_bytes(3), Some(&b"cde"[..]));
+    assert_eq!(lexer.cursor_position(), 5);
+    assert_eq!(lexer.take_bytes(3), Some(&b"fgh"[..]));
+    assert_eq!(lexer.cursor_position(), 8);
+}
+
+#[test]
+fn take_bytes_returns_none_on_overflow_without_moving_pos() {
+    // pos + len が usize オーバーフローする場合、None を返して pos が不変であることを確認する
+    let mut lexer = Lexer::new(b"abc");
+    // 入力長 3 に対して usize::MAX を渡すと checked_add で捕捉され None が返る
+    assert_eq!(lexer.take_bytes(usize::MAX), None);
+    assert_eq!(lexer.cursor_position(), 0);
+}
+
+#[test]
+fn input_returns_full_byte_slice() {
+    // input() が入力全体への参照を返すことを確認する
+    let lexer = Lexer::new(b"hello world");
+    assert_eq!(lexer.input(), b"hello world");
+}
+
+#[test]
+fn input_returns_empty_slice_for_empty_input() {
+    // 空入力の input() が空 slice を返すことを確認する
+    let lexer = Lexer::new(&[]);
+    assert_eq!(lexer.input(), b"");
+}
+
+#[test]
+fn skip_bytes_moves_position_within_bounds() {
+    // 範囲内で pos が n バイト進むことを確認する
+    let mut lexer = Lexer::new(b"abcdef");
+    assert_eq!(lexer.skip_bytes(3), Some(()));
+    assert_eq!(lexer.cursor_position(), 3);
+}
+
+#[test]
+fn skip_bytes_returns_none_when_out_of_bounds() {
+    // 範囲外の n を渡すと None を返し、pos は不変であることを確認する
+    let mut lexer = Lexer::new(b"abc");
+    assert_eq!(lexer.skip_bytes(5), None);
+    assert_eq!(lexer.cursor_position(), 0);
+}
+
+#[test]
+fn skip_bytes_zero_returns_some_without_moving_pos() {
+    // n=0 で Some(()) を返し、pos が動かないことを確認する
+    let mut lexer = Lexer::new(b"abc");
+    assert_eq!(lexer.skip_bytes(0), Some(()));
+    assert_eq!(lexer.cursor_position(), 0);
+}
+
+#[test]
+fn skip_bytes_to_end_of_input_succeeds() {
+    // 入力末尾ちょうどまでスキップできることを確認する（境界値）
+    let mut lexer = Lexer::new(b"abc");
+    assert_eq!(lexer.skip_bytes(3), Some(()));
+    assert_eq!(lexer.cursor_position(), 3);
+    assert!(lexer.is_eof());
+}

--- a/rust/crates/core/src/parser.rs
+++ b/rust/crates/core/src/parser.rs
@@ -20,6 +20,7 @@
 //! 保留中のトークンは次回 `parse_object` 系で透過的に取り出される（ISO 32000-1 §7.3.10）。
 
 pub mod error;
+mod stream_object;
 
 use crate::byte_offset::ByteOffset;
 use crate::lexer::token::{Primitive, Token};
@@ -123,13 +124,32 @@ impl<'a> Parser<'a> {
         let object_number = self.take_object_number()?;
         let generation = self.take_generation_number()?;
         self.expect_token(&Token::ObjBegin)?;
-        let object = self.parse_object()?;
+        let object = self.parse_object_or_stream()?;
         self.expect_token(&Token::ObjEnd)?;
         let id = ObjectId::new(
             ObjectNumber::new(object_number),
             GenerationNumber::new(generation),
         );
         Ok(IndirectObject::new(id, object))
+    }
+
+    /// `parse_object` の結果が [`PdfObject::Dictionary`] の場合のみ、直後に stream が
+    /// 続くかを試して昇格する。間接オブジェクト内でのみ呼ぶ（DC-7 でトップレベル
+    /// [`Self::parse_object`] は既存挙動を維持）。
+    ///
+    /// `peek_token_with_pos` で次トークンをバッファへ載せてから `position()` を取ることで、
+    /// content 直前の whitespace / comment を飛ばしたあとの実トークン開始位置（辞書なら `<<` の pos）
+    /// を `dict_start` として `parse_stream_object` に渡す（DC-5）。
+    fn parse_object_or_stream(&mut self) -> Result<PdfObject, ParseError> {
+        let dict_start = match self.lexer.peek_token_with_pos() {
+            Some((_, pos)) => ByteOffset::new(pos as u64),
+            None => ByteOffset::new(self.lexer.cursor_position() as u64),
+        };
+        let obj = self.parse_object()?;
+        match obj {
+            PdfObject::Dictionary(dict) => self.parse_stream_object(dict, dict_start),
+            other => Ok(other),
+        }
     }
 
     /// ヘッダ先頭の N を消費する。`Integer(N)` かつ `N >= 0` のみ受理し `u64` へ変換する。
@@ -414,6 +434,9 @@ mod indirect_object_tests;
 
 #[cfg(test)]
 mod indirect_reference_tests;
+
+#[cfg(test)]
+mod stream_object_tests;
 
 #[cfg(test)]
 mod tests {

--- a/rust/crates/core/src/parser/error.rs
+++ b/rust/crates/core/src/parser/error.rs
@@ -24,7 +24,9 @@ pub enum ParseErrorKind {
     MissingLength,
     /// `/Length` が間接参照 `N G R` になっている（Epic R2 で解決される予定）。
     IndirectLengthNotSupported,
-    /// `/Length` が Integer 以外の型（Real / String / Name / Array / Dictionary / Boolean / Null など）。
+    /// `/Length` が Integer 以外の型（Real / String / Name / Array / Dictionary / Boolean / Null など）、
+    /// または Integer だが `usize` に収まらない値（32bit ターゲットで `usize::try_from` が失敗する場合、
+    /// `actual_kind = "IntegerTooLarge"`）。
     InvalidLengthType {
         /// 実際に受け取った型を表す短い識別子。
         actual_kind: &'static str,

--- a/rust/crates/core/src/parser/error.rs
+++ b/rust/crates/core/src/parser/error.rs
@@ -24,9 +24,12 @@ pub enum ParseErrorKind {
     MissingLength,
     /// `/Length` が間接参照 `N G R` になっている（Epic R2 で解決される予定）。
     IndirectLengthNotSupported,
-    /// `/Length` が Integer 以外の型（Real / String / Name / Array / Dictionary / Boolean / Null など）、
+    /// `/Length` が Integer 以外の型（Real / String / Name / Array / Dictionary / Boolean など）、
     /// または Integer だが `usize` に収まらない値（32bit ターゲットで `usize::try_from` が失敗する場合、
     /// `actual_kind = "IntegerTooLarge"`）。
+    ///
+    /// 値が `Null` の場合は辞書パース時に ISO §7.3.7 に従いエントリ自体が削除されるため、
+    /// `/Length null` は本バリアントではなく [`Self::MissingLength`] として現れる。
     InvalidLengthType {
         /// 実際に受け取った型を表す短い識別子。
         actual_kind: &'static str,

--- a/rust/crates/core/src/parser/error.rs
+++ b/rust/crates/core/src/parser/error.rs
@@ -20,6 +20,21 @@ pub enum ParseErrorKind {
     },
     /// lexer が `None` を返した（malformed input）。入力末端ではない場合に発生する。
     LexerError,
+    /// ストリーム辞書に `/Length` エントリが存在しない。
+    MissingLength,
+    /// `/Length` が間接参照 `N G R` になっている（Epic R2 で解決される予定）。
+    IndirectLengthNotSupported,
+    /// `/Length` が Integer 以外の型（Real / String / Name / Array / Dictionary / Boolean / Null など）。
+    InvalidLengthType {
+        /// 実際に受け取った型を表す短い識別子。
+        actual_kind: &'static str,
+    },
+    /// `/Length` が Integer だが負の値。
+    NegativeLength,
+    /// `stream` キーワード直後が CRLF/LF 以外（CR 単体・SP・TAB・EOF など）。
+    InvalidStreamEol,
+    /// `Length` バイト消費後に `endstream` トークンが無い。
+    MissingEndstream,
 }
 
 /// パースエラー。位置情報を必須で保持する。
@@ -57,6 +72,54 @@ impl ParseError {
     pub fn lexer_error_at(position: ByteOffset) -> ParseError {
         ParseError {
             kind: ParseErrorKind::LexerError,
+            position,
+        }
+    }
+
+    /// [`ParseErrorKind::MissingLength`] を指定位置で構築する便利コンストラクタ。
+    pub fn missing_length_at(position: ByteOffset) -> ParseError {
+        ParseError {
+            kind: ParseErrorKind::MissingLength,
+            position,
+        }
+    }
+
+    /// [`ParseErrorKind::IndirectLengthNotSupported`] を指定位置で構築する便利コンストラクタ。
+    pub fn indirect_length_not_supported_at(position: ByteOffset) -> ParseError {
+        ParseError {
+            kind: ParseErrorKind::IndirectLengthNotSupported,
+            position,
+        }
+    }
+
+    /// [`ParseErrorKind::InvalidLengthType`] を指定位置・型識別子で構築する便利コンストラクタ。
+    pub fn invalid_length_type_at(position: ByteOffset, actual_kind: &'static str) -> ParseError {
+        ParseError {
+            kind: ParseErrorKind::InvalidLengthType { actual_kind },
+            position,
+        }
+    }
+
+    /// [`ParseErrorKind::NegativeLength`] を指定位置で構築する便利コンストラクタ。
+    pub fn negative_length_at(position: ByteOffset) -> ParseError {
+        ParseError {
+            kind: ParseErrorKind::NegativeLength,
+            position,
+        }
+    }
+
+    /// [`ParseErrorKind::InvalidStreamEol`] を指定位置で構築する便利コンストラクタ。
+    pub fn invalid_stream_eol_at(position: ByteOffset) -> ParseError {
+        ParseError {
+            kind: ParseErrorKind::InvalidStreamEol,
+            position,
+        }
+    }
+
+    /// [`ParseErrorKind::MissingEndstream`] を指定位置で構築する便利コンストラクタ。
+    pub fn missing_endstream_at(position: ByteOffset) -> ParseError {
+        ParseError {
+            kind: ParseErrorKind::MissingEndstream,
             position,
         }
     }
@@ -138,6 +201,67 @@ mod tests {
         // UnexpectedToken の actual_kind が異なる 2 つが != と判定されることを確認する
         let a = ParseError::unexpected_token_at(ByteOffset::new(0), "ArrayBegin");
         let b = ParseError::unexpected_token_at(ByteOffset::new(0), "DictBegin");
+        assert_ne!(a, b);
+    }
+
+    #[test]
+    fn missing_length_at_constructs_missing_length_kind() {
+        // missing_length_at が MissingLength バリアントを kind に持ち、position も透過することを確認する
+        let err = ParseError::missing_length_at(ByteOffset::new(11));
+        assert_eq!(err.kind, ParseErrorKind::MissingLength);
+        assert_eq!(err.position, ByteOffset::new(11));
+    }
+
+    #[test]
+    fn indirect_length_not_supported_at_constructs_indirect_length_kind() {
+        // indirect_length_not_supported_at が IndirectLengthNotSupported バリアントを持ち、position も透過することを確認する
+        let err = ParseError::indirect_length_not_supported_at(ByteOffset::new(21));
+        assert_eq!(err.kind, ParseErrorKind::IndirectLengthNotSupported);
+        assert_eq!(err.position, ByteOffset::new(21));
+    }
+
+    #[test]
+    fn invalid_length_type_at_constructs_with_actual_kind() {
+        // invalid_length_type_at が InvalidLengthType { actual_kind } を保持し、position も透過することを確認する
+        let err = ParseError::invalid_length_type_at(ByteOffset::new(31), "Real");
+        assert_eq!(
+            err.kind,
+            ParseErrorKind::InvalidLengthType {
+                actual_kind: "Real"
+            }
+        );
+        assert_eq!(err.position, ByteOffset::new(31));
+    }
+
+    #[test]
+    fn negative_length_at_constructs_negative_length_kind() {
+        // negative_length_at が NegativeLength バリアントを kind に持ち、position も透過することを確認する
+        let err = ParseError::negative_length_at(ByteOffset::new(41));
+        assert_eq!(err.kind, ParseErrorKind::NegativeLength);
+        assert_eq!(err.position, ByteOffset::new(41));
+    }
+
+    #[test]
+    fn invalid_stream_eol_at_constructs_invalid_stream_eol_kind() {
+        // invalid_stream_eol_at が InvalidStreamEol バリアントを kind に持ち、position も透過することを確認する
+        let err = ParseError::invalid_stream_eol_at(ByteOffset::new(51));
+        assert_eq!(err.kind, ParseErrorKind::InvalidStreamEol);
+        assert_eq!(err.position, ByteOffset::new(51));
+    }
+
+    #[test]
+    fn missing_endstream_at_constructs_missing_endstream_kind() {
+        // missing_endstream_at が MissingEndstream バリアントを kind に持ち、position も透過することを確認する
+        let err = ParseError::missing_endstream_at(ByteOffset::new(61));
+        assert_eq!(err.kind, ParseErrorKind::MissingEndstream);
+        assert_eq!(err.position, ByteOffset::new(61));
+    }
+
+    #[test]
+    fn invalid_length_type_different_actual_kind_are_not_equal() {
+        // InvalidLengthType の actual_kind が異なる 2 つが != と判定されることを確認する
+        let a = ParseError::invalid_length_type_at(ByteOffset::new(0), "Real");
+        let b = ParseError::invalid_length_type_at(ByteOffset::new(0), "Name");
         assert_ne!(a, b);
     }
 }

--- a/rust/crates/core/src/parser/indirect_object_tests/missing_endobj.rs
+++ b/rust/crates/core/src/parser/indirect_object_tests/missing_endobj.rs
@@ -1,4 +1,6 @@
 use super::super::super::byte_offset::ByteOffset;
+use super::super::super::object::name::PdfName;
+use super::super::super::object::pdf_object::PdfObject;
 use super::super::error::{ParseError, ParseErrorKind};
 use super::parser;
 
@@ -39,16 +41,39 @@ fn parse_indirect_object_empty_content_returns_unexpected_obj_end() {
 }
 
 #[test]
-fn parse_indirect_object_stream_content_fails_stably_at_stream_begin() {
-    // stream は対象外(安定失敗): 辞書を content 読取後 endobj 位置に stream(スコープ外)が来て UnexpectedToken{"StreamBegin"} を返す
+fn parse_indirect_object_stream_content_returns_stream_object_for_empty_data() {
+    // 以前は stream 昇格未サポートで UnexpectedToken{"StreamBegin"} を返すテストだったが、
+    // 本 Issue で parse_indirect_object 内の stream 昇格を実装したため、成功パスに書き換えている。
+    // 期待: /Length 0 の空データストリームが PdfObject::Stream として復元される
     let mut p = parser(b"1 0 obj << /Length 0 >> stream\nendstream endobj");
+    let indirect = p
+        .parse_indirect_object()
+        .expect("stream content indirect object must parse");
+    let stream = match indirect.object() {
+        PdfObject::Stream(stream) => stream,
+        other => panic!("expected Stream, got {other:?}"),
+    };
+    assert!(stream.data().is_empty());
+    let length = stream
+        .dictionary()
+        .get(&PdfName::new(b"Length".to_vec()))
+        .expect("dictionary must retain /Length after stream promotion");
+    assert_eq!(length, &PdfObject::Integer(0));
+}
+
+#[test]
+fn parse_indirect_object_returns_missing_endobj_error_for_non_endobj_token_after_stream() {
+    // stream 昇格後に endobj ではなく別トークン (Name) が来た場合、
+    // expect_token(ObjEnd) が UnexpectedToken を返すことを確認する（既存の missing_endobj 系統との整合）
+    let mut p = parser(b"1 0 obj << /Length 0 >> stream\nendstream /Extra endobj");
+    let err = p
+        .parse_indirect_object()
+        .expect_err("non-endobj token after stream must error");
     assert!(matches!(
-        p.parse_indirect_object(),
-        Err(ParseError {
-            kind: ParseErrorKind::UnexpectedToken {
-                actual_kind: "StreamBegin"
-            },
+        err,
+        ParseError {
+            kind: ParseErrorKind::UnexpectedToken { .. },
             ..
-        })
+        }
     ));
 }

--- a/rust/crates/core/src/parser/indirect_object_tests/missing_endobj.rs
+++ b/rust/crates/core/src/parser/indirect_object_tests/missing_endobj.rs
@@ -45,7 +45,7 @@ fn parse_indirect_object_stream_content_returns_stream_object_for_empty_data() {
     // 以前は stream 昇格未サポートで UnexpectedToken{"StreamBegin"} を返すテストだったが、
     // 本 Issue で parse_indirect_object 内の stream 昇格を実装したため、成功パスに書き換えている。
     // 期待: /Length 0 の空データストリームが PdfObject::Stream として復元される
-    let mut p = parser(b"1 0 obj << /Length 0 >> stream\nendstream endobj");
+    let mut p = parser(b"1 0 obj << /Length 0 >> stream\n\nendstream endobj");
     let indirect = p
         .parse_indirect_object()
         .expect("stream content indirect object must parse");
@@ -65,7 +65,7 @@ fn parse_indirect_object_stream_content_returns_stream_object_for_empty_data() {
 fn parse_indirect_object_returns_missing_endobj_error_for_non_endobj_token_after_stream() {
     // stream 昇格後に endobj ではなく別トークン (Name) が来た場合、
     // expect_token(ObjEnd) が UnexpectedToken を返すことを確認する（既存の missing_endobj 系統との整合）
-    let mut p = parser(b"1 0 obj << /Length 0 >> stream\nendstream /Extra endobj");
+    let mut p = parser(b"1 0 obj << /Length 0 >> stream\n\nendstream /Extra endobj");
     let err = p
         .parse_indirect_object()
         .expect_err("non-endobj token after stream must error");

--- a/rust/crates/core/src/parser/indirect_object_tests/missing_endobj.rs
+++ b/rust/crates/core/src/parser/indirect_object_tests/missing_endobj.rs
@@ -45,7 +45,7 @@ fn parse_indirect_object_stream_content_returns_stream_object_for_empty_data() {
     // 以前は stream 昇格未サポートで UnexpectedToken{"StreamBegin"} を返すテストだったが、
     // 本 Issue で parse_indirect_object 内の stream 昇格を実装したため、成功パスに書き換えている。
     // 期待: /Length 0 の空データストリームが PdfObject::Stream として復元される
-    let mut p = parser(b"1 0 obj << /Length 0 >> stream\n\nendstream endobj");
+    let mut p = parser(b"1 0 obj << /Length 0 >> stream\nendstream endobj");
     let indirect = p
         .parse_indirect_object()
         .expect("stream content indirect object must parse");
@@ -65,7 +65,7 @@ fn parse_indirect_object_stream_content_returns_stream_object_for_empty_data() {
 fn parse_indirect_object_returns_missing_endobj_error_for_non_endobj_token_after_stream() {
     // stream 昇格後に endobj ではなく別トークン (Name) が来た場合、
     // expect_token(ObjEnd) が UnexpectedToken を返すことを確認する（既存の missing_endobj 系統との整合）
-    let mut p = parser(b"1 0 obj << /Length 0 >> stream\n\nendstream /Extra endobj");
+    let mut p = parser(b"1 0 obj << /Length 0 >> stream\nendstream /Extra endobj");
     let err = p
         .parse_indirect_object()
         .expect_err("non-endobj token after stream must error");

--- a/rust/crates/core/src/parser/stream_object.rs
+++ b/rust/crates/core/src/parser/stream_object.rs
@@ -1,0 +1,160 @@
+//! ストリームオブジェクト（`<< /Length N >> stream ... endstream`）のパースを担う層。
+//!
+//! ISO 32000-1 §7.3.8 に従い、辞書パース完了直後の StreamBegin 検出、
+//! `/Length` バイトの生バイト切り出し、CRLF/LF 検証、`endstream` 検証を行う。
+//! 本モジュールは間接オブジェクト経由でのみ発火する（トップレベル
+//! [`Parser::parse_object`](super::Parser::parse_object) は従来通り `UnexpectedToken`）。
+//!
+//! `/Filter` によるデコードや間接参照 `/Length` の解決はスコープ外。仕様違反は
+//! 寛容フォールバックせず、専用の `ParseErrorKind` バリアントで即座に失敗する。
+
+use crate::byte_offset::ByteOffset;
+use crate::lexer::eol::EolKind;
+use crate::lexer::token::Token;
+use crate::object::dictionary::PdfDictionary;
+use crate::object::name::PdfName;
+use crate::object::pdf_object::PdfObject;
+use crate::object::stream::PdfStream;
+use crate::parser::error::ParseError;
+
+use super::Parser;
+
+impl<'a> Parser<'a> {
+    /// 辞書パース完了直後に呼ばれるストリーム昇格エントリ。
+    ///
+    /// 次トークンが [`Token::StreamBegin`] であれば `Length` バイトを切り出して
+    /// [`PdfObject::Stream`] を返す。`StreamBegin` でなければ受け取った辞書を
+    /// そのまま [`PdfObject::Dictionary`] として返す（副作用なし）。
+    ///
+    /// # 契約
+    /// - `peek_token` により内部バッファに保留されたトークンがあってもよいが、
+    ///   本メソッドは `take_token` で StreamBegin を消費してから生バイトを触るため、
+    ///   `take_bytes` の契約は本メソッド内で自然に満たされる。
+    ///
+    /// # 引数
+    /// - `dictionary`: 直前で `parse_object` が返した [`PdfDictionary`]（ムーブ）
+    /// - `dict_start`: 辞書 `<<` の開始位置。stream 系エラーの `position` として使う
+    pub(super) fn parse_stream_object(
+        &mut self,
+        dictionary: PdfDictionary,
+        dict_start: ByteOffset,
+    ) -> Result<PdfObject, ParseError> {
+        if !matches!(self.lexer.peek_token_at(0), Some(Token::StreamBegin)) {
+            return Ok(PdfObject::Dictionary(dictionary));
+        }
+        let _ = self.lexer.take_token();
+        let after_stream_pos = ByteOffset::new(self.lexer.cursor_position() as u64);
+
+        let length = Self::resolve_stream_length(&dictionary, dict_start)?;
+        self.consume_stream_eol(after_stream_pos)?;
+        let data_start = ByteOffset::new(self.lexer.cursor_position() as u64);
+        let data = self.take_stream_data(length, data_start)?;
+        self.expect_endstream()?;
+
+        Ok(PdfObject::Stream(PdfStream::new(dictionary, data)))
+    }
+
+    /// `/Length` を辞書から取り出し、非負 `usize` として返す。
+    ///
+    /// エラー位置はすべて `dict_start`（DC-5）。
+    /// `i64 → usize` は `usize::try_from` で行い、32bit ターゲットで
+    /// `usize` に収まらない場合は `InvalidLengthType { actual_kind: "IntegerTooLarge" }`
+    /// として返す（panic 不在契約）。
+    fn resolve_stream_length(
+        dictionary: &PdfDictionary,
+        dict_start: ByteOffset,
+    ) -> Result<usize, ParseError> {
+        let key = PdfName::new(b"Length".to_vec());
+        let value = dictionary
+            .get(&key)
+            .ok_or_else(|| ParseError::missing_length_at(dict_start))?;
+
+        match value {
+            PdfObject::Integer(n) if *n < 0 => Err(ParseError::negative_length_at(dict_start)),
+            PdfObject::Integer(n) => usize::try_from(*n)
+                .map_err(|_| ParseError::invalid_length_type_at(dict_start, "IntegerTooLarge")),
+            PdfObject::Reference(_) => {
+                Err(ParseError::indirect_length_not_supported_at(dict_start))
+            }
+            other => Err(ParseError::invalid_length_type_at(
+                dict_start,
+                Self::pdf_object_kind_label(other),
+            )),
+        }
+    }
+
+    /// `stream` キーワード直後の EOL を CRLF/LF のみ許容して消費する。
+    ///
+    /// [`EolKind::at`] を直接呼ぶことで `skip_whitespace` を経由せず、SP/TAB を
+    /// EOL として食わない（DC-4）。CR 単独 / SP / TAB / EOF はいずれも
+    /// [`ParseErrorKind::InvalidStreamEol`](super::error::ParseErrorKind::InvalidStreamEol)
+    /// として `after_stream_pos`（stream キーワード消費直後の位置）を返す。
+    fn consume_stream_eol(&mut self, after_stream_pos: ByteOffset) -> Result<(), ParseError> {
+        let pos = self.lexer.cursor_position();
+        let input = self.lexer.input();
+        match EolKind::at(input, pos) {
+            Some(EolKind::Lf) => {
+                let _ = self.lexer.skip_bytes(1);
+                Ok(())
+            }
+            Some(EolKind::CrLf) => {
+                let _ = self.lexer.skip_bytes(2);
+                Ok(())
+            }
+            Some(EolKind::Cr) | None => Err(ParseError::invalid_stream_eol_at(after_stream_pos)),
+        }
+    }
+
+    /// `Length` バイトを [`Vec<u8>`] にコピーする。範囲外なら `UnexpectedEof`。
+    fn take_stream_data(
+        &mut self,
+        length: usize,
+        data_start: ByteOffset,
+    ) -> Result<Vec<u8>, ParseError> {
+        self.lexer
+            .take_bytes(length)
+            .map(|slice| slice.to_vec())
+            .ok_or_else(|| ParseError::unexpected_eof_at(data_start))
+    }
+
+    /// 直後のトークンが [`Token::StreamEnd`] であることを検証する。
+    ///
+    /// 別トークン / EOF はいずれも
+    /// [`ParseErrorKind::MissingEndstream`](super::error::ParseErrorKind::MissingEndstream)
+    /// として返す。EOF 時の位置は現在の生カーソル位置（入力末尾）。lexer が malformed を
+    /// 検知した場合のみ [`ParseErrorKind::LexerError`](super::error::ParseErrorKind::LexerError)
+    /// を返す（既存 helper の EOF / malformed 区別方針と整合）。
+    fn expect_endstream(&mut self) -> Result<(), ParseError> {
+        match self.lexer.take_token_with_pos() {
+            Some((Token::StreamEnd, _)) => Ok(()),
+            Some((_, pos_before)) => Err(ParseError::missing_endstream_at(ByteOffset::new(
+                pos_before as u64,
+            ))),
+            None => {
+                let here = ByteOffset::new(self.lexer.cursor_position() as u64);
+                if self.lexer.is_eof() {
+                    Err(ParseError::missing_endstream_at(here))
+                } else {
+                    Err(ParseError::lexer_error_at(here))
+                }
+            }
+        }
+    }
+
+    /// [`PdfObject`] のバリアント名を [`ParseErrorKind::InvalidLengthType`](super::error::ParseErrorKind::InvalidLengthType) の
+    /// `actual_kind` フィールドに載せるための短い `'static` 識別子にマップする。
+    fn pdf_object_kind_label(object: &PdfObject) -> &'static str {
+        match object {
+            PdfObject::Null => "Null",
+            PdfObject::Boolean(_) => "Boolean",
+            PdfObject::Integer(_) => "Integer",
+            PdfObject::Real(_) => "Real",
+            PdfObject::String(_) => "String",
+            PdfObject::Name(_) => "Name",
+            PdfObject::Array(_) => "Array",
+            PdfObject::Dictionary(_) => "Dictionary",
+            PdfObject::Stream(_) => "Stream",
+            PdfObject::Reference(_) => "Reference",
+        }
+    }
+}

--- a/rust/crates/core/src/parser/stream_object.rs
+++ b/rust/crates/core/src/parser/stream_object.rs
@@ -52,7 +52,7 @@ impl<'a> Parser<'a> {
         self.consume_stream_eol(after_stream_pos)?;
         let data_start = ByteOffset::new(self.lexer.cursor_position() as u64);
         let data = self.take_stream_data(length, data_start)?;
-        self.expect_endstream()?;
+        self.expect_endstream(length)?;
 
         Ok(PdfObject::Stream(PdfStream::new(dictionary, data)))
     }
@@ -127,27 +127,37 @@ impl<'a> Parser<'a> {
     /// トレーリング空白 / コメント / SP / TAB は許容しない。
     ///
     /// # アルゴリズム
-    /// 1. カーソル位置に EOL (LF/CR/CRLF) があれば消費する。無ければ消費しない。
-    /// 2. カーソル位置から `endstream` バイト列が始まることを確認する。
-    /// 3. `endstream` の直前バイト（`cursor - 1`）が LF (0x0A) または CR (0x0D) であることを確認する。
-    ///
-    /// これにより `Length = 0` で `stream\nendstream` のように `stream` 直後の EOL が
-    /// そのまま `endstream` 直前の EOL を兼ねるケースも受理する（Copilot 指摘対応）。
-    /// 一方 `dataendstream`（EOL 無し）は前バイトが data 末尾になるため拒否される。
+    /// 1. `data_len > 0` の場合、`pos_after_data` に EOL (LF/CR/CRLF) が必須。無ければ拒否
+    ///    （`/Length` が data 末尾の EOL バイトを "データとして" 数え込んでいる spec 違反を
+    ///    catchする — Copilot 指摘対応）。`data_len = 0` の場合は post-stream EOL が
+    ///    pre-endstream EOL を兼ねる形も許容するため EOL 消費は任意
+    /// 2. カーソル位置から `endstream` バイト列が始まることを確認する
+    /// 3. `endstream` の直前バイト（`cursor - 1`）が LF (0x0A) または CR (0x0D) であることを確認する
+    ///    （Length=0 かつ pos_after_data で EOL が無かった場合の post-stream EOL 保証）
     ///
     /// # 受理 / 拒否パターン
     /// - `data\nendstream` / `data\r\nendstream` / `data\rendstream` → 受理
-    /// - `stream\nendstream`（Length=0）→ 受理（post-stream EOL が兼ねる）
+    /// - `stream\nendstream`（Length=0、post-stream EOL 兼用）→ 受理
+    /// - `stream\n\nendstream`（Length=0、余分な EOL）→ 受理
+    /// - `<< /Length 4 >>\nstream\nabc\nendstream`（Length が末尾 LF を含む spec 違反）→ 拒否
+    ///   （pos_after_data が 'e' で EOL 無しのため）
     /// - `dataendstream`（Length>0、EOL 無し）→ `MissingEndstream`
-    /// - `data \nendstream`（末尾 SP + EOL）→ `MissingEndstream`（cursor 位置が空白）
-    /// - `data\n endstream`（EOL + SP）→ `MissingEndstream`（rest が endstream で始まらない）
-    /// - `data\nendstream42`（キーワード境界違反）→ lexer の take_token が Keyword として返し `MissingEndstream`
-    fn expect_endstream(&mut self) -> Result<(), ParseError> {
+    /// - `data \nendstream` / `data\n endstream` → `MissingEndstream`
+    /// - `data\nendstream42`（キーワード境界違反）→ lexer が Keyword として返し `MissingEndstream`
+    fn expect_endstream(&mut self, data_len: usize) -> Result<(), ParseError> {
         let pos_after_data = self.lexer.cursor_position();
         let input = self.lexer.input();
 
-        if let Some(eol) = EolKind::at(input, pos_after_data) {
-            let _ = self.lexer.skip_bytes(eol.byte_len());
+        match EolKind::at(input, pos_after_data) {
+            Some(eol) => {
+                let _ = self.lexer.skip_bytes(eol.byte_len());
+            }
+            None if data_len > 0 => {
+                return Err(ParseError::missing_endstream_at(ByteOffset::new(
+                    pos_after_data as u64,
+                )));
+            }
+            None => {}
         }
 
         let cursor = self.lexer.cursor_position();

--- a/rust/crates/core/src/parser/stream_object.rs
+++ b/rust/crates/core/src/parser/stream_object.rs
@@ -1,12 +1,15 @@
 //! ストリームオブジェクト（`<< /Length N >> stream ... endstream`）のパースを担う層。
 //!
 //! ISO 32000-1 §7.3.8 に従い、辞書パース完了直後の StreamBegin 検出、
-//! `/Length` バイトの生バイト切り出し、CRLF/LF 検証、`endstream` 検証を行う。
+//! `/Length` バイトの生バイト切り出し、`stream` 直後の CRLF/LF 検証、
+//! および `endstream` 直前の必須 EOL とキーワード境界の厳格検証を行う。
 //! 本モジュールは間接オブジェクト経由でのみ発火する（トップレベル
 //! [`Parser::parse_object`](super::Parser::parse_object) は従来通り `UnexpectedToken`）。
 //!
 //! `/Filter` によるデコードや間接参照 `/Length` の解決はスコープ外。仕様違反は
 //! 寛容フォールバックせず、専用の `ParseErrorKind` バリアントで即座に失敗する。
+//! `endstream` 直前の空白 / コメントは `skip_whitespace` 経由での寛容化を行わず、
+//! LF / CRLF のみ許容する（[`expect_endstream`] を参照）。
 
 use crate::byte_offset::ByteOffset;
 use crate::lexer::eol::EolKind;
@@ -117,14 +120,49 @@ impl<'a> Parser<'a> {
             .ok_or_else(|| ParseError::unexpected_eof_at(data_start))
     }
 
-    /// 直後のトークンが [`Token::StreamEnd`] であることを検証する。
+    /// `Length` バイト消費直後の位置から、必須の EOL と `endstream` キーワードを厳格に検証する。
     ///
-    /// 別トークン / EOF はいずれも
+    /// ISO 32000-1 §7.3.8 は「`endstream` の直前に EOL がある」と規定するため、以下のパターンのみ受理:
+    /// - `\n` + `endstream`（LF）
+    /// - `\r\n` + `endstream`（CRLF）
+    ///
+    /// `dataendstream`（EOL 無し）、`data\rendstream`（CR 単体）、`data \nendstream`
+    /// （末尾空白 + EOL）、`data\n endstream`（EOL + 空白）はいずれも
     /// [`ParseErrorKind::MissingEndstream`](super::error::ParseErrorKind::MissingEndstream)
-    /// として返す。EOF 時の位置は現在の生カーソル位置（入力末尾）。lexer が malformed を
-    /// 検知した場合のみ [`ParseErrorKind::LexerError`](super::error::ParseErrorKind::LexerError)
-    /// を返す（既存 helper の EOF / malformed 区別方針と整合）。
+    /// として拒否する。`skip_whitespace` を経由せず raw byte 比較で判定するため、
+    /// `endstream` 直前のトレーリング空白 / コメント / SP / TAB は許容しない。
+    ///
+    /// キーワード境界（`endstreamXY` のような regular byte 連結）は
+    /// [`Lexer::take_token_with_pos`] に委ねる（`endstreamXY` は `Keyword` として返り、
+    /// 本関数は `MissingEndstream` として拒否する）。EOF は
+    /// `MissingEndstream at cursor`、lexer malformed は
+    /// [`ParseErrorKind::LexerError`](super::error::ParseErrorKind::LexerError) に集約する。
     fn expect_endstream(&mut self) -> Result<(), ParseError> {
+        let pos_after_data = self.lexer.cursor_position();
+        let input = self.lexer.input();
+
+        match EolKind::at(input, pos_after_data) {
+            Some(EolKind::Lf) => {
+                let _ = self.lexer.skip_bytes(1);
+            }
+            Some(EolKind::CrLf) => {
+                let _ = self.lexer.skip_bytes(2);
+            }
+            Some(EolKind::Cr) | None => {
+                return Err(ParseError::missing_endstream_at(ByteOffset::new(
+                    pos_after_data as u64,
+                )));
+            }
+        }
+
+        let cursor = self.lexer.cursor_position();
+        let remaining = self.lexer.input().get(cursor..).unwrap_or(&[]);
+        if !remaining.starts_with(b"endstream") {
+            return Err(ParseError::missing_endstream_at(ByteOffset::new(
+                cursor as u64,
+            )));
+        }
+
         match self.lexer.take_token_with_pos() {
             Some((Token::StreamEnd, _)) => Ok(()),
             Some((_, pos_before)) => Err(ParseError::missing_endstream_at(ByteOffset::new(

--- a/rust/crates/core/src/parser/stream_object.rs
+++ b/rust/crates/core/src/parser/stream_object.rs
@@ -120,44 +120,48 @@ impl<'a> Parser<'a> {
             .ok_or_else(|| ParseError::unexpected_eof_at(data_start))
     }
 
-    /// `Length` バイト消費直後の位置から、必須の EOL と `endstream` キーワードを厳格に検証する。
+    /// `Length` バイト消費直後の位置から、`endstream` キーワードとその直前 EOL を厳格に検証する。
     ///
-    /// ISO 32000-1 §7.3.8 は「`endstream` の直前に EOL がある」と規定するため、以下のパターンのみ受理:
-    /// - `\n` + `endstream`（LF）
-    /// - `\r\n` + `endstream`（CRLF）
+    /// ISO 32000-1 §7.3.8 は「`endstream` の直前に EOL マーカーがある」と規定する（EOL = LF / CR / CRLF）。
+    /// 本関数は `skip_whitespace` を経由せず raw byte で判定するため、`endstream` 直前の
+    /// トレーリング空白 / コメント / SP / TAB は許容しない。
     ///
-    /// `dataendstream`（EOL 無し）、`data\rendstream`（CR 単体）、`data \nendstream`
-    /// （末尾空白 + EOL）、`data\n endstream`（EOL + 空白）はいずれも
-    /// [`ParseErrorKind::MissingEndstream`](super::error::ParseErrorKind::MissingEndstream)
-    /// として拒否する。`skip_whitespace` を経由せず raw byte 比較で判定するため、
-    /// `endstream` 直前のトレーリング空白 / コメント / SP / TAB は許容しない。
+    /// # アルゴリズム
+    /// 1. カーソル位置に EOL (LF/CR/CRLF) があれば消費する。無ければ消費しない。
+    /// 2. カーソル位置から `endstream` バイト列が始まることを確認する。
+    /// 3. `endstream` の直前バイト（`cursor - 1`）が LF (0x0A) または CR (0x0D) であることを確認する。
     ///
-    /// キーワード境界（`endstreamXY` のような regular byte 連結）は
-    /// [`Lexer::take_token_with_pos`] に委ねる（`endstreamXY` は `Keyword` として返り、
-    /// 本関数は `MissingEndstream` として拒否する）。EOF は
-    /// `MissingEndstream at cursor`、lexer malformed は
-    /// [`ParseErrorKind::LexerError`](super::error::ParseErrorKind::LexerError) に集約する。
+    /// これにより `Length = 0` で `stream\nendstream` のように `stream` 直後の EOL が
+    /// そのまま `endstream` 直前の EOL を兼ねるケースも受理する（Copilot 指摘対応）。
+    /// 一方 `dataendstream`（EOL 無し）は前バイトが data 末尾になるため拒否される。
+    ///
+    /// # 受理 / 拒否パターン
+    /// - `data\nendstream` / `data\r\nendstream` / `data\rendstream` → 受理
+    /// - `stream\nendstream`（Length=0）→ 受理（post-stream EOL が兼ねる）
+    /// - `dataendstream`（Length>0、EOL 無し）→ `MissingEndstream`
+    /// - `data \nendstream`（末尾 SP + EOL）→ `MissingEndstream`（cursor 位置が空白）
+    /// - `data\n endstream`（EOL + SP）→ `MissingEndstream`（rest が endstream で始まらない）
+    /// - `data\nendstream42`（キーワード境界違反）→ lexer の take_token が Keyword として返し `MissingEndstream`
     fn expect_endstream(&mut self) -> Result<(), ParseError> {
         let pos_after_data = self.lexer.cursor_position();
         let input = self.lexer.input();
 
-        match EolKind::at(input, pos_after_data) {
-            Some(EolKind::Lf) => {
-                let _ = self.lexer.skip_bytes(1);
-            }
-            Some(EolKind::CrLf) => {
-                let _ = self.lexer.skip_bytes(2);
-            }
-            Some(EolKind::Cr) | None => {
-                return Err(ParseError::missing_endstream_at(ByteOffset::new(
-                    pos_after_data as u64,
-                )));
-            }
+        if let Some(eol) = EolKind::at(input, pos_after_data) {
+            let _ = self.lexer.skip_bytes(eol.byte_len());
         }
 
         let cursor = self.lexer.cursor_position();
         let remaining = self.lexer.input().get(cursor..).unwrap_or(&[]);
         if !remaining.starts_with(b"endstream") {
+            return Err(ParseError::missing_endstream_at(ByteOffset::new(
+                cursor as u64,
+            )));
+        }
+
+        let preceding_byte = cursor
+            .checked_sub(1)
+            .and_then(|p| self.lexer.input().get(p).copied());
+        if !matches!(preceding_byte, Some(0x0A) | Some(0x0D)) {
             return Err(ParseError::missing_endstream_at(ByteOffset::new(
                 cursor as u64,
             )));

--- a/rust/crates/core/src/parser/stream_object_tests.rs
+++ b/rust/crates/core/src/parser/stream_object_tests.rs
@@ -61,7 +61,6 @@ fn parse_stream_err(input: &[u8]) -> ParseError {
 ///
 /// 各エラーテストで `dict_start` の位置検証（DC-5）を透過的に行うため、
 /// テスト側で `ByteOffset::new(...)` を毎回書かずに済むようにする。
-#[allow(dead_code)]
 fn byte_offset(pos: u64) -> ByteOffset {
     ByteOffset::new(pos)
 }

--- a/rust/crates/core/src/parser/stream_object_tests.rs
+++ b/rust/crates/core/src/parser/stream_object_tests.rs
@@ -1,0 +1,67 @@
+//! `parse_stream_object` の単体・統合テスト。
+//!
+//! DC-9 に従い「1 パターン = 1 ファイル」で分割。
+//! 共通ヘルパは本ファイルに集約し、各テストファイルはこのヘルパを介して
+//! [`crate::object::stream::PdfStream`] または [`crate::parser::error::ParseError`] を検証する。
+
+use crate::byte_offset::ByteOffset;
+use crate::object::pdf_object::PdfObject;
+use crate::object::stream::PdfStream;
+use crate::parser::error::ParseError;
+
+use super::Parser;
+
+mod basic;
+mod binary_data;
+mod eof_boundary;
+mod indirect_length;
+mod integration;
+mod invalid_length_type;
+mod invalid_stream_eol;
+mod missing_endstream;
+mod missing_length;
+mod negative_length;
+mod pdf_sample;
+
+/// `<< /Length N >> stream ... endstream` の入力を丸ごと渡し、成功時の
+/// [`PdfStream`] を返すヘルパ。
+///
+/// `parse_object` で辞書を先に読み、続いて `parse_stream_object` を直接呼び出す
+/// ことで stream 昇格ロジックのみを分離テストする。
+fn parse_stream(input: &[u8]) -> PdfStream {
+    let mut parser = Parser::new(input);
+    let dict_start = parser.position();
+    let obj = parser.parse_object().expect("dictionary must parse");
+    let PdfObject::Dictionary(dictionary) = obj else {
+        panic!("expected dictionary at head of input, got {obj:?}");
+    };
+    let result = parser
+        .parse_stream_object(dictionary, dict_start)
+        .expect("stream must parse");
+    match result {
+        PdfObject::Stream(stream) => stream,
+        other => panic!("expected Stream, got {other:?}"),
+    }
+}
+
+/// stream 昇格でエラーを返すことを期待する入力向けヘルパ。
+fn parse_stream_err(input: &[u8]) -> ParseError {
+    let mut parser = Parser::new(input);
+    let dict_start = parser.position();
+    let obj = parser.parse_object().expect("dictionary must parse");
+    let PdfObject::Dictionary(dictionary) = obj else {
+        panic!("expected dictionary at head of input, got {obj:?}");
+    };
+    parser
+        .parse_stream_object(dictionary, dict_start)
+        .expect_err("stream parse must fail for this input")
+}
+
+/// dict_start を明示保持したまま `ByteOffset` にラップして返す薄いヘルパ。
+///
+/// 各エラーテストで `dict_start` の位置検証（DC-5）を透過的に行うため、
+/// テスト側で `ByteOffset::new(...)` を毎回書かずに済むようにする。
+#[allow(dead_code)]
+fn byte_offset(pos: u64) -> ByteOffset {
+    ByteOffset::new(pos)
+}

--- a/rust/crates/core/src/parser/stream_object_tests/basic.rs
+++ b/rust/crates/core/src/parser/stream_object_tests/basic.rs
@@ -1,0 +1,25 @@
+use super::parse_stream;
+
+#[test]
+fn parse_stream_object_returns_stream_for_lf_eol_with_length_four() {
+    // 正常系（LF）: /Length 4 と data="data" の間が LF で区切られたストリームが復元されることを確認する（DC-10）
+    let input = b"<< /Length 4 >>\nstream\ndata\nendstream";
+    let stream = parse_stream(input);
+    assert_eq!(stream.data(), b"data");
+}
+
+#[test]
+fn parse_stream_object_returns_stream_for_crlf_eol_with_length_four() {
+    // 正常系（CRLF）: stream キーワード直後の CRLF を 2 バイトの 1 改行として扱い data を切り出せることを確認する（DC-11: 1 パターン = 1 test）
+    let input = b"<< /Length 4 >>\nstream\r\ndata\r\nendstream";
+    let stream = parse_stream(input);
+    assert_eq!(stream.data(), b"data");
+}
+
+#[test]
+fn parse_stream_object_returns_empty_data_for_length_zero() {
+    // 境界値: /Length 0 の場合 take_bytes(0) が空 slice を返し、Vec::new() で保持されることを確認する
+    let input = b"<< /Length 0 >>\nstream\n\nendstream";
+    let stream = parse_stream(input);
+    assert!(stream.data().is_empty());
+}

--- a/rust/crates/core/src/parser/stream_object_tests/basic.rs
+++ b/rust/crates/core/src/parser/stream_object_tests/basic.rs
@@ -17,9 +17,30 @@ fn parse_stream_object_returns_stream_for_crlf_eol_with_length_four() {
 }
 
 #[test]
-fn parse_stream_object_returns_empty_data_for_length_zero() {
-    // 境界値: /Length 0 の場合 take_bytes(0) が空 slice を返し、Vec::new() で保持されることを確認する
+fn parse_stream_object_returns_empty_data_for_length_zero_without_extra_blank_line() {
+    // 境界値: /Length 0 で `stream\nendstream` のように post-stream EOL が pre-endstream EOL を
+    // 兼ねる最小形が受理されることを確認する（Copilot 指摘対応: 余分な空行を要求しない）。
+    // take_bytes(0) が空 slice を返し、Vec::new() で保持される。
+    let input = b"<< /Length 0 >>\nstream\nendstream";
+    let stream = parse_stream(input);
+    assert!(stream.data().is_empty());
+}
+
+#[test]
+fn parse_stream_object_returns_empty_data_for_length_zero_with_extra_blank_line() {
+    // 境界値: /Length 0 で `stream\n\nendstream` のように data の代わりに追加の EOL がある形も受理されることを確認する。
+    // 1 個目の EOL は consume_stream_eol、2 個目の EOL は expect_endstream の前置 EOL 消費で扱われる。
     let input = b"<< /Length 0 >>\nstream\n\nendstream";
     let stream = parse_stream(input);
     assert!(stream.data().is_empty());
+}
+
+#[test]
+fn parse_stream_object_returns_stream_for_cr_only_eol_before_endstream() {
+    // ISO 32000-1 §7.2.3 の EOL 定義は LF / CR / CRLF の 3 パターンをすべて許容する。
+    // data の末尾に CR 単体（`data\rendstream`）が来る形も endstream 前 EOL として受理する
+    // （Copilot 指摘対応: CR-only を寛容に扱う）。
+    let input = b"<< /Length 4 >>\nstream\ndata\rendstream";
+    let stream = parse_stream(input);
+    assert_eq!(stream.data(), b"data");
 }

--- a/rust/crates/core/src/parser/stream_object_tests/binary_data.rs
+++ b/rust/crates/core/src/parser/stream_object_tests/binary_data.rs
@@ -1,0 +1,55 @@
+use super::parse_stream;
+
+#[test]
+fn parse_stream_object_preserves_nul_bytes_in_data() {
+    // data 中に NUL バイト (0x00) を含んでも Length ベースで正しく切り出せることを確認する
+    let mut input = Vec::new();
+    input.extend_from_slice(b"<< /Length 5 >>\nstream\n");
+    input.extend_from_slice(&[b'a', 0x00, b'b', 0x00, b'c']);
+    input.extend_from_slice(b"\nendstream");
+    let stream = parse_stream(&input);
+    assert_eq!(stream.data(), &[b'a', 0x00, b'b', 0x00, b'c']);
+}
+
+#[test]
+fn parse_stream_object_treats_endstream_bytes_inside_data_as_regular_bytes() {
+    // data 中に "endstream" バイト列を含んでも Length で正しく切り分けられ、endstream をトークンとして誤検出しないことを確認する
+    let payload = b"endstream ignored";
+    let length = payload.len();
+    let mut input = Vec::new();
+    input.extend_from_slice(format!("<< /Length {length} >>\nstream\n").as_bytes());
+    input.extend_from_slice(payload);
+    input.extend_from_slice(b"\nendstream");
+    let stream = parse_stream(&input);
+    assert_eq!(stream.data(), payload);
+}
+
+#[test]
+fn parse_stream_object_preserves_cr_and_lf_control_bytes_inside_data() {
+    // data 中に CR / LF 制御バイトが含まれても Length ベース切り出しで忠実に保持されることを確認する
+    let payload: &[u8] = b"line1\r\nline2\nline3\rEND";
+    let length = payload.len();
+    let mut input = Vec::new();
+    input.extend_from_slice(format!("<< /Length {length} >>\nstream\n").as_bytes());
+    input.extend_from_slice(payload);
+    input.extend_from_slice(b"\nendstream");
+    let stream = parse_stream(&input);
+    assert_eq!(stream.data(), payload);
+}
+
+#[test]
+fn parse_stream_object_handles_64kb_data_blob_correctly() {
+    // 境界値・大容量: 64 KB 級 (65_536 バイト) の擬似ランダムデータを take_bytes が正しく切り出せることを確認する
+    // 擬似ランダムはハッシュ的計算 (i wrapping_mul 91) の下位バイトを使う (Math.random 非依存で決定的)
+    let payload: Vec<u8> = (0..65_536u32)
+        .map(|i| (i.wrapping_mul(91) & 0xFF) as u8)
+        .collect();
+    let length = payload.len();
+    let mut input = Vec::new();
+    input.extend_from_slice(format!("<< /Length {length} >>\nstream\n").as_bytes());
+    input.extend_from_slice(&payload);
+    input.extend_from_slice(b"\nendstream");
+    let stream = parse_stream(&input);
+    assert_eq!(stream.data().len(), payload.len());
+    assert_eq!(stream.data(), payload.as_slice());
+}

--- a/rust/crates/core/src/parser/stream_object_tests/eof_boundary.rs
+++ b/rust/crates/core/src/parser/stream_object_tests/eof_boundary.rs
@@ -1,0 +1,41 @@
+use super::super::error::ParseErrorKind;
+use super::parse_stream_err;
+
+#[test]
+fn parse_stream_object_returns_invalid_stream_eol_when_input_ends_immediately_after_stream_keyword()
+{
+    // 境界: stream キーワード直後で入力が尽きる場合、InvalidStreamEol を返すことを確認する
+    // （EolKind::at が None を返し、CRLF/LF 検証で失敗する）
+    let input = b"<< /Length 4 >>\nstream";
+    let err = parse_stream_err(input);
+    assert!(
+        matches!(err.kind, ParseErrorKind::InvalidStreamEol),
+        "expected InvalidStreamEol, got {:?}",
+        err.kind
+    );
+}
+
+#[test]
+fn parse_stream_object_returns_unexpected_eof_when_input_ends_mid_data() {
+    // 境界: EOL 後、Length バイト消費中に入力が尽きる場合、take_bytes が None を返し UnexpectedEof を返すことを確認する
+    let input = b"<< /Length 10 >>\nstream\nabc";
+    let err = parse_stream_err(input);
+    assert!(
+        matches!(err.kind, ParseErrorKind::UnexpectedEof),
+        "expected UnexpectedEof, got {:?}",
+        err.kind
+    );
+}
+
+#[test]
+fn parse_stream_object_returns_missing_endstream_when_input_ends_before_endstream_token() {
+    // 境界: Length バイト消費後、endstream の直前で入力が尽きる場合、
+    // expect_endstream が EOF を MissingEndstream に集約することを確認する（実装計画 §4.1 / §9.3）
+    let input = b"<< /Length 4 >>\nstream\ndata";
+    let err = parse_stream_err(input);
+    assert!(
+        matches!(err.kind, ParseErrorKind::MissingEndstream),
+        "expected MissingEndstream, got {:?}",
+        err.kind
+    );
+}

--- a/rust/crates/core/src/parser/stream_object_tests/indirect_length.rs
+++ b/rust/crates/core/src/parser/stream_object_tests/indirect_length.rs
@@ -1,0 +1,16 @@
+use super::super::error::{ParseError, ParseErrorKind};
+use super::{byte_offset, parse_stream_err};
+
+#[test]
+fn parse_stream_object_returns_indirect_length_not_supported_when_length_is_reference() {
+    // /Length が間接参照 (5 0 R) の場合、IndirectLengthNotSupported を辞書開始位置 (0) で返すことを確認する（DC-5）
+    let input = b"<< /Length 5 0 R >>\nstream\ndata\nendstream";
+    let err = parse_stream_err(input);
+    assert_eq!(
+        err,
+        ParseError {
+            kind: ParseErrorKind::IndirectLengthNotSupported,
+            position: byte_offset(0),
+        }
+    );
+}

--- a/rust/crates/core/src/parser/stream_object_tests/integration.rs
+++ b/rust/crates/core/src/parser/stream_object_tests/integration.rs
@@ -1,0 +1,68 @@
+use super::super::super::byte_offset::ByteOffset;
+use super::super::super::object::name::PdfName;
+use super::super::super::object::pdf_object::PdfObject;
+use super::super::error::{ParseError, ParseErrorKind};
+use super::super::Parser;
+
+#[test]
+fn parse_indirect_object_returns_stream_object_end_to_end() {
+    // 統合: `N G obj << /Length n >> stream ... endstream endobj` を parse_indirect_object で丸ごと復元し、
+    // id / dictionary / data が期待どおり保持されることを確認する（Issue #411 受け入れ基準）
+    let input = b"5 3 obj << /Length 11 /Type /XObject >> stream\nHello world\nendstream endobj";
+    let mut parser = Parser::new(input);
+    let indirect = parser
+        .parse_indirect_object()
+        .expect("integration parse must succeed");
+
+    assert_eq!(indirect.id().object_number().value(), 5);
+    assert_eq!(indirect.id().generation_number().value(), 3);
+
+    let stream = match indirect.object() {
+        PdfObject::Stream(stream) => stream,
+        other => panic!("expected Stream, got {other:?}"),
+    };
+    assert_eq!(stream.data(), b"Hello world");
+
+    let length = stream
+        .dictionary()
+        .get(&PdfName::new(b"Length".to_vec()))
+        .expect("/Length must remain in the stream dictionary");
+    assert_eq!(length, &PdfObject::Integer(11));
+
+    let type_entry = stream
+        .dictionary()
+        .get(&PdfName::new(b"Type".to_vec()))
+        .expect("/Type must remain in the stream dictionary");
+    assert_eq!(type_entry, &PdfObject::Name(PdfName::from("XObject")));
+}
+
+#[test]
+fn parse_indirect_object_with_dictionary_content_still_returns_dictionary() {
+    // 副作用ゼロ検証: 辞書 content の直後に stream が続かない場合は Dictionary のままで、
+    // stream 昇格が発火しないことを確認する（DC-7 の副作用限定境界）
+    let input = b"1 0 obj << /Type /Catalog >> endobj";
+    let mut parser = Parser::new(input);
+    let indirect = parser
+        .parse_indirect_object()
+        .expect("dictionary content must still parse");
+    assert!(matches!(indirect.object(), PdfObject::Dictionary(_)));
+}
+
+#[test]
+fn parse_indirect_object_reports_missing_length_at_dictionary_open_position() {
+    // 位置検証（DC-5）: `1 0 obj << ...` で /Length 欠落エラーの position が
+    // `<<` の実位置（byte 8）を指すことを確認する。dict_start が obj の直後の空白ではなく、
+    // 実トークン開始位置に揃っていることを保証する（Codex 指摘対応）。
+    let input = b"1 0 obj << /Filter /FlateDecode >>\nstream\nxxxx\nendstream endobj";
+    let mut parser = Parser::new(input);
+    let err = parser
+        .parse_indirect_object()
+        .expect_err("stream without /Length must fail");
+    assert_eq!(
+        err,
+        ParseError {
+            kind: ParseErrorKind::MissingLength,
+            position: ByteOffset::new(8),
+        }
+    );
+}

--- a/rust/crates/core/src/parser/stream_object_tests/invalid_length_type.rs
+++ b/rust/crates/core/src/parser/stream_object_tests/invalid_length_type.rs
@@ -96,3 +96,23 @@ fn parse_stream_object_returns_invalid_length_type_when_length_is_boolean() {
         }
     );
 }
+
+#[cfg(target_pointer_width = "32")]
+#[test]
+fn parse_stream_object_returns_invalid_length_type_when_length_exceeds_usize_on_32bit() {
+    // 32bit ターゲット限定: /Length が i64 → usize::try_from で失敗する値の場合
+    // InvalidLengthType { actual_kind: "IntegerTooLarge" } を返すことを確認する。
+    // 2^32 = 4294967296 は 32bit の usize(u32::MAX = 4294967295) に収まらないため
+    // 32bit ターゲットでのみ try_from が失敗する（64bit では成功して別の経路に流れるため cfg でガード）。
+    let input = b"<< /Length 4294967296 >>\nstream\ndata\nendstream";
+    let err = parse_stream_err(input);
+    assert_eq!(
+        err,
+        ParseError {
+            kind: ParseErrorKind::InvalidLengthType {
+                actual_kind: "IntegerTooLarge"
+            },
+            position: byte_offset(0),
+        }
+    );
+}

--- a/rust/crates/core/src/parser/stream_object_tests/invalid_length_type.rs
+++ b/rust/crates/core/src/parser/stream_object_tests/invalid_length_type.rs
@@ -1,0 +1,98 @@
+use super::super::error::{ParseError, ParseErrorKind};
+use super::{byte_offset, parse_stream_err};
+
+#[test]
+fn parse_stream_object_returns_invalid_length_type_when_length_is_real() {
+    // /Length が Real の場合、InvalidLengthType { actual_kind: "Real" } を辞書開始位置 (0) で返すことを確認する（DC-11: 1 パターン = 1 test）
+    let input = b"<< /Length 1.5 >>\nstream\ndata\nendstream";
+    let err = parse_stream_err(input);
+    assert_eq!(
+        err,
+        ParseError {
+            kind: ParseErrorKind::InvalidLengthType {
+                actual_kind: "Real"
+            },
+            position: byte_offset(0),
+        }
+    );
+}
+
+#[test]
+fn parse_stream_object_returns_invalid_length_type_when_length_is_string() {
+    // /Length が String の場合、InvalidLengthType { actual_kind: "String" } を返すことを確認する
+    let input = b"<< /Length (hi) >>\nstream\ndata\nendstream";
+    let err = parse_stream_err(input);
+    assert_eq!(
+        err,
+        ParseError {
+            kind: ParseErrorKind::InvalidLengthType {
+                actual_kind: "String"
+            },
+            position: byte_offset(0),
+        }
+    );
+}
+
+#[test]
+fn parse_stream_object_returns_invalid_length_type_when_length_is_name() {
+    // /Length が Name の場合、InvalidLengthType { actual_kind: "Name" } を返すことを確認する
+    let input = b"<< /Length /Big >>\nstream\ndata\nendstream";
+    let err = parse_stream_err(input);
+    assert_eq!(
+        err,
+        ParseError {
+            kind: ParseErrorKind::InvalidLengthType {
+                actual_kind: "Name"
+            },
+            position: byte_offset(0),
+        }
+    );
+}
+
+#[test]
+fn parse_stream_object_returns_invalid_length_type_when_length_is_array() {
+    // /Length が Array の場合、InvalidLengthType { actual_kind: "Array" } を返すことを確認する
+    let input = b"<< /Length [1 2 3] >>\nstream\ndata\nendstream";
+    let err = parse_stream_err(input);
+    assert_eq!(
+        err,
+        ParseError {
+            kind: ParseErrorKind::InvalidLengthType {
+                actual_kind: "Array"
+            },
+            position: byte_offset(0),
+        }
+    );
+}
+
+#[test]
+fn parse_stream_object_returns_invalid_length_type_when_length_is_dictionary() {
+    // /Length が Dictionary の場合、InvalidLengthType { actual_kind: "Dictionary" } を返すことを確認する
+    let input = b"<< /Length << /K 1 >> >>\nstream\ndata\nendstream";
+    let err = parse_stream_err(input);
+    assert_eq!(
+        err,
+        ParseError {
+            kind: ParseErrorKind::InvalidLengthType {
+                actual_kind: "Dictionary"
+            },
+            position: byte_offset(0),
+        }
+    );
+}
+
+#[test]
+fn parse_stream_object_returns_invalid_length_type_when_length_is_boolean() {
+    // /Length が Boolean の場合、InvalidLengthType { actual_kind: "Boolean" } を返すことを確認する
+    let input = b"<< /Length true >>\nstream\ndata\nendstream";
+    let err = parse_stream_err(input);
+    assert_eq!(
+        err,
+        ParseError {
+            kind: ParseErrorKind::InvalidLengthType {
+                actual_kind: "Boolean"
+            },
+            position: byte_offset(0),
+        }
+    );
+}

--- a/rust/crates/core/src/parser/stream_object_tests/invalid_stream_eol.rs
+++ b/rust/crates/core/src/parser/stream_object_tests/invalid_stream_eol.rs
@@ -3,7 +3,7 @@ use super::parse_stream_err;
 
 #[test]
 fn parse_stream_object_returns_invalid_stream_eol_when_only_cr_follows_stream_keyword() {
-    // stream キーワード直後が CR 単体（LF が続かない）の場合、InvalidStreamEol を stream キーワード位置で返すことを確認する（DC-11）
+    // stream キーワード直後が CR 単体（LF が続かない）の場合、InvalidStreamEol を返すことを確認する（DC-11）
     let input = b"<< /Length 4 >>\nstream\rdata\rendstream";
     let err = parse_stream_err(input);
     assert!(

--- a/rust/crates/core/src/parser/stream_object_tests/invalid_stream_eol.rs
+++ b/rust/crates/core/src/parser/stream_object_tests/invalid_stream_eol.rs
@@ -1,15 +1,21 @@
-use super::super::error::ParseErrorKind;
-use super::parse_stream_err;
+use super::super::error::{ParseError, ParseErrorKind};
+use super::{byte_offset, parse_stream_err};
+
+/// `<< /Length 4 >>\nstream` は 22 バイトなので、`stream` キーワード消費直後の位置は 22。
+/// 本ファイルの全テストがこの prefix を共有するため、`InvalidStreamEol` の期待 position はすべて 22 になる。
+const AFTER_STREAM_POS: u64 = 22;
 
 #[test]
 fn parse_stream_object_returns_invalid_stream_eol_when_only_cr_follows_stream_keyword() {
     // stream キーワード直後が CR 単体（LF が続かない）の場合、InvalidStreamEol を返すことを確認する（DC-11）
     let input = b"<< /Length 4 >>\nstream\rdata\rendstream";
     let err = parse_stream_err(input);
-    assert!(
-        matches!(err.kind, ParseErrorKind::InvalidStreamEol),
-        "expected InvalidStreamEol, got {:?}",
-        err.kind
+    assert_eq!(
+        err,
+        ParseError {
+            kind: ParseErrorKind::InvalidStreamEol,
+            position: byte_offset(AFTER_STREAM_POS),
+        }
     );
 }
 
@@ -18,10 +24,12 @@ fn parse_stream_object_returns_invalid_stream_eol_when_space_follows_stream_keyw
     // stream キーワード直後が SP（EOL でない）の場合、InvalidStreamEol を返すことを確認する（DC-4: skip_whitespace を経由しない）
     let input = b"<< /Length 4 >>\nstream data\nendstream";
     let err = parse_stream_err(input);
-    assert!(
-        matches!(err.kind, ParseErrorKind::InvalidStreamEol),
-        "expected InvalidStreamEol, got {:?}",
-        err.kind
+    assert_eq!(
+        err,
+        ParseError {
+            kind: ParseErrorKind::InvalidStreamEol,
+            position: byte_offset(AFTER_STREAM_POS),
+        }
     );
 }
 
@@ -30,10 +38,12 @@ fn parse_stream_object_returns_invalid_stream_eol_when_tab_follows_stream_keywor
     // stream キーワード直後が TAB（EOL でない）の場合、InvalidStreamEol を返すことを確認する
     let input = b"<< /Length 4 >>\nstream\tdata\nendstream";
     let err = parse_stream_err(input);
-    assert!(
-        matches!(err.kind, ParseErrorKind::InvalidStreamEol),
-        "expected InvalidStreamEol, got {:?}",
-        err.kind
+    assert_eq!(
+        err,
+        ParseError {
+            kind: ParseErrorKind::InvalidStreamEol,
+            position: byte_offset(AFTER_STREAM_POS),
+        }
     );
 }
 
@@ -42,9 +52,11 @@ fn parse_stream_object_returns_invalid_stream_eol_when_input_ends_after_stream_k
     // stream キーワード直後で EOF に達した場合、InvalidStreamEol を返すことを確認する（EolKind::at が None）
     let input = b"<< /Length 4 >>\nstream";
     let err = parse_stream_err(input);
-    assert!(
-        matches!(err.kind, ParseErrorKind::InvalidStreamEol),
-        "expected InvalidStreamEol, got {:?}",
-        err.kind
+    assert_eq!(
+        err,
+        ParseError {
+            kind: ParseErrorKind::InvalidStreamEol,
+            position: byte_offset(AFTER_STREAM_POS),
+        }
     );
 }

--- a/rust/crates/core/src/parser/stream_object_tests/invalid_stream_eol.rs
+++ b/rust/crates/core/src/parser/stream_object_tests/invalid_stream_eol.rs
@@ -1,0 +1,50 @@
+use super::super::error::ParseErrorKind;
+use super::parse_stream_err;
+
+#[test]
+fn parse_stream_object_returns_invalid_stream_eol_when_only_cr_follows_stream_keyword() {
+    // stream キーワード直後が CR 単体（LF が続かない）の場合、InvalidStreamEol を stream キーワード位置で返すことを確認する（DC-11）
+    let input = b"<< /Length 4 >>\nstream\rdata\rendstream";
+    let err = parse_stream_err(input);
+    assert!(
+        matches!(err.kind, ParseErrorKind::InvalidStreamEol),
+        "expected InvalidStreamEol, got {:?}",
+        err.kind
+    );
+}
+
+#[test]
+fn parse_stream_object_returns_invalid_stream_eol_when_space_follows_stream_keyword() {
+    // stream キーワード直後が SP（EOL でない）の場合、InvalidStreamEol を返すことを確認する（DC-4: skip_whitespace を経由しない）
+    let input = b"<< /Length 4 >>\nstream data\nendstream";
+    let err = parse_stream_err(input);
+    assert!(
+        matches!(err.kind, ParseErrorKind::InvalidStreamEol),
+        "expected InvalidStreamEol, got {:?}",
+        err.kind
+    );
+}
+
+#[test]
+fn parse_stream_object_returns_invalid_stream_eol_when_tab_follows_stream_keyword() {
+    // stream キーワード直後が TAB（EOL でない）の場合、InvalidStreamEol を返すことを確認する
+    let input = b"<< /Length 4 >>\nstream\tdata\nendstream";
+    let err = parse_stream_err(input);
+    assert!(
+        matches!(err.kind, ParseErrorKind::InvalidStreamEol),
+        "expected InvalidStreamEol, got {:?}",
+        err.kind
+    );
+}
+
+#[test]
+fn parse_stream_object_returns_invalid_stream_eol_when_input_ends_after_stream_keyword() {
+    // stream キーワード直後で EOF に達した場合、InvalidStreamEol を返すことを確認する（EolKind::at が None）
+    let input = b"<< /Length 4 >>\nstream";
+    let err = parse_stream_err(input);
+    assert!(
+        matches!(err.kind, ParseErrorKind::InvalidStreamEol),
+        "expected InvalidStreamEol, got {:?}",
+        err.kind
+    );
+}

--- a/rust/crates/core/src/parser/stream_object_tests/missing_endstream.rs
+++ b/rust/crates/core/src/parser/stream_object_tests/missing_endstream.rs
@@ -1,0 +1,39 @@
+use super::super::error::ParseErrorKind;
+use super::parse_stream_err;
+
+#[test]
+fn parse_stream_object_returns_missing_endstream_when_name_token_follows_data() {
+    // data 後に endstream ではなく Name トークンが来た場合、MissingEndstream を返すことを確認する
+    let input = b"<< /Length 4 >>\nstream\ndata\n/Foo";
+    let err = parse_stream_err(input);
+    assert!(
+        matches!(err.kind, ParseErrorKind::MissingEndstream),
+        "expected MissingEndstream, got {:?}",
+        err.kind
+    );
+}
+
+#[test]
+fn parse_stream_object_returns_missing_endstream_when_integer_token_follows_data() {
+    // data 後に endstream ではなく Integer トークンが来た場合、MissingEndstream を返すことを確認する
+    let input = b"<< /Length 4 >>\nstream\ndata\n42";
+    let err = parse_stream_err(input);
+    assert!(
+        matches!(err.kind, ParseErrorKind::MissingEndstream),
+        "expected MissingEndstream, got {:?}",
+        err.kind
+    );
+}
+
+#[test]
+fn parse_stream_object_returns_missing_endstream_when_input_ends_before_endstream() {
+    // data 後に endstream 前で EOF に達した場合、MissingEndstream を返すことを確認する
+    // （実装計画 §4.1 / §9.3 に従い、EOF は UnexpectedEof ではなく MissingEndstream として扱う）
+    let input = b"<< /Length 4 >>\nstream\ndata";
+    let err = parse_stream_err(input);
+    assert!(
+        matches!(err.kind, ParseErrorKind::MissingEndstream),
+        "expected MissingEndstream, got {:?}",
+        err.kind
+    );
+}

--- a/rust/crates/core/src/parser/stream_object_tests/missing_endstream.rs
+++ b/rust/crates/core/src/parser/stream_object_tests/missing_endstream.rs
@@ -89,3 +89,18 @@ fn parse_stream_object_returns_missing_endstream_when_endstream_is_followed_by_r
         err.kind
     );
 }
+
+#[test]
+fn parse_stream_object_returns_missing_endstream_when_length_includes_trailing_eol_byte() {
+    // ISO 32000-1 §7.3.8 違反: /Length が data 末尾の LF バイトを "データとして" 数え込んでいるケース。
+    // 例: /Length 4 で "abc\n" を data として指定し、直後に endstream が続く。cursor は 'e' を指し、
+    // pos_after_data 位置に EOL が無いため MissingEndstream として拒否されることを確認する。
+    // （Copilot 指摘対応: pos_after_data の EOL 必須化）
+    let input = b"<< /Length 4 >>\nstream\nabc\nendstream";
+    let err = parse_stream_err(input);
+    assert!(
+        matches!(err.kind, ParseErrorKind::MissingEndstream),
+        "expected MissingEndstream, got {:?}",
+        err.kind
+    );
+}

--- a/rust/crates/core/src/parser/stream_object_tests/missing_endstream.rs
+++ b/rust/crates/core/src/parser/stream_object_tests/missing_endstream.rs
@@ -37,3 +37,55 @@ fn parse_stream_object_returns_missing_endstream_when_input_ends_before_endstrea
         err.kind
     );
 }
+
+#[test]
+fn parse_stream_object_returns_missing_endstream_when_no_eol_before_endstream_keyword() {
+    // ISO 32000-1 §7.3.8 は endstream 直前の EOL を必須とする。
+    // data の直後に EOL 無しで endstream が続く入力は MissingEndstream として拒否されることを確認する。
+    let input = b"<< /Length 4 >>\nstream\ndataendstream";
+    let err = parse_stream_err(input);
+    assert!(
+        matches!(err.kind, ParseErrorKind::MissingEndstream),
+        "expected MissingEndstream, got {:?}",
+        err.kind
+    );
+}
+
+#[test]
+fn parse_stream_object_returns_missing_endstream_when_trailing_space_precedes_endstream() {
+    // 末尾に空白 + EOL のパターン (data + " " + LF + endstream) は EOL 検証で失敗し、
+    // MissingEndstream として拒否されることを確認する（skip_whitespace を経由しない厳格チェック）。
+    let input = b"<< /Length 4 >>\nstream\ndata \nendstream";
+    let err = parse_stream_err(input);
+    assert!(
+        matches!(err.kind, ParseErrorKind::MissingEndstream),
+        "expected MissingEndstream, got {:?}",
+        err.kind
+    );
+}
+
+#[test]
+fn parse_stream_object_returns_missing_endstream_when_space_between_eol_and_endstream() {
+    // data + LF + 空白 + endstream のパターン。EOL 消費後に endstream キーワード直前で空白が混入していると
+    // MissingEndstream として拒否されることを確認する（EOL 後の raw byte 一致で判定）。
+    let input = b"<< /Length 4 >>\nstream\ndata\n endstream";
+    let err = parse_stream_err(input);
+    assert!(
+        matches!(err.kind, ParseErrorKind::MissingEndstream),
+        "expected MissingEndstream, got {:?}",
+        err.kind
+    );
+}
+
+#[test]
+fn parse_stream_object_returns_missing_endstream_when_endstream_is_followed_by_regular_bytes() {
+    // endstream の直後に regular byte (例: 42) が連続する場合、lexer は "endstream42" を Keyword として読むため
+    // StreamEnd トークンにならず MissingEndstream として拒否されることを確認する（キーワード境界検証）。
+    let input = b"<< /Length 4 >>\nstream\ndata\nendstream42";
+    let err = parse_stream_err(input);
+    assert!(
+        matches!(err.kind, ParseErrorKind::MissingEndstream),
+        "expected MissingEndstream, got {:?}",
+        err.kind
+    );
+}

--- a/rust/crates/core/src/parser/stream_object_tests/missing_length.rs
+++ b/rust/crates/core/src/parser/stream_object_tests/missing_length.rs
@@ -1,0 +1,16 @@
+use super::super::error::{ParseError, ParseErrorKind};
+use super::{byte_offset, parse_stream_err};
+
+#[test]
+fn parse_stream_object_returns_missing_length_when_length_key_absent() {
+    // /Length エントリが辞書に無い場合、MissingLength を辞書開始位置 (0) で返すことを確認する
+    let input = b"<< /Type /XObject >>\nstream\ndata\nendstream";
+    let err = parse_stream_err(input);
+    assert_eq!(
+        err,
+        ParseError {
+            kind: ParseErrorKind::MissingLength,
+            position: byte_offset(0),
+        }
+    );
+}

--- a/rust/crates/core/src/parser/stream_object_tests/negative_length.rs
+++ b/rust/crates/core/src/parser/stream_object_tests/negative_length.rs
@@ -1,0 +1,16 @@
+use super::super::error::{ParseError, ParseErrorKind};
+use super::{byte_offset, parse_stream_err};
+
+#[test]
+fn parse_stream_object_returns_negative_length_when_length_is_minus_one() {
+    // /Length が負の値 (-1) の場合、NegativeLength を辞書開始位置 (0) で返すことを確認する（DC-6: unit variant）
+    let input = b"<< /Length -1 >>\nstream\ndata\nendstream";
+    let err = parse_stream_err(input);
+    assert_eq!(
+        err,
+        ParseError {
+            kind: ParseErrorKind::NegativeLength,
+            position: byte_offset(0),
+        }
+    );
+}

--- a/rust/crates/core/src/parser/stream_object_tests/pdf_sample.rs
+++ b/rust/crates/core/src/parser/stream_object_tests/pdf_sample.rs
@@ -5,7 +5,7 @@ use super::super::Parser;
 /// ISO 32000-1 §7.3.8 の Length を明示したストリームのサンプル。
 /// content には ISO §7.3.4.4 相当の Tj によるテキスト描画を含む簡易な形。
 const STREAM_SAMPLE: &[u8] =
-    b"7 0 obj\n<< /Length 35 >>\nstream\nBT\n/F1 12 Tf\n72 712 Td\n(ABC) Tj\nET\nendstream\nendobj";
+    b"7 0 obj\n<< /Length 34 >>\nstream\nBT\n/F1 12 Tf\n72 712 Td\n(ABC) Tj\nET\nendstream\nendobj";
 
 #[test]
 fn parse_stream_sample_extracts_object_id() {
@@ -30,7 +30,7 @@ fn parse_stream_sample_content_is_stream() {
 
 #[test]
 fn parse_stream_sample_data_is_content_stream_bytes() {
-    // ISO §7.3.8 サンプルの data が /Length 35 バイト分の content stream として復元されることを確認する
+    // ISO §7.3.8 サンプルの data が /Length 34 バイト分の content stream として復元されることを確認する
     let mut parser = Parser::new(STREAM_SAMPLE);
     let indirect = parser
         .parse_indirect_object()
@@ -39,13 +39,13 @@ fn parse_stream_sample_data_is_content_stream_bytes() {
         PdfObject::Stream(stream) => stream,
         other => panic!("expected Stream, got {other:?}"),
     };
-    assert_eq!(stream.data(), b"BT\n/F1 12 Tf\n72 712 Td\n(ABC) Tj\nET\n");
-    assert_eq!(stream.data().len(), 35);
+    assert_eq!(stream.data(), b"BT\n/F1 12 Tf\n72 712 Td\n(ABC) Tj\nET");
+    assert_eq!(stream.data().len(), 34);
 }
 
 #[test]
 fn parse_stream_sample_dictionary_retains_length_entry() {
-    // ISO §7.3.8 サンプルの stream 辞書に /Length 35 がそのまま保持されることを確認する
+    // ISO §7.3.8 サンプルの stream 辞書に /Length 34 がそのまま保持されることを確認する
     let mut parser = Parser::new(STREAM_SAMPLE);
     let indirect = parser
         .parse_indirect_object()
@@ -58,5 +58,5 @@ fn parse_stream_sample_dictionary_retains_length_entry() {
         .dictionary()
         .get(&PdfName::new(b"Length".to_vec()))
         .expect("/Length must remain in the stream dictionary");
-    assert_eq!(length, &PdfObject::Integer(35));
+    assert_eq!(length, &PdfObject::Integer(34));
 }

--- a/rust/crates/core/src/parser/stream_object_tests/pdf_sample.rs
+++ b/rust/crates/core/src/parser/stream_object_tests/pdf_sample.rs
@@ -1,0 +1,62 @@
+use super::super::super::object::name::PdfName;
+use super::super::super::object::pdf_object::PdfObject;
+use super::super::Parser;
+
+/// ISO 32000-1 §7.3.8 の Length を明示したストリームのサンプル。
+/// content には ISO §7.3.4.4 相当の Tj によるテキスト描画を含む簡易な形。
+const STREAM_SAMPLE: &[u8] =
+    b"7 0 obj\n<< /Length 35 >>\nstream\nBT\n/F1 12 Tf\n72 712 Td\n(ABC) Tj\nET\nendstream\nendobj";
+
+#[test]
+fn parse_stream_sample_extracts_object_id() {
+    // ISO §7.3.8 サンプルの id が ObjectId(7, 0) として抽出されることを確認する
+    let mut parser = Parser::new(STREAM_SAMPLE);
+    let indirect = parser
+        .parse_indirect_object()
+        .expect("stream sample should parse");
+    assert_eq!(indirect.id().object_number().value(), 7);
+    assert_eq!(indirect.id().generation_number().value(), 0);
+}
+
+#[test]
+fn parse_stream_sample_content_is_stream() {
+    // ISO §7.3.8 サンプルの content 種別が PdfObject::Stream であることを確認する
+    let mut parser = Parser::new(STREAM_SAMPLE);
+    let indirect = parser
+        .parse_indirect_object()
+        .expect("stream sample should parse");
+    assert!(matches!(indirect.object(), PdfObject::Stream(_)));
+}
+
+#[test]
+fn parse_stream_sample_data_is_content_stream_bytes() {
+    // ISO §7.3.8 サンプルの data が /Length 35 バイト分の content stream として復元されることを確認する
+    let mut parser = Parser::new(STREAM_SAMPLE);
+    let indirect = parser
+        .parse_indirect_object()
+        .expect("stream sample should parse");
+    let stream = match indirect.object() {
+        PdfObject::Stream(stream) => stream,
+        other => panic!("expected Stream, got {other:?}"),
+    };
+    assert_eq!(stream.data(), b"BT\n/F1 12 Tf\n72 712 Td\n(ABC) Tj\nET\n");
+    assert_eq!(stream.data().len(), 35);
+}
+
+#[test]
+fn parse_stream_sample_dictionary_retains_length_entry() {
+    // ISO §7.3.8 サンプルの stream 辞書に /Length 35 がそのまま保持されることを確認する
+    let mut parser = Parser::new(STREAM_SAMPLE);
+    let indirect = parser
+        .parse_indirect_object()
+        .expect("stream sample should parse");
+    let stream = match indirect.object() {
+        PdfObject::Stream(stream) => stream,
+        other => panic!("expected Stream, got {other:?}"),
+    };
+    let length = stream
+        .dictionary()
+        .get(&PdfName::new(b"Length".to_vec()))
+        .expect("/Length must remain in the stream dictionary");
+    assert_eq!(length, &PdfObject::Integer(35));
+}


### PR DESCRIPTION
## 概要

`<< /Length N >> stream ... endstream` を `PdfObject::Stream(PdfStream)` にパースするエントリを実装。ISO 32000-1 §7.3.8 準拠、`parse_indirect_object` 経由でのみ stream 昇格するよう副作用ゼロで組み込む。`/Filter` デコードや Indirect `/Length` 解決はスコープ外。仕様違反は寛容フォールバックせず、6 種類の専用 `ParseErrorKind` バリアントで即座に失敗する。

## 変更内容

### 🎯 変更の種類

- [x] ✨ 新機能 (New feature)
- [x] ♻️ リファクタリング (Refactoring) — `parse_indirect_object` の内部フロー変更
- [x] 🚨 テスト追加/修正 (Tests) — 33 件の新規テスト + 既存 1 件書き換え

### 📝 詳細な変更内容

#### 追加された機能・修正

- **`ParseErrorKind` に 6 バリアント追加**（`parser/error.rs`）
  - `MissingLength` / `IndirectLengthNotSupported` / `InvalidLengthType { actual_kind }` / `NegativeLength` / `InvalidStreamEol` / `MissingEndstream`
  - 便利コンストラクタ 6 個（既存 suffix `_at` 統一パターン）
- **`Lexer` 生バイトアクセス API 3 種追加**（`lexer/cursor.rs`）
  - `pub(crate) take_bytes(len)` / `input()` / `skip_bytes(n)` — 「バッファフラッシュ責務は呼び出し側」の契約を doc に明記
- **`parse_stream_object` エントリ実装**（`parser/stream_object.rs` [NEW]）
  - `resolve_stream_length` / `consume_stream_eol` / `take_stream_data` / `expect_endstream` / `pdf_object_kind_label` の補助関数群
  - CRLF/LF のみ許容の EOL 検証（`EolKind::at` 直呼び、`skip_whitespace` は経由しない）
  - `/Length` バイトの決定的切り出し（`endstream` バイト列を含むデータでも安全）
  - EOF は `UnexpectedEof` ではなく `MissingEndstream` に集約（実装計画 §4.1 / §9.3）
- **`parse_indirect_object` 接続**（`parser.rs`）
  - 新規 `parse_object_or_stream` メソッド追加。`peek_token_with_pos` で辞書 `<<` の実位置を `dict_start` として捕捉し、`PdfObject::Dictionary` のみ stream 昇格を試みる
  - トップレベル `parse_object(b\"stream\")` の従来挙動（`UnexpectedToken`）は変更なし（DC-7）

#### 変更されたファイル

- `rust/crates/core/src/parser/error.rs` — 6 バリアント + 6 コンストラクタ追加
- `rust/crates/core/src/lexer/cursor.rs` — 3 API 追加
- `rust/crates/core/src/lexer/tests.rs` — `lexer_take_bytes` テストモジュール登録
- `rust/crates/core/src/parser.rs` — `mod stream_object` 追加 / `parse_indirect_object` を `parse_object_or_stream` 経由に変更
- `rust/crates/core/src/parser/indirect_object_tests/missing_endobj.rs` — DC-8 に基づく既存テスト書き換え（`UnexpectedToken{\"StreamBegin\"}` → 成功パス `PdfObject::Stream` 復元）

#### 新規追加ファイル（14 件）

- `parser/stream_object.rs` — 本体
- `parser/stream_object_tests.rs` — 共通ヘルパ (`parse_stream` / `parse_stream_err`)
- `parser/stream_object_tests/{basic, binary_data, eof_boundary, indirect_length, integration, invalid_length_type, invalid_stream_eol, missing_endstream, missing_length, negative_length, pdf_sample}.rs` — 1 パターン = 1 ファイル方針（DC-9）
- `lexer/tests/lexer_take_bytes.rs` — Lexer 生バイト API テスト

## 📊 システム図

### `parse_stream_object` の状態マシン

```mermaid
flowchart TD
    Start([parse_indirect_object])
    Start --> PO[parse_object_or_stream]
    PO -->|peek_token_with_pos で dict_start 捕捉| ParseObj[parse_object]
    ParseObj --> IsDict{PdfObject::Dictionary?}
    IsDict -->|No| ReturnAsIs[return as-is]
    IsDict -->|Yes| PSO[parse_stream_object]:::new

    PSO --> PeekStream{peek == StreamBegin?}
    PeekStream -->|No| ReturnDict[return Dictionary]
    PeekStream -->|Yes| ConsumeStream[take_token StreamBegin]:::new
    ConsumeStream --> AfterStream[after_stream_pos 捕捉]:::new

    AfterStream --> ResolveLen[resolve_stream_length]:::new
    ResolveLen -->|None| ErrMissing[MissingLength at dict_start]:::err
    ResolveLen -->|Reference| ErrIndirect[IndirectLengthNotSupported]:::err
    ResolveLen -->|Integer n < 0| ErrNeg[NegativeLength]:::err
    ResolveLen -->|Integer n >= 0| EolCheck[consume_stream_eol]:::new
    ResolveLen -->|Other type| ErrType[InvalidLengthType]:::err

    EolCheck -->|LF / CRLF| TakeData[take_stream_data via Lexer::take_bytes]:::new
    EolCheck -->|CR / SP / TAB / EOF| ErrEol[InvalidStreamEol at after_stream_pos]:::err

    TakeData -->|Some| ExpectEnd[expect_endstream]:::new
    TakeData -->|None| ErrEof[UnexpectedEof at data_start]:::err

    ExpectEnd -->|StreamEnd| Emit[PdfObject::Stream PdfStream::new]:::new
    ExpectEnd -->|Other token| ErrMe1[MissingEndstream at token pos]:::err
    ExpectEnd -->|EOF| ErrMe2[MissingEndstream at cursor]:::err

    Emit --> Ret[return to parse_indirect_object]

    classDef new fill:#ffe4b5,stroke:#d97706,stroke-width:2px
    classDef err fill:#fecaca,stroke:#dc2626,stroke-width:1px
```

## 📋 関連 Issue

- Closes #411
- Refs #252（親 Epic Phase R1）
- Depends on #408 (辞書パース) / #410 (間接オブジェクトパース) / #267 (PdfStream 型)

## 🧪 テスト

### テスト実行方法

\`\`\`bash
cd rust
cargo test -p pdfmod-core parser::stream_object_tests
cargo test -p pdfmod-core lexer::tests::lexer_take_bytes
cargo test --workspace
\`\`\`

### テスト項目

- [x] 単体テスト — `parser::stream_object_tests::*` 33 件、`lexer::tests::lexer_take_bytes::*` 11 件
- [x] 統合テスト — `stream_object_tests::integration` / `stream_object_tests::pdf_sample`（ISO 32000-1 §7.3.8 サンプル）
- [x] 境界テスト — `stream_object_tests::eof_boundary`（stream 直後 EOF / データ途中 EOF / endstream 前 EOF）
- [x] 手動テスト — `cargo fmt --check` / `cargo clippy -- -D warnings` / `cargo test --workspace`

### テスト結果

- `cargo build --workspace` ✅ 通過
- `cargo fmt --all -- --check` ✅ 差分なし
- `cargo clippy --workspace --all-targets -- -D warnings` ✅ 警告ゼロ
- `cargo test --workspace` ✅ **1081 tests pass, 0 failed**

### 網羅した観点

| 観点 | テストファイル |
|---|---|
| 正常系 EOL (LF / CRLF) | `basic.rs` |
| 空データ (/Length 0) | `basic.rs` |
| バイナリデータ (NUL / endstream 部分列 / CR-LF / 64KB) | `binary_data.rs` |
| /Length エラー系 (欠落 / 参照 / 負値 / 型不正 6 種) | `missing_length.rs` / `indirect_length.rs` / `negative_length.rs` / `invalid_length_type.rs` |
| EOL エラー系 (CR 単体 / SP / TAB / EOF) | `invalid_stream_eol.rs` |
| endstream エラー系 (別トークン / EOF) | `missing_endstream.rs` |
| 境界 (stream 直後 EOF / データ途中 EOF / endstream 前 EOF) | `eof_boundary.rs` |
| 統合 (`parse_indirect_object` 経由) | `integration.rs` |
| ISO §7.3.8 サンプル | `pdf_sample.rs` |

## 🔍 レビューポイント

- **`Lexer::take_bytes` の契約**: バッファフラッシュ責務が呼び出し側にある設計（DC-3）。`stream_object.rs` の呼び出し順（`take_token(StreamBegin)` → `take_bytes` → `take_token(StreamEnd)`）が契約を満たしているか
- **エラー位置の一貫性**: 6 種類の `/Length` 系エラーが `dict_start`（`<<` の実位置）、`InvalidStreamEol` が `after_stream_pos`（`stream` キーワード消費直後）を指すこと（DC-5）
- **副作用ゼロ (DC-7)**: トップレベル `parse_object(b\"stream\")` の従来挙動が維持されていること（`parser.rs:713-737` の既存テストが引き続きパス）
- **`endstream` バイト列を含むデータ**: Length ベースの決定的切り出しで安全に処理できること（`binary_data.rs::parse_stream_object_treats_endstream_bytes_inside_data_as_regular_bytes`）
- **32bit プラットフォーム対応**: `usize::try_from(i64)` 失敗を `InvalidLengthType { actual_kind: \"IntegerTooLarge\" }` に集約（panic 不在契約）

## 📚 追加情報

### 参考資料

- ISO 32000-1:2008 §7.3.8 (Stream Objects)
- `docs/specs/01_lexical_conventions.md` §3.9
- `.plugin-workspace/.specs/073-stream-object-parser/implementation-plan.md`

### スコープ外項目（DC-12）

- `/Filter`（FlateDecode 等）の適用によるデータのデコード — 辞書に属性として保持のみ
- `/Length` が間接参照 `N G R` だった場合の実オブジェクト解決 — Epic R2 (#253) 側
- 壊れた PDF に対する寛容パース / リカバリ
- ストリームの保存・再エンコード
- トップレベル `Parser::parse_object(b\"stream\")` の受理

### Codex AI レビュー

`.plugin-workspace/.specs/073-stream-object-parser/code-review/` に review-001（MEDIUM 3 件 / LOW 1 件） → 修正 → review-002（LGTM）の履歴あり。修正内容:
1. `dict_start` が `<<` の実位置を指すよう `peek_token_with_pos` で捕捉
2. `stream_keyword_pos` を `after_stream_pos` に改名し `take_token` 後の位置を捕捉
3. EOF 時に `UnexpectedEof` ではなく `MissingEndstream` を返すよう `expect_endstream` を書き直し
4. pdf_sample.rs コメントの `/Length 44` → `/Length 35`

## ✅ チェックリスト

- [x] コードレビューの準備ができている（Codex review-002 で LGTM 取得済み）
- [x] テストが正常に実行される（1081 tests pass）
- [x] コミットメッセージが適切な形式で書かれている（4 コミット分割）
- [x] 関連する Issue が PR の「Development」に Linked されている（Closes #411）
- [x] セルフレビューを実施した
- [x] 破壊的変更はない（既存 API シグネチャは変更なし、DC-7 副作用ゼロ）