### PR TITLE
✨ [New Feature]: #482 mpHandler (MP marked-content point operator) を新規実装

### DIFF
--- a/packages/core/src/content-stream/operators/marked-content/mp/__tests__/mp.basic.test.ts
+++ b/packages/core/src/content-stream/operators/marked-content/mp/__tests__/mp.basic.test.ts
@@ -1,0 +1,133 @@
+import { assert, expect, test } from "vitest";
+import type {
+  PdfName,
+  PdfObject,
+} from "../../../../../pdf/types/pdf-types/index";
+import { none } from "../../../../../utils/option/index";
+import { GraphicsStateStack } from "../../../../graphics-state/index";
+import type { MarkedContentEntry } from "../../../../marked-content/stack";
+import { MarkedContentStack } from "../../../../marked-content/stack";
+import { OperandStack } from "../../../../operand-stack/index";
+import type { OperatorHandlerContext } from "../../../../operator-registry/index";
+import { mpHandler } from "../index";
+
+const buildContext = (operands: PdfObject[]): OperatorHandlerContext => {
+  const operandStack = OperandStack.create();
+  for (const operand of operands) {
+    OperandStack.push(operandStack, operand);
+  }
+  return {
+    operandStack,
+    graphicsStateStack: GraphicsStateStack.create(),
+    markedContentStack: MarkedContentStack.create(),
+  };
+};
+
+// markedContentStack を depth=1 の非空状態にして組み立てる（seeded stack の非破壊 pin down 用）
+const buildNestedContext = (
+  operands: PdfObject[],
+  seededTag: PdfName,
+): OperatorHandlerContext => {
+  const operandStack = OperandStack.create();
+  for (const operand of operands) {
+    OperandStack.push(operandStack, operand);
+  }
+  const seededEntry: MarkedContentEntry = { tag: seededTag, properties: none };
+  return {
+    operandStack,
+    graphicsStateStack: GraphicsStateStack.create(),
+    markedContentStack: MarkedContentStack.push(
+      MarkedContentStack.create(),
+      seededEntry,
+    ),
+  };
+};
+
+test("name { type: 'name', value: 'Span' } を受理し ok を返す", () => {
+  const ctx = buildContext([{ type: "name", value: "Span" }]);
+
+  const result = mpHandler(ctx);
+
+  assert(result.ok);
+});
+
+test("成功時に markedContentStack は入力と同一参照で返る（BMC との本質的差分）", () => {
+  const ctx = buildContext([{ type: "name", value: "Span" }]);
+
+  const result = mpHandler(ctx);
+
+  assert(result.ok);
+  expect(result.value.markedContentStack).toBe(ctx.markedContentStack);
+});
+
+test("成功時に markedContentStack の depth が 0 → 0 のまま（push しない）", () => {
+  const ctx = buildContext([{ type: "name", value: "Span" }]);
+
+  const result = mpHandler(ctx);
+
+  assert(result.ok);
+  expect(MarkedContentStack.depth(result.value.markedContentStack)).toBe(0);
+});
+
+test("既存 seeded stack (depth=1) でも depth=1 のまま（push しない / BMC は 1→2）", () => {
+  const seededTag: PdfName = { type: "name", value: "Artifact" };
+  const ctx = buildNestedContext([{ type: "name", value: "Span" }], seededTag);
+
+  const result = mpHandler(ctx);
+
+  assert(result.ok);
+  expect(MarkedContentStack.depth(result.value.markedContentStack)).toBe(1);
+});
+
+test("成功時に operandStack は入力と同一参照で返る（in-place mutate）", () => {
+  const ctx = buildContext([{ type: "name", value: "Span" }]);
+
+  const result = mpHandler(ctx);
+
+  assert(result.ok);
+  expect(result.value.operandStack).toBe(ctx.operandStack);
+});
+
+test("成功時に operand が 1 個消費され operandStack の depth=0 になる", () => {
+  const ctx = buildContext([{ type: "name", value: "Span" }]);
+
+  const result = mpHandler(ctx);
+
+  assert(result.ok);
+  expect(OperandStack.depth(result.value.operandStack)).toBe(0);
+});
+
+test("余剰 operand があるとき末尾 1 個のみ消費する（depth=3 → depth=2）", () => {
+  const surplus0: PdfObject = { type: "integer", value: 1 };
+  const surplus1: PdfObject = { type: "integer", value: 2 };
+  const ctx = buildContext([
+    surplus0,
+    surplus1,
+    { type: "name", value: "Span" },
+  ]);
+
+  const result = mpHandler(ctx);
+
+  assert(result.ok);
+  expect(OperandStack.depth(result.value.operandStack)).toBe(2);
+  const top = OperandStack.peek(result.value.operandStack);
+  assert(top.some);
+  expect(top.value).toEqual(surplus1);
+});
+
+test("成功時に graphicsStateStack は入力と同一参照で返る", () => {
+  const ctx = buildContext([{ type: "name", value: "Span" }]);
+
+  const result = mpHandler(ctx);
+
+  assert(result.ok);
+  expect(result.value.graphicsStateStack).toBe(ctx.graphicsStateStack);
+});
+
+test("name 値が空文字 ('') でも受理する（値域検証なし pin down）", () => {
+  const ctx = buildContext([{ type: "name", value: "" }]);
+
+  const result = mpHandler(ctx);
+
+  assert(result.ok);
+});

--- a/packages/core/src/content-stream/operators/marked-content/mp/__tests__/mp.error.test.ts
+++ b/packages/core/src/content-stream/operators/marked-content/mp/__tests__/mp.error.test.ts
@@ -1,0 +1,144 @@
+import { assert, expect, test } from "vitest";
+import type {
+  PdfName,
+  PdfObject,
+} from "../../../../../pdf/types/pdf-types/index";
+import { none } from "../../../../../utils/option/index";
+import { GraphicsStateStack } from "../../../../graphics-state/index";
+import type { MarkedContentEntry } from "../../../../marked-content/stack";
+import { MarkedContentStack } from "../../../../marked-content/stack";
+import { OperandStack } from "../../../../operand-stack/index";
+import type { OperatorHandlerContext } from "../../../../operator-registry/index";
+import { mpHandler } from "../index";
+
+const buildContext = (operands: PdfObject[]): OperatorHandlerContext => {
+  const operandStack = OperandStack.create();
+  for (const operand of operands) {
+    OperandStack.push(operandStack, operand);
+  }
+  return {
+    operandStack,
+    graphicsStateStack: GraphicsStateStack.create(),
+    markedContentStack: MarkedContentStack.create(),
+  };
+};
+
+// markedContentStack を depth=1 の非空状態にして組み立てる（MISSING 時の不変性検証用）
+const buildSeededContext = (
+  operands: PdfObject[],
+  seededTag: PdfName,
+): OperatorHandlerContext => {
+  const operandStack = OperandStack.create();
+  for (const operand of operands) {
+    OperandStack.push(operandStack, operand);
+  }
+  const seededEntry: MarkedContentEntry = { tag: seededTag, properties: none };
+  return {
+    operandStack,
+    graphicsStateStack: GraphicsStateStack.create(),
+    markedContentStack: MarkedContentStack.push(
+      MarkedContentStack.create(),
+      seededEntry,
+    ),
+  };
+};
+
+const NON_NAME_CASES: ReadonlyArray<[string, PdfObject]> = [
+  ["integer", { type: "integer", value: 42 }],
+  ["real", { type: "real", value: 3.14 }],
+  ["string", { type: "string", value: new Uint8Array(), encoding: "literal" }],
+  ["boolean", { type: "boolean", value: true }],
+  ["null", { type: "null" }],
+  ["array", { type: "array", elements: [] }],
+  ["dictionary", { type: "dictionary", entries: new Map() }],
+  [
+    "indirect-ref",
+    { type: "indirect-ref", objectNumber: 1, generationNumber: 0 },
+  ],
+  [
+    "stream",
+    {
+      type: "stream",
+      dictionary: { type: "dictionary", entries: new Map() },
+      data: new Uint8Array(),
+    },
+  ],
+];
+
+test("operand 0 個のとき MISSING を返す（required:1, actual:0, operatorName:'MP'）", () => {
+  const ctx = buildContext([]);
+
+  const result = mpHandler(ctx);
+
+  assert(!result.ok);
+  assert(result.error.code === "OPERATOR_OPERAND_MISSING");
+  expect(result.error.operatorName).toBe("MP");
+  expect(result.error.required).toBe(1);
+  expect(result.error.actual).toBe(0);
+});
+
+test("MISSING メッセージは \"Operator 'MP' requires 1 operand(s), got 0\" と完全一致", () => {
+  const ctx = buildContext([]);
+
+  const result = mpHandler(ctx);
+
+  assert(!result.ok);
+  assert(result.error.code === "OPERATOR_OPERAND_MISSING");
+  expect(result.error.message).toBe(
+    "Operator 'MP' requires 1 operand(s), got 0",
+  );
+});
+
+test("MISSING 時 markedContentStack は push されず不変（非空 stack で depth=1 のまま）", () => {
+  const ctx = buildSeededContext([], { type: "name", value: "Span" });
+
+  const result = mpHandler(ctx);
+
+  assert(!result.ok);
+  expect(MarkedContentStack.depth(ctx.markedContentStack)).toBe(1);
+});
+
+test.each<[string, PdfObject]>(
+  NON_NAME_CASES,
+)("top が %s のとき TYPE_MISMATCH を返す（expected:'name', actual=top の type 名）", (type, operand) => {
+  const ctx = buildContext([operand]);
+
+  const result = mpHandler(ctx);
+
+  assert(!result.ok);
+  assert(result.error.code === "OPERATOR_OPERAND_TYPE_MISMATCH");
+  expect(result.error.expected).toBe("name");
+  expect(result.error.actual).toBe(type);
+});
+
+test("TYPE_MISMATCH の operatorName が 'MP' でメッセージが完全一致する（top: integer）", () => {
+  const ctx = buildContext([{ type: "integer", value: 42 }]);
+
+  const result = mpHandler(ctx);
+
+  assert(!result.ok);
+  assert(result.error.code === "OPERATOR_OPERAND_TYPE_MISMATCH");
+  expect(result.error.operatorName).toBe("MP");
+  expect(result.error.message).toBe(
+    "Operator 'MP' expected name operand, got integer",
+  );
+});
+
+test("TYPE_MISMATCH 時 markedContentStack は push されず不変（depth 変わらず 0）", () => {
+  const ctx = buildContext([{ type: "integer", value: 42 }]);
+
+  const result = mpHandler(ctx);
+
+  assert(!result.ok);
+  expect(MarkedContentStack.depth(ctx.markedContentStack)).toBe(0);
+});
+
+test("TYPE_MISMATCH 後に部分消費した operand は復元しない（operandStack depth=1 → depth=0 のまま）", () => {
+  const ctx = buildContext([{ type: "integer", value: 42 }]);
+  expect(OperandStack.depth(ctx.operandStack)).toBe(1);
+
+  const result = mpHandler(ctx);
+
+  assert(!result.ok);
+  expect(OperandStack.depth(ctx.operandStack)).toBe(0);
+});

--- a/packages/core/src/content-stream/operators/marked-content/mp/index.ts
+++ b/packages/core/src/content-stream/operators/marked-content/mp/index.ts
@@ -11,7 +11,7 @@ const OPERATOR_NAME = "MP";
 const OPERAND_COUNT = 1;
 
 /**
- * ISO 32000-1:2008 §14.6 `MP` operator (marked-content point) のハンドラ。
+ * ISO 32000-2:2020 §14.6 `MP` operator (marked-content point) のハンドラ。
  *
  * operand stack から tag (name) を 1 個 pop し、name 型であれば
  * marked content stack を変化させずに現在のコンテキストを返す。

--- a/packages/core/src/content-stream/operators/marked-content/mp/index.ts
+++ b/packages/core/src/content-stream/operators/marked-content/mp/index.ts
@@ -1,0 +1,64 @@
+import type { PdfError } from "../../../../pdf/errors/index";
+import { PdfName } from "../../../../pdf/types/pdf-types/index";
+import { err, ok } from "../../../../utils/result/index";
+import { OperandStack } from "../../../operand-stack/index";
+import type {
+  OperatorHandler,
+  OperatorHandlerContext,
+} from "../../../operator-registry/index";
+
+const OPERATOR_NAME = "MP";
+const OPERAND_COUNT = 1;
+
+/**
+ * ISO 32000-1:2008 §14.6 `MP` operator (marked-content point) のハンドラ。
+ *
+ * operand stack から tag (name) を 1 個 pop し、name 型であれば
+ * marked content stack を変化させずに現在のコンテキストを返す。
+ * MP は「単発マーク点」であり BMC/EMC の対を持たないため、
+ * MarkedContentStack への push は行わない。
+ *
+ * 検査順序（厳守 / doHandler 準拠）:
+ *   (1) operand pop（none なら `OPERATOR_OPERAND_MISSING`）
+ *   (2) 型検査（PdfName.is が false なら `OPERATOR_OPERAND_TYPE_MISMATCH`）
+ *   (3) 両方通過 → 3 つの stack を同一参照で列挙して ok
+ *
+ * - tag の値域（空文字 等）は検証しない。
+ * - operandStack は pop で in-place 消費済み。graphicsStateStack と
+ *   markedContentStack は入力と同一参照で返す。
+ * - エラー時に部分消費した operand stack は復元しない（既存ハンドラ規約）。
+ *
+ * @param context - 実行コンテキスト
+ * @returns 成功なら入力と同じ 3 stack を持つコンテキスト、失敗なら PdfError
+ */
+export const mpHandler: OperatorHandler = (context: OperatorHandlerContext) => {
+  const popped = OperandStack.pop(context.operandStack);
+  if (!popped.some) {
+    const error: PdfError = {
+      code: "OPERATOR_OPERAND_MISSING",
+      message: `Operator '${OPERATOR_NAME}' requires ${OPERAND_COUNT} operand(s), got 0`,
+      operatorName: OPERATOR_NAME,
+      required: OPERAND_COUNT,
+      actual: 0,
+    };
+    return err(error);
+  }
+
+  const operand = popped.value;
+  if (!PdfName.is(operand)) {
+    const error: PdfError = {
+      code: "OPERATOR_OPERAND_TYPE_MISMATCH",
+      message: `Operator '${OPERATOR_NAME}' expected name operand, got ${operand.type}`,
+      operatorName: OPERATOR_NAME,
+      expected: "name",
+      actual: operand.type,
+    };
+    return err(error);
+  }
+
+  return ok({
+    operandStack: context.operandStack,
+    graphicsStateStack: context.graphicsStateStack,
+    markedContentStack: context.markedContentStack,
+  });
+};


### PR DESCRIPTION
## 概要

PDF content stream の `MP` (marked point) operator を処理する `mpHandler` を新規実装しました。ISO 32000-1:2008 §14.6 準拠。Phase 4-J (Epic #479) の一部で、依存済み #480 (BMC/EMC + MarkedContentStack) / #481 (BDC) の後に位置します。

## 変更の種類

- ✨ 新機能（純粋な追加のみ・破壊的変更なし）
- 🚨 テスト追加

## 詳細な変更内容

### `packages/core/src/content-stream/operators/marked-content/mp/index.ts` [NEW]

`doHandler` (`xobject/do/index.ts`) の骨格をそのまま流用し、operator 名（`"Do"` → `"MP"`）と JSDoc の ISO 章番号（§8.8 → §14.6）だけを差し替え。

- `OPERATOR_NAME = "MP"`, `OPERAND_COUNT = 1`
- **検査順序**: (1) `OperandStack.pop` → (2) `PdfName.is` 型検査 → (3) 3 stack を同一参照で `ok` 返却
- MP は「単発マーク点」で BMC/EMC の対を持たないため、`MarkedContentStack.push` を行わず `markedContentStack` は入力と同一参照でパススルー
- エラーコードは `OPERATOR_OPERAND_MISSING` (operand 0 個) と `OPERATOR_OPERAND_TYPE_MISMATCH` (Name 以外) の 2 種

### `packages/core/src/content-stream/operators/marked-content/mp/__tests__/mp.basic.test.ts` [NEW]

正常系 9 テスト（フラット構造 / `describe` 未使用）:

- Name tag 受理 / `markedContentStack` 同一参照（BMC との本質的差分）/ depth 0→0 不変 / seeded stack depth 1→1 不変
- `operandStack` 同一参照（in-place mutate）/ 1 個消費 depth=0 / 余剰 operand は末尾 1 個のみ消費（depth=3→2）
- `graphicsStateStack` 同一参照 / 空文字 name 受理（値域検証なし pin down）

### `packages/core/src/content-stream/operators/marked-content/mp/__tests__/mp.error.test.ts` [NEW]

異常系 15 テスト:

- MISSING: フィールド検証 / メッセージ `"Operator 'MP' requires 1 operand(s), got 0"` 完全一致 / seeded stack `markedContentStack` 不変
- TYPE_MISMATCH: `test.each` で 9 バリアント（integer/real/string/boolean/null/array/dictionary/indirect-ref/stream）/ operatorName='MP' + メッセージ `"Operator 'MP' expected name operand, got integer"` 完全一致 / `markedContentStack` 不変 / operand 非復元

## システム図

```mermaid
flowchart TD
    S[mpHandler context]
    P[OperandStack.pop]
    T{PdfName.is operand?}
    M[err OPERATOR_OPERAND_MISSING<br/>required:1 actual:0]
    X[err OPERATOR_OPERAND_TYPE_MISMATCH<br/>expected:name actual:operand.type]
    O[ok 3 stack を同一参照で返却<br/>★markedContentStack は push しない]

    S --> P
    P -- none --> M
    P -- some --> T
    T -- false --> X
    T -- true --> O

    style O fill:#e6ffe6,stroke:#0a0
    style M fill:#ffe6e6,stroke:#a00
    style X fill:#ffe6e6,stroke:#a00
```

## スコープ外（本 PR で意図的に触っていない）

- `marked-content-operators/index.ts` の `MARKED_CONTENT_OPERATORS` 配列への登録 → 次 spec
- `content-stream/interpreter/*` の integration test 追加 → 次 spec
- `doHandler` / `bmcHandler` / `bdcHandler` / `tfHandler` との共通ヘルパー化 (`createSingleNameHandler` 等) → 5 handler をまとめて扱う別 Issue で

## 関連Issue

Refs #482
Relates to Epic #479 (Phase 4-J)
Depends on #480 (BMC/EMC + MarkedContentStack) / #481 (BDC handler)

## テスト

- ✅ `pnpm --filter @pdfmod/core exec vitest run src/content-stream/operators/marked-content/mp` → 2 files / 24 tests all green
- ✅ `pnpm --filter @pdfmod/core test` → 251 files / 3077 tests all green（リグレッションなし）
- ✅ 既存 `marked-content-operators.integration.test.ts` の `"MP は登録されない"` テスト → 引き続き pass（`MARKED_CONTENT_OPERATORS` 未変更）
- ✅ `pnpm --filter @pdfmod/core typecheck` → 成功
- ✅ `pnpm --filter @pdfmod/core build` → 成功（vite build + tsc declaration）
- ✅ `pnpm lint` (biome + oxlint) → 0 warnings / 0 errors

## レビューポイント

1. **骨格テンプレートの選択**: `bmcHandler` ではなく `doHandler` を骨格ソースに選んだ理由（`doHandler` は既に `MarkedContentStack.push` を含まない構造で、operator 名を差し替えるだけで MP になる。BMC 出発だと push を落とす加工 + import 削除の 2 step が必要）
2. **3 stack の同一参照返却**: `ok(context)` の省略形ではなく 3 プロパティを明示列挙するスタイル（既存 BMC/BDC/EMC と一貫 / requirements.md C-2）
3. **エラーコードの用語**: hearing-notes の `OBJECT_PARSE_UNEXPECTED_OPERAND` はコードベース非存在。`OPERATOR_OPERAND_MISSING` / `OPERATOR_OPERAND_TYPE_MISMATCH` の 2 コードに使い分け（requirements.md C-1）
4. **import 構成**: `mp/index.ts` は `MarkedContentStack` / `MarkedContentEntry` / `none` を **import しない**（`doHandler` と同じ / BMC と異なる）— 型レベルで「MP は marked content stack に触らない」ことを保証
5. **spec ドキュメント**: `.plugin-workspace/.specs/073-mp-handler/` に requirements / exploration-report / implementation-plan / tasks / implementation-notes / understanding-quiz-impl.html を格納

## チェックリスト

- [x] コードレビューの準備完了
- [x] テスト正常実行（24 新規 + リグレッションなし）
- [x] ドキュメント更新（spec ドキュメント / JSDoc は §14.6 参照付き）
- [x] 適切なコミットメッセージ（`✨ [New Feature]: #482` プレフィックス）
- [x] IssueがPRにLinked（Refs #482）
- [x] セルフレビュー実施（DoD 15 項目全充足）
- [x] 破壊的変更なし（純粋な追加のみ / 既存ファイル未変更 / `"MP は登録されない"` テスト維持）