### PR TITLE
📝 [Doc]: #353 TextObject の Phase 表記コメントを実装済みの現状に合わせて修正

### DIFF
--- a/packages/core/src/content-stream/graphics-state/text-object/index.ts
+++ b/packages/core/src/content-stream/graphics-state/text-object/index.ts
@@ -17,7 +17,8 @@ type TextObjectFields = {
  * - `textMatrix`     : 現在のテキスト行列 (ISO 32000-1:2008 §9.4.2)。
  * - `textLineMatrix` : 現在のテキスト行の行列 (同 §9.4.2)。
  *
- * Phase 4-E の `Td` / `TD` / `Tm` / `T*` で matrix を更新する基盤となる。
+ * `Td` / `TD` / `Tm` / `T*` ハンドラが `translateLine` / `setMatrix` を通じて
+ * matrix を更新する。
  */
 export type TextObject = Brand<TextObjectFields, typeof TextObjectBrand>;
 
@@ -53,8 +54,10 @@ export const TextObject = {
    * `active = false` に戻し、両 matrix を identity に戻す。
    * 既に inactive な state に対しても冪等 (同値の inactive を返す)。
    *
-   * 現在は state を参照せず `inactive()` に委譲する。Phase 4-E で matrix
-   * 更新ロジックが入った際のシグネチャを保つために state を受け取る形にしてある。
+   * `ET` は現在の matrix の値によらず無条件で inactive に戻る仕様のため、
+   * `_state` は参照せず `inactive()` に委譲する。引数として `_state` を
+   * 受け取るシグネチャは、companion object 内の他メソッドとの統一のために
+   * 維持している。
    *
    * @param _state - 終了対象の TextObject (現在は読まない)
    * @returns 非アクティブな TextObject (`inactive()` と同値)


### PR DESCRIPTION
## 概要
- `packages/core/src/content-stream/graphics-state/text-object/index.ts` の「Phase 4-E で実装予定」という将来形コメントを、実装済みの現状を説明する記述に修正

## 変更の種類
- 📖 ドキュメント

## 詳細な変更内容
- 型ドキュメント（`TextObject` 型コメント）: 「Phase 4-E の `Td`/`TD`/`Tm`/`T*` で matrix を更新する基盤となる」という将来形の記述を、「`Td`/`TD`/`Tm`/`T*` ハンドラが `translateLine`/`setMatrix` を通じて matrix を更新する」という現在形の説明に修正（`T*` ハンドラ（`t-star/index.ts`）も既に実装・登録済みのため「T* は未実装」とはしていない）
- `end()` のコメント: 「Phase 4-E で matrix 更新ロジックが入った際のシグネチャを保つため」という将来形の理由を、「`ET` は現在の matrix の値によらず無条件で inactive に戻る仕様のため `_state` を参照しない」という現状ベースの理由に修正

## 関連Issue
Closes #353

## テスト
- コメントのみの修正のため、既存の型チェック・lintが通ることを確認
- ロジック変更なし、テスト追加不要

## レビューポイント
- 記述が現在の実装（`Td`/`TD`/`Tm`/`T*` ハンドラおよび `end()` の実装）と一致しているか