### PR TITLE
📝 [Doc]: #356 dispatch内のnull解決4分岐にISO 32000-1 §7.3.10の根拠コメントを追加

### DIFF
--- a/packages/core/src/objects/object-store/index.ts
+++ b/packages/core/src/objects/object-store/index.ts
@@ -165,6 +165,9 @@ export class ObjectStore {
   /**
    * xref エントリの type 別分岐を行う。
    *
+   * ISO 32000-1 §7.3.10 により、未定義オブジェクト・フリーエントリ・世代番号不一致の
+   * 間接参照はエラーではなく null オブジェクトとして解決する。
+   *
    * @param ref - 解決対象の間接参照
    * @param ancestors - 呼び出しチェーンの祖先キー
    * @param cacheKey - キャッシュキー文字列
@@ -177,15 +180,20 @@ export class ObjectStore {
   ): Promise<Result<PdfObject, PdfError>> {
     const entry = this.source.xref.entries.get(ref.objectNumber);
     if (entry === undefined) {
+      // ISO 32000-1 §7.3.10: 未定義オブジェクトへの間接参照は null オブジェクトとして解決する
       return ok({ type: "null" });
     }
 
     switch (entry.type) {
       case 0:
+        // ISO 32000-1 §7.3.10: フリーエントリ（type 0）への参照は未定義オブジェクトと同様に
+        // null オブジェクトとして解決する
         return ok({ type: "null" });
 
       case 1: {
         if (entry.generationNumber !== ref.generationNumber) {
+          // ISO 32000-1 §7.3.10: 世代番号が一致しない参照は未定義オブジェクトとみなし
+          // null オブジェクトとして解決する
           return ok({ type: "null" });
         }
         const resolver: ObjectResolver = (
@@ -215,6 +223,8 @@ export class ObjectStore {
 
       case 2: {
         if (ref.generationNumber !== GenerationNumber.of(0)) {
+          // ISO 32000-1 §7.3.10: ObjStm 内オブジェクトの世代番号は常に 0 のため、
+          // 0 以外を指定する参照は未定義オブジェクトとみなし null オブジェクトとして解決する
           return ok({ type: "null" });
         }
 


### PR DESCRIPTION
## 概要
- `ObjectStore#dispatch` 内で未定義オブジェクト・フリーエントリ・世代番号不一致の間接参照を `ok({ type: "null" })` として静かに解決している4分岐に、ISO 32000-1 §7.3.10 に基づく仕様準拠動作である旨のコメントを追加

## 変更の種類
- 📖 ドキュメント

## 詳細な変更内容
- `dispatch` メソッドの JSDoc に ISO 32000-1 §7.3.10 に基づく null 解決方針の説明を追加
- xref にエントリがない参照（178-181行付近）に根拠コメントを追加
- type 0（フリー）エントリ（184-187行付近）に根拠コメントを追加
- type 1 で世代番号不一致（188-190行付近）に根拠コメントを追加
- type 2 で世代番号≠0（217-219行付近）に根拠コメントを追加

## 関連Issue
Closes #356

## テスト
- コメントのみの修正のため、既存の型チェック・lintが通ることを確認
  - `pnpm --filter @pdfmod/core typecheck` 通過
  - `pnpm lint` 通過
- ロジック変更なし、テスト追加不要

## レビューポイント
- 各分岐に付与した ISO 32000-1 §7.3.10 の仕様根拠の記述が正確か