### PR TITLE
📝 [Doc]: #360 DoS防止用上限定数に選定根拠のコメントを追加

### DIFF
--- a/packages/core/src/document/page-tree/page-tree-walker/index.ts
+++ b/packages/core/src/document/page-tree/page-tree-walker/index.ts
@@ -23,6 +23,7 @@ export interface WalkPageTreeResult {
   warnings: PdfWarning[];
 }
 
+// PDF仕様上の明示的な上限はなく、ページツリーの循環参照検出のための防御的な上限値。
 const MAX_TREE_DEPTH = 50;
 
 const DISPATCH_PAGES = "Pages";

--- a/packages/core/src/document/pdf-document/index.ts
+++ b/packages/core/src/document/pdf-document/index.ts
@@ -27,6 +27,7 @@ import type { ResolvedPage } from "../page-tree/resolved-page";
 const PDF_HEADER_SIGNATURE: number[] = Array.from(
   new TextEncoder().encode("%PDF-"),
 );
+// PDF仕様上の規定ではなく、Adobe実装ノートで一般的に使われる慣行値。
 const HEADER_SCAN_LIMIT = 1024;
 const VERSION_MAX_LEN = 8;
 

--- a/packages/core/src/objects/object-parser/direct-object/index.ts
+++ b/packages/core/src/objects/object-parser/direct-object/index.ts
@@ -15,6 +15,7 @@ import { err, ok } from "../../../utils/result/index";
 import type { BufferedTokenizer } from "../buffered-tokenizer/index";
 import { decodeHexString, decodeLiteralString } from "../string-decoder/index";
 
+// PDF仕様上の明示的な上限はなく、再帰的な配列/辞書ネストによるスタックオーバーフロー防止のための防御的な上限値。
 const MAX_NESTING_DEPTH = 100;
 
 /**

--- a/packages/core/src/xref/merger/max-depth/index.ts
+++ b/packages/core/src/xref/merger/max-depth/index.ts
@@ -21,6 +21,7 @@ declare const MaxDepthBrand: unique symbol;
  */
 export type MaxDepth = Brand<number, typeof MaxDepthBrand>;
 
+// PDF仕様上の明示的な上限はなく、xrefの `/Prev` チェーンの循環参照防止のための防御的な上限値。
 const DEFAULT_MAX_PREV_CHAIN_DEPTH = 100;
 
 export const MaxDepth = {


### PR DESCRIPTION
## 概要
- DoS/暴走防止用の上限定数（MAX_TREE_DEPTH, MAX_NESTING_DEPTH, DEFAULT_MAX_PREV_CHAIN_DEPTH, HEADER_SCAN_LIMIT）に、選定根拠を1行コメントで追記

## 変更の種類
- 📖 ドキュメント

## 詳細な変更内容
- `packages/core/src/document/page-tree/page-tree-walker/index.ts`: `MAX_TREE_DEPTH = 50` に、PDF仕様上の明示的な上限はなくページツリーの循環参照検出のための防御的上限である旨のコメントを追加
- `packages/core/src/objects/object-parser/direct-object/index.ts`: `MAX_NESTING_DEPTH = 100` に、PDF仕様上の明示的な上限はなく配列/辞書ネストによるスタックオーバーフロー防止のための防御的上限である旨のコメントを追加
- `packages/core/src/xref/merger/max-depth/index.ts`: `DEFAULT_MAX_PREV_CHAIN_DEPTH = 100` に、PDF仕様上の明示的な上限はなくxrefの `/Prev` チェーンの循環参照防止のための防御的上限である旨のコメントを追加
- `packages/core/src/document/pdf-document/index.ts`: `HEADER_SCAN_LIMIT = 1024` に、PDF仕様上の規定ではなくAdobe実装ノートで一般的に使われる慣行値である旨のコメントを追加

## 関連Issue
Closes #360

## テスト
- コメントのみの修正のため、既存の型チェック・lintが通ることを確認
- ロジック変更なし、テスト追加不要

## レビューポイント
- 根拠の記述が適切か、断定しすぎていないか