### PR TITLE
♻️ [Refactoring]: #393 PdfObject::as_string を as_string_bytes にリネーム

### DIFF
--- a/rust/crates/core/src/lexer/token.rs
+++ b/rust/crates/core/src/lexer/token.rs
@@ -93,7 +93,7 @@ impl Primitive {
 
     /// `LiteralString` のとき内部のバイト列を `&[u8]` として `Some` で取り出す（他は `None`）。
     ///
-    /// ヒープ保持のため参照返し（`PdfObject::as_string` と同方針）。
+    /// ヒープ保持のため参照返し（`PdfObject::as_string_bytes` と同方針）。
     pub fn as_literal_string(&self) -> Option<&[u8]> {
         match self {
             Self::LiteralString(bytes) => Some(bytes.as_slice()),

--- a/rust/crates/core/src/object/pdf_object.rs
+++ b/rust/crates/core/src/object/pdf_object.rs
@@ -102,7 +102,7 @@ impl PdfObject {
     /// `String` のとき内部のバイト列を `&[u8]` として `Some` で取り出す（他は `None`）。
     ///
     /// ヒープ保持のため参照返し（`PdfName::as_bytes` と同方針）。
-    pub fn as_string(&self) -> Option<&[u8]> {
+    pub fn as_string_bytes(&self) -> Option<&[u8]> {
         match self {
             Self::String(bytes) => Some(bytes.as_slice()),
             _ => None,
@@ -121,7 +121,7 @@ impl PdfObject {
 
     /// `Array` のとき内部の要素列を `&[PdfObject]` として `Some` で取り出す（他は `None`）。
     ///
-    /// ヒープ保持のため参照返し（`as_string` の `as_slice()` と同方針）。
+    /// ヒープ保持のため参照返し（`as_string_bytes` の `as_slice()` と同方針）。
     pub fn as_array(&self) -> Option<&[PdfObject]> {
         match self {
             Self::Array(items) => Some(items.as_slice()),

--- a/rust/crates/core/src/object/pdf_object/tests/string_name.rs
+++ b/rust/crates/core/src/object/pdf_object/tests/string_name.rs
@@ -9,10 +9,10 @@ fn string_constructs_and_matches_string_arm() {
 }
 
 #[test]
-fn as_string_returns_some_for_string() {
-    // String(b"abc") に as_string() を呼ぶと Some(b"abc") を返すことを確認する
+fn as_string_bytes_returns_some_for_string() {
+    // String(b"abc") に as_string_bytes() を呼ぶと Some(b"abc") を返すことを確認する
     assert_eq!(
-        PdfObject::String(b"abc".to_vec()).as_string(),
+        PdfObject::String(b"abc".to_vec()).as_string_bytes(),
         Some(b"abc".as_slice())
     );
 }
@@ -35,8 +35,8 @@ fn as_name_returns_some_for_name() {
 }
 
 #[test]
-fn as_string_returns_none_for_non_string_variants() {
-    // String 以外（Null/Boolean/Integer/Real/Name/Stream/Reference）では as_string() が None を返すことを確認する
+fn as_string_bytes_returns_none_for_non_string_variants() {
+    // String 以外（Null/Boolean/Integer/Real/Name/Stream/Reference）では as_string_bytes() が None を返すことを確認する
     let variants = [
         PdfObject::Null,
         PdfObject::Boolean(true),
@@ -47,7 +47,7 @@ fn as_string_returns_none_for_non_string_variants() {
         PdfObject::Reference(make_ref(1, 0)),
     ];
     for obj in &variants {
-        assert_eq!(obj.as_string(), None);
+        assert_eq!(obj.as_string_bytes(), None);
     }
 }
 
@@ -69,19 +69,19 @@ fn as_name_returns_none_for_non_name_variants() {
 }
 
 #[test]
-fn as_string_returns_empty_slice_for_empty_string() {
-    // 空バイト列の String(b"") は as_string() で Some(空スライス) を返すことを確認する
+fn as_string_bytes_returns_empty_slice_for_empty_string() {
+    // 空バイト列の String(b"") は as_string_bytes() で Some(空スライス) を返すことを確認する
     assert_eq!(
-        PdfObject::String(b"".to_vec()).as_string(),
+        PdfObject::String(b"".to_vec()).as_string_bytes(),
         Some(b"".as_slice())
     );
 }
 
 #[test]
-fn as_string_preserves_nul_non_utf8_and_high_bytes() {
-    // String(vec![0x00, 0x80, 0xFF]) を as_string() で取り出すと同一バイト列がテキスト解釈されず忠実に返ることを確認する
+fn as_string_bytes_preserves_nul_non_utf8_and_high_bytes() {
+    // String(vec![0x00, 0x80, 0xFF]) を as_string_bytes() で取り出すと同一バイト列がテキスト解釈されず忠実に返ることを確認する
     let obj = PdfObject::String(vec![0x00, 0x80, 0xFF]);
-    assert_eq!(obj.as_string(), Some([0x00, 0x80, 0xFF].as_slice()));
+    assert_eq!(obj.as_string_bytes(), Some([0x00, 0x80, 0xFF].as_slice()));
 }
 
 #[test]
@@ -132,8 +132,8 @@ fn clone_preserves_string_and_name_and_keeps_original_usable() {
     // String/Name を clone() すると複製の中身が元と一致し、元も引き続き使用可能なことを確認する
     let original_string = PdfObject::String(b"abc".to_vec());
     let cloned_string = original_string.clone();
-    assert_eq!(cloned_string.as_string(), Some(b"abc".as_slice()));
-    assert_eq!(original_string.as_string(), Some(b"abc".as_slice()));
+    assert_eq!(cloned_string.as_string_bytes(), Some(b"abc".as_slice()));
+    assert_eq!(original_string.as_string_bytes(), Some(b"abc".as_slice()));
 
     let original_name = PdfObject::Name(PdfName::from("Type"));
     let cloned_name = original_name.clone();
@@ -142,12 +142,12 @@ fn clone_preserves_string_and_name_and_keeps_original_usable() {
 }
 
 #[test]
-fn as_string_preserves_long_multibyte_bytes() {
-    // 長い+多バイトUTF-8（"名前"）混在のバイト列が as_string() で往復一致することを確認する（任意・優先度低）
+fn as_string_bytes_preserves_long_multibyte_bytes() {
+    // 長い+多バイトUTF-8（"名前"）混在のバイト列が as_string_bytes() で往復一致することを確認する（任意・優先度低）
     let mut bytes = "名前".as_bytes().to_vec();
     bytes.resize(bytes.len() + 300, b'a');
     let obj = PdfObject::String(bytes.clone());
-    assert_eq!(obj.as_string(), Some(bytes.as_slice()));
+    assert_eq!(obj.as_string_bytes(), Some(bytes.as_slice()));
 }
 
 #[test]


### PR DESCRIPTION
## 概要

`PdfObject::as_string(&self) -> Option<&[u8]>` を `PdfObject::as_string_bytes` にリネームする Refactor。同クレートの `PdfName::as_bytes` と語彙を揃え、「バイト列を返す `as_*` 命名」の一貫性を回復する。シグネチャ・戻り型・可視性・マッチアーム本体は完全不変で振る舞いは等価。

## 変更内容

### 🎯 変更の種類

- [x] ♻️ リファクタリング (Refactoring)

### 📝 詳細な変更内容

#### 追加された機能・修正

- `PdfObject::as_string_bytes(&self) -> Option<&[u8]>` として新命名を採用（doc 本文「`PdfName::as_bytes` と同方針」は維持）

#### 変更されたファイル

- `rust/crates/core/src/object/pdf_object.rs` — メソッド定義 L105 と `as_array` の doc 内相互参照 L124 を新名に更新
- `rust/crates/core/src/lexer/token.rs` — `Primitive::as_literal_string` の doc クロスリファレンス L96 を新名に追随
- `rust/crates/core/src/object/pdf_object/tests/string_name.rs` — テスト関数名 5（T1–T5）+ `.as_string()` 呼び出し 7 + 日本語コメント内 API 名 5 を新名に一括置換

#### 削除されたファイル・機能

- 旧 `PdfObject::as_string()` を削除（`#[deprecated]` を挟まず即削除。呼び出しは全て pdfmod-core クレート内テストのみ）

## 📊 システム図

### API 名のライフサイクル（旧名 → 新名）

```mermaid
flowchart LR
    A["`STATE_A(旧名)`<br/>`PdfObject::as_string`<br/>戻り型: `Option<&[u8]>`<br/>呼び出し: テスト 7 箇所<br/>doc 参照: 2 箇所"] -->|一括リネーム<br/>3 ファイル・20 箇所| B["`STATE_B(新名)`<br/>`PdfObject::as_string_bytes`<br/>戻り型: `Option<&[u8]>` (不変)<br/>呼び出し: テスト 7 箇所 (新名)<br/>doc 参照: 2 箇所 (新名)"]:::new
    B --> C["`DoD 検証`<br/>fmt/clippy/test + grep"]
    C -->|GREEN| G([合格])
    C -->|旧名残存あり| R([残存箇所を再置換])
    R --> B

    classDef new fill:#ffe4b5,stroke:#d97706,stroke-width:2px
```

### 変更の伝播経路

```
[Source of Truth] rust/crates/core/src/object/pdf_object.rs:105
    │  pub fn as_string_bytes(&self) -> Option<&[u8]>  [CHANGED]
    │      └─ 定義本体（マッチアーム不変）
    │
    ├─→ [同ファイル doc 相互参照] pdf_object.rs:124  [CHANGED]
    │       └─ as_array の doc 内「`as_string_bytes` の `as_slice()` と同方針」
    │
    ├─→ [外部 doc 参照] lexer/token.rs:96  [CHANGED]
    │       └─ Primitive::as_literal_string の doc 内「`PdfObject::as_string_bytes` と同方針」
    │
    └─→ [テストファイル] pdf_object/tests/string_name.rs  [CHANGED]
            ├─ テスト関数名 5 個（T1-T5, `as_string_bytes_*` prefix）
            ├─ .as_string_bytes() 呼び出し 7 箇所
            └─ 日本語コメント内 API 名文字列 5 箇所
```

## 📋 関連 Issue

- Refs #393

## 🧪 テスト

### テスト実行方法

```bash
cargo fmt --check
cargo clippy --all-targets -- -D warnings
cargo test -p pdfmod-core
```

### テスト項目

- [x] 単体テスト (Unit tests)

### テスト結果

- `cargo fmt --check`: exit 0 ✅
- `cargo clippy --all-targets -- -D warnings`: exit 0 ✅
- `cargo test -p pdfmod-core`: **1029 passed / 0 failed** ✅
- string_name サブモジュール: **17 passed / 0 failed**（T1–T5 + `clone_preserves_*` 含む全 6 対象テスト緑）
- 旧名残存検証: `grep -rn "as_string\b" rust/crates/core/ | grep -v as_string_bytes` = **0 件** ✅
- 新名分布: `pdf_object.rs`（定義 1 + doc 参照 1）+ `lexer/token.rs`（doc 参照 1）+ `tests/string_name.rs`（17）= **20 箇所** ✅

## 🔍 レビューポイント

- **振る舞い不変性**: diff がすべて識別子・doc・コメント文字列に閉じており、マッチアーム本体・戻り値・可視性・引数リストに変更がないことを `git diff` で確認可能（+20 / -20）
- **`clone_preserves_string_and_name_and_keeps_original_usable` の非対称**: 関数名を据え置き、本文の `.as_string()` 呼び出し 2 箇所（L135・L136）のみ新名に置換。この関数は String と Name の両方を検証するため、API 名がテスト名に露出していない元設計を尊重
- **doc 本文の維持**: `PdfObject::as_string_bytes` の定義側 doc「ヒープ保持のため参照返し（`PdfName::as_bytes` と同方針）」は完全に維持（hearing-notes Q9 の合意）
- **スコープ限定**: `Primitive::as_literal_string` / `Primitive::as_hex_string` / `Token::as_keyword` などの類似命名不整合は本 PR 対象外（将来 Follow-up Issue で扱う想定）
- **命名規約の docs 化なし**: CLAUDE.md / docs/ への恒久ルール追加は今回は行わない（Follow-up の完了時にまとめて追記する想定）

## ⚠️ 破壊的変更

- [x] この変更は既存の API に破壊的変更を含みます

### 破壊的変更の詳細

- `PdfObject::as_string()` を削除し `PdfObject::as_string_bytes()` にリネーム。`#[deprecated]` を挟まず同 PR で即削除
- 呼び出しは全て pdfmod-core クレート内テスト（7 箇所）に閉じており、プロダクション側の呼び出しは 0 件
- 外部利用者への影響は本クレートを未リリースのため無し

## 📚 追加情報

### 参考資料

- 実装計画: `.plugin-workspace/.specs/archive/073-pdf-object-as-string-bytes-rename/implementation-plan.md`
- コードレビュー: `.plugin-workspace/.specs/archive/073-pdf-object-as-string-bytes-rename/spec-based-code-review/review-001.md`
  - CRITICAL 0 / WARNING 0 / INFO 10（うち Follow-up 提案 3・観察 7）

### 注意事項

- 本 PR マージ後、類似の命名不整合を持つ `Primitive::as_literal_string` / `Primitive::as_hex_string` / `Token::as_keyword` のリネームを Follow-up Issue として起票することを推奨（本 PR の review-001.md I-001 参照）

## ✅ チェックリスト

- [x] コードレビューの準備ができている
- [x] テストが正常に実行される
- [x] ドキュメントが更新されている（doc コメント相互参照を新名に追随済み）
- [x] コミットメッセージが適切な形式で書かれている
- [x] 関連する Issue が PR の「Development」に Linked されている
- [x] PR 本文に `Refs #393` で Issue が記載されている
- [x] セルフレビューを実施した（5 エージェント並列コードレビューで CRITICAL/WARNING 0 を確認）
- [x] 破壊的変更は明記されている