### PR TITLE
♻️ [Refactoring]: #382 PdfErrorCode に Display を実装し PdfError::fmt から委譲する

### DIFF
--- a/rust/crates/core/src/error/pdf_error.rs
+++ b/rust/crates/core/src/error/pdf_error.rs
@@ -9,9 +9,9 @@
 //! - `message` は所有 `String`（`format!` で動的に値・期待トークン等を埋め込める。std のみで完結）。
 //! - 構築はビルダー風: `new(code)` を基点に `with_position` / `with_message` を任意で重ねる。
 //! - `Copy` は付与しない（`String` を保持するため不可）。`Debug, Clone, PartialEq, Eq` のみ derive。
-//! - `Display` を手実装し、`{code:?}` を流用して種別を表示する（`PdfErrorCode` への
-//!   `Display` 追加は #259 スコープのため行わない）。位置・メッセージは Some のときだけ
-//!   連結し、None の要素は記号ごと省略する。
+//! - `Display` を手実装し、種別部分は `PdfErrorCode` の `Display` に委譲する
+//!   （人間可読な英語短文を出力）。位置・メッセージは Some のときだけ連結し、
+//!   None の要素は記号ごと省略する。
 //! - `std::error::Error` を実装する（`Box<dyn Error>` と相互運用可能）。`source()` は当面
 //!   下位エラーを保持しないためデフォルト実装（`None`）のままとする。
 //! - 外部 crate 依存ゼロ（`thiserror` 等は使わず std のみで実装）。
@@ -79,10 +79,11 @@ impl PdfError {
 }
 
 impl fmt::Display for PdfError {
-    /// "{code:?}" を基点に、position があれば " at byte N"、message があれば ": <message>"
-    /// を連結する。None の要素は記号ごと省略し、余分な記号を出さない。
+    /// `PdfErrorCode` の `Display` 出力（人間可読な英語短文）を基点に、
+    /// position があれば " at byte N"、message があれば ": <message>" を連結する。
+    /// None の要素は記号ごと省略し、余分な記号を出さない。
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{:?}", self.code)?;
+        write!(f, "{}", self.code)?;
         if let Some(position) = self.position {
             write!(f, " at byte {}", position.value())?;
         }
@@ -166,30 +167,30 @@ mod tests {
     #[test]
     fn display_with_code_only() {
         let err = PdfError::new(PdfErrorCode::UnexpectedEof);
-        assert_eq!(format!("{}", err), "UnexpectedEof");
+        assert_eq!(format!("{}", err), "unexpected end of file");
     }
 
     // 正常系（Display）: position ありのときは " at byte N" を連結する。
     #[test]
     fn display_with_position() {
         let err = PdfError::new(PdfErrorCode::UnexpectedEof).with_position(ByteOffset::new(12));
-        assert_eq!(format!("{}", err), "UnexpectedEof at byte 12");
+        assert_eq!(format!("{}", err), "unexpected end of file at byte 12");
     }
 
     // 正常系（Display）: message のみのときは ": <message>" を連結し、" at byte" は出さない。
     #[test]
     fn display_with_message_only() {
         let err = PdfError::new(PdfErrorCode::UnexpectedToken).with_message("unexpected");
-        assert_eq!(format!("{}", err), "UnexpectedToken: unexpected");
+        assert_eq!(format!("{}", err), "unexpected token: unexpected");
     }
 
-    // 正常系（Display）: 全要素ありのときは "{code:?} at byte N: <message>" 形式になる。
+    // 正常系（Display）: 全要素ありのときは "{code} at byte N: <message>" 形式になる。
     #[test]
     fn display_with_all_fields() {
         let err = PdfError::new(PdfErrorCode::UnexpectedEof)
             .with_position(ByteOffset::new(12))
             .with_message("eof");
-        assert_eq!(format!("{}", err), "UnexpectedEof at byte 12: eof");
+        assert_eq!(format!("{}", err), "unexpected end of file at byte 12: eof");
     }
 
     // 境界値（Display）: 空文字列メッセージ Some("") を無検証で受理し ":" の後が空になる。
@@ -197,7 +198,7 @@ mod tests {
     fn display_with_empty_message() {
         let err = PdfError::new(PdfErrorCode::UnexpectedEof).with_message("");
         assert_eq!(err.message(), Some(""));
-        assert_eq!(format!("{}", err), "UnexpectedEof: ");
+        assert_eq!(format!("{}", err), "unexpected end of file: ");
     }
 
     // 正常系（等価）: 同一の code/position/message を持つ 2 値は == で等価になる。

--- a/rust/crates/core/src/error/pdf_error_code.rs
+++ b/rust/crates/core/src/error/pdf_error_code.rs
@@ -118,18 +118,12 @@ mod tests {
     #[test]
     fn display_invalid_number() {
         // InvalidNumber の Display 出力が "invalid number" になることを確認する
-        assert_eq!(
-            format!("{}", PdfErrorCode::InvalidNumber),
-            "invalid number"
-        );
+        assert_eq!(format!("{}", PdfErrorCode::InvalidNumber), "invalid number");
     }
 
     #[test]
     fn display_invalid_syntax() {
         // InvalidSyntax の Display 出力が "invalid syntax" になることを確認する
-        assert_eq!(
-            format!("{}", PdfErrorCode::InvalidSyntax),
-            "invalid syntax"
-        );
+        assert_eq!(format!("{}", PdfErrorCode::InvalidSyntax), "invalid syntax");
     }
 }

--- a/rust/crates/core/src/error/pdf_error_code.rs
+++ b/rust/crates/core/src/error/pdf_error_code.rs
@@ -5,6 +5,8 @@
 //! 詳細情報は後続の `PdfError`(#260) 側が保持する。本タスクでは R0／R1
 //! （レクサー・パーサ段階）の最小バリアント集合のみを定義する（Issue #259）。
 
+use std::fmt;
+
 /// PDF 解析エラーの分類タグ。
 ///
 /// 各バリアントはエラーの「種類」のみを表し、付随情報は持たない（unit variant）。
@@ -22,6 +24,23 @@ pub enum PdfErrorCode {
     InvalidNumber,
     /// PDF の構文規則に違反する入力を検出した。
     InvalidSyntax,
+}
+
+/// バリアントごとに人間可読な英語短文を返す。文言は `std::io::ErrorKind` の
+/// 慣習に倣い、小文字始まり・句点なし。`#[non_exhaustive]` を付けないため、
+/// 将来バリアントを追加した際は `match` の非網羅性がコンパイル時エラーとなり、
+/// Display 文言の追加漏れが自動検出される。Debug は導出のまま（バリアント
+/// 識別子）で、開発者向けダンプ用途との役割分離を保つ。
+impl fmt::Display for PdfErrorCode {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let text = match self {
+            PdfErrorCode::UnexpectedEof => "unexpected end of file",
+            PdfErrorCode::UnexpectedToken => "unexpected token",
+            PdfErrorCode::InvalidNumber => "invalid number",
+            PdfErrorCode::InvalidSyntax => "invalid syntax",
+        };
+        f.write_str(text)
+    }
 }
 
 #[cfg(test)]
@@ -76,5 +95,41 @@ mod tests {
         assert!(format!("{:?}", PdfErrorCode::UnexpectedToken).contains("UnexpectedToken"));
         assert!(format!("{:?}", PdfErrorCode::InvalidNumber).contains("InvalidNumber"));
         assert!(format!("{:?}", PdfErrorCode::InvalidSyntax).contains("InvalidSyntax"));
+    }
+
+    #[test]
+    fn display_unexpected_eof() {
+        // UnexpectedEof の Display 出力が "unexpected end of file" になることを確認する
+        assert_eq!(
+            format!("{}", PdfErrorCode::UnexpectedEof),
+            "unexpected end of file"
+        );
+    }
+
+    #[test]
+    fn display_unexpected_token() {
+        // UnexpectedToken の Display 出力が "unexpected token" になることを確認する
+        assert_eq!(
+            format!("{}", PdfErrorCode::UnexpectedToken),
+            "unexpected token"
+        );
+    }
+
+    #[test]
+    fn display_invalid_number() {
+        // InvalidNumber の Display 出力が "invalid number" になることを確認する
+        assert_eq!(
+            format!("{}", PdfErrorCode::InvalidNumber),
+            "invalid number"
+        );
+    }
+
+    #[test]
+    fn display_invalid_syntax() {
+        // InvalidSyntax の Display 出力が "invalid syntax" になることを確認する
+        assert_eq!(
+            format!("{}", PdfErrorCode::InvalidSyntax),
+            "invalid syntax"
+        );
     }
 }


### PR DESCRIPTION
## 概要

`PdfError::fmt` が `write!(f, "{:?}", self.code)` として `PdfErrorCode` の Debug 導出（バリアント識別子）に依存していた技術的負債を解消するリファクタリング。`PdfErrorCode` に `impl fmt::Display` を追加し、`PdfError::fmt` は `{}` で委譲するよう変更した。

## 変更内容

### 🎯 変更の種類

- [x] ♻️ リファクタリング (Refactoring)

### 📝 詳細な変更内容

#### 追加された機能・修正

- `PdfErrorCode` に `impl fmt::Display` を追加（4 バリアントを網羅する `match` で `&'static str` を選択し `f.write_str` する）
  - `UnexpectedEof` → `"unexpected end of file"`
  - `UnexpectedToken` → `"unexpected token"`
  - `InvalidNumber` → `"invalid number"`
  - `InvalidSyntax` → `"invalid syntax"`
- 文言スタイルは `std::io::ErrorKind` 慣習（小文字始まり・句点なし）に準拠。プロジェクト内の Display 実装の先例となる
- `#[non_exhaustive]` は付与せず、将来のバリアント追加時に `match` の非網羅性エラーで Display 文言追加漏れを自動検出できる設計を維持
- `PdfError::fmt` の `write!(f, "{:?}", self.code)` を `write!(f, "{}", self.code)` に置換して `PdfErrorCode::Display` に委譲
- `pdf_error.rs` のモジュール doc / `PdfError::fmt` の doc コメントを委譲構造が伝わる文言に更新
- `pdf_error_code.rs` の `#[cfg(test)] mod tests` に Display 単体テスト 4 個を追加（`display_unexpected_eof` / `display_unexpected_token` / `display_invalid_number` / `display_invalid_syntax`）
- `pdf_error.rs` の既存 Display 期待文字列テスト 5 個の期待値を新表記に更新（`display_with_code_only` / `display_with_position` / `display_with_message_only` / `display_with_all_fields` / `display_with_empty_message`）

#### 変更されたファイル

- `rust/crates/core/src/error/pdf_error_code.rs`（`use std::fmt` + `impl Display` + 新規テスト 4 個）
- `rust/crates/core/src/error/pdf_error.rs`（`{:?}` → `{}` 置換 + doc 更新 + 既存 5 テストの期待値更新）

#### 削除されたファイル・機能

- なし

### ⚠️ 破壊的変更（受容済み）

`PdfError::to_string()` の先頭文言が変わる:

- `"UnexpectedEof"` → `"unexpected end of file"`
- `"UnexpectedToken"` → `"unexpected token"`
- `"InvalidNumber"` → `"invalid number"`
- `"InvalidSyntax"` → `"invalid syntax"`

crate は `version = "0.0.1"` で未リリースのため受容決定済み（requirements / hearing-notes 参照）。`Debug` 出力（`format!("{:?}", ...)` → `"UnexpectedEof"` 等）は自動導出のまま変更なしで、`debug_format_contains_variant_name` テストで安定性を継続保証。

## 📊 システム図

### 状態マシン / フロー図

```mermaid
flowchart TD
    Caller["format!(\"{}\", err) / err.to_string()"] --> PdfErrorFmt["PdfError::fmt (impl fmt::Display)"]
    PdfErrorFmt -->|"write!(f, &quot;{}&quot;, self.code) [CHANGED]"| PdfErrorCodeFmt["PdfErrorCode::fmt [NEW]"]
    PdfErrorCodeFmt --> Match{match self}
    Match --> UEof["UnexpectedEof<br/>&quot;unexpected end of file&quot;"]
    Match --> UTok["UnexpectedToken<br/>&quot;unexpected token&quot;"]
    Match --> INum["InvalidNumber<br/>&quot;invalid number&quot;"]
    Match --> ISyn["InvalidSyntax<br/>&quot;invalid syntax&quot;"]
    UEof --> Write["f.write_str(text)"]
    UTok --> Write
    INum --> Write
    ISyn --> Write
    Write --> Pos{self.position は Some?}
    Pos -->|YES| PosOut["write!(f, &quot; at byte {}&quot;, position.value())"]
    Pos -->|NO| Msg{self.message は Some?}
    PosOut --> Msg
    Msg -->|YES| MsgOut["write!(f, &quot;: {}&quot;, msg)"]
    Msg -->|NO| End([Ok])
    MsgOut --> End

    Debug["format!(\"{:?}\", pdf_error_code)"] --> DebugDerive["#[derive(Debug)] 自動導出（変更なし）"]
    DebugDerive --> DebugOut["&quot;UnexpectedEof&quot; / &quot;UnexpectedToken&quot; / ...<br/>（バリアント識別子）"]

    classDef new fill:#ffe4b5,stroke:#d97706,stroke-width:2px
    classDef changed fill:#dbeafe,stroke:#2563eb,stroke-width:2px
    class PdfErrorCodeFmt,Match,UEof,UTok,INum,ISyn,Write new
    class PdfErrorFmt changed
```

### データフロー

```
呼び出し側（parser / lexer / 将来 xref・リゾルバ / JS バインディング）
    ↓
PdfError { code, position, message }
    ↓
├─ impl Display for PdfError  (pdf_error.rs)
│      ↓ write!(f, "{}", self.code)     [CHANGED] {:?} → {}
│      ↓
│   impl Display for PdfErrorCode  (pdf_error_code.rs)  [NEW]
│      ↓ let text = match self { ... } → &'static str
│      ↓ f.write_str(text)
│      ↓
│   Formatter （"unexpected end of file" 等）
│      ↓
├─ position: Option<ByteOffset>
│      ↓ Some ⇒ " at byte {u64}"    （既存挙動、変更なし）
│      ↓ None ⇒ 何もしない
│      ↓
├─ message: Option<String>
│      ↓ Some ⇒ ": {message}"       （既存挙動、変更なし）
│      ↓ None ⇒ 何もしない
│      ↓
└─ Formatter → 呼び出し側の String

並行して（別ルート、変更なし）:
PdfErrorCode → #[derive(Debug)] 自動導出 → "UnexpectedEof" 等
                                          （開発者向けダンプ用）
```

## 📋 関連 Issue

- Closes #382

## 🧪 テスト

### テスト実行方法

```bash
cd rust
cargo test -p pdfmod-core
cargo check -p pdfmod-core
cargo clippy -p pdfmod-core --all-targets -- -D warnings
```

### テスト項目

- [x] 単体テスト (Unit tests) — `pdf_error_code.rs` / `pdf_error.rs` の inline `#[cfg(test)] mod tests`

### テスト結果

- `cargo test -p pdfmod-core`: **1092 passed / 0 failed / 0 ignored**
  - `error::pdf_error_code::tests::*` — 新規 4 (`display_unexpected_eof` / `display_unexpected_token` / `display_invalid_number` / `display_invalid_syntax`) + 既存 5（`debug_format_contains_variant_name` 含む）すべて緑
  - `error::pdf_error::tests::*` — 既存 15 テストすべて緑（Display 期待値更新分 5 個含む）
- `cargo check -p pdfmod-core --all-targets`: 警告 0 / エラー 0
- `cargo clippy -p pdfmod-core --all-targets -- -D warnings`: 警告 0 / エラー 0
- 外部 crate 依存ゼロ維持（`rust/crates/core/Cargo.toml` の `[dependencies]` セクション空）

## 🔍 レビューポイント

- **破壊的変更（受容済み）**: `PdfError::to_string()` の文言スタイル変更が意図通りか（`std::io::ErrorKind` 慣習準拠）
- **`#[non_exhaustive]` 不付与の設計判断**: 将来のバリアント追加時に `impl Display` の `match` を非網羅性エラーにしてコンパイル時検出させる意図（`impl fmt::Display for PdfErrorCode` 直前の doc コメントに明示）
- **Display と Debug の役割分離**: `debug_format_contains_variant_name` テストを残し、Debug 出力の安定性（バリアント識別子）を継続保証
- **委譲によるスコープ限定**: `PdfError::fmt` の position/message 連結ロジック（既存挙動）は 1 行の置換のみで維持

## 実装ノート・クイズ

- 実装ノート: `.plugin-workspace/.specs/073-pdf-error-code-display/implementation-notes.md`（Deviations / 既存コードパス依存 / 想定 vs 実際 / 実装判断メモ）
- 実装後 理解度クイズ（advisory）: `.plugin-workspace/.specs/073-pdf-error-code-display/understanding-quiz-impl.html`（9 問 / パスライン 80%）