### PR TITLE
📝 [Doc]: #352 NumericPdfObject のコメントを実際の利用範囲に合わせて修正

### DIFF
--- a/packages/core/src/content-stream/operators/graphics-state/numeric-pdf-object/index.ts
+++ b/packages/core/src/content-stream/operators/graphics-state/numeric-pdf-object/index.ts
@@ -2,7 +2,7 @@ import type { PdfObject } from "../../../../pdf/types/pdf-types/index";
 
 /**
  * `integer` または `real` の PdfObject に narrow した型。
- * graphics-state operator (cm / w / J / j / M) が期待する数値 operand の型。
+ * 数値 operand を取る content stream operator ハンドラが扱う型。
  */
 export type NumericPdfObject = Extract<PdfObject, { type: "integer" | "real" }>;
 
@@ -13,7 +13,7 @@ export type NumericPdfObject = Extract<PdfObject, { type: "integer" | "real" }>;
 export const NumericPdfObject = {
   /**
    * PdfObject が `integer` または `real` であるかを判定する type guard。
-   * graphics-state operator (cm / w / J / j / M) が共通で行う数値 operand チェック。
+   * 数値 operand を取る content stream operator ハンドラ共通の型ガード。
    *
    * @param operand - 判定対象の PdfObject
    * @returns integer / real のいずれかなら true


### PR DESCRIPTION
## 概要
- `NumericPdfObject` のコメントが「graphics-state operator (cm / w / J / j / M) が期待する/共通で行う」という誤った利用範囲を記述していたため、実態に合わせて修正

## 変更の種類
- 📖 ドキュメント

## 詳細な変更内容
- 実際に `NumericPdfObject.is` を使っているのは graphics-state 系では `cm` のみで、`w` / `J` / `j` / `M` はインライン判定（例: `line-width-handler/index.ts`）であり「共通で行う」は誤りだった
- 現状は color 系 6 ファイル・path 系 4 ファイル・text 系 11 ファイル・graphics-state の `cm` の計 22 モジュールが import しており、特定オペレータへの列挙は古くなりやすいため、具体的なオペレータ列挙をやめ「数値 operand を取る content stream operator ハンドラ(共通の型ガード/が扱う型)」という一般的な記述に書き直した
- ロジックの変更は行っていない

## 関連Issue
Closes #352

## テスト
- コメントのみの修正のため、既存の型チェック・lintが通ることを確認
- ロジック変更なし、テスト追加不要

## レビューポイント
- 記述が実際の利用範囲と一致しているか