### PR TITLE
📝 [Doc]: #351 ByteOffset/ObjectNumber/GenerationNumberにJSDocを追加

### DIFF
--- a/packages/core/src/pdf/types/byte-offset/index.ts
+++ b/packages/core/src/pdf/types/byte-offset/index.ts
@@ -5,9 +5,24 @@ import { err, ok } from "../../../utils/result/index";
 
 declare const ByteOffsetBrand: unique symbol;
 
+/**
+ * PDFファイル先頭からのバイトオフセット。
+ * 相互参照テーブルのエントリ（`XRefUsedEntry.offset`）やトレーラの `/Prev` など、
+ * ファイル内の物理位置を示す値に使う。
+ */
 type ByteOffset = Brand<number, typeof ByteOffsetBrand>;
 
+/**
+ * `ByteOffset` の factory / 演算 utility を束ねた namespace。
+ */
 const ByteOffset = {
+  /**
+   * 数値を検証し、ブランド付き ByteOffset を Result で返す。
+   * 0以上の safe integer のみ有効とする。
+   *
+   * @param n - 検証対象の数値
+   * @returns 検証成功時は `ok(ByteOffset)`、失敗時は `err(エラーメッセージ)`
+   */
   create(n: number): Result<ByteOffset, string> {
     if (!NumberEx.isSafeIntegerAtLeastZero(n)) {
       return err(
@@ -17,10 +32,25 @@ const ByteOffset = {
     return ok(n as ByteOffset);
   },
 
+  /**
+   * 数値を検証なしで ByteOffset にキャストする。
+   * unchecked cast であり、0以上の safe integer であることの保証は呼び出し側の責務。
+   * 未検証の入力（外部データ由来の値など）には `create` を使うこと。
+   *
+   * @param n - キャスト対象の数値
+   * @returns n を ByteOffset としてキャストした値
+   */
   of(n: number): ByteOffset {
     return n as ByteOffset;
   },
 
+  /**
+   * 2つの ByteOffset を加算する。
+   *
+   * @param a - 加算対象の ByteOffset
+   * @param b - 加算対象の ByteOffset
+   * @returns a と b を加算した ByteOffset
+   */
   add(a: ByteOffset, b: ByteOffset): ByteOffset {
     return ((a as number) + (b as number)) as ByteOffset;
   },

--- a/packages/core/src/pdf/types/generation-number/index.ts
+++ b/packages/core/src/pdf/types/generation-number/index.ts
@@ -4,11 +4,27 @@ import { err, ok } from "../../../utils/result/index";
 
 declare const GenerationNumberBrand: unique symbol;
 
+/** 世代番号の許容最大値（ISO 32000-1 §7.5.4 が規定する範囲 0–65535 の上限）。 */
 const MAX_GENERATION_NUMBER = 65535;
 
+/**
+ * PDF間接オブジェクトの世代番号 (`N G obj` の `G`)。
+ * オブジェクト番号（`ObjectNumber`）と組になり `IndirectRef` / `ObjectId` を構成する。
+ * 仕様上の許容範囲は 0–65535（ISO 32000-1 §7.5.4）。
+ */
 type GenerationNumber = Brand<number, typeof GenerationNumberBrand>;
 
+/**
+ * `GenerationNumber` の factory utility を束ねた namespace。
+ */
 const GenerationNumber = {
+  /**
+   * 数値を検証し、ブランド付き GenerationNumber を Result で返す。
+   * ISO 32000-1 §7.5.4 が規定する範囲 0–65535 の整数のみ有効とする。
+   *
+   * @param n - 検証対象の数値
+   * @returns 検証成功時は `ok(GenerationNumber)`、失敗時は `err(エラーメッセージ)`
+   */
   create(n: number): Result<GenerationNumber, string> {
     if (!Number.isInteger(n) || n < 0 || n > MAX_GENERATION_NUMBER) {
       return err(
@@ -18,6 +34,14 @@ const GenerationNumber = {
     return ok(n as GenerationNumber);
   },
 
+  /**
+   * 数値を検証なしで GenerationNumber にキャストする。
+   * unchecked cast であり、範囲 0–65535 の整数であることの保証は呼び出し側の責務。
+   * 未検証の入力（外部データ由来の値など）には `create` を使うこと。
+   *
+   * @param n - キャスト対象の数値
+   * @returns n を GenerationNumber としてキャストした値
+   */
   of(n: number): GenerationNumber {
     return n as GenerationNumber;
   },

--- a/packages/core/src/pdf/types/object-number/index.ts
+++ b/packages/core/src/pdf/types/object-number/index.ts
@@ -5,9 +5,23 @@ import { err, ok } from "../../../utils/result/index";
 
 declare const ObjectNumberBrand: unique symbol;
 
+/**
+ * PDF間接オブジェクトのオブジェクト番号 (`N G obj` の `N`)。
+ * 世代番号（`GenerationNumber`）と組になり `IndirectRef` / `ObjectId` を構成する。
+ */
 type ObjectNumber = Brand<number, typeof ObjectNumberBrand>;
 
+/**
+ * `ObjectNumber` の factory utility を束ねた namespace。
+ */
 const ObjectNumber = {
+  /**
+   * 数値を検証し、ブランド付き ObjectNumber を Result で返す。
+   * 0以上の safe integer のみ有効とする。
+   *
+   * @param n - 検証対象の数値
+   * @returns 検証成功時は `ok(ObjectNumber)`、失敗時は `err(エラーメッセージ)`
+   */
   create(n: number): Result<ObjectNumber, string> {
     if (!NumberEx.isSafeIntegerAtLeastZero(n)) {
       return err(
@@ -17,6 +31,14 @@ const ObjectNumber = {
     return ok(n as ObjectNumber);
   },
 
+  /**
+   * 数値を検証なしで ObjectNumber にキャストする。
+   * unchecked cast であり、0以上の safe integer であることの保証は呼び出し側の責務。
+   * 未検証の入力（外部データ由来の値など）には `create` を使うこと。
+   *
+   * @param n - キャスト対象の数値
+   * @returns n を ObjectNumber としてキャストした値
+   */
   of(n: number): ObjectNumber {
     return n as ObjectNumber;
   },


### PR DESCRIPTION
## 概要
- packages/core/src/pdf/types/byte-offset, object-number, generation-number の3型にJSDocを追加

## 変更の種類
- 📖 ドキュメント

## 詳細な変更内容
- `byte-offset/index.ts`: 型 `ByteOffset`、companion object、`create`/`of`/`add` にJSDocを追加。`of` が unchecked cast であり呼び出し側で妥当性を保証する必要がある旨を明記
- `object-number/index.ts`: 型 `ObjectNumber`、companion object、`create`/`of` にJSDocを追加。`of` が unchecked cast である旨を明記
- `generation-number/index.ts`: 型 `GenerationNumber`、`MAX_GENERATION_NUMBER`、companion object、`create`/`of` にJSDocを追加。範囲 0–65535 の根拠として ISO 32000-1 §7.5.4 を明記（Rust側 `generation_number.rs` の記述と整合）

## 関連Issue
Closes #351

## テスト
- コメントのみの修正のため、既存の型チェック・lintが通ることを確認
- ロジック変更なし、テスト追加不要

## レビューポイント
- JSDocの内容が実装（検証規則・unchecked castの挙動）と一致しているか
- ISO 32000-1 §7.5.4 の引用が適切か