### PR TITLE
📝 [Doc]: #362 lib.rsとindex.tsのトップレベルdocを実装状況に合わせて修正

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,6 +1,6 @@
 /**
  * `@pdfmod/core` — PDF処理エンジン。
- * ISO 32000-1:2008 (PDF 1.7) 準拠のPDF字句解析・構造解析を提供する。
+ * ISO 32000-1:2008 (PDF 1.7) およびISO 32000-2:2020 (PDF 2.0) 準拠のPDF字句解析・構造解析を提供する。
  *
  * @packageDocumentation
  */

--- a/rust/crates/core/src/lib.rs
+++ b/rust/crates/core/src/lib.rs
@@ -8,7 +8,8 @@
 //! - **外部 crate 依存ゼロ**。Rust 標準ライブラリ (`std`) のみを使う。
 //! - **`Result` / `Option` は std のものをそのまま使う**（自作しない）。
 //!
-//! 各モジュールの実装は後続 PR で追加する。
+//! byte_offset / error / lexer / object / parser の各モジュールは実装済み。
+//! xref / trailer など、PDF ファイル構造を扱う後続モジュールは今後の PR で追加する。
 
 pub mod byte_offset;
 pub mod error;


### PR DESCRIPTION
## 概要
- rust/crates/core/src/lib.rs の「各モジュールの実装は後続 PR で追加する。」を、実装済みモジュール（byte_offset/error/lexer/object/parser）と今後追加予定のファイル構造系モジュール（xref/trailer 等）を分けた記述に修正
- packages/core/src/index.ts の `@packageDocumentation` に ISO 32000-2:2020 (PDF 2.0) への言及を追加

## 変更の種類
- 📖 ドキュメント

## 詳細な変更内容
- `rust/crates/core/src/lib.rs`: 「各モジュールの実装は後続 PR で追加する。」という記述は、byte_offset/error/lexer/object/parser の5モジュールが既に実装済みの現状と乖離していたため、実装済みモジュール名を明記した上で、xref/trailer 等ファイル構造を扱う後続モジュールは今後の PR で追加する、という限定表現に修正した
- `packages/core/src/index.ts`: `@packageDocumentation` が「ISO 32000-1:2008 (PDF 1.7) 準拠」とのみ記載していたが、プロジェクト目標（CLAUDE.md、rust lib.rs）および実装（`PdfVersion` が "2.0" を受理、inheritance-resolver が ISO 32000-2:2020 §7.7.3.4 を引用）は PDF 2.0 も対象のため、「ISO 32000-1:2008 (PDF 1.7) およびISO 32000-2:2020 (PDF 2.0) 準拠」に修正した

## 関連Issue
Closes #362

## テスト
- コメントのみの修正のため、既存の型チェック・lint・cargo fmt/clippyが通ることを確認
  - `pnpm --filter @pdfmod/core typecheck`: 成功
  - `pnpm lint`（biome + oxlint）: 成功
  - `cargo fmt --check`（rust/）: 成功
  - `cargo clippy --all-targets -- -D warnings`（rust/）: 成功
- ロジック変更なし、テスト追加不要

## レビューポイント
- lib.rs の「実装済みモジュール」「後続モジュール」の切り分け方が実装の現状と一致しているか
- index.ts の PDF 2.0 への言及がプロジェクト目標・実装と整合しているか