### PR TITLE
📝 [Doc]: #363 PdfObject の型数コメントの二重カウントを修正

### DIFF
--- a/packages/core/src/pdf/types/pdf-types/index.ts
+++ b/packages/core/src/pdf/types/pdf-types/index.ts
@@ -183,7 +183,7 @@ export type PdfValue =
 
 /**
  * PDF object 全体型 (ISO 32000 7.3)。
- * PDF 仕様の "PDF object" 概念に対応。9つの基本型 + 間接参照 + stream をすべて含む。
+ * PDF 仕様の "PDF object" 概念に対応。`PdfValue`（間接参照を含む9種）+ stream の10バリアントをすべて含む。
  * `parseIndirectObject` の body（間接オブジェクトの中身）として使われる。
  */
 export type PdfObject = PdfValue | PdfStream;


### PR DESCRIPTION
## 概要
- `PdfObject` の JSDoc コメントにある型数の数え方の誤りを修正

## 変更の種類
- 📖 ドキュメント

## 詳細な変更内容
- `packages/core/src/pdf/types/pdf-types/index.ts` の `PdfObject` コメントを修正
  - 修正前: 「9つの基本型 + 間接参照 + stream をすべて含む」（`PdfValue` が既に間接参照込みで9型のため二重カウント）
  - 修正後: 「`PdfValue`（間接参照を含む9種）+ stream の10バリアントをすべて含む」

## 関連Issue
Closes #363

## テスト
- コメントのみの修正のため、既存の型チェック（`tsc --noEmit`）とbiomeチェックが通ることを確認
- ロジック変更なし、テスト追加不要

## レビューポイント
- 修正後の記述が実際の型構成（`PdfValue` 9種 + `PdfStream`）と一致しているか