### PR TITLE
✨ [New Feature]: #481 bdcHandler (BDC marked content operator handler) を新規実装

### DIFF
--- a/packages/core/src/content-stream/interpreter/__tests__/interpreter.dict-operand.test.ts
+++ b/packages/core/src/content-stream/interpreter/__tests__/interpreter.dict-operand.test.ts
@@ -1,11 +1,13 @@
 import { assert, expect, test } from "vitest";
 import type { PdfObject } from "../../../pdf/index";
 import { ok } from "../../../utils/result/index";
+import { MarkedContentStack } from "../../marked-content/stack/index";
 import { OperandStack } from "../../operand-stack/index";
 import {
   type OperatorHandler,
   OperatorRegistry,
 } from "../../operator-registry/index";
+import { registerMarkedContentOperators } from "../../operators/marked-content/marked-content-operators/index";
 import { ContentStreamInterpreter } from "../index";
 
 const encode = (value: string): Uint8Array => new TextEncoder().encode(value);
@@ -55,19 +57,24 @@ test("`<</K /V>> op` operand を含む handler が PdfDictionary を pop でき�
   ]);
 });
 
-// 未登録 operator は operand stack を clear するため、本テストでは「dict が積まれた後に
-// BDC が dict を pop する」までは検証しない。全体完走と UNKNOWN_OPERATOR warning の
-// 発火のみを smoke test として確認する。dict pop の検証は他のテストが担う。
-test("`<</ActualText (x)>> BDC` は未登録 BDC で UNKNOWN_OPERATOR warning を出すが result.ok のまま完走する", () => {
+// BDC は registerMarkedContentOperators 経由で登録済みのため、dict operand を
+// pop して MarkedContentStack へ push する end-to-end のふるまいをここで pin down する。
+// interpreter は末尾で markedContentStack 非空を OBJECT_PARSE_UNTERMINATED として弾く
+// 仕様なので、BDC EMC のペアで 1 段開閉する形にする。
+test("`/T <</ActualText (x)>> BDC EMC` は登録済み BDC/EMC が warning なしで 1 段開閉する", () => {
+  const registered = registerMarkedContentOperators(OperatorRegistry.create());
+  assert(registered.ok);
+
   const result = ContentStreamInterpreter.execute({
-    data: encode("<</ActualText (x)>> BDC"),
-    registry: OperatorRegistry.create(),
+    data: encode("/T <</ActualText (x)>> BDC EMC"),
+    registry: registered.value,
   });
 
   assert(result.ok);
-  expect(result.value.warnings).toHaveLength(1);
-  expect(result.value.warnings[0]?.code).toBe("UNKNOWN_OPERATOR");
-  expect(result.value.warnings[0]?.message).toBe("Unknown operator: BDC");
+  expect(result.value.warnings).toHaveLength(0);
+  expect(
+    MarkedContentStack.depth(result.value.context.markedContentStack),
+  ).toBe(0);
 });
 
 // 辞書→配列の相互再帰経路を入口テストで pin down する。

--- a/packages/core/src/content-stream/interpreter/__tests__/interpreter.marked-content.test.ts
+++ b/packages/core/src/content-stream/interpreter/__tests__/interpreter.marked-content.test.ts
@@ -12,7 +12,7 @@ import { ContentStreamInterpreter } from "../index";
 const encode = (value: string): Uint8Array => new TextEncoder().encode(value);
 
 /**
- * BMC/EMC を登録した registry を生成する。
+ * marked-content operator を registerMarkedContentOperators で登録した registry を生成する。
  */
 const buildRegistry = (): OperatorRegistry => {
   const registered = registerMarkedContentOperators(OperatorRegistry.create());
@@ -82,6 +82,58 @@ test("ネスト未閉じ `/Span BMC /Foo BMC` で depth=2・last tag=/Foo の OB
   expect(result.error.message).toBe(
     "Unterminated marked-content sequence(s): depth=2, last tag=/Foo",
   );
+});
+
+test("`/T <</MCID 0>> BDC EMC` で 1 段開閉が完了する（dict properties）", () => {
+  const result = ContentStreamInterpreter.execute({
+    data: encode("/T <</MCID 0>> BDC EMC"),
+    registry: buildRegistry(),
+  });
+
+  assert(result.ok);
+  expect(result.value.warnings).toHaveLength(0);
+  expect(
+    MarkedContentStack.depth(result.value.context.markedContentStack),
+  ).toBe(0);
+});
+
+test("`/T /MC0 BDC EMC` で 1 段開閉が完了する（name properties、resource 解決しない）", () => {
+  const result = ContentStreamInterpreter.execute({
+    data: encode("/T /MC0 BDC EMC"),
+    registry: buildRegistry(),
+  });
+
+  assert(result.ok);
+  expect(result.value.warnings).toHaveLength(0);
+  expect(
+    MarkedContentStack.depth(result.value.context.markedContentStack),
+  ).toBe(0);
+});
+
+test("`/A BMC /B <<>> BDC EMC EMC` で BMC → BDC → EMC → EMC が LIFO で閉じる", () => {
+  const result = ContentStreamInterpreter.execute({
+    data: encode("/A BMC /B <<>> BDC EMC EMC"),
+    registry: buildRegistry(),
+  });
+
+  assert(result.ok);
+  expect(result.value.warnings).toHaveLength(0);
+  expect(
+    MarkedContentStack.depth(result.value.context.markedContentStack),
+  ).toBe(0);
+});
+
+test("`/A <<>> BDC /B BMC EMC EMC` で BDC → BMC → EMC → EMC が LIFO で閉じる", () => {
+  const result = ContentStreamInterpreter.execute({
+    data: encode("/A <<>> BDC /B BMC EMC EMC"),
+    registry: buildRegistry(),
+  });
+
+  assert(result.ok);
+  expect(result.value.warnings).toHaveLength(0);
+  expect(
+    MarkedContentStack.depth(result.value.context.markedContentStack),
+  ).toBe(0);
 });
 
 test('`data: ""` + 非空 initialContext（depth=1, tag /Span）で OBJECT_PARSE_UNTERMINATED', () => {

--- a/packages/core/src/content-stream/operators/marked-content/bdc/__tests__/bdc.dict.test.ts
+++ b/packages/core/src/content-stream/operators/marked-content/bdc/__tests__/bdc.dict.test.ts
@@ -1,0 +1,236 @@
+import { assert, expect, test } from "vitest";
+import type {
+  PdfDictionary,
+  PdfName,
+  PdfObject,
+  PdfValue,
+} from "../../../../../pdf/types/pdf-types/index";
+import { none } from "../../../../../utils/option/index";
+import { GraphicsStateStack } from "../../../../graphics-state/index";
+import type { MarkedContentEntry } from "../../../../marked-content/stack";
+import { MarkedContentStack } from "../../../../marked-content/stack";
+import { OperandStack } from "../../../../operand-stack/index";
+import type { OperatorHandlerContext } from "../../../../operator-registry/index";
+import { bdcHandler } from "../index";
+
+// buildContext は operand を底 → 頂上の順に push する。pop 順は逆。
+const buildContext = (operands: PdfObject[]): OperatorHandlerContext => {
+  const operandStack = OperandStack.create();
+  for (const operand of operands) {
+    OperandStack.push(operandStack, operand);
+  }
+  return {
+    operandStack,
+    graphicsStateStack: GraphicsStateStack.create(),
+    markedContentStack: MarkedContentStack.create(),
+  };
+};
+
+// markedContentStack を depth=1 の非空状態にして組み立てる（ネスト push 検証用）
+const buildNestedContext = (
+  operands: PdfObject[],
+  seededTag: PdfName,
+): OperatorHandlerContext => {
+  const operandStack = OperandStack.create();
+  for (const operand of operands) {
+    OperandStack.push(operandStack, operand);
+  }
+  const seededEntry: MarkedContentEntry = { tag: seededTag, properties: none };
+  return {
+    operandStack,
+    graphicsStateStack: GraphicsStateStack.create(),
+    markedContentStack: MarkedContentStack.push(
+      MarkedContentStack.create(),
+      seededEntry,
+    ),
+  };
+};
+
+test("tag + dict properties を受理して ok を返す", () => {
+  const tag: PdfName = { type: "name", value: "Span" };
+  const properties: PdfDictionary = {
+    type: "dictionary",
+    entries: new Map([["MCID", { type: "integer", value: 0 }]]),
+  };
+  const ctx = buildContext([tag, properties]);
+
+  const result = bdcHandler(ctx);
+
+  assert(result.ok);
+});
+
+test("成功時 markedContentStack は入力と別参照で返る（非破壊）", () => {
+  const tag: PdfName = { type: "name", value: "Span" };
+  const properties: PdfDictionary = {
+    type: "dictionary",
+    entries: new Map([["MCID", { type: "integer", value: 0 }]]),
+  };
+  const ctx = buildContext([tag, properties]);
+
+  const result = bdcHandler(ctx);
+
+  assert(result.ok);
+  expect(result.value.markedContentStack).not.toBe(ctx.markedContentStack);
+});
+
+test("成功時 markedContentStack の depth が 0 → 1 になる", () => {
+  const tag: PdfName = { type: "name", value: "Span" };
+  const properties: PdfDictionary = {
+    type: "dictionary",
+    entries: new Map(),
+  };
+  const ctx = buildContext([tag, properties]);
+
+  const result = bdcHandler(ctx);
+
+  assert(result.ok);
+  expect(MarkedContentStack.depth(result.value.markedContentStack)).toBe(1);
+});
+
+test("成功後も入力 ctx.markedContentStack は非破壊で depth=0 のまま", () => {
+  const tag: PdfName = { type: "name", value: "Span" };
+  const properties: PdfDictionary = {
+    type: "dictionary",
+    entries: new Map(),
+  };
+  const ctx = buildContext([tag, properties]);
+
+  const result = bdcHandler(ctx);
+
+  assert(result.ok);
+  expect(MarkedContentStack.depth(ctx.markedContentStack)).toBe(0);
+});
+
+test("push された entry の tag は pop した Name と一致し properties は some(dict)", () => {
+  const tag: PdfName = { type: "name", value: "Span" };
+  const properties: PdfDictionary = {
+    type: "dictionary",
+    entries: new Map([["MCID", { type: "integer", value: 0 }]]),
+  };
+  const ctx = buildContext([tag, properties]);
+
+  const result = bdcHandler(ctx);
+
+  assert(result.ok);
+  const popped = MarkedContentStack.pop(result.value.markedContentStack);
+  assert(popped.some);
+  expect(popped.value.popped.tag).toEqual(tag);
+  assert(popped.value.popped.properties.some);
+  expect(popped.value.popped.properties.value).toEqual(properties);
+});
+
+test("dict の中身（/MCID 0, /ActualText (fi)）はそのまま保持され検証されない", () => {
+  const tag: PdfName = { type: "name", value: "Span" };
+  const properties: PdfDictionary = {
+    type: "dictionary",
+    entries: new Map<string, PdfValue>([
+      ["MCID", { type: "integer", value: 0 }],
+      [
+        "ActualText",
+        {
+          type: "string",
+          value: new Uint8Array([0x66, 0x69]),
+          encoding: "literal",
+        },
+      ],
+    ]),
+  };
+  const ctx = buildContext([tag, properties]);
+
+  const result = bdcHandler(ctx);
+
+  assert(result.ok);
+  const popped = MarkedContentStack.pop(result.value.markedContentStack);
+  assert(popped.some);
+  assert(popped.value.popped.properties.some);
+  expect(popped.value.popped.properties.value).toBe(properties);
+});
+
+test("空 dict `<<>>` でも受理する（中身検証なしの pin down）", () => {
+  const tag: PdfName = { type: "name", value: "Span" };
+  const properties: PdfDictionary = {
+    type: "dictionary",
+    entries: new Map(),
+  };
+  const ctx = buildContext([tag, properties]);
+
+  const result = bdcHandler(ctx);
+
+  assert(result.ok);
+});
+
+test("成功時 operandStack は入力と同一参照（in-place mutate）", () => {
+  const tag: PdfName = { type: "name", value: "Span" };
+  const properties: PdfDictionary = {
+    type: "dictionary",
+    entries: new Map(),
+  };
+  const ctx = buildContext([tag, properties]);
+
+  const result = bdcHandler(ctx);
+
+  assert(result.ok);
+  expect(result.value.operandStack).toBe(ctx.operandStack);
+});
+
+test("成功時 operand が 2 個消費され operandStack depth=0 になる", () => {
+  const tag: PdfName = { type: "name", value: "Span" };
+  const properties: PdfDictionary = {
+    type: "dictionary",
+    entries: new Map(),
+  };
+  const ctx = buildContext([tag, properties]);
+
+  const result = bdcHandler(ctx);
+
+  assert(result.ok);
+  expect(OperandStack.depth(result.value.operandStack)).toBe(0);
+});
+
+test("成功時 graphicsStateStack は入力と同一参照で返る", () => {
+  const tag: PdfName = { type: "name", value: "Span" };
+  const properties: PdfDictionary = {
+    type: "dictionary",
+    entries: new Map(),
+  };
+  const ctx = buildContext([tag, properties]);
+
+  const result = bdcHandler(ctx);
+
+  assert(result.ok);
+  expect(result.value.graphicsStateStack).toBe(ctx.graphicsStateStack);
+});
+
+test("余剰 operand があるとき末尾 2 個のみ消費する（depth=4 → depth=2）", () => {
+  const surplus0: PdfObject = { type: "integer", value: 1 };
+  const surplus1: PdfObject = { type: "integer", value: 2 };
+  const tag: PdfName = { type: "name", value: "Span" };
+  const properties: PdfDictionary = {
+    type: "dictionary",
+    entries: new Map(),
+  };
+  const ctx = buildContext([surplus0, surplus1, tag, properties]);
+
+  const result = bdcHandler(ctx);
+
+  assert(result.ok);
+  expect(OperandStack.depth(result.value.operandStack)).toBe(2);
+  const top = OperandStack.peek(result.value.operandStack);
+  assert(top.some);
+  expect(top.value).toEqual(surplus1);
+});
+
+test("既存の非空 stack（depth=1）へネスト push すると depth=2 になる", () => {
+  const seededTag: PdfName = { type: "name", value: "Artifact" };
+  const tag: PdfName = { type: "name", value: "Span" };
+  const properties: PdfDictionary = {
+    type: "dictionary",
+    entries: new Map(),
+  };
+  const ctx = buildNestedContext([tag, properties], seededTag);
+
+  const result = bdcHandler(ctx);
+
+  assert(result.ok);
+  expect(MarkedContentStack.depth(result.value.markedContentStack)).toBe(2);
+});

--- a/packages/core/src/content-stream/operators/marked-content/bdc/__tests__/bdc.error.test.ts
+++ b/packages/core/src/content-stream/operators/marked-content/bdc/__tests__/bdc.error.test.ts
@@ -1,0 +1,266 @@
+import { assert, expect, test } from "vitest";
+import type {
+  PdfDictionary,
+  PdfName,
+  PdfObject,
+} from "../../../../../pdf/types/pdf-types/index";
+import { none } from "../../../../../utils/option/index";
+import { GraphicsStateStack } from "../../../../graphics-state/index";
+import type { MarkedContentEntry } from "../../../../marked-content/stack";
+import { MarkedContentStack } from "../../../../marked-content/stack";
+import { OperandStack } from "../../../../operand-stack/index";
+import type { OperatorHandlerContext } from "../../../../operator-registry/index";
+import { bdcHandler } from "../index";
+
+const buildContext = (operands: PdfObject[]): OperatorHandlerContext => {
+  const operandStack = OperandStack.create();
+  for (const operand of operands) {
+    OperandStack.push(operandStack, operand);
+  }
+  return {
+    operandStack,
+    graphicsStateStack: GraphicsStateStack.create(),
+    markedContentStack: MarkedContentStack.create(),
+  };
+};
+
+// markedContentStack を depth=1 の非空状態にして組み立てる（MISSING 時の不変性検証用）
+const buildSeededContext = (
+  operands: PdfObject[],
+  seededTag: PdfName,
+): OperatorHandlerContext => {
+  const operandStack = OperandStack.create();
+  for (const operand of operands) {
+    OperandStack.push(operandStack, operand);
+  }
+  const seededEntry: MarkedContentEntry = { tag: seededTag, properties: none };
+  return {
+    operandStack,
+    graphicsStateStack: GraphicsStateStack.create(),
+    markedContentStack: MarkedContentStack.push(
+      MarkedContentStack.create(),
+      seededEntry,
+    ),
+  };
+};
+
+// properties 位置に許容されない型（dict/name 以外の 8 バリアント）
+const NON_DICT_OR_NAME_CASES: ReadonlyArray<[string, PdfObject]> = [
+  ["integer", { type: "integer", value: 42 }],
+  ["real", { type: "real", value: 3.14 }],
+  ["string", { type: "string", value: new Uint8Array(), encoding: "literal" }],
+  ["boolean", { type: "boolean", value: true }],
+  ["null", { type: "null" }],
+  ["array", { type: "array", elements: [] }],
+  [
+    "indirect-ref",
+    { type: "indirect-ref", objectNumber: 1, generationNumber: 0 },
+  ],
+  [
+    "stream",
+    {
+      type: "stream",
+      dictionary: { type: "dictionary", entries: new Map() },
+      data: new Uint8Array(),
+    },
+  ],
+];
+
+// tag 位置に許容されない型（name 以外の 9 バリアント、bmc.error.test.ts の NON_NAME_CASES と同一）
+const NON_NAME_CASES: ReadonlyArray<[string, PdfObject]> = [
+  ["integer", { type: "integer", value: 42 }],
+  ["real", { type: "real", value: 3.14 }],
+  ["string", { type: "string", value: new Uint8Array(), encoding: "literal" }],
+  ["boolean", { type: "boolean", value: true }],
+  ["null", { type: "null" }],
+  ["array", { type: "array", elements: [] }],
+  ["dictionary", { type: "dictionary", entries: new Map() }],
+  [
+    "indirect-ref",
+    { type: "indirect-ref", objectNumber: 1, generationNumber: 0 },
+  ],
+  [
+    "stream",
+    {
+      type: "stream",
+      dictionary: { type: "dictionary", entries: new Map() },
+      data: new Uint8Array(),
+    },
+  ],
+];
+
+// -------- MISSING 系 --------
+
+test("operand 0 個で MISSING を返す（required:2, actual:0, operatorName:'BDC'）", () => {
+  const ctx = buildContext([]);
+
+  const result = bdcHandler(ctx);
+
+  assert(!result.ok);
+  assert(result.error.code === "OPERATOR_OPERAND_MISSING");
+  expect(result.error.operatorName).toBe("BDC");
+  expect(result.error.required).toBe(2);
+  expect(result.error.actual).toBe(0);
+});
+
+test("operand 0 個の MISSING メッセージが完全一致する（`Operator 'BDC' requires 2 operand(s), got 0`）", () => {
+  const ctx = buildContext([]);
+
+  const result = bdcHandler(ctx);
+
+  assert(!result.ok);
+  assert(result.error.code === "OPERATOR_OPERAND_MISSING");
+  expect(result.error.message).toBe(
+    "Operator 'BDC' requires 2 operand(s), got 0",
+  );
+});
+
+test("operand 1 個（properties 位置 name のみ）で MISSING を返す（actual=1）", () => {
+  const ctx = buildContext([{ type: "name", value: "Span" }]);
+
+  const result = bdcHandler(ctx);
+
+  assert(!result.ok);
+  assert(result.error.code === "OPERATOR_OPERAND_MISSING");
+  expect(result.error.actual).toBe(1);
+});
+
+test("operand 1 個の MISSING メッセージが完全一致する（`Operator 'BDC' requires 2 operand(s), got 1`）", () => {
+  const ctx = buildContext([{ type: "name", value: "Span" }]);
+
+  const result = bdcHandler(ctx);
+
+  assert(!result.ok);
+  assert(result.error.code === "OPERATOR_OPERAND_MISSING");
+  expect(result.error.message).toBe(
+    "Operator 'BDC' requires 2 operand(s), got 1",
+  );
+});
+
+test("非空 seeded stack (depth=1) でも MISSING 時に markedContentStack は depth=1 のまま", () => {
+  const ctx = buildSeededContext([], { type: "name", value: "Span" });
+
+  const result = bdcHandler(ctx);
+
+  assert(!result.ok);
+  expect(MarkedContentStack.depth(ctx.markedContentStack)).toBe(1);
+});
+
+test("MISSING 時（operand 0）markedContentStack は push されず depth=0 のまま", () => {
+  const ctx = buildContext([]);
+
+  const result = bdcHandler(ctx);
+
+  assert(!result.ok);
+  expect(MarkedContentStack.depth(ctx.markedContentStack)).toBe(0);
+});
+
+// -------- properties TYPE_MISMATCH --------
+
+test.each<[string, PdfObject]>(
+  NON_DICT_OR_NAME_CASES,
+)("properties が %s のとき TYPE_MISMATCH を返す（expected='name or dictionary', actual=type）", (type, operand) => {
+  const ctx = buildContext([operand]);
+
+  const result = bdcHandler(ctx);
+
+  assert(!result.ok);
+  assert(result.error.code === "OPERATOR_OPERAND_TYPE_MISMATCH");
+  expect(result.error.operatorName).toBe("BDC");
+  expect(result.error.expected).toBe("name or dictionary");
+  expect(result.error.actual).toBe(type);
+});
+
+test("properties TYPE_MISMATCH のメッセージが完全一致する（`Operator 'BDC' expected name or dictionary operand, got integer`）", () => {
+  const ctx = buildContext([{ type: "integer", value: 42 }]);
+
+  const result = bdcHandler(ctx);
+
+  assert(!result.ok);
+  assert(result.error.code === "OPERATOR_OPERAND_TYPE_MISMATCH");
+  expect(result.error.message).toBe(
+    "Operator 'BDC' expected name or dictionary operand, got integer",
+  );
+});
+
+test("properties TYPE_MISMATCH 時 markedContentStack は push されず不変（depth=0）", () => {
+  const ctx = buildContext([{ type: "integer", value: 42 }]);
+
+  const result = bdcHandler(ctx);
+
+  assert(!result.ok);
+  expect(MarkedContentStack.depth(ctx.markedContentStack)).toBe(0);
+});
+
+test("properties TYPE_MISMATCH 時、部分消費した operand は復元しない（depth=1 → depth=0）", () => {
+  const ctx = buildContext([{ type: "integer", value: 42 }]);
+  expect(OperandStack.depth(ctx.operandStack)).toBe(1);
+
+  const result = bdcHandler(ctx);
+
+  assert(!result.ok);
+  expect(OperandStack.depth(ctx.operandStack)).toBe(0);
+});
+
+// -------- tag TYPE_MISMATCH --------
+
+test.each<[string, PdfObject]>(
+  NON_NAME_CASES,
+)("tag が %s のとき TYPE_MISMATCH を返す（expected='name', actual=type）", (type, operand) => {
+  const properties: PdfDictionary = {
+    type: "dictionary",
+    entries: new Map(),
+  };
+  const ctx = buildContext([operand, properties]);
+
+  const result = bdcHandler(ctx);
+
+  assert(!result.ok);
+  assert(result.error.code === "OPERATOR_OPERAND_TYPE_MISMATCH");
+  expect(result.error.operatorName).toBe("BDC");
+  expect(result.error.expected).toBe("name");
+  expect(result.error.actual).toBe(type);
+});
+
+test("tag TYPE_MISMATCH のメッセージが完全一致する（`Operator 'BDC' expected name operand, got integer`）", () => {
+  const properties: PdfDictionary = {
+    type: "dictionary",
+    entries: new Map(),
+  };
+  const ctx = buildContext([{ type: "integer", value: 42 }, properties]);
+
+  const result = bdcHandler(ctx);
+
+  assert(!result.ok);
+  assert(result.error.code === "OPERATOR_OPERAND_TYPE_MISMATCH");
+  expect(result.error.message).toBe(
+    "Operator 'BDC' expected name operand, got integer",
+  );
+});
+
+test("tag TYPE_MISMATCH 時 markedContentStack は push されず不変（depth=0）", () => {
+  const properties: PdfDictionary = {
+    type: "dictionary",
+    entries: new Map(),
+  };
+  const ctx = buildContext([{ type: "integer", value: 42 }, properties]);
+
+  const result = bdcHandler(ctx);
+
+  assert(!result.ok);
+  expect(MarkedContentStack.depth(ctx.markedContentStack)).toBe(0);
+});
+
+test("tag TYPE_MISMATCH 時、両方 pop 済みで operandStack depth=0", () => {
+  const properties: PdfDictionary = {
+    type: "dictionary",
+    entries: new Map(),
+  };
+  const ctx = buildContext([{ type: "integer", value: 42 }, properties]);
+  expect(OperandStack.depth(ctx.operandStack)).toBe(2);
+
+  const result = bdcHandler(ctx);
+
+  assert(!result.ok);
+  expect(OperandStack.depth(ctx.operandStack)).toBe(0);
+});

--- a/packages/core/src/content-stream/operators/marked-content/bdc/__tests__/bdc.name.test.ts
+++ b/packages/core/src/content-stream/operators/marked-content/bdc/__tests__/bdc.name.test.ts
@@ -1,0 +1,97 @@
+import { assert, expect, test } from "vitest";
+import type {
+  PdfName,
+  PdfObject,
+} from "../../../../../pdf/types/pdf-types/index";
+import { GraphicsStateStack } from "../../../../graphics-state/index";
+import { MarkedContentStack } from "../../../../marked-content/stack";
+import { OperandStack } from "../../../../operand-stack/index";
+import type { OperatorHandlerContext } from "../../../../operator-registry/index";
+import { bdcHandler } from "../index";
+
+// buildContext は operand を底 → 頂上の順に push する。pop 順は逆。
+const buildContext = (operands: PdfObject[]): OperatorHandlerContext => {
+  const operandStack = OperandStack.create();
+  for (const operand of operands) {
+    OperandStack.push(operandStack, operand);
+  }
+  return {
+    operandStack,
+    graphicsStateStack: GraphicsStateStack.create(),
+    markedContentStack: MarkedContentStack.create(),
+  };
+};
+
+test("tag + name properties (/MC0) を受理して ok を返す", () => {
+  const tag: PdfName = { type: "name", value: "Span" };
+  const properties: PdfName = { type: "name", value: "MC0" };
+  const ctx = buildContext([tag, properties]);
+
+  const result = bdcHandler(ctx);
+
+  assert(result.ok);
+});
+
+test("push された entry の properties は some(name) で resource 解決されず /MC0 のまま", () => {
+  const tag: PdfName = { type: "name", value: "Span" };
+  const properties: PdfName = { type: "name", value: "MC0" };
+  const ctx = buildContext([tag, properties]);
+
+  const result = bdcHandler(ctx);
+
+  assert(result.ok);
+  const popped = MarkedContentStack.pop(result.value.markedContentStack);
+  assert(popped.some);
+  assert(popped.value.popped.properties.some);
+  expect(popped.value.popped.properties.value).toEqual({
+    type: "name",
+    value: "MC0",
+  });
+});
+
+test("entry.tag と entry.properties.value はどちらも PdfName で別インスタンス", () => {
+  const tag: PdfName = { type: "name", value: "Span" };
+  const properties: PdfName = { type: "name", value: "MC0" };
+  const ctx = buildContext([tag, properties]);
+
+  const result = bdcHandler(ctx);
+
+  assert(result.ok);
+  const popped = MarkedContentStack.pop(result.value.markedContentStack);
+  assert(popped.some);
+  assert(popped.value.popped.properties.some);
+  expect(popped.value.popped.tag).not.toBe(
+    popped.value.popped.properties.value,
+  );
+});
+
+test("空文字 name `//` (value='') を properties として受理する", () => {
+  const tag: PdfName = { type: "name", value: "Span" };
+  const properties: PdfName = { type: "name", value: "" };
+  const ctx = buildContext([tag, properties]);
+
+  const result = bdcHandler(ctx);
+
+  assert(result.ok);
+});
+
+test("空文字 tag `//` (value='') でも受理する（値域検証なしの pin down）", () => {
+  const tag: PdfName = { type: "name", value: "" };
+  const properties: PdfName = { type: "name", value: "MC0" };
+  const ctx = buildContext([tag, properties]);
+
+  const result = bdcHandler(ctx);
+
+  assert(result.ok);
+});
+
+test("成功時 operandStack が depth=0 まで消費される", () => {
+  const tag: PdfName = { type: "name", value: "Span" };
+  const properties: PdfName = { type: "name", value: "MC0" };
+  const ctx = buildContext([tag, properties]);
+
+  const result = bdcHandler(ctx);
+
+  assert(result.ok);
+  expect(OperandStack.depth(result.value.operandStack)).toBe(0);
+});

--- a/packages/core/src/content-stream/operators/marked-content/bdc/index.ts
+++ b/packages/core/src/content-stream/operators/marked-content/bdc/index.ts
@@ -1,0 +1,112 @@
+import type { PdfError } from "../../../../pdf/errors/index";
+import type {
+  PdfDictionary,
+  PdfName,
+} from "../../../../pdf/types/pdf-types/index";
+import { PdfName as PdfNameCompanion } from "../../../../pdf/types/pdf-types/index";
+import { some } from "../../../../utils/option/index";
+import { err, ok } from "../../../../utils/result/index";
+import type { MarkedContentEntry } from "../../../marked-content/stack/index";
+import { MarkedContentStack } from "../../../marked-content/stack/index";
+import { OperandStack } from "../../../operand-stack/index";
+import type {
+  OperatorHandler,
+  OperatorHandlerContext,
+} from "../../../operator-registry/index";
+
+const OPERATOR_NAME = "BDC";
+const OPERAND_COUNT = 2;
+
+/**
+ * ISO 32000-2:2020 §14.6 `BDC` operator (begin marked-content sequence with
+ * property list) のハンドラ。
+ *
+ * operand stack 頂上から properties → tag の順に 2 個 pop し、両方の型検査を
+ * 通過したら `{ tag, properties: some(properties) }` を marked content stack へ
+ * push した新しい context を返す。
+ *
+ * 検査順序（厳守 / bmcHandler / tfHandler 準拠）:
+ *   (1) properties pop（none なら OPERATOR_OPERAND_MISSING, actual=0）
+ *   (2) properties 型検査（dictionary/name 以外は OPERATOR_OPERAND_TYPE_MISMATCH）
+ *   (3) tag pop（none なら OPERATOR_OPERAND_MISSING, actual=1）
+ *   (4) tag 型検査（PdfName.is が false なら OPERATOR_OPERAND_TYPE_MISMATCH）
+ *   (5) 全通過 → MarkedContentStack.push で markedContentStack を差し替えて ok
+ *
+ * `actual` フィールドの意味（既存 handler の流儀）:
+ *   - MISSING: 数値。pop 成功数（0 段目失敗=0 / 1 段目失敗=1）
+ *   - TYPE_MISMATCH: 文字列。実際に来た operand の `type` フィールド
+ *
+ * - properties が PdfName の場合、resource 解決は本 handler で行わない。
+ * - dict の中身（/MCID, /ActualText 等）の妥当性は検証しない。
+ * - 更新するのは markedContentStack のみ。operandStack（pop で in-place 消費済み）・
+ *   graphicsStateStack は入力と同一参照で返す。
+ * - エラー時に部分消費した operand stack は復元しない（既存ハンドラ規約）。
+ *
+ * @param context - 実行コンテキスト
+ * @returns 成功なら更新後 context、失敗なら PdfError
+ */
+export const bdcHandler: OperatorHandler = (
+  context: OperatorHandlerContext,
+) => {
+  const poppedProperties = OperandStack.pop(context.operandStack);
+  if (!poppedProperties.some) {
+    const error: PdfError = {
+      code: "OPERATOR_OPERAND_MISSING",
+      message: `Operator '${OPERATOR_NAME}' requires ${OPERAND_COUNT} operand(s), got 0`,
+      operatorName: OPERATOR_NAME,
+      required: OPERAND_COUNT,
+      actual: 0,
+    };
+    return err(error);
+  }
+  const properties = poppedProperties.value;
+
+  if (properties.type !== "dictionary" && !PdfNameCompanion.is(properties)) {
+    const error: PdfError = {
+      code: "OPERATOR_OPERAND_TYPE_MISMATCH",
+      message: `Operator '${OPERATOR_NAME}' expected name or dictionary operand, got ${properties.type}`,
+      operatorName: OPERATOR_NAME,
+      expected: "name or dictionary",
+      actual: properties.type,
+    };
+    return err(error);
+  }
+  const validatedProperties: PdfDictionary | PdfName = properties;
+
+  const poppedTag = OperandStack.pop(context.operandStack);
+  if (!poppedTag.some) {
+    const error: PdfError = {
+      code: "OPERATOR_OPERAND_MISSING",
+      message: `Operator '${OPERATOR_NAME}' requires ${OPERAND_COUNT} operand(s), got 1`,
+      operatorName: OPERATOR_NAME,
+      required: OPERAND_COUNT,
+      actual: 1,
+    };
+    return err(error);
+  }
+  const tag = poppedTag.value;
+
+  if (!PdfNameCompanion.is(tag)) {
+    const error: PdfError = {
+      code: "OPERATOR_OPERAND_TYPE_MISMATCH",
+      message: `Operator '${OPERATOR_NAME}' expected name operand, got ${tag.type}`,
+      operatorName: OPERATOR_NAME,
+      expected: "name",
+      actual: tag.type,
+    };
+    return err(error);
+  }
+
+  const entry: MarkedContentEntry = {
+    tag,
+    properties: some(validatedProperties),
+  };
+  return ok({
+    operandStack: context.operandStack,
+    graphicsStateStack: context.graphicsStateStack,
+    markedContentStack: MarkedContentStack.push(
+      context.markedContentStack,
+      entry,
+    ),
+  });
+};

--- a/packages/core/src/content-stream/operators/marked-content/bdc/index.ts
+++ b/packages/core/src/content-stream/operators/marked-content/bdc/index.ts
@@ -1,9 +1,6 @@
 import type { PdfError } from "../../../../pdf/errors/index";
-import type {
-  PdfDictionary,
-  PdfName,
-} from "../../../../pdf/types/pdf-types/index";
-import { PdfName as PdfNameCompanion } from "../../../../pdf/types/pdf-types/index";
+import type { PdfDictionary } from "../../../../pdf/types/pdf-types/index";
+import { PdfName } from "../../../../pdf/types/pdf-types/index";
 import { some } from "../../../../utils/option/index";
 import { err, ok } from "../../../../utils/result/index";
 import type { MarkedContentEntry } from "../../../marked-content/stack/index";
@@ -61,7 +58,7 @@ export const bdcHandler: OperatorHandler = (
   }
   const properties = poppedProperties.value;
 
-  if (properties.type !== "dictionary" && !PdfNameCompanion.is(properties)) {
+  if (properties.type !== "dictionary" && !PdfName.is(properties)) {
     const error: PdfError = {
       code: "OPERATOR_OPERAND_TYPE_MISMATCH",
       message: `Operator '${OPERATOR_NAME}' expected name or dictionary operand, got ${properties.type}`,
@@ -86,7 +83,7 @@ export const bdcHandler: OperatorHandler = (
   }
   const tag = poppedTag.value;
 
-  if (!PdfNameCompanion.is(tag)) {
+  if (!PdfName.is(tag)) {
     const error: PdfError = {
       code: "OPERATOR_OPERAND_TYPE_MISMATCH",
       message: `Operator '${OPERATOR_NAME}' expected name operand, got ${tag.type}`,

--- a/packages/core/src/content-stream/operators/marked-content/marked-content-operators/__tests__/marked-content-operators.error.test.ts
+++ b/packages/core/src/content-stream/operators/marked-content/marked-content-operators/__tests__/marked-content-operators.error.test.ts
@@ -36,3 +36,18 @@ test("EMC の重複登録で fail-fast する（register 呼び出しは BMC 登
   const calledNames = spy.mock.calls.map((call) => call[1]);
   expect(calledNames).toEqual(["BMC", "EMC"]);
 });
+
+test("BDC の重複登録で fail-fast する（register 呼び出しは EMC 登録後に止まる）", () => {
+  const base = OperatorRegistry.create();
+  const seeded = OperatorRegistry.register(base, "BDC", (ctx) => ok(ctx));
+  assert(seeded.ok);
+
+  const spy = vi.spyOn(OperatorRegistry, "register");
+  const result = registerMarkedContentOperators(seeded.value);
+
+  assert(!result.ok);
+  assert(result.error.code === "OPERATOR_ALREADY_REGISTERED");
+  expect(result.error.operatorName).toBe("BDC");
+  const calledNames = spy.mock.calls.map((call) => call[1]);
+  expect(calledNames).toEqual(["BMC", "EMC", "BDC"]);
+});

--- a/packages/core/src/content-stream/operators/marked-content/marked-content-operators/__tests__/marked-content-operators.integration.test.ts
+++ b/packages/core/src/content-stream/operators/marked-content/marked-content-operators/__tests__/marked-content-operators.integration.test.ts
@@ -22,11 +22,11 @@ test("EMC が登録される", () => {
   expect(OperatorRegistry.has(registered.value, "EMC")).toBe(true);
 });
 
-test("BDC は登録されない（未登録の保証）", () => {
+test("BDC が登録される", () => {
   const registered = registerMarkedContentOperators(OperatorRegistry.create());
 
   assert(registered.ok);
-  expect(OperatorRegistry.has(registered.value, "BDC")).toBe(false);
+  expect(OperatorRegistry.has(registered.value, "BDC")).toBe(true);
 });
 
 test("MP は登録されない", () => {

--- a/packages/core/src/content-stream/operators/marked-content/marked-content-operators/index.ts
+++ b/packages/core/src/content-stream/operators/marked-content/marked-content-operators/index.ts
@@ -3,22 +3,25 @@ import type { Result } from "../../../../utils/result/index";
 import { flatMap, ok } from "../../../../utils/result/index";
 import type { OperatorHandler } from "../../../operator-registry/index";
 import { OperatorRegistry } from "../../../operator-registry/index";
+import { bdcHandler } from "../bdc/index";
 import { bmcHandler } from "../bmc/index";
 import { emcHandler } from "../emc/index";
 
+export { bdcHandler } from "../bdc/index";
 export { bmcHandler } from "../bmc/index";
 export { emcHandler } from "../emc/index";
 
-// BMC/EMC のみ。BDC/MP/DP は後続 issue で登録する（本 issue では未登録のまま）。
+// BMC / BDC / EMC を登録。MP / DP は後続 issue で登録する（本 issue では未登録のまま）。
 const MARKED_CONTENT_OPERATORS: ReadonlyArray<
   readonly [string, OperatorHandler]
 > = [
   ["BMC", bmcHandler],
   ["EMC", emcHandler],
+  ["BDC", bdcHandler],
 ];
 
 /**
- * Marked-content operator (BMC / EMC) を OperatorRegistry に一括登録するヘルパ。
+ * Marked-content operator (BMC / EMC / BDC) を OperatorRegistry に一括登録するヘルパ。
  *
  * fail-fast: いずれかの register が Err を返した時点で reduce 内 flatMap が
  * 短絡し、後続 operator の register は呼ばれない。


### PR DESCRIPTION
## 概要

ISO 32000-2:2020 §14.6 の `BDC` operator (begin marked-content sequence with property list) の handler を新規実装し、`registerMarkedContentOperators` で BMC / EMC と共に一括登録できるようにする。

## 変更内容

### 🎯 変更の種類

- [x] ✨ 新機能 (New feature)

### 📝 詳細な変更内容

#### 追加された機能

- **`bdcHandler`** (`packages/core/src/content-stream/operators/marked-content/bdc/index.ts`): operand stack 頂上から `properties → tag` の順に 2 段 pop し、両方の型検査を通過したら `{ tag, properties: some(properties) }` を `MarkedContentStack` へ push
  - properties は `PdfDictionary | PdfName` を受理
  - tag は `PdfName` のみ受理
  - name properties の resource 解決は本 issue のスコープ外（そのまま `MarkedContentEntry.properties` に保存）
  - pop 順序 / 部分消費規約 / `actual` フィールド (pop 成功数) は `bmcHandler` / `tfHandler` 流儀を継承
- **`MARKED_CONTENT_OPERATORS` への追加**: `["BDC", bdcHandler]` を末尾に追記、`registerMarkedContentOperators` が BMC / EMC / BDC を一括登録するようになる

#### 変更されたファイル

- `packages/core/src/content-stream/operators/marked-content/bdc/index.ts` (新規)
- `packages/core/src/content-stream/operators/marked-content/bdc/__tests__/bdc.dict.test.ts` (新規, 12 tests)
- `packages/core/src/content-stream/operators/marked-content/bdc/__tests__/bdc.name.test.ts` (新規, 6 tests)
- `packages/core/src/content-stream/operators/marked-content/bdc/__tests__/bdc.error.test.ts` (新規, 29 tests)
- `packages/core/src/content-stream/operators/marked-content/marked-content-operators/index.ts` (BDC 登録)
- `packages/core/src/content-stream/operators/marked-content/marked-content-operators/__tests__/marked-content-operators.integration.test.ts` (「BDC は登録されない」→「BDC が登録される」)
- `packages/core/src/content-stream/operators/marked-content/marked-content-operators/__tests__/marked-content-operators.error.test.ts` (BDC 重複登録 fail-fast テスト追加)
- `packages/core/src/content-stream/interpreter/__tests__/interpreter.dict-operand.test.ts` (BDC/EMC 登録済み registry での end-to-end 検証へ更新)
- `packages/core/src/content-stream/interpreter/__tests__/interpreter.marked-content.test.ts` (BDC+EMC dict/name + BMC/BDC 混在ネスト 2 方向を追記)

## 📊 システム図

### 状態マシン / フロー図

```mermaid
flowchart TD
    Start([BDC 呼び出し<br/>OperatorHandlerContext]) --> PopProp[properties を pop]
    PopProp -->|none| MissingA[ERR MISSING<br/>actual=0]
    PopProp -->|some| CheckProp{properties 型検査<br/>dictionary or PdfName?}
    CheckProp -->|その他| TypeA[ERR TYPE_MISMATCH<br/>expected='name or dictionary']
    CheckProp -->|dict / name| PopTag[tag を pop]
    PopTag -->|none| MissingB[ERR MISSING<br/>actual=1]
    PopTag -->|some| CheckTag{tag 型検査<br/>PdfName?}
    CheckTag -->|その他| TypeB[ERR TYPE_MISMATCH<br/>expected='name']
    CheckTag -->|PdfName| Push[MarkedContentStack.push<br/>&#123; tag, properties: some&#40;prop&#41; &#125;]:::new
    Push --> Ok([OK<br/>markedContentStack 差し替え<br/>operandStack / graphicsStateStack は同一参照]):::new

    classDef new fill:#ffe4b5,stroke:#d97706,stroke-width:2px
```

### データフロー

```
Content stream bytes (Uint8Array)
    ↓
ContentStreamTokenizer
    ↓
ContentStreamInterpreter.execute
    ├─→ OperandStack (RPN, mutable)
    │       [/T, <</MCID 0>>] ← BDC 直前の状態
    │
    └─→ OperatorRegistry.lookup("BDC") → Some(bdcHandler)  [NEW]
            ↓
        bdcHandler(context)  [NEW]
            ├─→ OperandStack.pop → properties (dict or name)
            ├─→ OperandStack.pop → tag (PdfName)
            └─→ MarkedContentStack.push({ tag, properties: some(properties) })  [NEW]
                    ↓
                markedContentStack: depth 0 → 1
                (兄弟: BMC は properties: none で push / EMC は 1 段閉じる)
```

## 📋 関連 Issue

- Refs #481 (親 Epic #479 / 依存 #480)

## 🧪 テスト

### テスト実行方法

\`\`\`bash
pnpm --filter @pdfmod/core test
pnpm --filter @pdfmod/core build
pnpm --filter @pdfmod/core typecheck
pnpm run lint
\`\`\`

### テスト項目

- [x] 単体テスト (Unit tests): bdc.dict (12) / bdc.name (6) / bdc.error (29)
- [x] 統合テスト (Integration tests): marked-content-operators / interpreter.dict-operand / interpreter.marked-content

### テスト結果

- **全体**: 249 test files / 3053 tests all pass ✅
- **build / typecheck / lint**: エラーなし ✅
- **カバレッジ**: `bdc/index.ts` の全 branch（properties MISSING / properties TYPE / tag MISSING / tag TYPE / 成功）が単体テストで網羅

## 🔍 レビューポイント

- **エラーコードの使い分け**: `OPERATOR_OPERAND_MISSING`（不足）と `OPERATOR_OPERAND_TYPE_MISMATCH`（型不一致）を既存 `bmcHandler` と同じ流儀で使い分け（`actual` は MISSING では pop 成功数、TYPE_MISMATCH では operand.type 文字列）
- **name properties の非解決**: `/MC0` のような name reference が来ても resource 解決は行わず、そのまま `MarkedContentEntry.properties` に保存する設計判断
- **interpreter EOF 検査との整合**: PR #516 で導入された EOF 検査により、`interpreter.dict-operand.test.ts` の入力を `BDC` 単独から `BDC EMC` ペアに変更（詳細は 073-bdc-handler の implementation-notes.md D-1）
- **`MARKED_CONTENT_OPERATORS` の順序**: `[BMC, EMC, BDC]` の順で末尾追加。fail-fast テストの `calledNames === ["BMC", "EMC", "BDC"]` と一致
- **spec-based-code-review 実施済み**: CRITICAL 1（既存 vi.spyOn パターン踏襲、別 issue 扱い）/ WARNING 3（うち 2 件は本 PR で修正済み: PR 参照コメント削除 + `buildRegistry` JSDoc 更新）

## ✅ チェックリスト

- [x] コードレビューの準備ができている
- [x] テストが正常に実行される
- [x] コミットメッセージが適切な形式で書かれている
- [x] 関連する Issue #481 を PR にリンク
- [x] セルフレビューを実施
- [ ] 破壊的変更なし（既存 API は変更していない）

🤖 Generated with [Claude Code](https://claude.com/claude-code)