### PR TITLE
📝 [Doc]: #358 Tokenizer.seek と parseSubsectionHeader の @returns を実際の戻り値に修正

### DIFF
--- a/packages/core/src/lexer/tokenizer/index.ts
+++ b/packages/core/src/lexer/tokenizer/index.ts
@@ -110,7 +110,7 @@ export class Tokenizer {
    * 次に読み取る byte offset を設定する。
    *
    * @param position - 移動先 byte offset
-   * @returns 移動できない場合は PdfError
+   * @returns 移動できた場合は `none`、範囲外の場合は `some(PdfError)`
    */
   seek(position: number): Option<PdfError> {
     if (

--- a/packages/core/src/xref/table/parser/index.ts
+++ b/packages/core/src/xref/table/parser/index.ts
@@ -241,7 +241,11 @@ function parseEntry(
  *
  * @param data - PDFバイト配列
  * @param pos - ヘッダ開始位置
- * @returns Some({ firstObj, count, nextPos }) または None (trailer 検出時)
+ * @returns 成功時は `ok(some({ firstObj, count, nextPos }))`、
+ *   trailer 検出時は `ok(none)`、
+ *   数値オーバーフローや構文不正 (object number / entry count 欠如、
+ *   区切りのホワイトスペース欠如、トークン境界不正など) の場合は
+ *   `err(PdfParseError)` (コード: `XREF_TABLE_INVALID`)
  */
 function parseSubsectionHeader(
   data: Uint8Array,


### PR DESCRIPTION
## 概要
- `Tokenizer.seek` と `parseSubsectionHeader` のJSDoc `@returns` を、実際の戻り値の型・挙動と一致するように修正

## 変更の種類
- 📖 ドキュメント

## 詳細な変更内容
- `packages/core/src/lexer/tokenizer/index.ts` の `seek` の `@returns` を「移動できない場合はPdfError」から「成功時は `none`、範囲外の場合は `some(PdfError)`」に修正（検証系はOption\<E\>を返す規約に沿った記述に統一）
- `packages/core/src/xref/table/parser/index.ts` の `parseSubsectionHeader` の `@returns` に、戻り値が `Result<Option<...>, PdfParseError>` であることを踏まえ、`ok(some(...))` / `ok(none)` (trailer検出時) に加えて `err(PdfParseError)` を返すケース（object number / entry countの数値オーバーフロー、桁欠如、区切りホワイトスペース欠如、トークン境界不正など、コード: `XREF_TABLE_INVALID`）を追記

## 関連Issue
Closes #358

## テスト
- コメントのみの修正のため、既存の型チェック・lintが通ることを確認
  - `pnpm --filter @pdfmod/core typecheck` : 成功
  - `pnpm lint` : 成功
- ロジック変更なし、テスト追加不要

## レビューポイント
- 修正後の `@returns` の記述が実際の戻り値（`seek`: `Option<PdfError>`、`parseSubsectionHeader`: `Result<Option<{...}>, PdfParseError>`）と一致しているか