### PR TITLE
📝 [Doc]: #359 xref/lexer の行コメント・セクション見出しを日本語に統一

### DIFF
--- a/packages/core/src/lexer/bytes/index.ts
+++ b/packages/core/src/lexer/bytes/index.ts
@@ -1,12 +1,12 @@
-// --- PDF byte constants (ISO 32000) ---
-// Whitespace (Table 1)
+// --- PDFバイト定数 (ISO 32000) ---
+// ホワイトスペース (Table 1)
 const PdfNul = 0x00;
 const PdfTab = 0x09;
 const PdfLf = 0x0a;
 const PdfFf = 0x0c;
 const PdfCr = 0x0d;
 const PdfSpace = 0x20;
-// Delimiter (Table 2)
+// 区切り文字 (Table 2)
 const PdfPercent = 0x25;
 const PdfLeftParen = 0x28;
 const PdfRightParen = 0x29;
@@ -17,7 +17,7 @@ const PdfLeftBracket = 0x5b;
 const PdfRightBracket = 0x5d;
 const PdfLeftBrace = 0x7b;
 const PdfRightBrace = 0x7d;
-// ASCII digits ('0'-'9')
+// ASCII数字 ('0'-'9')
 const PdfDigit0 = 0x30;
 const PdfDigit9 = 0x39;
 

--- a/packages/core/src/lexer/tokenizer/index.ts
+++ b/packages/core/src/lexer/tokenizer/index.ts
@@ -13,7 +13,7 @@ import {
 const isWhitespace = isPdfWhitespace;
 const isDelimiter = isPdfDelimiter;
 
-// --- ASCII code point constants ---
+// --- ASCII コードポイント定数 ---
 const AsciiDigit0 = 48; // '0'
 const AsciiDigit7 = 55; // '7'
 const AsciiDigit9 = 57; // '9'
@@ -35,7 +35,7 @@ const AsciiLowerT = 116; // 't'
 const AsciiLowerB = 98; // 'b'
 const AsciiLowerF = 102; // 'f'
 
-// --- Numeric constants ---
+// --- 数値定数 ---
 const EofByte = -1;
 const DecimalRadix = 10;
 const OctalRadix = 8;

--- a/packages/core/src/xref/startxref/scanner/index.ts
+++ b/packages/core/src/xref/startxref/scanner/index.ts
@@ -197,7 +197,7 @@ export function scanStartXRef(
     return failStartXRef("invalid startxref offset value");
   }
 
-  // Verify only whitespace/comments remain between digits and %%EOF
+  // 数字と %%EOF の間に空白・コメント以外が残っていないことを検証する
   const trailing = skipWhitespaceAndComments(data, pos, eofOffset);
   if (trailing !== eofOffset) {
     return failStartXRef("invalid startxref offset value");

--- a/packages/core/src/xref/table/parser/index.ts
+++ b/packages/core/src/xref/table/parser/index.ts
@@ -181,7 +181,7 @@ function parseEntry(
     });
   }
 
-  // status flag ('n' or 'f')
+  // ステータスフラグ ('n' または 'f')
   const flagPos = flagSepPos + 1;
   const flagByte = data[flagPos];
 


### PR DESCRIPTION
## 概要
- xref/lexer 配下で英語のまま残っていた行コメント・セクション見出しを日本語に統一（技術用語・識別子は英語のまま）

## 変更の種類
- 📖 ドキュメント

## 詳細な変更内容
- `packages/core/src/xref/table/parser/index.ts`: `// status flag ('n' or 'f')` を `// ステータスフラグ ('n' または 'f')` に変更
- `packages/core/src/xref/startxref/scanner/index.ts`: `// Verify only whitespace/comments remain between digits and %%EOF` を `// 数字と %%EOF の間に空白・コメント以外が残っていないことを検証する` に変更
- `packages/core/src/lexer/tokenizer/index.ts`: セクション見出し `// --- ASCII code point constants ---` を `// --- ASCII コードポイント定数 ---` に、`// --- Numeric constants ---` を `// --- 数値定数 ---` に変更
- `packages/core/src/lexer/bytes/index.ts`: セクション見出し `// --- PDF byte constants (ISO 32000) ---` を `// --- PDFバイト定数 (ISO 32000) ---` に、`// Whitespace (Table 1)` を `// ホワイトスペース (Table 1)` に、`// Delimiter (Table 2)` を `// 区切り文字 (Table 2)` に、`// ASCII digits ('0'-'9')` を `// ASCII数字 ('0'-'9')` に変更

## 関連Issue
Closes #359

## テスト
- コメントのみの修正のため、既存の型チェック・lintが通ることを確認
- ロジック変更なし、テスト追加不要

## レビューポイント
- 日本語化漏れがないか