### PR TITLE
✨ [New Feature]: #482 registerMarkedContentOperators に MP / DP を追加し interpreter 完走を pin down

### DIFF
--- a/packages/core/src/content-stream/interpreter/__tests__/interpreter.marked-content.test.ts
+++ b/packages/core/src/content-stream/interpreter/__tests__/interpreter.marked-content.test.ts
@@ -136,6 +136,71 @@ test("`/A <<>> BDC /B BMC EMC EMC` で BDC → BMC → EMC → EMC が LIFO で�
   ).toBe(0);
 });
 
+test("`/Tag MP` が ok で完走し warnings 空・末尾 depth 0", () => {
+  const result = ContentStreamInterpreter.execute({
+    data: encode("/Tag MP"),
+    registry: buildRegistry(),
+  });
+
+  assert(result.ok);
+  expect(result.value.warnings).toHaveLength(0);
+  expect(
+    MarkedContentStack.depth(result.value.context.markedContentStack),
+  ).toBe(0);
+});
+
+test("`/Tag /PropName DP` が ok で完走し warnings 空・末尾 depth 0（name properties）", () => {
+  const result = ContentStreamInterpreter.execute({
+    data: encode("/Tag /PropName DP"),
+    registry: buildRegistry(),
+  });
+
+  assert(result.ok);
+  expect(result.value.warnings).toHaveLength(0);
+  expect(
+    MarkedContentStack.depth(result.value.context.markedContentStack),
+  ).toBe(0);
+});
+
+test("`/Tag <</K (v)>> DP` が ok で完走し warnings 空・末尾 depth 0（dict properties）", () => {
+  const result = ContentStreamInterpreter.execute({
+    data: encode("/Tag <</K (v)>> DP"),
+    registry: buildRegistry(),
+  });
+
+  assert(result.ok);
+  expect(result.value.warnings).toHaveLength(0);
+  expect(
+    MarkedContentStack.depth(result.value.context.markedContentStack),
+  ).toBe(0);
+});
+
+test("`/Span BMC /Point MP EMC` で MP を挟んでも depth 不変・末尾 0（MP は push しない）", () => {
+  const result = ContentStreamInterpreter.execute({
+    data: encode("/Span BMC /Point MP EMC"),
+    registry: buildRegistry(),
+  });
+
+  assert(result.ok);
+  expect(result.value.warnings).toHaveLength(0);
+  expect(
+    MarkedContentStack.depth(result.value.context.markedContentStack),
+  ).toBe(0);
+});
+
+test("`/Span BMC /Point <<>> DP EMC` で DP を挟んでも depth 不変・末尾 0（DP は push しない）", () => {
+  const result = ContentStreamInterpreter.execute({
+    data: encode("/Span BMC /Point <<>> DP EMC"),
+    registry: buildRegistry(),
+  });
+
+  assert(result.ok);
+  expect(result.value.warnings).toHaveLength(0);
+  expect(
+    MarkedContentStack.depth(result.value.context.markedContentStack),
+  ).toBe(0);
+});
+
 test('`data: ""` + 非空 initialContext（depth=1, tag /Span）で OBJECT_PARSE_UNTERMINATED', () => {
   const seededEntry: MarkedContentEntry = {
     tag: { type: "name", value: "Span" },

--- a/packages/core/src/content-stream/operators/marked-content/marked-content-operators/__tests__/marked-content-operators.integration.test.ts
+++ b/packages/core/src/content-stream/operators/marked-content/marked-content-operators/__tests__/marked-content-operators.integration.test.ts
@@ -29,16 +29,16 @@ test("BDC が登録される", () => {
   expect(OperatorRegistry.has(registered.value, "BDC")).toBe(true);
 });
 
-test("MP は登録されない", () => {
+test("MP が登録される", () => {
   const registered = registerMarkedContentOperators(OperatorRegistry.create());
 
   assert(registered.ok);
-  expect(OperatorRegistry.has(registered.value, "MP")).toBe(false);
+  expect(OperatorRegistry.has(registered.value, "MP")).toBe(true);
 });
 
-test("DP は登録されない", () => {
+test("DP が登録される", () => {
   const registered = registerMarkedContentOperators(OperatorRegistry.create());
 
   assert(registered.ok);
-  expect(OperatorRegistry.has(registered.value, "DP")).toBe(false);
+  expect(OperatorRegistry.has(registered.value, "DP")).toBe(true);
 });

--- a/packages/core/src/content-stream/operators/marked-content/marked-content-operators/index.ts
+++ b/packages/core/src/content-stream/operators/marked-content/marked-content-operators/index.ts
@@ -5,19 +5,28 @@ import type { OperatorHandler } from "../../../operator-registry/index";
 import { OperatorRegistry } from "../../../operator-registry/index";
 import { bdcHandler } from "../bdc/index";
 import { bmcHandler } from "../bmc/index";
+import { dpHandler } from "../dp/index";
 import { emcHandler } from "../emc/index";
+import { mpHandler } from "../mp/index";
 
 export { bdcHandler } from "../bdc/index";
 export { bmcHandler } from "../bmc/index";
+export { dpHandler } from "../dp/index";
 export { emcHandler } from "../emc/index";
+export { mpHandler } from "../mp/index";
 
-// BMC / BDC / EMC を登録。MP / DP は後続 issue で登録する（本 issue では未登録のまま）。
+// BMC / EMC / BDC / MP / DP を登録。
+// 登録順は既存 fail-fast テスト（marked-content-operators.error.test.ts）が
+// ["BMC"] / ["BMC","EMC"] / ["BMC","EMC","BDC"] を pin down しているため、
+// この順序を維持する（末尾追加のみ）。
 const MARKED_CONTENT_OPERATORS: ReadonlyArray<
   readonly [string, OperatorHandler]
 > = [
   ["BMC", bmcHandler],
   ["EMC", emcHandler],
   ["BDC", bdcHandler],
+  ["MP", mpHandler],
+  ["DP", dpHandler],
 ];
 
 /**


### PR DESCRIPTION
## 概要

Issue #482（Phase 4-J: MP / DP handler 実装）の**残タスク**を完了する PR。dpHandler / mpHandler 本体と各単体テストは既に別 PR (#521, #523) でマージ済みのため、本 PR は以下 3 点のみをスコープとする:

1. `registerMarkedContentOperators` の登録配列末尾に `["MP", mpHandler]` `["DP", dpHandler]` を追加
2. `marked-content-operators.integration.test.ts` の「MP は登録されない」「DP は登録されない」pin down 2 件を「登録される」に反転
3. `interpreter.marked-content.test.ts` に MP / DP 完走テスト 5 件を追加

これで Epic #479 の Definition of Done「BMC / BDC / EMC / MP / DP が UNKNOWN_OPERATOR warning なしで完走する」を全 15 test（既存 10 + 新規 5）の `warnings.toHaveLength(0)` で担保する。

## 変更内容

### 🎯 変更の種類

- [x] ✨ 新機能 (New feature)
- [x] 🚨 テスト追加 (Tests)

### 📝 詳細な変更内容

#### 追加された機能・修正

- `MARKED_CONTENT_OPERATORS` 配列に MP / DP を追加。**登録順は `["BMC","EMC","BDC","MP","DP"]` 厳守**（末尾追加のみで既存 fail-fast テストの prefix 順 assert に影響なし）
- `dpHandler` / `mpHandler` の import・re-export を追加（re-export はハンドラ名アルファベット順に統一: bdc → bmc → dp → emc → mp）
- 冒頭コメントを「BMC / EMC / BDC / MP / DP を登録」+ 登録順維持理由に更新
- interpreter 統合テストに MP / DP の完走テスト 5 件を追加

#### 変更されたファイル

- `packages/core/src/content-stream/operators/marked-content/marked-content-operators/index.ts` — MP / DP 登録追加（+11 / -3）
- `packages/core/src/content-stream/operators/marked-content/marked-content-operators/__tests__/marked-content-operators.integration.test.ts` — 2 pin down 反転（+4 / -4）
- `packages/core/src/content-stream/interpreter/__tests__/interpreter.marked-content.test.ts` — 完走テスト 5 件追加（+65）

## 📊 システム図

### 状態マシン / フロー図 — MP / DP dispatch

```mermaid
flowchart TD
    Start([tokenizer.next]) --> Op{Operator?}
    Op -->|MP| RegMP[registry.lookup MP]
    Op -->|DP| RegDP[registry.lookup DP]

    RegMP -->|Some mpHandler<br/>NEW| MPPop[operandStack.pop tag]
    RegDP -->|Some dpHandler<br/>NEW| DPPopProps[operandStack.pop properties]

    MPPop --> MPCheck{PdfName?}
    MPCheck -->|Yes| MPOk[ok: 3 stack 同一参照<br/>MarkedContentStack push しない]
    MPCheck -->|No| MPErr[TYPE_MISMATCH]

    DPPopProps --> DPCheckProps{dict or name?}
    DPCheckProps -->|Yes| DPPopTag[operandStack.pop tag]
    DPCheckProps -->|No| DPPropsErr[TYPE_MISMATCH]
    DPPopTag --> DPCheckTag{PdfName?}
    DPCheckTag -->|Yes| DPOk[ok: 3 stack 同一参照<br/>MarkedContentStack push しない]
    DPCheckTag -->|No| DPTagErr[TYPE_MISMATCH]

    MPOk --> Next([次の token へ])
    DPOk --> Next
    Next --> Eof{EOF?}
    Eof -->|No| Start
    Eof -->|Yes| Depth{depth === 0?}
    Depth -->|Yes| Done[ok warnings空]
    Depth -->|No| Unterm[OBJECT_PARSE_UNTERMINATED]

    classDef new fill:#ffe4b5,stroke:#d97706,stroke-width:2px
    class RegMP,RegDP,MPPop,MPCheck,MPOk,DPPopProps,DPCheckProps,DPPopTag,DPCheckTag,DPOk new
```

### データフロー — registerMarkedContentOperators

```
OperatorRegistry.create()
  ↓
registerMarkedContentOperators
  ├─ ["BMC", bmcHandler]  (既存)
  ├─ ["EMC", emcHandler]  (既存)
  ├─ ["BDC", bdcHandler]  (既存)
  ├─ ["MP",  mpHandler]   [NEW]
  └─ ["DP",  dpHandler]   [NEW]
      ↓ reduce + flatMap (fail-fast)
  Result<OperatorRegistry, PdfError>
      ↓
  ContentStreamInterpreter.execute で lookup → dispatch
      ↓
  warnings === [] (UNKNOWN_OPERATOR 発生せず) ⇒ Epic #479 DoD 達成
```

## 📋 関連 Issue

- Closes #482 (Phase 4-J: MP / DP handler)
- Refs #479 (Phase 4-J Epic: marked content operators)

**Epic #479 の Definition of Done を本 PR 完了時点で満たす**: BMC / BDC / EMC / MP / DP が UNKNOWN_OPERATOR warning なしで完走。

## 🧪 テスト

### テスト実行方法

```bash
# 追加分ピンポイント
pnpm --filter @pdfmod/core test interpreter.marked-content
pnpm --filter @pdfmod/core test marked-content-operators

# 回帰含む全体
pnpm --filter @pdfmod/core test
pnpm --filter @pdfmod/core build
```

### テスト項目

- [x] 単体テスト (Unit tests) — dp.dict/dp.name/dp.error/mp.basic/mp.error は無変更 pass
- [x] 統合テスト (Integration tests) — MP/DP 登録 pin down 反転 + interpreter 完走テスト 5 件追加

### テスト結果

- ✅ `pnpm --filter @pdfmod/core test` — **254 file / 3129 test all green**
- ✅ `pnpm --filter @pdfmod/core build` — Vite build + tsc `--emitDeclarationOnly` 両方成功
- ✅ `pnpm run lint` — biome 0 fix / oxlint 0 warning / 0 error
- ✅ `interpreter.marked-content.test.ts` 全 15 test（既存 10 + 新規 5）で `warnings.toHaveLength(0)` pass — **Epic #479 DoD 達成**
- ✅ `marked-content-operators.integration.test.ts` 6 test 全 pass（`ok を返す` + BMC/EMC/BDC/MP/DP の 5 handler 登録 pin down）
- ✅ `marked-content-operators.error.test.ts` fail-fast 3 test（`["BMC"]` / `["BMC","EMC"]` / `["BMC","EMC","BDC"]` の prefix 順 assert）が**無変更で green** — 末尾追加のみによる回帰防止を実測担保

## 🔍 レビューポイント

1. **登録順**: `MARKED_CONTENT_OPERATORS` は `["BMC","EMC","BDC","MP","DP"]` の**末尾追加のみ**。先頭に MP/DP を置くと既存 fail-fast pin down（prefix 順 assert）が壊れる点は index.ts の冒頭コメントで明示済み。
2. **push しない構造的差分**: MP / DP は marked-content-stack を push しない（BMC/BDC との差分）。interpreter テストの `/Span BMC /Point MP EMC` / `/Span BMC /Point <<>> DP EMC` の depth 0 assert が「MP/DP は push しない」の interpreter レベルでの pin down。
3. **レイヤー分離**: エラー系（operand 不足・型不一致）は各 handler の単体テスト（`dp.error.test.ts` / `mp.error.test.ts`）で完結。統合テスト（`interpreter.marked-content.test.ts`）は完走のみを見る。requirements 論点 3 に準拠。
4. **`<</K (v)>>` の受理経路**: DP handler は `properties.type === "dictionary"` か `PdfName.is(properties)` かをチェックするだけで、dict の中身は検証しない（tokenizer が単一 PdfDictionary object として構築する既存責務分離に依存）。

## ⚠️ 破壊的変更

- [ ] この変更は既存の API に破壊的変更を含みます

**破壊的変更なし**。純粋な機能追加（配列末尾に 2 エントリ追加 + テスト反転 + テスト追加）。

## 📚 追加情報

### 参考資料

- 仕様: `.plugin-workspace/.specs/073-mp-dp-marked-point-handler/implementation-plan.md`
- 実装ノート: `.plugin-workspace/.specs/073-mp-dp-marked-point-handler/implementation-notes.md`（Deviations: Phase 1 のファイル書き出し → 既存ファイル（PR #523 でマージ済み）とのバイト一致検証への置換）
- セルフレビュー: `.plugin-workspace/.specs/073-mp-dp-marked-point-handler/code-review/review-001.md`（Codex は usage limit 到達のためセルフレビューで代替）
- 理解度クイズ (advisory): `.plugin-workspace/.specs/073-mp-dp-marked-point-handler/understanding-quiz-impl.html`

### 注意事項

- `dpHandler` 本体 + 3 単体テスト（dp.dict / dp.name / dp.error）は PR #523 (`a3530dc`) で既にマージ済み。本 PR は spec 起草時点（PR #523 マージ前）の「`git show 3b8b53f:<path>` で書き出す」計画を、実装時点の「既存ファイルが `3b8b53f` とバイト一致することを diff で検証」に置き換えた（implementation-notes D-1 参照）。

## ✅ チェックリスト

- [x] コードレビューの準備完了（セルフレビュー実施済み）
- [x] テスト正常実行（3129/3129 green）
- [x] 適切なコミットメッセージ（絵文字付きタイプ + Issue 番号）
- [x] 関連 Issue の記載（`Closes #482` / `Refs #479`）
- [x] セルフレビュー実施（`code-review/review-001.md`）
- [x] 破壊的変更なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)