### PR TITLE
✨ [New Feature]: #482 dpHandler (DP marked-content point with property list operator) を新規実装

### DIFF
--- a/packages/core/src/content-stream/operators/marked-content/dp/__tests__/dp.dict.test.ts
+++ b/packages/core/src/content-stream/operators/marked-content/dp/__tests__/dp.dict.test.ts
@@ -1,0 +1,221 @@
+import { assert, expect, test } from "vitest";
+import type {
+  PdfDictionary,
+  PdfName,
+  PdfObject,
+  PdfValue,
+} from "../../../../../pdf/types/pdf-types/index";
+import { none } from "../../../../../utils/option/index";
+import { GraphicsStateStack } from "../../../../graphics-state/index";
+import type { MarkedContentEntry } from "../../../../marked-content/stack";
+import { MarkedContentStack } from "../../../../marked-content/stack";
+import { OperandStack } from "../../../../operand-stack/index";
+import type { OperatorHandlerContext } from "../../../../operator-registry/index";
+import { dpHandler } from "../index";
+
+// buildContext は operand を底 → 頂上の順に push する。pop 順は逆。
+const buildContext = (operands: PdfObject[]): OperatorHandlerContext => {
+  const operandStack = OperandStack.create();
+  for (const operand of operands) {
+    OperandStack.push(operandStack, operand);
+  }
+  return {
+    operandStack,
+    graphicsStateStack: GraphicsStateStack.create(),
+    markedContentStack: MarkedContentStack.create(),
+  };
+};
+
+// markedContentStack を depth=1 の非空状態にして組み立てる（push しないことの pin down 用）
+const buildNestedContext = (
+  operands: PdfObject[],
+  seededTag: PdfName,
+): OperatorHandlerContext => {
+  const operandStack = OperandStack.create();
+  for (const operand of operands) {
+    OperandStack.push(operandStack, operand);
+  }
+  const seededEntry: MarkedContentEntry = { tag: seededTag, properties: none };
+  return {
+    operandStack,
+    graphicsStateStack: GraphicsStateStack.create(),
+    markedContentStack: MarkedContentStack.push(
+      MarkedContentStack.create(),
+      seededEntry,
+    ),
+  };
+};
+
+test("tag + dict properties を受理して ok を返す", () => {
+  const tag: PdfName = { type: "name", value: "Span" };
+  const properties: PdfDictionary = {
+    type: "dictionary",
+    entries: new Map([["MCID", { type: "integer", value: 0 }]]),
+  };
+  const ctx = buildContext([tag, properties]);
+
+  const result = dpHandler(ctx);
+
+  assert(result.ok);
+});
+
+test("成功時 markedContentStack は入力と同一参照で返る（BDC との本質的差分 / push しない）", () => {
+  const tag: PdfName = { type: "name", value: "Span" };
+  const properties: PdfDictionary = {
+    type: "dictionary",
+    entries: new Map([["MCID", { type: "integer", value: 0 }]]),
+  };
+  const ctx = buildContext([tag, properties]);
+
+  const result = dpHandler(ctx);
+
+  assert(result.ok);
+  // DP は marked-content point であり BMC/EMC の対を持たないため
+  // markedContentStack は入力と同一参照でそのまま返る
+  expect(result.value.markedContentStack).toBe(ctx.markedContentStack);
+});
+
+test("成功時 markedContentStack の depth が 0 → 0 のまま（push しない）", () => {
+  const tag: PdfName = { type: "name", value: "Span" };
+  const properties: PdfDictionary = {
+    type: "dictionary",
+    entries: new Map(),
+  };
+  const ctx = buildContext([tag, properties]);
+
+  const result = dpHandler(ctx);
+
+  assert(result.ok);
+  expect(MarkedContentStack.depth(result.value.markedContentStack)).toBe(0);
+});
+
+test("成功後も入力 ctx.markedContentStack は非破壊で depth=0 のまま", () => {
+  const tag: PdfName = { type: "name", value: "Span" };
+  const properties: PdfDictionary = {
+    type: "dictionary",
+    entries: new Map(),
+  };
+  const ctx = buildContext([tag, properties]);
+
+  const result = dpHandler(ctx);
+
+  assert(result.ok);
+  expect(MarkedContentStack.depth(ctx.markedContentStack)).toBe(0);
+});
+
+test("dict の中身（/MCID 0, /ActualText (fi)）はそのまま保持され検証されない", () => {
+  const tag: PdfName = { type: "name", value: "Span" };
+  const properties: PdfDictionary = {
+    type: "dictionary",
+    entries: new Map<string, PdfValue>([
+      ["MCID", { type: "integer", value: 0 }],
+      [
+        "ActualText",
+        {
+          type: "string",
+          value: new Uint8Array([0x66, 0x69]),
+          encoding: "literal",
+        },
+      ],
+    ]),
+  };
+  const ctx = buildContext([tag, properties]);
+
+  const result = dpHandler(ctx);
+
+  assert(result.ok);
+  // DP は markedContentStack を差し替えないため、dict の中身は handler の関知外。
+  // 同一参照返しであることで「中身検証も加工もしていない」ことを pin down する。
+  expect(result.value.markedContentStack).toBe(ctx.markedContentStack);
+});
+
+test("空 dict `<<>>` でも受理する（中身検証なしの pin down）", () => {
+  const tag: PdfName = { type: "name", value: "Span" };
+  const properties: PdfDictionary = {
+    type: "dictionary",
+    entries: new Map(),
+  };
+  const ctx = buildContext([tag, properties]);
+
+  const result = dpHandler(ctx);
+
+  assert(result.ok);
+});
+
+test("成功時 operandStack は入力と同一参照（in-place mutate）", () => {
+  const tag: PdfName = { type: "name", value: "Span" };
+  const properties: PdfDictionary = {
+    type: "dictionary",
+    entries: new Map(),
+  };
+  const ctx = buildContext([tag, properties]);
+
+  const result = dpHandler(ctx);
+
+  assert(result.ok);
+  expect(result.value.operandStack).toBe(ctx.operandStack);
+});
+
+test("成功時 operand が 2 個消費され operandStack depth=0 になる", () => {
+  const tag: PdfName = { type: "name", value: "Span" };
+  const properties: PdfDictionary = {
+    type: "dictionary",
+    entries: new Map(),
+  };
+  const ctx = buildContext([tag, properties]);
+
+  const result = dpHandler(ctx);
+
+  assert(result.ok);
+  expect(OperandStack.depth(result.value.operandStack)).toBe(0);
+});
+
+test("成功時 graphicsStateStack は入力と同一参照で返る", () => {
+  const tag: PdfName = { type: "name", value: "Span" };
+  const properties: PdfDictionary = {
+    type: "dictionary",
+    entries: new Map(),
+  };
+  const ctx = buildContext([tag, properties]);
+
+  const result = dpHandler(ctx);
+
+  assert(result.ok);
+  expect(result.value.graphicsStateStack).toBe(ctx.graphicsStateStack);
+});
+
+test("余剰 operand があるとき末尾 2 個のみ消費する（depth=4 → depth=2）", () => {
+  const surplus0: PdfObject = { type: "integer", value: 1 };
+  const surplus1: PdfObject = { type: "integer", value: 2 };
+  const tag: PdfName = { type: "name", value: "Span" };
+  const properties: PdfDictionary = {
+    type: "dictionary",
+    entries: new Map(),
+  };
+  const ctx = buildContext([surplus0, surplus1, tag, properties]);
+
+  const result = dpHandler(ctx);
+
+  assert(result.ok);
+  expect(OperandStack.depth(result.value.operandStack)).toBe(2);
+  const top = OperandStack.peek(result.value.operandStack);
+  assert(top.some);
+  expect(top.value).toEqual(surplus1);
+});
+
+test("既存 seeded stack (depth=1) でも depth=1 のまま（push しない / BDC は 1→2）", () => {
+  const seededTag: PdfName = { type: "name", value: "Artifact" };
+  const tag: PdfName = { type: "name", value: "Span" };
+  const properties: PdfDictionary = {
+    type: "dictionary",
+    entries: new Map(),
+  };
+  const ctx = buildNestedContext([tag, properties], seededTag);
+
+  const result = dpHandler(ctx);
+
+  assert(result.ok);
+  // seeded depth=1 の状態で DP を呼んでも push されないため depth=1 のまま。
+  // BDC なら 1→2 になるが、DP は marked-content point のため加算しない。
+  expect(MarkedContentStack.depth(result.value.markedContentStack)).toBe(1);
+});

--- a/packages/core/src/content-stream/operators/marked-content/dp/__tests__/dp.error.test.ts
+++ b/packages/core/src/content-stream/operators/marked-content/dp/__tests__/dp.error.test.ts
@@ -1,0 +1,282 @@
+import { assert, expect, test } from "vitest";
+import type {
+  PdfDictionary,
+  PdfName,
+  PdfObject,
+} from "../../../../../pdf/types/pdf-types/index";
+import { none } from "../../../../../utils/option/index";
+import { GraphicsStateStack } from "../../../../graphics-state/index";
+import type { MarkedContentEntry } from "../../../../marked-content/stack";
+import { MarkedContentStack } from "../../../../marked-content/stack";
+import { OperandStack } from "../../../../operand-stack/index";
+import type { OperatorHandlerContext } from "../../../../operator-registry/index";
+import { dpHandler } from "../index";
+
+const buildContext = (operands: PdfObject[]): OperatorHandlerContext => {
+  const operandStack = OperandStack.create();
+  for (const operand of operands) {
+    OperandStack.push(operandStack, operand);
+  }
+  return {
+    operandStack,
+    graphicsStateStack: GraphicsStateStack.create(),
+    markedContentStack: MarkedContentStack.create(),
+  };
+};
+
+// markedContentStack を depth=1 の非空状態にして組み立てる（MISSING 時の不変性検証用）
+const buildSeededContext = (
+  operands: PdfObject[],
+  seededTag: PdfName,
+): OperatorHandlerContext => {
+  const operandStack = OperandStack.create();
+  for (const operand of operands) {
+    OperandStack.push(operandStack, operand);
+  }
+  const seededEntry: MarkedContentEntry = { tag: seededTag, properties: none };
+  return {
+    operandStack,
+    graphicsStateStack: GraphicsStateStack.create(),
+    markedContentStack: MarkedContentStack.push(
+      MarkedContentStack.create(),
+      seededEntry,
+    ),
+  };
+};
+
+// properties 位置に許容されない型（dict/name 以外の 8 バリアント）
+const NON_DICT_OR_NAME_CASES: ReadonlyArray<[string, PdfObject]> = [
+  ["integer", { type: "integer", value: 42 }],
+  ["real", { type: "real", value: 3.14 }],
+  ["string", { type: "string", value: new Uint8Array(), encoding: "literal" }],
+  ["boolean", { type: "boolean", value: true }],
+  ["null", { type: "null" }],
+  ["array", { type: "array", elements: [] }],
+  [
+    "indirect-ref",
+    { type: "indirect-ref", objectNumber: 1, generationNumber: 0 },
+  ],
+  [
+    "stream",
+    {
+      type: "stream",
+      dictionary: { type: "dictionary", entries: new Map() },
+      data: new Uint8Array(),
+    },
+  ],
+];
+
+// tag 位置に許容されない型（name 以外の 9 バリアント）
+const NON_NAME_CASES: ReadonlyArray<[string, PdfObject]> = [
+  ["integer", { type: "integer", value: 42 }],
+  ["real", { type: "real", value: 3.14 }],
+  ["string", { type: "string", value: new Uint8Array(), encoding: "literal" }],
+  ["boolean", { type: "boolean", value: true }],
+  ["null", { type: "null" }],
+  ["array", { type: "array", elements: [] }],
+  ["dictionary", { type: "dictionary", entries: new Map() }],
+  [
+    "indirect-ref",
+    { type: "indirect-ref", objectNumber: 1, generationNumber: 0 },
+  ],
+  [
+    "stream",
+    {
+      type: "stream",
+      dictionary: { type: "dictionary", entries: new Map() },
+      data: new Uint8Array(),
+    },
+  ],
+];
+
+// -------- MISSING 系 --------
+
+test("operand 0 個で MISSING を返す（required:2, actual:0, operatorName:'DP'）", () => {
+  const ctx = buildContext([]);
+
+  const result = dpHandler(ctx);
+
+  assert(!result.ok);
+  assert(result.error.code === "OPERATOR_OPERAND_MISSING");
+  expect(result.error.operatorName).toBe("DP");
+  expect(result.error.required).toBe(2);
+  expect(result.error.actual).toBe(0);
+});
+
+test("operand 0 個の MISSING メッセージが完全一致する（`Operator 'DP' requires 2 operand(s), got 0`）", () => {
+  const ctx = buildContext([]);
+
+  const result = dpHandler(ctx);
+
+  assert(!result.ok);
+  assert(result.error.code === "OPERATOR_OPERAND_MISSING");
+  expect(result.error.message).toBe(
+    "Operator 'DP' requires 2 operand(s), got 0",
+  );
+});
+
+test("operand 1 個（properties 位置 name のみ）で MISSING を返す（actual=1）", () => {
+  const ctx = buildContext([{ type: "name", value: "Span" }]);
+
+  const result = dpHandler(ctx);
+
+  assert(!result.ok);
+  assert(result.error.code === "OPERATOR_OPERAND_MISSING");
+  expect(result.error.actual).toBe(1);
+});
+
+test("operand 1 個の MISSING メッセージが完全一致する（`Operator 'DP' requires 2 operand(s), got 1`）", () => {
+  const ctx = buildContext([{ type: "name", value: "Span" }]);
+
+  const result = dpHandler(ctx);
+
+  assert(!result.ok);
+  assert(result.error.code === "OPERATOR_OPERAND_MISSING");
+  expect(result.error.message).toBe(
+    "Operator 'DP' requires 2 operand(s), got 1",
+  );
+});
+
+test("非空 seeded stack (depth=1) でも MISSING 時に markedContentStack は depth=1 のまま", () => {
+  const ctx = buildSeededContext([], { type: "name", value: "Span" });
+
+  const result = dpHandler(ctx);
+
+  assert(!result.ok);
+  expect(MarkedContentStack.depth(ctx.markedContentStack)).toBe(1);
+});
+
+test("MISSING 時（operand 0）markedContentStack は push されず depth=0 のまま", () => {
+  const ctx = buildContext([]);
+
+  const result = dpHandler(ctx);
+
+  assert(!result.ok);
+  expect(MarkedContentStack.depth(ctx.markedContentStack)).toBe(0);
+});
+
+// -------- properties TYPE_MISMATCH --------
+
+test.each<[string, PdfObject]>(
+  NON_DICT_OR_NAME_CASES,
+)("properties が %s のとき TYPE_MISMATCH を返す（expected='name or dictionary', actual=type）", (type, operand) => {
+  const ctx = buildContext([operand]);
+
+  const result = dpHandler(ctx);
+
+  assert(!result.ok);
+  assert(result.error.code === "OPERATOR_OPERAND_TYPE_MISMATCH");
+  expect(result.error.operatorName).toBe("DP");
+  expect(result.error.expected).toBe("name or dictionary");
+  expect(result.error.actual).toBe(type);
+});
+
+test("properties TYPE_MISMATCH のメッセージが完全一致する（`Operator 'DP' expected name or dictionary operand, got integer`）", () => {
+  const ctx = buildContext([{ type: "integer", value: 42 }]);
+
+  const result = dpHandler(ctx);
+
+  assert(!result.ok);
+  assert(result.error.code === "OPERATOR_OPERAND_TYPE_MISMATCH");
+  expect(result.error.message).toBe(
+    "Operator 'DP' expected name or dictionary operand, got integer",
+  );
+});
+
+test("properties TYPE_MISMATCH 時 markedContentStack は push されず不変（depth=0）", () => {
+  const ctx = buildContext([{ type: "integer", value: 42 }]);
+
+  const result = dpHandler(ctx);
+
+  assert(!result.ok);
+  expect(MarkedContentStack.depth(ctx.markedContentStack)).toBe(0);
+});
+
+test("properties TYPE_MISMATCH 時、部分消費した operand は復元しない（depth=1 → depth=0）", () => {
+  const ctx = buildContext([{ type: "integer", value: 42 }]);
+  expect(OperandStack.depth(ctx.operandStack)).toBe(1);
+
+  const result = dpHandler(ctx);
+
+  assert(!result.ok);
+  expect(OperandStack.depth(ctx.operandStack)).toBe(0);
+});
+
+// -------- tag TYPE_MISMATCH --------
+
+test.each<[string, PdfObject]>(
+  NON_NAME_CASES,
+)("tag が %s のとき TYPE_MISMATCH を返す（expected='name', actual=type）", (type, operand) => {
+  const properties: PdfDictionary = {
+    type: "dictionary",
+    entries: new Map(),
+  };
+  const ctx = buildContext([operand, properties]);
+
+  const result = dpHandler(ctx);
+
+  assert(!result.ok);
+  assert(result.error.code === "OPERATOR_OPERAND_TYPE_MISMATCH");
+  expect(result.error.operatorName).toBe("DP");
+  expect(result.error.expected).toBe("name");
+  expect(result.error.actual).toBe(type);
+});
+
+test("tag TYPE_MISMATCH のメッセージが完全一致する（`Operator 'DP' expected name operand, got integer`）", () => {
+  const properties: PdfDictionary = {
+    type: "dictionary",
+    entries: new Map(),
+  };
+  const ctx = buildContext([{ type: "integer", value: 42 }, properties]);
+
+  const result = dpHandler(ctx);
+
+  assert(!result.ok);
+  assert(result.error.code === "OPERATOR_OPERAND_TYPE_MISMATCH");
+  expect(result.error.message).toBe(
+    "Operator 'DP' expected name operand, got integer",
+  );
+});
+
+test("tag TYPE_MISMATCH 時 markedContentStack は push されず不変（depth=0）", () => {
+  const properties: PdfDictionary = {
+    type: "dictionary",
+    entries: new Map(),
+  };
+  const ctx = buildContext([{ type: "integer", value: 42 }, properties]);
+
+  const result = dpHandler(ctx);
+
+  assert(!result.ok);
+  expect(MarkedContentStack.depth(ctx.markedContentStack)).toBe(0);
+});
+
+test("tag TYPE_MISMATCH 時、両方 pop 済みで operandStack depth=0", () => {
+  const properties: PdfDictionary = {
+    type: "dictionary",
+    entries: new Map(),
+  };
+  const ctx = buildContext([{ type: "integer", value: 42 }, properties]);
+  expect(OperandStack.depth(ctx.operandStack)).toBe(2);
+
+  const result = dpHandler(ctx);
+
+  assert(!result.ok);
+  expect(OperandStack.depth(ctx.operandStack)).toBe(0);
+});
+
+test("MISSING actual=1 時、properties 側は pop 済みで operandStack depth=0 のまま（復元されない）", () => {
+  // properties 位置に name を 1 個だけ push した状態で DP を呼ぶと、
+  // properties は pop 成功するが tag pop で MISSING actual=1 になる。
+  // このとき properties は既に pop 済みで operandStack は空。
+  // BDC handler と同じく、エラー時の operand 復元は行わない規約の pin down。
+  const ctx = buildContext([{ type: "name", value: "Span" }]);
+  expect(OperandStack.depth(ctx.operandStack)).toBe(1);
+
+  const result = dpHandler(ctx);
+
+  assert(!result.ok);
+  assert(result.error.code === "OPERATOR_OPERAND_MISSING");
+  expect(result.error.actual).toBe(1);
+  expect(OperandStack.depth(ctx.operandStack)).toBe(0);
+});

--- a/packages/core/src/content-stream/operators/marked-content/dp/__tests__/dp.name.test.ts
+++ b/packages/core/src/content-stream/operators/marked-content/dp/__tests__/dp.name.test.ts
@@ -1,0 +1,87 @@
+import { assert, expect, test } from "vitest";
+import type {
+  PdfName,
+  PdfObject,
+} from "../../../../../pdf/types/pdf-types/index";
+import { GraphicsStateStack } from "../../../../graphics-state/index";
+import { MarkedContentStack } from "../../../../marked-content/stack";
+import { OperandStack } from "../../../../operand-stack/index";
+import type { OperatorHandlerContext } from "../../../../operator-registry/index";
+import { dpHandler } from "../index";
+
+// buildContext は operand を底 → 頂上の順に push する。pop 順は逆。
+const buildContext = (operands: PdfObject[]): OperatorHandlerContext => {
+  const operandStack = OperandStack.create();
+  for (const operand of operands) {
+    OperandStack.push(operandStack, operand);
+  }
+  return {
+    operandStack,
+    graphicsStateStack: GraphicsStateStack.create(),
+    markedContentStack: MarkedContentStack.create(),
+  };
+};
+
+test("tag + name properties (/MC0) を受理して ok を返す", () => {
+  const tag: PdfName = { type: "name", value: "Span" };
+  const properties: PdfName = { type: "name", value: "MC0" };
+  const ctx = buildContext([tag, properties]);
+
+  const result = dpHandler(ctx);
+
+  assert(result.ok);
+});
+
+test("成功時 markedContentStack は入力と同一参照で返る（push しない / BDC との差分）", () => {
+  const tag: PdfName = { type: "name", value: "Span" };
+  const properties: PdfName = { type: "name", value: "MC0" };
+  const ctx = buildContext([tag, properties]);
+
+  const result = dpHandler(ctx);
+
+  assert(result.ok);
+  // properties が name の場合でも push しない（resource dictionary の解決も本 handler では行わない）
+  expect(result.value.markedContentStack).toBe(ctx.markedContentStack);
+});
+
+test("成功時 markedContentStack の depth が 0 → 0 のまま（push しない / resource 解決なし）", () => {
+  const tag: PdfName = { type: "name", value: "Span" };
+  const properties: PdfName = { type: "name", value: "MC0" };
+  const ctx = buildContext([tag, properties]);
+
+  const result = dpHandler(ctx);
+
+  assert(result.ok);
+  expect(MarkedContentStack.depth(result.value.markedContentStack)).toBe(0);
+});
+
+test("空文字 name `//` (value='') を properties として受理する", () => {
+  const tag: PdfName = { type: "name", value: "Span" };
+  const properties: PdfName = { type: "name", value: "" };
+  const ctx = buildContext([tag, properties]);
+
+  const result = dpHandler(ctx);
+
+  assert(result.ok);
+});
+
+test("空文字 tag `//` (value='') でも受理する（値域検証なしの pin down）", () => {
+  const tag: PdfName = { type: "name", value: "" };
+  const properties: PdfName = { type: "name", value: "MC0" };
+  const ctx = buildContext([tag, properties]);
+
+  const result = dpHandler(ctx);
+
+  assert(result.ok);
+});
+
+test("成功時 operandStack が depth=0 まで消費される", () => {
+  const tag: PdfName = { type: "name", value: "Span" };
+  const properties: PdfName = { type: "name", value: "MC0" };
+  const ctx = buildContext([tag, properties]);
+
+  const result = dpHandler(ctx);
+
+  assert(result.ok);
+  expect(OperandStack.depth(result.value.operandStack)).toBe(0);
+});

--- a/packages/core/src/content-stream/operators/marked-content/dp/index.ts
+++ b/packages/core/src/content-stream/operators/marked-content/dp/index.ts
@@ -1,0 +1,97 @@
+import type { PdfError } from "../../../../pdf/errors/index";
+import { PdfName } from "../../../../pdf/types/pdf-types/index";
+import { err, ok } from "../../../../utils/result/index";
+import { OperandStack } from "../../../operand-stack/index";
+import type {
+  OperatorHandler,
+  OperatorHandlerContext,
+} from "../../../operator-registry/index";
+
+const OPERATOR_NAME = "DP";
+const OPERAND_COUNT = 2;
+
+/**
+ * ISO 32000-2:2020 §14.6 `DP` operator (marked-content point with property
+ * list) のハンドラ。
+ *
+ * operand stack 頂上から properties → tag の順に 2 個 pop し、両方の型検査を
+ * 通過したら 3 つの stack を入力と同一参照で保持した context を返す。DP は
+ * 「単発マーク点」であり BMC/EMC の対を持たないため、`MarkedContentStack` への
+ * push は行わない（BDC との本質的差分）。
+ *
+ * 検査順序（厳守 / bdcHandler 準拠）:
+ *   (1) properties pop（none なら OPERATOR_OPERAND_MISSING, actual=0）
+ *   (2) properties 型検査（dictionary/name 以外は OPERATOR_OPERAND_TYPE_MISMATCH）
+ *   (3) tag pop（none なら OPERATOR_OPERAND_MISSING, actual=1）
+ *   (4) tag 型検査（PdfName.is が false なら OPERATOR_OPERAND_TYPE_MISMATCH）
+ *   (5) 全通過 → 3 つの stack を同一参照で列挙して ok
+ *
+ * `actual` フィールドの意味（既存 handler の流儀）:
+ *   - MISSING: 数値。pop 成功数（0 段目失敗=0 / 1 段目失敗=1）
+ *   - TYPE_MISMATCH: 文字列。実際に来た operand の `type` フィールド
+ *
+ * - properties が PdfName の場合、resource 解決は本 handler で行わない。
+ * - dict の中身（/MCID, /ActualText 等）の妥当性は検証しない。
+ * - tag の値域（空文字 等）は検証しない。
+ * - operandStack は pop で in-place 消費済み。graphicsStateStack と
+ *   markedContentStack は入力と同一参照で返す。
+ * - エラー時に部分消費した operand stack は復元しない（既存ハンドラ規約）。
+ *
+ * @param context - 実行コンテキスト
+ * @returns 成功なら入力と同じ 3 stack を持つコンテキスト、失敗なら PdfError
+ */
+export const dpHandler: OperatorHandler = (context: OperatorHandlerContext) => {
+  const poppedProperties = OperandStack.pop(context.operandStack);
+  if (!poppedProperties.some) {
+    const error: PdfError = {
+      code: "OPERATOR_OPERAND_MISSING",
+      message: `Operator '${OPERATOR_NAME}' requires ${OPERAND_COUNT} operand(s), got 0`,
+      operatorName: OPERATOR_NAME,
+      required: OPERAND_COUNT,
+      actual: 0,
+    };
+    return err(error);
+  }
+  const properties = poppedProperties.value;
+
+  if (properties.type !== "dictionary" && !PdfName.is(properties)) {
+    const error: PdfError = {
+      code: "OPERATOR_OPERAND_TYPE_MISMATCH",
+      message: `Operator '${OPERATOR_NAME}' expected name or dictionary operand, got ${properties.type}`,
+      operatorName: OPERATOR_NAME,
+      expected: "name or dictionary",
+      actual: properties.type,
+    };
+    return err(error);
+  }
+
+  const poppedTag = OperandStack.pop(context.operandStack);
+  if (!poppedTag.some) {
+    const error: PdfError = {
+      code: "OPERATOR_OPERAND_MISSING",
+      message: `Operator '${OPERATOR_NAME}' requires ${OPERAND_COUNT} operand(s), got 1`,
+      operatorName: OPERATOR_NAME,
+      required: OPERAND_COUNT,
+      actual: 1,
+    };
+    return err(error);
+  }
+  const tag = poppedTag.value;
+
+  if (!PdfName.is(tag)) {
+    const error: PdfError = {
+      code: "OPERATOR_OPERAND_TYPE_MISMATCH",
+      message: `Operator '${OPERATOR_NAME}' expected name operand, got ${tag.type}`,
+      operatorName: OPERATOR_NAME,
+      expected: "name",
+      actual: tag.type,
+    };
+    return err(error);
+  }
+
+  return ok({
+    operandStack: context.operandStack,
+    graphicsStateStack: context.graphicsStateStack,
+    markedContentStack: context.markedContentStack,
+  });
+};


### PR DESCRIPTION
## 概要

PDF content stream の `DP` (marked-content point with property list) operator を処理する `dpHandler` を新規実装しました。ISO 32000-2:2020 §14.6 準拠。Phase 4-J (Epic #479) の一部で、依存済み #480 (BMC/EMC + MarkedContentStack) / #481 (BDC) / #521 (MP) の後に位置します。

## 変更の種類

- ✨ 新機能（純粋な追加のみ・破壊的変更なし）
- 🚨 テスト追加

## 詳細な変更内容

### `packages/core/src/content-stream/operators/marked-content/dp/index.ts` [NEW]

`bdcHandler` を骨格ソースに独立実装（`MP` と `BMC` が独立で書かれているのと対称）。差分は「成功時に `MarkedContentStack.push` を呼ばず、3 stack すべてを入力と同一参照で返す」の 1 点だけ。

- `OPERATOR_NAME = "DP"`, `OPERAND_COUNT = 2`
- **検査順序**: (1) properties pop → (2) properties 型検査 (dict/name) → (3) tag pop → (4) tag 型検査 (name) → (5) 3 stack を同一参照で `ok` 返却
- DP は「単発マーク点」で BMC/EMC の対を持たないため、`MarkedContentStack.push` を行わず `markedContentStack` は入力と同一参照でパススルー（BDC との本質的差分）
- BDC からの依存削減: `MarkedContentEntry` / `MarkedContentStack` / `some` / `PdfDictionary` の 4 種を import から削除
- BDC L71 の `const validatedProperties: PdfDictionary | PdfName = properties;` は成功時に使わないため削除
- エラーコードは `OPERATOR_OPERAND_MISSING` (operand 0/1 個) と `OPERATOR_OPERAND_TYPE_MISMATCH` (properties が dict/name 以外 / tag が name 以外) の 2 種（Issue 本文の `OBJECT_PARSE_UNEXPECTED_OPERAND` ではなく既存 handler と揃える）

### `packages/core/src/content-stream/operators/marked-content/dp/__tests__/dp.dict.test.ts` [NEW]

properties=dict の正常系 11 テスト（フラット構造 / `describe` 未使用）:

- tag + dict properties 受理 / `markedContentStack` 同一参照（BDC との本質的差分 / push しない）/ depth 0→0 のまま / seeded stack depth 1→1 のまま（BDC は 1→2）
- dict の中身 (/MCID, /ActualText) 保持と検証なしの pin down / 空 dict `<<>>` 受理
- `operandStack` 同一参照（in-place mutate）/ 2 個消費 depth=0 / 余剰 operand は末尾 2 個のみ消費（depth=4→2）
- `graphicsStateStack` 同一参照

### `packages/core/src/content-stream/operators/marked-content/dp/__tests__/dp.name.test.ts` [NEW]

properties=name の正常系 6 テスト:

- tag + name properties (/MC0) 受理 / `markedContentStack` 同一参照（push しない / resource 解決なし）/ depth 0→0 のまま
- 空文字 name (`value=''`) を properties / tag として受理（値域検証なし pin down）
- `operandStack` depth=0 まで消費

### `packages/core/src/content-stream/operators/marked-content/dp/__tests__/dp.error.test.ts` [NEW]

異常系 15 test（`test.each` 展開込みで実行 30 test）:

- MISSING: フィールド検証 (`actual=0` / `actual=1`) / メッセージ `\"Operator 'DP' requires 2 operand(s), got 0/1\"` 完全一致 / seeded stack `markedContentStack` 不変 / operand 0 個時 `markedContentStack` 不変
- properties TYPE_MISMATCH: `test.each` で 8 バリアント（integer/real/string/boolean/null/array/indirect-ref/stream）/ `operatorName='DP'` + メッセージ `\"Operator 'DP' expected name or dictionary operand, got integer\"` 完全一致 / `markedContentStack` 不変 / operand 非復元
- tag TYPE_MISMATCH: `test.each` で 9 バリアント（integer/real/string/boolean/null/array/dictionary/indirect-ref/stream）/ `operatorName='DP'` + メッセージ `\"Operator 'DP' expected name operand, got integer\"` 完全一致 / `markedContentStack` 不変 / operand 両方 pop
- **DP 固有の追加 test**: MISSING `actual=1` 時、properties 側は pop 済みで `operandStack` depth=0 のまま（復元されない）— BDC handler にはない pin down

## システム図

```mermaid
flowchart TD
    S[dpHandler context]
    P1[OperandStack.pop properties]
    T1{properties.type<br/>=== dictionary OR<br/>PdfName.is}
    P2[OperandStack.pop tag]
    T2{PdfName.is tag?}
    M0[err OPERATOR_OPERAND_MISSING<br/>required:2 actual:0]
    M1[err OPERATOR_OPERAND_MISSING<br/>required:2 actual:1]
    X1[err OPERATOR_OPERAND_TYPE_MISMATCH<br/>expected: name or dictionary<br/>actual: properties.type]
    X2[err OPERATOR_OPERAND_TYPE_MISMATCH<br/>expected: name<br/>actual: tag.type]
    O[ok 3 stack を同一参照で返却<br/>★markedContentStack は push しない<br/>BDC との本質的差分]

    S --> P1
    P1 -- none --> M0
    P1 -- some --> T1
    T1 -- false --> X1
    T1 -- true --> P2
    P2 -- none --> M1
    P2 -- some --> T2
    T2 -- false --> X2
    T2 -- true --> O

    style O fill:#e6ffe6,stroke:#0a0
    style M0 fill:#ffe6e6,stroke:#a00
    style M1 fill:#ffe6e6,stroke:#a00
    style X1 fill:#ffe6e6,stroke:#a00
    style X2 fill:#ffe6e6,stroke:#a00
```

## スコープ外（本 PR で意図的に触っていない）

- `marked-content-operators/index.ts` の `MARKED_CONTENT_OPERATORS` 配列への `DP` 登録 → 次 spec（Issue #482 タスク3）
- `content-stream/interpreter/*` の integration test 追加 → 次 spec（Issue #482 タスク4）
- `bdcHandler` / `bmcHandler` / `emcHandler` / `mpHandler` との共通ヘルパー化 → 別 Issue で 5 handler をまとめて扱う
- DP dict の中身検証（`/MCID`, `/ActualText` などの妥当性）→ 別フェーズ（accessibility 出力時）

## 関連Issue

Refs #482
Relates to Epic #479 (Phase 4-J)
Depends on #480 (BMC/EMC + MarkedContentStack) / #481 (BDC handler) / #521 (MP handler)

## テスト

- ✅ `pnpm --filter @pdfmod/core test src/content-stream/operators/marked-content/dp` → 3 files / 47 tests all green（11 dict + 6 name + 30 error）
- ✅ `pnpm --filter @pdfmod/core test` → 254 files / 3124 tests all green（リグレッションなし）
- ✅ 既存 `marked-content-operators.integration.test.ts` の `\"DP は登録されない\"` テスト → 引き続き pass（`MARKED_CONTENT_OPERATORS` 未変更）
- ✅ `pnpm --filter @pdfmod/core build` → 成功（vite build + tsc declaration、型エラーなし）
- ✅ `pnpm lint` (biome + oxlint) → 0 warnings / 0 errors

## レビューポイント

1. **骨格テンプレートの選択**: `mpHandler` ではなく `bdcHandler` を骨格ソースに選んだ理由（DP は 2 operand (`tag properties`) を取り、properties 側で `dictionary or name` の複合型検査を持つ点が BDC と同じ。MP 出発だと 2 operand 化と型検査追加の 2 step が必要）
2. **BDC からの依存削減**: `dp/index.ts` は BDC の import 節から 4 種（`MarkedContentEntry` / `MarkedContentStack` / `some` / `PdfDictionary`）を削減。`MarkedContentStack` を型レベルで一切参照しないことで「DP は marked content stack に触らない」ことを保証
3. **`validatedProperties` 中間変数の削除**: BDC L71 の `const validatedProperties: PdfDictionary | PdfName = properties;` は DP では成功時に参照しないため削除。BDC との差分を明確にする意図
4. **エラーコードの用語**: hearing-notes の `OBJECT_PARSE_UNEXPECTED_OPERAND` はコードベース非存在。`OPERATOR_OPERAND_MISSING` / `OPERATOR_OPERAND_TYPE_MISMATCH` の 2 コードに使い分け（既存 BDC/MP handler と揃える / requirements.md C-3）
5. **DP 固有のテスト追加**: `dp.error.test.ts` に「MISSING actual=1 時、properties 側は pop 済みで `operandStack` depth=0 のまま」を追加（BDC にはない pin down）。既存 handler 規約「エラー時に部分消費した operand は復元しない」を DP 側で明示的にセルフチェック
6. **spec ドキュメント**: `.plugin-workspace/.specs/073-dp-operator-handler/` に requirements / exploration-report / implementation-plan / tasks / implementation-notes / understanding-quiz-impl.html / code-review を格納（.gitignore 済み）

## チェックリスト

- [x] コードレビューの準備完了
- [x] テスト正常実行（47 新規 + リグレッションなし）
- [x] ドキュメント更新（spec ドキュメント / JSDoc は §14.6 参照付き）
- [x] 適切なコミットメッセージ（`✨ [New Feature]: #482` プレフィックス）
- [x] IssueがPRにLinked（Refs #482）
- [x] セルフレビュー実施（DoD 15 項目全充足）
- [x] 破壊的変更なし（純粋な追加のみ / 既存ファイル未変更 / `\"DP は登録されない\"` テスト維持）