### PR TITLE
🔧 [Config]: #388 clippy missing_const_for_fn を workspace lints で明示 allow し const fn 方針を文書化

### DIFF
--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -4,3 +4,12 @@ members = ["crates/core"]
 
 # pdfmod の Rust 実装。外部 crate には一切依存しない（std のみ）方針。
 # 依存を追加しないこと自体が設計制約のため、[workspace.dependencies] は空のままにする。
+
+# const fn は const 文脈（定数定義・配列長など）で実際に必要になった時点で個別に付与する。
+# 予防的な一括 const 化はしない方針のため、この lint は明示的に allow する。
+# 将来 lint グループ（例: nursery / pedantic）を有効化する場合は、グループ側に
+# priority = -1 を指定し、この個別 allow が優先される状態を維持すること。
+# 新規メンバー crate を追加する際は、その crate の Cargo.toml に
+# [lints] workspace = true を指定すること（指定しないとこの設定が適用されない）。
+[workspace.lints.clippy]
+missing_const_for_fn = "allow"

--- a/rust/crates/core/Cargo.toml
+++ b/rust/crates/core/Cargo.toml
@@ -8,3 +8,7 @@ repository = "https://github.com/DIO0550/pdfmod"
 
 # 外部依存ゼロが本クレートの設計制約。ここには何も追加しないこと。
 [dependencies]
+
+# lint 設定は workspace（rust/Cargo.toml の [workspace.lints]）で一元管理する。
+[lints]
+workspace = true


### PR DESCRIPTION
## 概要

Issue #388（構築子・アクセサの一括 const fn 化推奨・clippy 検出）への**逆方向の対応**。一括 const fn 化は行わず、`clippy::missing_const_for_fn`（nursery lint・デフォルト無効）を workspace の `[lints]` で明示 allow し、「const fn は const 文脈で実際に必要になった時点で個別に付与する。予防的な一括 const 化はしない」という方針をマニフェスト上に恒久文書化する。

変更はマニフェスト2ファイル・計13行の追加のみで、`.rs` ソース・CI 設定・実行時挙動・公開 API の変更はゼロ（探索で const 文脈使用ゼロを確認済み）。

## 変更内容

### 🎯 変更の種類

- [x] 🔧 設定変更 (Configuration)

### 📝 詳細な変更内容

#### 追加された機能・修正

- `[workspace.lints.clippy]` セクションを新設し `missing_const_for_fn = "allow"` を設定
- allow 直上に方針コメントを記載（const fn 個別付与方針・将来 lint グループ有効化時は グループ側に `priority = -1` を指定する運用ルール・新規メンバー crate 追加時は `[lints] workspace = true` の指定が必須である旨の注意書き）
- core crate を workspace lint 設定へ opt-in（`[lints] workspace = true`）

#### 変更されたファイル

- `rust/Cargo.toml`（+9行）
- `rust/crates/core/Cargo.toml`（+4行）

#### 削除されたファイル・機能

- なし

## 📊 システム図

### lint 解決フロー

```mermaid
flowchart TD
    CMD([cargo clippy --workspace --all-targets]) --> WS["rust/Cargo.toml<br/>[workspace.lints.clippy]<br/>missing_const_for_fn = allow"]:::new
    WS --> OPTIN{"crates/core/Cargo.toml<br/>[lints] workspace = true"}:::new
    OPTIN -->|opt-in あり| APPLIED[allow が rustc / clippy へ<br/>lint レベルとして伝播]
    OPTIN -.->|指定漏れ| SILENT[設定は静かに無視され<br/>暗黙デフォルトに戻る<br/>※コメントの注意書きで防止]
    APPLIED --> CI["CI: -D warnings を警告0件で通過<br/>（nursery は元々無効のため挙動不変）"]
    APPLIED -.->|"CLI で -W 明示（後段適用）"| AUDIT[警告を再表示して棚卸し可能]

    classDef new fill:#ffe4b5,stroke:#d97706,stroke-width:2px
```

## 📋 関連 Issue

- Closes #388（一括 const 化の推奨に対し、「必要時に個別付与」方針の明文化をもって恒久的な回答とする）

## 🧪 テスト

### テスト実行方法

```bash
cd rust
cargo clippy --workspace --all-targets -- -D warnings
cargo fmt --all -- --check
cargo test
# allow の実効性確認（CLI フラグは [lints] より後段適用のため警告が再表示されれば設定が生きている）
cargo clippy --workspace --all-targets -- -W clippy::missing_const_for_fn
```

### テスト項目

- [x] 単体テスト (Unit tests)
- [x] 手動テスト (Manual testing)

### テスト結果

- `cargo clippy --workspace --all-targets -- -D warnings`: 警告0件・exit 0（`unused manifest key` 警告なし。CI 挙動不変）
- `cargo fmt --all -- --check`: 差分0・exit 0
- `cargo test`: 1131件全パス・failed 0（`.rs` 変更ゼロのリグレッション確認）
- `-W clippy::missing_const_for_fn` の CLI 明示で警告の再表示を確認（allow が workspace→crate に伝播している裏取り）
- codex による AI コードレビュー: 「問題なし」

## 🔍 レビューポイント

- 方針コメントの文言が「恒久的に正しい方針文」になっているか（意図的に Issue 番号・検出件数を書いていない。件数はドリフトして陳腐化するため）
- 個別 allow に `priority` を明示していない点（cargo の標準パターン「グループ側に `priority = -1`、個別はデフォルト 0」に従い、将来のグループ有効化時も allow が後勝ちで維持される設計）
- `[lints] workspace = true` の opt-in 漏れ防止の注意書きが workspace 側コメントにあること

## ⚠️ 破壊的変更

- [ ] この変更は既存の API に破壊的変更を含みます

なし（実行時挙動・公開 API・CI コマンドの変更ゼロ）。

## ✅ チェックリスト

- [x] コードレビューの準備ができている
- [x] テストが正常に実行される
- [x] コミットメッセージが適切な形式で書かれている
- [x] PR 本文に `Closes #` で Issue が記載されている
- [x] セルフレビューを実施した

🤖 Generated with [Claude Code](https://claude.com/claude-code)