### PR TITLE
♻️ [Refactoring]: #349 不正値のサイレントなデフォルト置換の一貫化 (Warning/Err 方針整合)

### DIFF
--- a/packages/core/src/__tests__/namespace-export.type.test.ts
+++ b/packages/core/src/__tests__/namespace-export.type.test.ts
@@ -107,6 +107,7 @@ test("ParsedCatalog型とResolveRef型が参照できる", () => {
       generationNumber: 0 as ParsedCatalog["pagesRef"]["generationNumber"],
     },
     version,
+    warnings: [],
   };
   const resolver: ResolveRef = async () => Result.ok({ type: "null" as const });
   expect(parsed.version).toBe(version);

--- a/packages/core/src/content-stream/graphics-state/stack/__tests__/stack.basic.test.ts
+++ b/packages/core/src/content-stream/graphics-state/stack/__tests__/stack.basic.test.ts
@@ -1,5 +1,4 @@
 import { expect, test } from "vitest";
-import type { PdfWarning } from "../../../../pdf/errors/warning/index";
 import { GraphicsState, LineCap } from "../../index";
 import { GraphicsStateStack } from "../../stack";
 
@@ -20,12 +19,13 @@ test("save後restoreは保存時のcurrentへ戻す", () => {
     }),
   );
 
-  const restored = GraphicsStateStack.restore(changed);
+  const { stack: restored, warning } = GraphicsStateStack.restore(changed);
 
   expect(saved).not.toBe(stack);
   expect(changed).not.toBe(saved);
   expect(restored).not.toBe(changed);
   expect(GraphicsStateStack.current(restored)).toEqual(GraphicsState.create());
+  expect(warning).toBeUndefined();
 });
 
 test("restoreはLIFO順に保存状態へ戻す", () => {
@@ -43,21 +43,23 @@ test("restoreはLIFO順に保存状態へ戻す", () => {
     secondSaved,
     GraphicsState.update(second, { lineWidth: 8.0 }),
   );
-  const firstRestore = GraphicsStateStack.restore(changed);
-  const secondRestore = GraphicsStateStack.restore(firstRestore);
+  const { stack: firstRestore } = GraphicsStateStack.restore(changed);
+  const { stack: secondRestore } = GraphicsStateStack.restore(firstRestore);
 
   expect(GraphicsStateStack.current(firstRestore)).toEqual(second);
   expect(GraphicsStateStack.current(secondRestore)).toEqual(first);
 });
 
-test("空スタックのrestoreはcurrentを変更しない", () => {
+test("空スタックの restore は current 不変で UNBALANCED_RESTORE warning を返す", () => {
+  // unbalanced Q operator の検出: 戻り値 warning に警告が乗る
   const stack = GraphicsStateStack.create();
   const current = GraphicsStateStack.current(stack);
 
-  const restored = GraphicsStateStack.restore(stack);
+  const { stack: restored, warning } = GraphicsStateStack.restore(stack);
 
   expect(restored).not.toBe(stack);
   expect(GraphicsStateStack.current(restored)).toBe(current);
+  expect(warning?.code).toBe("UNBALANCED_RESTORE");
 });
 
 test("replaceCurrentは元stackを変更しない", () => {
@@ -73,52 +75,25 @@ test("replaceCurrentは元stackを変更しない", () => {
   expect(GraphicsStateStack.current(updated)).toEqual(next);
 });
 
-test("空スタック restore で warnings 引数を渡すと UNBALANCED_RESTORE が push される", () => {
-  // unbalanced Q operator の検出: warnings buffer に警告が積まれる
-  const stack = GraphicsStateStack.create();
-  const current = GraphicsStateStack.current(stack);
-  const warnings: PdfWarning[] = [];
-
-  const restored = GraphicsStateStack.restore(stack, warnings);
-
-  expect(warnings).toHaveLength(1);
-  expect(warnings[0]?.code).toBe("UNBALANCED_RESTORE");
-  // 返り値の shape は現状維持: 新しい stack で current 不変・saved 空
-  expect(restored).not.toBe(stack);
-  expect(GraphicsStateStack.current(restored)).toBe(current);
-});
-
-test("空スタック restore で warnings 引数省略時は警告なし（後方互換）", () => {
-  // warnings 未指定の既存呼び出しは変更なし・警告なしで no-op
-  const stack = GraphicsStateStack.create();
-  const current = GraphicsStateStack.current(stack);
-
-  const restored = GraphicsStateStack.restore(stack);
-
-  expect(restored).not.toBe(stack);
-  expect(GraphicsStateStack.current(restored)).toBe(current);
-});
-
-test("warnings 引数付きで saved が非空時に警告は push されない", () => {
+test("saved が非空の restore は warning: undefined を返す", () => {
   // 正常な q/Q 対応時は warning 発行なし
   const stack = GraphicsStateStack.create();
   const saved = GraphicsStateStack.save(stack);
-  const warnings: PdfWarning[] = [];
 
-  GraphicsStateStack.restore(saved, warnings);
+  const { warning } = GraphicsStateStack.restore(saved);
 
-  expect(warnings).toHaveLength(0);
+  expect(warning).toBeUndefined();
 });
 
-test("連続 unbalanced restore で警告が複数 push される", () => {
-  // 呼び出しごとに 1 件ずつ積まれる（3 回で 3 件）
+test("連続 unbalanced restore はそれぞれ独立に warning を返す", () => {
+  // 呼び出しごとに個別 warning が返る（3 回で 3 件）
   const stack = GraphicsStateStack.create();
-  const warnings: PdfWarning[] = [];
 
-  const r1 = GraphicsStateStack.restore(stack, warnings);
-  const r2 = GraphicsStateStack.restore(r1, warnings);
-  GraphicsStateStack.restore(r2, warnings);
+  const r1 = GraphicsStateStack.restore(stack);
+  const r2 = GraphicsStateStack.restore(r1.stack);
+  const r3 = GraphicsStateStack.restore(r2.stack);
 
-  expect(warnings).toHaveLength(3);
-  expect(warnings.every((w) => w.code === "UNBALANCED_RESTORE")).toBe(true);
+  expect(r1.warning?.code).toBe("UNBALANCED_RESTORE");
+  expect(r2.warning?.code).toBe("UNBALANCED_RESTORE");
+  expect(r3.warning?.code).toBe("UNBALANCED_RESTORE");
 });

--- a/packages/core/src/content-stream/graphics-state/stack/__tests__/stack.basic.test.ts
+++ b/packages/core/src/content-stream/graphics-state/stack/__tests__/stack.basic.test.ts
@@ -1,4 +1,5 @@
 import { expect, test } from "vitest";
+import type { PdfWarning } from "../../../../pdf/errors/warning/index";
 import { GraphicsState, LineCap } from "../../index";
 import { GraphicsStateStack } from "../../stack";
 
@@ -70,4 +71,54 @@ test("replaceCurrentは元stackを変更しない", () => {
   expect(updated).not.toBe(stack);
   expect(GraphicsStateStack.current(stack)).toEqual(GraphicsState.create());
   expect(GraphicsStateStack.current(updated)).toEqual(next);
+});
+
+test("空スタック restore で warnings 引数を渡すと UNBALANCED_RESTORE が push される", () => {
+  // unbalanced Q operator の検出: warnings buffer に警告が積まれる
+  const stack = GraphicsStateStack.create();
+  const current = GraphicsStateStack.current(stack);
+  const warnings: PdfWarning[] = [];
+
+  const restored = GraphicsStateStack.restore(stack, warnings);
+
+  expect(warnings).toHaveLength(1);
+  expect(warnings[0]?.code).toBe("UNBALANCED_RESTORE");
+  // 返り値の shape は現状維持: 新しい stack で current 不変・saved 空
+  expect(restored).not.toBe(stack);
+  expect(GraphicsStateStack.current(restored)).toBe(current);
+});
+
+test("空スタック restore で warnings 引数省略時は警告なし（後方互換）", () => {
+  // warnings 未指定の既存呼び出しは変更なし・警告なしで no-op
+  const stack = GraphicsStateStack.create();
+  const current = GraphicsStateStack.current(stack);
+
+  const restored = GraphicsStateStack.restore(stack);
+
+  expect(restored).not.toBe(stack);
+  expect(GraphicsStateStack.current(restored)).toBe(current);
+});
+
+test("warnings 引数付きで saved が非空時に警告は push されない", () => {
+  // 正常な q/Q 対応時は warning 発行なし
+  const stack = GraphicsStateStack.create();
+  const saved = GraphicsStateStack.save(stack);
+  const warnings: PdfWarning[] = [];
+
+  GraphicsStateStack.restore(saved, warnings);
+
+  expect(warnings).toHaveLength(0);
+});
+
+test("連続 unbalanced restore で警告が複数 push される", () => {
+  // 呼び出しごとに 1 件ずつ積まれる（3 回で 3 件）
+  const stack = GraphicsStateStack.create();
+  const warnings: PdfWarning[] = [];
+
+  const r1 = GraphicsStateStack.restore(stack, warnings);
+  const r2 = GraphicsStateStack.restore(r1, warnings);
+  GraphicsStateStack.restore(r2, warnings);
+
+  expect(warnings).toHaveLength(3);
+  expect(warnings.every((w) => w.code === "UNBALANCED_RESTORE")).toBe(true);
 });

--- a/packages/core/src/content-stream/graphics-state/stack/index.ts
+++ b/packages/core/src/content-stream/graphics-state/stack/index.ts
@@ -1,3 +1,4 @@
+import type { PdfWarning } from "../../../pdf/errors/warning/index";
 import type { Brand } from "../../../utils/brand/index";
 import type { GraphicsState } from "../graphics-state";
 import { GraphicsState as GraphicsStateFactory } from "../graphics-state";
@@ -80,14 +81,27 @@ export const GraphicsStateStack = {
 
   /**
    * 直近に保存したグラフィックスステートを復元する。
-   * 保存状態がない場合は PDF 仕様メモの実装例に合わせて no-op とする。
+   * 保存状態がない場合は no-op で新しい stack（current 維持、saved:[]）を返す。
+   * `warnings` を渡した場合、unbalanced restore 検出時に `UNBALANCED_RESTORE`
+   * を push する。省略時は従来通り無警告 no-op（後方互換）。
    *
    * @param stack - 復元元スタック
+   * @param warnings - unbalanced 時に警告を push する buffer（省略時は無警告）
    * @returns 復元後の新しい `GraphicsStateStack`
    */
-  restore(stack: GraphicsStateStack): GraphicsStateStack {
+  restore(
+    stack: GraphicsStateStack,
+    warnings?: PdfWarning[],
+  ): GraphicsStateStack {
     const lastIndex = stack.saved.length - 1;
     if (lastIndex < 0) {
+      if (warnings !== undefined) {
+        warnings.push({
+          code: "UNBALANCED_RESTORE",
+          message:
+            "Q operator called with empty graphics state stack (no matching q)",
+        });
+      }
       return {
         current: stack.current,
         saved: [],

--- a/packages/core/src/content-stream/graphics-state/stack/index.ts
+++ b/packages/core/src/content-stream/graphics-state/stack/index.ts
@@ -109,7 +109,7 @@ export const GraphicsStateStack = {
         warning: {
           code: "UNBALANCED_RESTORE",
           message:
-            "Q operator called with empty graphics state stack (no matching q)",
+            "Cannot restore graphics state: no saved state on stack (unbalanced restore)",
         },
       };
     }

--- a/packages/core/src/content-stream/graphics-state/stack/index.ts
+++ b/packages/core/src/content-stream/graphics-state/stack/index.ts
@@ -26,6 +26,16 @@ export type GraphicsStateStack = Brand<
   typeof GraphicsStateStackBrand
 >;
 
+/**
+ * `GraphicsStateStack.restore` の返却型。
+ * `stack` は復元後の新しいスタック、`warning` は unbalanced restore を
+ * 検出したときに `UNBALANCED_RESTORE` を含む。それ以外は `undefined`。
+ */
+export interface RestoreResult {
+  stack: GraphicsStateStack;
+  warning?: PdfWarning;
+}
+
 export const GraphicsStateStack = {
   /**
    * デフォルトグラフィックスステートを current に持つスタックを生成する。
@@ -81,37 +91,35 @@ export const GraphicsStateStack = {
 
   /**
    * 直近に保存したグラフィックスステートを復元する。
-   * 保存状態がない場合は no-op で新しい stack（current 維持、saved:[]）を返す。
-   * `warnings` を渡した場合、unbalanced restore 検出時に `UNBALANCED_RESTORE`
-   * を push する。省略時は従来通り無警告 no-op（後方互換）。
+   * 保存状態がない場合は no-op で新しい stack（current 維持、saved:[]）を返し、
+   * `warning: UNBALANCED_RESTORE` を含む結果を返す。呼び出し元は `warning`
+   * 未使用時はそのまま無視できる。
    *
    * @param stack - 復元元スタック
-   * @param warnings - unbalanced 時に警告を push する buffer（省略時は無警告）
-   * @returns 復元後の新しい `GraphicsStateStack`
+   * @returns 復元後の `GraphicsStateStack` と、unbalanced 検出時の警告（あれば）
    */
-  restore(
-    stack: GraphicsStateStack,
-    warnings?: PdfWarning[],
-  ): GraphicsStateStack {
+  restore(stack: GraphicsStateStack): RestoreResult {
     const lastIndex = stack.saved.length - 1;
     if (lastIndex < 0) {
-      if (warnings !== undefined) {
-        warnings.push({
+      return {
+        stack: {
+          current: stack.current,
+          saved: [],
+        } as unknown as GraphicsStateStack,
+        warning: {
           code: "UNBALANCED_RESTORE",
           message:
             "Q operator called with empty graphics state stack (no matching q)",
-        });
-      }
-      return {
-        current: stack.current,
-        saved: [],
-      } as unknown as GraphicsStateStack;
+        },
+      };
     }
 
     const state = stack.saved[lastIndex] as GraphicsState;
     return {
-      current: state,
-      saved: stack.saved.slice(0, lastIndex),
-    } as unknown as GraphicsStateStack;
+      stack: {
+        current: state,
+        saved: stack.saved.slice(0, lastIndex),
+      } as unknown as GraphicsStateStack,
+    };
   },
 } as const;

--- a/packages/core/src/content-stream/interpreter/__tests__/interpreter.dispatch.test.ts
+++ b/packages/core/src/content-stream/interpreter/__tests__/interpreter.dispatch.test.ts
@@ -451,9 +451,8 @@ test("qとQはregistry handler経由でgraphics state stackを更新する", () 
   const registry = registerOperator(changeRegistry, "Q", (context) =>
     ok({
       ...context,
-      graphicsStateStack: GraphicsStateStack.restore(
-        context.graphicsStateStack,
-      ),
+      graphicsStateStack: GraphicsStateStack.restore(context.graphicsStateStack)
+        .stack,
     }),
   );
 

--- a/packages/core/src/content-stream/operators/graphics-state/graphics-state-operators/__tests__/graphics-state-operators.integration.test.ts
+++ b/packages/core/src/content-stream/operators/graphics-state/graphics-state-operators/__tests__/graphics-state-operators.integration.test.ts
@@ -23,7 +23,8 @@ const qHandler: OperatorHandler = (context) =>
 const qRestoreHandler: OperatorHandler = (context) =>
   ok({
     ...context,
-    graphicsStateStack: GraphicsStateStack.restore(context.graphicsStateStack),
+    graphicsStateStack: GraphicsStateStack.restore(context.graphicsStateStack)
+      .stack,
   });
 
 test("barrel 経由で `1 0 0 1 100 200 cm 2 w` を実行すると CTM と lineWidth が更新される", () => {

--- a/packages/core/src/content-stream/operators/path/fill-stroke/__tests__/fill-stroke.basic.test.ts
+++ b/packages/core/src/content-stream/operators/path/fill-stroke/__tests__/fill-stroke.basic.test.ts
@@ -301,7 +301,7 @@ test("`q` 済み (saved state あり) 状態で `B` を実行しても saved sta
 
   assert(result.ok);
 
-  const restoredAfter = GraphicsStateStack.restore(
+  const { stack: restoredAfter } = GraphicsStateStack.restore(
     result.value.graphicsStateStack,
   );
   const restoredAfterCurrent = GraphicsStateStack.current(restoredAfter);
@@ -311,7 +311,9 @@ test("`q` 済み (saved state あり) 状態で `B` を実行しても saved sta
     PathSegment.moveTo(0, 0),
   ]);
 
-  const restoredInput = GraphicsStateStack.restore(ctx.graphicsStateStack);
+  const { stack: restoredInput } = GraphicsStateStack.restore(
+    ctx.graphicsStateStack,
+  );
   const restoredInputCurrent = GraphicsStateStack.current(restoredInput);
   expect(restoredInputCurrent.lineWidth).toBe(5);
   expect(restoredInputCurrent.ctm).toBe(savedCtm);

--- a/packages/core/src/content-stream/operators/path/fill/__tests__/fill.basic.test.ts
+++ b/packages/core/src/content-stream/operators/path/fill/__tests__/fill.basic.test.ts
@@ -301,7 +301,7 @@ test("`q` 済み (saved state あり) 状態で `f` を実行しても saved sta
 
   assert(result.ok);
 
-  const restoredAfter = GraphicsStateStack.restore(
+  const { stack: restoredAfter } = GraphicsStateStack.restore(
     result.value.graphicsStateStack,
   );
   const restoredAfterCurrent = GraphicsStateStack.current(restoredAfter);
@@ -311,7 +311,9 @@ test("`q` 済み (saved state あり) 状態で `f` を実行しても saved sta
     PathSegment.moveTo(0, 0),
   ]);
 
-  const restoredInput = GraphicsStateStack.restore(ctx.graphicsStateStack);
+  const { stack: restoredInput } = GraphicsStateStack.restore(
+    ctx.graphicsStateStack,
+  );
   const restoredInputCurrent = GraphicsStateStack.current(restoredInput);
   expect(restoredInputCurrent.lineWidth).toBe(5);
   expect(restoredInputCurrent.ctm).toBe(savedCtm);

--- a/packages/core/src/content-stream/operators/xobject/xobject-operators/__tests__/xobject-operators.integration.test.ts
+++ b/packages/core/src/content-stream/operators/xobject/xobject-operators/__tests__/xobject-operators.integration.test.ts
@@ -27,7 +27,8 @@ const qHandler: OperatorHandler = (context) =>
 const qRestoreHandler: OperatorHandler = (context) =>
   ok({
     ...context,
-    graphicsStateStack: GraphicsStateStack.restore(context.graphicsStateStack),
+    graphicsStateStack: GraphicsStateStack.restore(context.graphicsStateStack)
+      .stack,
   });
 
 // XObject + text-state + graphics-state (cm/w/J/j/M) + inline q/Q を併用登録した registry を作るヘルパ。

--- a/packages/core/src/document/catalog/catalog-parser/__tests__/catalog-parser.behavior.test.ts
+++ b/packages/core/src/document/catalog/catalog-parser/__tests__/catalog-parser.behavior.test.ts
@@ -1,5 +1,6 @@
 import { expect, test } from "vitest";
 import type { PdfError } from "../../../../pdf/errors/error/index";
+import type { PdfWarning } from "../../../../pdf/errors/warning/index";
 import type {
   PdfObject,
   PdfValue,
@@ -196,7 +197,7 @@ test("/Type /Catalog + /Pages 間接参照が揃う場合 Ok を返す", async (
   expect(parsed.version as string).toBe("1.7");
 });
 
-test("/Version が欠損ならヘッダバージョンを採用", async () => {
+test("/Version が欠損ならヘッダバージョンを採用し warnings は空", async () => {
   const entries = makeCatalogEntries({
     type: validCatalogName,
     pages: validPagesRef,
@@ -207,13 +208,17 @@ test("/Version が欠損ならヘッダバージョンを採用", async () => {
     resolveToDict(entries),
   );
   expect(result.ok).toBe(true);
-  expect(
-    (result as { ok: true; value: { version: string } }).value
-      .version as string,
-  ).toBe("1.7");
+  const parsed = (
+    result as {
+      ok: true;
+      value: { version: string; warnings: readonly PdfWarning[] };
+    }
+  ).value;
+  expect(parsed.version as string).toBe("1.7");
+  expect(parsed.warnings).toHaveLength(0);
 });
 
-test("/Version が name でなければヘッダを採用", async () => {
+test("/Version が name でなければヘッダを採用し warnings は空", async () => {
   const entries = makeCatalogEntries({
     type: validCatalogName,
     pages: validPagesRef,
@@ -225,17 +230,27 @@ test("/Version が name でなければヘッダを採用", async () => {
     resolveToDict(entries),
   );
   expect(result.ok).toBe(true);
-  expect(
-    (result as { ok: true; value: { version: string } }).value
-      .version as string,
-  ).toBe("1.7");
+  const parsed = (
+    result as {
+      ok: true;
+      value: { version: string; warnings: readonly PdfWarning[] };
+    }
+  ).value;
+  expect(parsed.version as string).toBe("1.7");
+  expect(parsed.warnings).toHaveLength(0);
 });
 
-test("/Version が major.minor 形式でなければヘッダを採用", async () => {
+test.each([
+  "1.x",
+  "BogusName",
+  "1.2.3",
+  "",
+])("/Version が不正 name '%s' の場合 CATALOG_VERSION_INVALID を warnings に push しヘッダを採用", async (invalidName) => {
+  // pickNewerVersion は PdfVersion.create 失敗時に 1 件 warning を push、ヘッダ版へ fallback
   const entries = makeCatalogEntries({
     type: validCatalogName,
     pages: validPagesRef,
-    version: { type: "name", value: "1.x" },
+    version: { type: "name", value: invalidName },
   });
   const result = await CatalogParser.parse(
     makeTrailerDict(makeRef(1)),
@@ -243,10 +258,37 @@ test("/Version が major.minor 形式でなければヘッダを採用", async (
     resolveToDict(entries),
   );
   expect(result.ok).toBe(true);
-  expect(
-    (result as { ok: true; value: { version: string } }).value
-      .version as string,
-  ).toBe("1.7");
+  const parsed = (
+    result as {
+      ok: true;
+      value: { version: string; warnings: readonly PdfWarning[] };
+    }
+  ).value;
+  expect(parsed.version as string).toBe("1.7");
+  expect(parsed.warnings).toHaveLength(1);
+  expect(parsed.warnings[0]?.code).toBe("CATALOG_VERSION_INVALID");
+});
+
+test("CATALOG_VERSION_INVALID の message に invalid name が含まれる", () => {
+  // 検証補助: message から何が invalid だったか特定できる
+  const invalidName = "BogusName";
+  return CatalogParser.parse(
+    makeTrailerDict(makeRef(1)),
+    pdfVersion("1.7"),
+    resolveToDict(
+      makeCatalogEntries({
+        type: validCatalogName,
+        pages: validPagesRef,
+        version: { type: "name", value: invalidName },
+      }),
+    ),
+  ).then((result) => {
+    expect(result.ok).toBe(true);
+    const parsed = (
+      result as { ok: true; value: { warnings: readonly PdfWarning[] } }
+    ).value;
+    expect(parsed.warnings[0]?.message).toContain(invalidName);
+  });
 });
 
 test("/Version がヘッダと同値ならヘッダを採用", async () => {

--- a/packages/core/src/document/catalog/catalog-parser/index.ts
+++ b/packages/core/src/document/catalog/catalog-parser/index.ts
@@ -110,46 +110,58 @@ const extractPagesRef = (
 };
 
 /**
+ * `pickNewerVersion` の返却型。
+ * 採用バージョンと、発行された警告（あれば）を含む。
+ */
+interface PickNewerVersionResult {
+  version: PdfVersion;
+  warnings: readonly PdfWarning[];
+}
+
+/**
  * カタログ辞書の `/Version` とヘッダバージョンを比較し、採用するバージョンを決める。
  * `/Version` が name で存在するが `PdfVersion.create` に失敗した場合、
- * `CATALOG_VERSION_INVALID` 警告を warnings buffer に push してヘッダ版へフォールバックする。
+ * `CATALOG_VERSION_INVALID` 警告を含めてヘッダ版へフォールバックする。
  * `/Version` 不在または `type !== "name"` の場合は警告を発行しない。
  *
  * @param entries - カタログ辞書のエントリ
  * @param headerVersion - PDF ヘッダ由来のバージョン
- * @param warnings - 警告を push する buffer（呼び出し元で mutable 配列を渡す）
- * @returns ヘッダ / カタログのうち大きい方（不正・同値時はヘッダ）
+ * @returns 採用バージョンと警告配列。不正な `/Version` name の場合のみ
+ *   `warnings` に `CATALOG_VERSION_INVALID` を含む
  */
 const pickNewerVersion = (
   entries: Map<string, PdfValue>,
   headerVersion: PdfVersion,
-  warnings: PdfWarning[],
-): PdfVersion => {
+): PickNewerVersionResult => {
   const versionEntry = entries.get("Version");
 
   if (versionEntry === undefined || versionEntry.type !== "name") {
-    return headerVersion;
+    return { version: headerVersion, warnings: [] };
   }
 
   const catalogVersionResult = PdfVersion.create(versionEntry.value);
 
   if (!catalogVersionResult.ok) {
-    warnings.push({
-      code: "CATALOG_VERSION_INVALID",
-      message:
-        `Catalog /Version '${versionEntry.value}' is not a valid PDF version ` +
-        `(${catalogVersionResult.error}); using header version`,
-    });
-    return headerVersion;
+    return {
+      version: headerVersion,
+      warnings: [
+        {
+          code: "CATALOG_VERSION_INVALID",
+          message:
+            `Catalog /Version '${versionEntry.value}' is not a valid PDF version ` +
+            `(${catalogVersionResult.error}); using header version`,
+        },
+      ],
+    };
   }
 
   const catalogVersion = catalogVersionResult.value;
 
   if (PdfVersion.compare(catalogVersion, headerVersion) > 0) {
-    return catalogVersion;
+    return { version: catalogVersion, warnings: [] };
   }
 
-  return headerVersion;
+  return { version: headerVersion, warnings: [] };
 };
 
 /**
@@ -197,8 +209,10 @@ export const CatalogParser = {
       return pagesRefResult;
     }
 
-    const warnings: PdfWarning[] = [];
-    const version = pickNewerVersion(catalog.entries, headerVersion, warnings);
+    const { version, warnings } = pickNewerVersion(
+      catalog.entries,
+      headerVersion,
+    );
 
     return ok({
       catalog,

--- a/packages/core/src/document/catalog/catalog-parser/index.ts
+++ b/packages/core/src/document/catalog/catalog-parser/index.ts
@@ -1,5 +1,6 @@
 import { NumberEx } from "../../../ext/number/index";
 import type { PdfError, PdfParseError } from "../../../pdf/errors/error/index";
+import type { PdfWarning } from "../../../pdf/errors/warning/index";
 import { GenerationNumber } from "../../../pdf/types/generation-number/index";
 import { ObjectNumber } from "../../../pdf/types/object-number/index";
 import { PdfType } from "../../../pdf/types/pdf-type/index";
@@ -33,6 +34,11 @@ export interface ParsedCatalog {
   pagesRef: IndirectRef;
   /** 採用 PDF バージョン（ヘッダ / カタログのうち新しい方） */
   version: PdfVersion;
+  /**
+   * カタログ解析中に検出された回復可能な警告。
+   * 呼び出し元からは読み取り専用として扱う（内部生成のみ mutable）。
+   */
+  warnings: readonly PdfWarning[];
 }
 
 /**
@@ -105,14 +111,19 @@ const extractPagesRef = (
 
 /**
  * カタログ辞書の `/Version` とヘッダバージョンを比較し、採用するバージョンを決める。
+ * `/Version` が name で存在するが `PdfVersion.create` に失敗した場合、
+ * `CATALOG_VERSION_INVALID` 警告を warnings buffer に push してヘッダ版へフォールバックする。
+ * `/Version` 不在または `type !== "name"` の場合は警告を発行しない。
  *
  * @param entries - カタログ辞書のエントリ
  * @param headerVersion - PDF ヘッダ由来のバージョン
+ * @param warnings - 警告を push する buffer（呼び出し元で mutable 配列を渡す）
  * @returns ヘッダ / カタログのうち大きい方（不正・同値時はヘッダ）
  */
 const pickNewerVersion = (
   entries: Map<string, PdfValue>,
   headerVersion: PdfVersion,
+  warnings: PdfWarning[],
 ): PdfVersion => {
   const versionEntry = entries.get("Version");
 
@@ -123,6 +134,12 @@ const pickNewerVersion = (
   const catalogVersionResult = PdfVersion.create(versionEntry.value);
 
   if (!catalogVersionResult.ok) {
+    warnings.push({
+      code: "CATALOG_VERSION_INVALID",
+      message:
+        `Catalog /Version '${versionEntry.value}' is not a valid PDF version ` +
+        `(${catalogVersionResult.error}); using header version`,
+    });
     return headerVersion;
   }
 
@@ -180,12 +197,14 @@ export const CatalogParser = {
       return pagesRefResult;
     }
 
-    const version = pickNewerVersion(catalog.entries, headerVersion);
+    const warnings: PdfWarning[] = [];
+    const version = pickNewerVersion(catalog.entries, headerVersion, warnings);
 
     return ok({
       catalog,
       pagesRef: pagesRefResult.value,
       version,
+      warnings,
     });
   },
 } as const;

--- a/packages/core/src/document/pdf-document/__tests__/pdf-document.test.helpers.ts
+++ b/packages/core/src/document/pdf-document/__tests__/pdf-document.test.helpers.ts
@@ -295,6 +295,24 @@ export const buildPdfWithCorruptXRefAndNoTrailer = (): Uint8Array => {
 };
 
 /**
+ * `/Version` に不正な name を持つ Catalog + 1 ページの PDF を生成する。
+ *
+ * Catalog (1 0 obj) の body に `/Version /BogusName` を追加し、
+ * `PdfVersion.create("BogusName")` を失敗させる。`CatalogParser.parse` は
+ * `CATALOG_VERSION_INVALID` warning を `ParsedCatalog.warnings` に push し、
+ * `pdf-document/index.ts` の `emitWarnings` が `onWarning` へ配線する。
+ * `PdfDocument.load` の e2e smoke テストで使用する。
+ *
+ * @returns 不正 `/Version` name を持つ 1 ページ PDF のバイト列
+ */
+export const buildPdfWithInvalidCatalogVersion = (): Uint8Array =>
+  assembleTextPdf([
+    "<< /Type /Catalog /Pages 2 0 R /Version /BogusName >>",
+    PAGES_BODY_SINGLE,
+    PAGE_BODY,
+  ]);
+
+/**
  * ヘッダのみで本体を持たない PDF を生成する。
  *
  * `%PDF-1.7\n%%EOF\n` のみを返す。`startxref` キーワードが存在しないため、

--- a/packages/core/src/document/pdf-document/__tests__/pdf-document.warning.test.ts
+++ b/packages/core/src/document/pdf-document/__tests__/pdf-document.warning.test.ts
@@ -4,6 +4,7 @@ import { PdfDocument } from "../../pdf-document";
 import {
   buildMinimalSinglePagePdf,
   buildPdfWithCorruptStartXRef,
+  buildPdfWithInvalidCatalogVersion,
   buildPdfWithInvalidInfoRef,
 } from "./pdf-document.test.helpers";
 
@@ -47,4 +48,23 @@ test("/Info の参照が不正な PDF を load すると INFO_RESOLVE_FAILED war
   assert(result.ok);
   expect(Object.keys(result.value.metadata)).toHaveLength(0);
   expect(seen.map((w) => w.code)).toEqual(["INFO_RESOLVE_FAILED"]);
+});
+
+test("Catalog /Version が invalid name の PDF を onWarning 指定で load すると CATALOG_VERSION_INVALID が観測される", async () => {
+  // CatalogParser.parse が返す warnings が pdf-document/index.ts:293 の
+  // emitWarnings 経由で onWarning に伝わる e2e smoke。
+  const seen: PdfWarning[] = [];
+  const result = await PdfDocument.load(buildPdfWithInvalidCatalogVersion(), {
+    onWarning: (w) => seen.push(w),
+  });
+
+  assert(result.ok);
+  expect(seen.map((w) => w.code)).toContain("CATALOG_VERSION_INVALID");
+});
+
+test("Catalog /Version が invalid name でも onWarning 未指定なら load は Ok を返す", async () => {
+  // warning はエラーにならない後方互換の smoke
+  const result = await PdfDocument.load(buildPdfWithInvalidCatalogVersion());
+
+  assert(result.ok);
 });

--- a/packages/core/src/document/pdf-document/index.ts
+++ b/packages/core/src/document/pdf-document/index.ts
@@ -297,6 +297,7 @@ export class PdfDocument {
     if (!catalogResult.ok) {
       return catalogResult;
     }
+    emitWarnings(catalogResult.value.warnings);
 
     const walkResult = await PageTreeWalker.walk(
       catalogResult.value.pagesRef,

--- a/packages/core/src/pdf/errors/error/__tests__/error.type-export.test.ts
+++ b/packages/core/src/pdf/errors/error/__tests__/error.type-export.test.ts
@@ -50,6 +50,7 @@ const allPdfParseErrorCodes = [
   "PAGES_NOT_FOUND",
   "CATALOG_ROOT_NOT_DICTIONARY",
   "NOT_IMPLEMENTED",
+  "XREF_MAX_DEPTH_INVALID",
 ] as const satisfies readonly PdfParseErrorCode[];
 
 // 配列の要素型がPdfParseErrorCodeと完全一致することを型レベルで保証
@@ -61,7 +62,7 @@ const _exhaustive: Exact<
 
 test("PdfParseErrorCodeは網羅的に列挙されている", () => {
   expect(_exhaustive).toBe(true);
-  expect(allPdfParseErrorCodes).toHaveLength(26);
+  expect(allPdfParseErrorCodes).toHaveLength(27);
 });
 
 test("型エクスポートが利用可能", () => {

--- a/packages/core/src/pdf/errors/error/index.ts
+++ b/packages/core/src/pdf/errors/error/index.ts
@@ -3,11 +3,12 @@ import type { ObjectId } from "../../types/index";
 
 /**
  * PDFパースエラーのエラーコード。
- * 構造的・構文的な問題、および未実装機能など実装側都合の致命的エラーを分類する。
+ * 構造的・構文的な問題、未実装機能、および
+ * ライブラリ API への不正な入力（呼び出し元の契約違反）による致命的エラーを分類する。
  *
  * @example
  * ```ts
- * const code: PdfParseErrorCode = "STARTXREF_NOT_FOUND";
+ * const code: PdfParseErrorCode = "XREF_MAX_DEPTH_INVALID";
  * ```
  */
 export type PdfParseErrorCode =
@@ -36,7 +37,8 @@ export type PdfParseErrorCode =
   | "CATALOG_TYPE_INVALID"
   | "PAGES_NOT_FOUND"
   | "CATALOG_ROOT_NOT_DICTIONARY"
-  | "NOT_IMPLEMENTED";
+  | "NOT_IMPLEMENTED"
+  | "XREF_MAX_DEPTH_INVALID";
 
 /**
  * 全致命的PDFエラーコードの共用体型。

--- a/packages/core/src/pdf/errors/warning/__tests__/warning.type.test.ts
+++ b/packages/core/src/pdf/errors/warning/__tests__/warning.type.test.ts
@@ -45,3 +45,8 @@ test("PdfWarningCode に CATALOG_VERSION_INVALID が含まれる", () => {
   const code: PdfWarningCode = "CATALOG_VERSION_INVALID";
   expect(code).toBe("CATALOG_VERSION_INVALID");
 });
+
+test("PdfWarningCode に UNBALANCED_RESTORE が含まれる", () => {
+  const code: PdfWarningCode = "UNBALANCED_RESTORE";
+  expect(code).toBe("UNBALANCED_RESTORE");
+});

--- a/packages/core/src/pdf/errors/warning/__tests__/warning.type.test.ts
+++ b/packages/core/src/pdf/errors/warning/__tests__/warning.type.test.ts
@@ -40,3 +40,8 @@ test("PdfWarningCode に TRAPPED_INVALID が含まれる", () => {
   const code: PdfWarningCode = "TRAPPED_INVALID";
   expect(code).toBe("TRAPPED_INVALID");
 });
+
+test("PdfWarningCode に CATALOG_VERSION_INVALID が含まれる", () => {
+  const code: PdfWarningCode = "CATALOG_VERSION_INVALID";
+  expect(code).toBe("CATALOG_VERSION_INVALID");
+});

--- a/packages/core/src/pdf/errors/warning/index.ts
+++ b/packages/core/src/pdf/errors/warning/index.ts
@@ -27,7 +27,8 @@ export type PdfWarningCode =
   | "STRING_DECODE_FAILED"
   | "TRAPPED_INVALID"
   | "UNKNOWN_OPERATOR"
-  | "CATALOG_VERSION_INVALID";
+  | "CATALOG_VERSION_INVALID"
+  | "UNBALANCED_RESTORE";
 
 /**
  * 回復可能なPDF問題の警告。

--- a/packages/core/src/pdf/errors/warning/index.ts
+++ b/packages/core/src/pdf/errors/warning/index.ts
@@ -4,7 +4,7 @@
  *
  * @example
  * ```ts
- * const code: PdfWarningCode = "EOF_NOT_FOUND";
+ * const code: PdfWarningCode = "CATALOG_VERSION_INVALID";
  * ```
  */
 export type PdfWarningCode =
@@ -26,7 +26,8 @@ export type PdfWarningCode =
   | "INFO_NOT_DICTIONARY"
   | "STRING_DECODE_FAILED"
   | "TRAPPED_INVALID"
-  | "UNKNOWN_OPERATOR";
+  | "UNKNOWN_OPERATOR"
+  | "CATALOG_VERSION_INVALID";
 
 /**
  * 回復可能なPDF問題の警告。

--- a/packages/core/src/xref/merger/__tests__/merger.boundary.test.ts
+++ b/packages/core/src/xref/merger/__tests__/merger.boundary.test.ts
@@ -92,13 +92,60 @@ test("maxDepth オプション指定: カスタム深さ制限が適用される
   expect(result.error.code).toBe("XREF_PREV_CHAIN_TOO_DEEP");
 });
 
+test("maxDepth 未指定（options 省略）はデフォルト 100 で単一 xref を成功させる", () => {
+  // 未指定経路: options 省略時に MaxDepth.DEFAULT (100) が採用され成功
+  const callback: ParseCallback = (_offset: ByteOffset) =>
+    ok({
+      xref: makeXRef([[1, usedEntry(100)]], 2),
+      trailer: makeTrailer(2),
+    });
+
+  const result = mergeXRefChain(ByteOffset.of(500), callback);
+
+  assert(result.ok);
+  expect(result.value.mergedXRef.size).toBe(2);
+});
+
+test("maxDepth: undefined 明示指定でもデフォルト 100 が適用される", () => {
+  // 明示 undefined でも MaxDepth.DEFAULT が採用される
+  const callback: ParseCallback = (_offset: ByteOffset) =>
+    ok({
+      xref: makeXRef([[1, usedEntry(100)]], 2),
+      trailer: makeTrailer(2),
+    });
+
+  const result = mergeXRefChain(ByteOffset.of(500), callback, {
+    maxDepth: undefined,
+  });
+
+  assert(result.ok);
+});
+
+test("maxDepth = Number.MAX_SAFE_INTEGER で単一 xref を成功させる", () => {
+  // safe integer 上限も有効値として受理される
+  const callback: ParseCallback = (_offset: ByteOffset) =>
+    ok({
+      xref: makeXRef([[1, usedEntry(100)]], 2),
+      trailer: makeTrailer(2),
+    });
+
+  const result = mergeXRefChain(ByteOffset.of(500), callback, {
+    maxDepth: Number.MAX_SAFE_INTEGER,
+  });
+
+  assert(result.ok);
+});
+
 test.each([
   0,
   -1,
-  NaN,
   1.5,
   Infinity,
-])("maxDepth に無効値 %s を渡した場合、デフォルト値（100）が適用される", (invalidValue) => {
+  -Infinity,
+  Number.MAX_SAFE_INTEGER + 1,
+])("maxDepth に無効値 %s を渡した場合、XREF_MAX_DEPTH_INVALID を返す", (invalidValue) => {
+  // 異常系: 詳細な境界値は max-depth.validation.test.ts に集約。
+  // ここでは「mergeXRefChain が MaxDepth.create の Err を素通しする」ことを確認する
   const callback: ParseCallback = (_offset: ByteOffset) =>
     ok({
       xref: makeXRef([[1, usedEntry(100)]], 2),
@@ -109,8 +156,36 @@ test.each([
     maxDepth: invalidValue,
   });
 
-  assert(
-    result.ok,
-    `maxDepth=${invalidValue} should fallback to default and succeed`,
-  );
+  assert(!result.ok);
+  expect(result.error.code).toBe("XREF_MAX_DEPTH_INVALID");
+});
+
+test("maxDepth = NaN で XREF_MAX_DEPTH_INVALID を返す", () => {
+  // NaN は test.each の label 表示が壊れるため単独 test に分離
+  const callback: ParseCallback = (_offset: ByteOffset) =>
+    ok({
+      xref: makeXRef([[1, usedEntry(100)]], 2),
+      trailer: makeTrailer(2),
+    });
+
+  const result = mergeXRefChain(ByteOffset.of(500), callback, {
+    maxDepth: NaN,
+  });
+
+  assert(!result.ok);
+  expect(result.error.code).toBe("XREF_MAX_DEPTH_INVALID");
+});
+
+test("XREF_MAX_DEPTH_INVALID の message に invalid 値が含まれる", () => {
+  // 検証補助: エラーメッセージから何が invalid だったかが分かる
+  const callback: ParseCallback = (_offset: ByteOffset) =>
+    ok({
+      xref: makeXRef([[1, usedEntry(100)]], 2),
+      trailer: makeTrailer(2),
+    });
+
+  const result = mergeXRefChain(ByteOffset.of(500), callback, { maxDepth: -1 });
+
+  assert(!result.ok);
+  expect(result.error.message).toContain("-1");
 });

--- a/packages/core/src/xref/merger/index.ts
+++ b/packages/core/src/xref/merger/index.ts
@@ -1,12 +1,10 @@
-import { NumberEx } from "../../ext/number/index";
 import type { PdfParseError } from "../../pdf/errors/index";
 import type { ByteOffset } from "../../pdf/types/byte-offset/index";
 import type { TrailerDict, XRefEntry, XRefTable } from "../../pdf/types/index";
 import type { ObjectNumber } from "../../pdf/types/object-number/index";
 import type { Err, Result } from "../../utils/result/index";
 import { err, ok } from "../../utils/result/index";
-
-const DEFAULT_MAX_PREV_CHAIN_DEPTH = 100;
+import { MaxDepth } from "./max-depth/index";
 
 /**
  * /Prevチェーン走査エラーを生成する。
@@ -22,18 +20,6 @@ function failPrevChain(
   offset?: ByteOffset,
 ): Err<PdfParseError> {
   return err({ code, message, offset });
-}
-
-/**
- * maxDepth オプションを検証し、有効な値またはデフォルト値を返す。
- *
- * @param maxDepth - ユーザー指定の最大深さ（未定義または無効値の場合デフォルト適用）
- * @returns 有効な最大深さ
- */
-function resolveMaxDepth(maxDepth: number | undefined): number {
-  return maxDepth !== undefined && NumberEx.isPositiveSafeInteger(maxDepth)
-    ? maxDepth
-    : DEFAULT_MAX_PREV_CHAIN_DEPTH;
 }
 
 /**
@@ -75,8 +61,12 @@ type XRefParseCallback = (
  *
  * @param startOffset - 最初のxrefセクションのバイトオフセット（startxrefの値）
  * @param parseCallback - オフセットからxref+trailerをパースするコールバック
- * @param options - オプション（maxDepth: /Prevチェーンの最大走査深さ、デフォルト100）
- * @returns マージ済みXRefTableと最新TrailerDict、またはPdfParseError
+ * @param options - オプション（maxDepth: /Prevチェーンの最大走査深さ。
+ *   `undefined` は既定値 100 を採用、正の safe integer 以外は
+ *   `XREF_MAX_DEPTH_INVALID` を含む Err）
+ * @returns マージ済みXRefTableと最新TrailerDict、
+ *   maxDepth 不正時は `XREF_MAX_DEPTH_INVALID`、
+ *   その他の失敗時は該当する `PdfParseError`
  */
 export function mergeXRefChain(
   startOffset: ByteOffset,
@@ -86,7 +76,11 @@ export function mergeXRefChain(
   { mergedXRef: XRefTable; latestTrailer: TrailerDict },
   PdfParseError
 > {
-  const maxDepth = resolveMaxDepth(options?.maxDepth);
+  const maxDepthResult = MaxDepth.create(options?.maxDepth);
+  if (!maxDepthResult.ok) {
+    return maxDepthResult;
+  }
+  const maxDepth = maxDepthResult.value;
   const traversedOffsets = new Set<ByteOffset>();
   const chain: Array<{ xref: XRefTable; trailer: TrailerDict }> = [];
 
@@ -102,10 +96,10 @@ export function mergeXRefChain(
       );
     }
 
-    if (depth >= maxDepth) {
+    if (depth >= (maxDepth as number)) {
       return failPrevChain(
         "XREF_PREV_CHAIN_TOO_DEEP",
-        `/Prev chain exceeds maximum depth of ${maxDepth}`,
+        `/Prev chain exceeds maximum depth of ${String(maxDepth as number)}`,
         currentOffset,
       );
     }

--- a/packages/core/src/xref/merger/max-depth/__tests__/max-depth.validation.test.ts
+++ b/packages/core/src/xref/merger/max-depth/__tests__/max-depth.validation.test.ts
@@ -1,0 +1,59 @@
+import { assert, expect, test } from "vitest";
+import { MaxDepth } from "../index";
+
+test("MaxDepth.create(undefined) は MaxDepth.DEFAULT を含む Ok を返す", () => {
+  // 未指定経路: undefined を渡すと default 100 が採用される
+  const result = MaxDepth.create(undefined);
+
+  assert(result.ok);
+  expect(result.value).toBe(MaxDepth.DEFAULT);
+});
+
+test.each([
+  1,
+  42,
+  100,
+  Number.MAX_SAFE_INTEGER,
+])("正の safe integer %s は同値を Brand 化した Ok を返す", (n) => {
+  // 正常系: 有効な正整数は Brand 化されて返る
+  const result = MaxDepth.create(n);
+
+  assert(result.ok);
+  expect(result.value as number).toBe(n);
+});
+
+test.each([
+  0,
+  -1,
+  1.5,
+  Infinity,
+  -Infinity,
+  Number.MAX_SAFE_INTEGER + 1,
+])("不正値 %s は XREF_MAX_DEPTH_INVALID を返す", (invalid) => {
+  // 異常系: 0 / 負数 / 非整数 / ±Infinity / safe integer 超過は全て Err
+  const result = MaxDepth.create(invalid);
+
+  assert(!result.ok);
+  expect(result.error.code).toBe("XREF_MAX_DEPTH_INVALID");
+});
+
+test("MaxDepth.create(NaN) は XREF_MAX_DEPTH_INVALID を返す", () => {
+  // NaN は test.each の label 表示が壊れるため単独で検証
+  const result = MaxDepth.create(NaN);
+
+  assert(!result.ok);
+  expect(result.error.code).toBe("XREF_MAX_DEPTH_INVALID");
+});
+
+test("XREF_MAX_DEPTH_INVALID の message に invalid 値が含まれる", () => {
+  // 検証補助: エラーメッセージから何が invalid だったかが分かる
+  const result = MaxDepth.create(-1);
+
+  assert(!result.ok);
+  expect(result.error.message).toContain("-1");
+});
+
+test("MaxDepth.DEFAULT は 100 に等しい", () => {
+  // 定数値の契約: DEFAULT は 100（既存 mergeXRefChain の default 動作と同値）
+  expect(MaxDepth.DEFAULT as number).toBe(100);
+});

--- a/packages/core/src/xref/merger/max-depth/index.ts
+++ b/packages/core/src/xref/merger/max-depth/index.ts
@@ -40,7 +40,7 @@ export const MaxDepth = {
    */
   create(n: number | undefined): Result<MaxDepth, PdfParseError> {
     if (n === undefined) {
-      return ok(DEFAULT_MAX_PREV_CHAIN_DEPTH as MaxDepth);
+      return ok(MaxDepth.DEFAULT);
     }
     if (!NumberEx.isPositiveSafeInteger(n)) {
       return err({

--- a/packages/core/src/xref/merger/max-depth/index.ts
+++ b/packages/core/src/xref/merger/max-depth/index.ts
@@ -1,5 +1,5 @@
 import { NumberEx } from "../../../ext/number/index";
-import type { PdfParseError } from "../../../pdf/errors/error/index";
+import type { PdfParseError } from "../../../pdf/errors/index";
 import type { Brand } from "../../../utils/brand/index";
 import type { Result } from "../../../utils/result/index";
 import { err, ok } from "../../../utils/result/index";

--- a/packages/core/src/xref/merger/max-depth/index.ts
+++ b/packages/core/src/xref/merger/max-depth/index.ts
@@ -1,0 +1,53 @@
+import { NumberEx } from "../../../ext/number/index";
+import type { PdfParseError } from "../../../pdf/errors/error/index";
+import type { Brand } from "../../../utils/brand/index";
+import type { Result } from "../../../utils/result/index";
+import { err, ok } from "../../../utils/result/index";
+
+declare const MaxDepthBrand: unique symbol;
+
+/**
+ * `mergeXRefChain` の `/Prev` チェーン走査上限。
+ * 正の safe integer のみが有効値。生の `number` から `MaxDepth.create` 経由でのみ
+ * 生成でき、`XREF_MAX_DEPTH_INVALID` エラー路を型で強制する。
+ *
+ * @example
+ * ```ts
+ * const result = MaxDepth.create(50);
+ * if (result.ok) {
+ *   const depth: MaxDepth = result.value;
+ * }
+ * ```
+ */
+export type MaxDepth = Brand<number, typeof MaxDepthBrand>;
+
+const DEFAULT_MAX_PREV_CHAIN_DEPTH = 100;
+
+export const MaxDepth = {
+  /** `options.maxDepth` 未指定時に採用される既定値（100）。 */
+  DEFAULT: DEFAULT_MAX_PREV_CHAIN_DEPTH as MaxDepth,
+
+  /**
+   * ユーザー指定の maxDepth を検証して `MaxDepth` に変換する。
+   *
+   * - `undefined`（未指定）→ `MaxDepth.DEFAULT` を含む Ok
+   * - 正の safe integer → その値を含む Ok
+   * - それ以外（0 / 負数 / 非整数 / NaN / ±Infinity / safe integer 超過）→
+   *   `XREF_MAX_DEPTH_INVALID` を含む Err
+   *
+   * @param n - ユーザー指定の maxDepth（未指定可）
+   * @returns 検証済み `MaxDepth` を含む Ok、または `XREF_MAX_DEPTH_INVALID` を含む Err
+   */
+  create(n: number | undefined): Result<MaxDepth, PdfParseError> {
+    if (n === undefined) {
+      return ok(DEFAULT_MAX_PREV_CHAIN_DEPTH as MaxDepth);
+    }
+    if (!NumberEx.isPositiveSafeInteger(n)) {
+      return err({
+        code: "XREF_MAX_DEPTH_INVALID",
+        message: `Invalid options.maxDepth: ${n} (must be a positive safe integer)`,
+      });
+    }
+    return ok(n as MaxDepth);
+  },
+} as const;


### PR DESCRIPTION
## 概要

コードベース方針「回復可能な問題は `PdfWarning` で通知／回復不能なライブラリ入力ミスは `Result` の `Err` で返す」に反していた 3 箇所を、方針整合させるリファクタリング。

- `mergeXRefChain(options.maxDepth)` の無効値 → 従来 silent default 100 fallback → **`Err({ code: "XREF_MAX_DEPTH_INVALID" })`**（後方非互換）
- カタログ `/Version` の不正 name → 従来 silent header fallback → **戻り値 `{ version, warnings }` タプルに `CATALOG_VERSION_INVALID` を含める + header fallback**
- `GraphicsStateStack.restore` の unbalanced 呼び出し → 従来 silent no-op → **戻り値 `{ stack, warning? }` タプル、unbalanced 時は `UNBALANCED_RESTORE` warning を含む**（後方非互換）

## 変更内容

### 🎯 変更の種類

- [x] ♻️ リファクタリング (Refactoring)
- [x] ✨ 新機能 (New feature) — API 追加（`ParsedCatalog.warnings` / `restore` の戻り値型）
- [x] 💥 破壊的変更 (Breaking change) — 3 点（下記「破壊的変更の詳細」参照）
- [x] 🚨 テスト追加/修正 (Tests)

### 📝 詳細な変更内容

#### 追加された機能・修正

- **型追加**:
  - `PdfParseErrorCode` に `"XREF_MAX_DEPTH_INVALID"`
  - `PdfWarningCode` に `"CATALOG_VERSION_INVALID"` / `"UNBALANCED_RESTORE"`
- **Brand 型新設**: `MaxDepth`（`packages/core/src/xref/merger/max-depth/`）
  - `MaxDepth.create(n)` が maxDepth 検証を封入、`MaxDepth.DEFAULT` は 100
- **`ParsedCatalog` shape 拡張**（**public 型 breaking**）
  - 必須フィールド `warnings: readonly PdfWarning[]` を追加
- **`GraphicsStateStack.restore` シグネチャ変更**（**戻り値型 breaking**）
  - 戻り値を `GraphicsStateStack` から `RestoreResult = { stack, warning? }` タプルへ変更
  - unbalanced restore 検出時は `warning: UNBALANCED_RESTORE` を含む
  - 既存 caller 6 箇所（interpreter.dispatch / xobject-operators / graphics-state-operators / fill / fill-stroke / stack.basic の各テスト）を `{ stack: ... }` 分解代入に更新
- **pdf-document の warnings 配線**
  - `emitWarnings(catalogResult.value.warnings)` を追加、既存 `walkResult` / `infoResult` と同じパターン

#### 変更されたファイル

- `packages/core/src/pdf/errors/error/index.ts` + `__tests__/error.type-export.test.ts`
- `packages/core/src/pdf/errors/warning/index.ts` + `__tests__/warning.type.test.ts`
- `packages/core/src/xref/merger/max-depth/index.ts`（新規）+ `__tests__/max-depth.validation.test.ts`（新規）
- `packages/core/src/xref/merger/index.ts` + `__tests__/merger.boundary.test.ts`
- `packages/core/src/document/catalog/catalog-parser/index.ts` + `__tests__/catalog-parser.behavior.test.ts`
- `packages/core/src/document/pdf-document/index.ts` + `__tests__/pdf-document.warning.test.ts` + `__tests__/pdf-document.test.helpers.ts`
- `packages/core/src/content-stream/graphics-state/stack/index.ts` + `__tests__/stack.basic.test.ts`
- `packages/core/src/content-stream/interpreter/__tests__/interpreter.dispatch.test.ts`
- `packages/core/src/content-stream/operators/xobject/xobject-operators/__tests__/xobject-operators.integration.test.ts`
- `packages/core/src/content-stream/operators/graphics-state/graphics-state-operators/__tests__/graphics-state-operators.integration.test.ts`
- `packages/core/src/content-stream/operators/path/fill/__tests__/fill.basic.test.ts`
- `packages/core/src/content-stream/operators/path/fill-stroke/__tests__/fill-stroke.basic.test.ts`
- `packages/core/src/__tests__/namespace-export.type.test.ts`

## 📊 システム図

### `mergeXRefChain` の入口検証フロー（変更後）

```mermaid
flowchart TD
    Entry([mergeXRefChain 呼び出し]) --> Validate{options.maxDepth の値}
    Validate -->|undefined| Default[MaxDepth.DEFAULT = 100]
    Validate -->|正の safe integer| Valid[有効値をそのまま Brand 化]
    Validate -->|0 / 負 / 非整数 / NaN / ±Infinity / MAX_SAFE_INTEGER 超| Invalid[Err XREF_MAX_DEPTH_INVALID]:::new
    Default --> Chain[chain walk へ]
    Valid --> Chain
    Invalid --> ReturnErr([return Err])
    Chain --> ChainEnd([既存の while ループ])

    classDef new fill:#ffe4b5,stroke:#d97706,stroke-width:2px
```

### `CatalogParser.parse` の warnings 集約フロー

```mermaid
flowchart TD
    Catalog[CatalogParser.parse] --> PickVer[pickNewerVersion entries headerVersion]
    PickVer --> Check{/Version の状態}
    Check -->|不在 / type != name| Header1[version = header, warnings = 空]
    Check -->|name だが PdfVersion.create 失敗| Push[warnings = CATALOG_VERSION_INVALID]:::new
    Push --> Header2[version = header]
    Check -->|name で成功 かつヘッダより大| Catalog2[version = catalog, warnings = 空]
    Check -->|name で成功 かつヘッダ以下| Header3[version = header, warnings = 空]
    Header1 --> Return[ok ParsedCatalog with warnings]
    Header2 --> Return
    Catalog2 --> Return
    Header3 --> Return
    Return --> Emit[pdf-document で emitWarnings]:::new
    Emit --> Callback([LoadOptions.onWarning])

    classDef new fill:#ffe4b5,stroke:#d97706,stroke-width:2px
```

### `GraphicsStateStack.restore` の分岐（変更後）

```mermaid
flowchart TD
    Restore[restore stack] --> Check{stack.saved 空?}
    Check -->|No| Pop[top を pop current 復元]
    Check -->|Yes| WarnBranch[warning UNBALANCED_RESTORE を含めて返す]:::new
    WarnBranch --> ReturnStack[stack current 維持 saved 空 warning あり]
    Pop --> ReturnStack2[stack top を current saved n-1 warning なし]

    classDef new fill:#ffe4b5,stroke:#d97706,stroke-width:2px
```

## 📋 関連 Issue

- Closes #349

## 🧪 テスト

### テスト実行方法

```bash
pnpm --filter @pdfmod/core exec vitest run
pnpm --filter @pdfmod/core exec tsc --noEmit
pnpm lint
```

### テスト項目

- [x] 単体テスト (Unit tests) — 全 3107 tests pass
- [x] 統合テスト — `pdf-document.warning.test.ts` に `CATALOG_VERSION_INVALID` の e2e smoke 追加

### テスト結果

- ✅ 全 3107 tests pass (252 test files)
- ✅ typecheck: エラーなし
- ✅ lint (biome + oxlint): 449 files checked、0 warnings, 0 errors

## 🔍 レビューポイント

- **破壊的変更** (3 点、詳細は下記参照):
  1. `mergeXRefChain` の invalid maxDepth が Err を返すようになった
  2. `ParsedCatalog` に必須フィールド `warnings` が追加された
  3. `GraphicsStateStack.restore` の戻り値型が `RestoreResult` に変わった（caller の `.stack` 抽出が必要）
- **設計方針**: warnings 伝搬は **戻り値タプル**型で統一（`pickNewerVersion` / `restore` とも）。引数 buffer への push（mutation-through-parameter）は避けた
- **警告発行の狭義解釈**（本 PR のスコープ制約）:
  - `pickNewerVersion` の警告は「不正な name」限定。`/Version` 不在および `type !== "name"` は警告対象外
- **本 PR のスコープ外**:
  - **Q operator handler の新設は含めない**。したがって本 PR merge 後も production では `UNBALANCED_RESTORE` は emit されない（`restore` の直接呼び出し経路のみ観測可能）
  - フォローアップ Issue「Q operator handler 新設 + `UNBALANCED_RESTORE` の production 経路配線」の作成を予定

## ⚠️ 破壊的変更

- [x] この変更は既存の API に破壊的変更を含みます

### 破壊的変更の詳細

1. **`mergeXRefChain({ maxDepth: 0 })` 等の invalid maxDepth**: 従来 Ok（default fallback）→ **`Err({ code: "XREF_MAX_DEPTH_INVALID" })`**
   - 移行: invalid な値を渡していた呼び出し元は Err ハンドリングを追加、または有効値／`undefined` へ変更
2. **`ParsedCatalog` の型 shape**: `warnings: readonly PdfWarning[]` が必須フィールドに追加される
   - 移行: リテラル構築している呼び出し元は `warnings: []` の追加が必要
3. **`GraphicsStateStack.restore` の戻り値型**: `GraphicsStateStack` → `RestoreResult = { stack: GraphicsStateStack; warning?: PdfWarning }`
   - 移行: `const restored = restore(stack)` → `const { stack: restored } = restore(stack)` へ分解代入で更新。`warning` を利用しない呼び出し元は既存挙動と等価
   - 本 PR 内の 6 caller（interpreter.dispatch / xobject-operators / graphics-state-operators / fill / fill-stroke / stack.basic の各テスト）は更新済

## ✅ チェックリスト

- [x] コードレビューの準備ができている
- [x] テストが正常に実行される (3107 pass)
- [x] JSDoc 更新（5 箇所: 2 union type + `mergeXRefChain` / `CatalogParser.parse` / `restore` の 3 関数）
- [x] コミットメッセージが適切な形式（Step ごとに 8 コミット + mutation パターン廃止の追加リファクタ 1 コミット = 計 8 コミット）
- [x] 関連 Issue が PR の「Development」に Linked されている (Closes #349)
- [x] セルフレビュー実施
- [x] 破壊的変更を明記
