### PR TITLE
📝 [Doc]: #364 サブシステム境界バレルに@module要約コメントを追加

### DIFF
--- a/packages/core/src/content-stream/graphics-state/index.ts
+++ b/packages/core/src/content-stream/graphics-state/index.ts
@@ -1,3 +1,9 @@
+/**
+ * コンテンツストリーム実行時のグラフィックス状態（色、パス、行列、テキスト状態、q/Qスタック等）を表す型群を公開するバレル。
+ *
+ * @module
+ */
+
 export { Color } from "./color";
 export { ColorSpace } from "./color-space";
 export { CurrentPath } from "./current-path";

--- a/packages/core/src/document/catalog/index.ts
+++ b/packages/core/src/document/catalog/index.ts
@@ -1,2 +1,8 @@
+/**
+ * `/Root` カタログ辞書（ISO 32000-1 §7.7.2）を解析する `CatalogParser` を公開するバレル。
+ *
+ * @module
+ */
+
 export type { ParsedCatalog, ResolveRef } from "./catalog-parser";
 export { CatalogParser } from "./catalog-parser";

--- a/packages/core/src/document/date/index.ts
+++ b/packages/core/src/document/date/index.ts
@@ -1,1 +1,7 @@
+/**
+ * PDF日付文字列（`D:YYYYMMDD...`, ISO 32000-1 §7.9.4）を `Date` に変換する `parsePdfDate` を公開するバレル。
+ *
+ * @module
+ */
+
 export { parsePdfDate } from "./pdf-date";

--- a/packages/core/src/document/encoding/index.ts
+++ b/packages/core/src/document/encoding/index.ts
@@ -1,3 +1,9 @@
+/**
+ * PDF文字列のデコード（リテラル文字列復号、PDFDocEncoding変換）を提供するバレル。
+ *
+ * @module
+ */
+
 export { decodePdfString } from "./decode-pdf-string";
 export {
   decodePdfDocEncoding,

--- a/packages/core/src/document/index.ts
+++ b/packages/core/src/document/index.ts
@@ -1,3 +1,9 @@
+/**
+ * PDF文書モデル（Catalog解析、メタデータ、ページツリー、PdfDocument/PdfPage）をまとめて公開するサブシステムのバレル。
+ *
+ * @module
+ */
+
 export type { ParsedCatalog, ResolveRef } from "./catalog";
 export { CatalogParser } from "./catalog";
 export type { DocumentMetadata, ParsedDocumentInfo } from "./metadata";

--- a/packages/core/src/document/metadata/index.ts
+++ b/packages/core/src/document/metadata/index.ts
@@ -1,3 +1,9 @@
+/**
+ * `/Info` 辞書の解析（`DocumentInfoParser`）とメタデータ型（`DocumentMetadata`, `PdfTrapped`）を公開するバレル。
+ *
+ * @module
+ */
+
 export type { ParsedDocumentInfo } from "./document-info-parser";
 export { DocumentInfoParser } from "./document-info-parser";
 export type { DocumentMetadata } from "./document-metadata";

--- a/packages/core/src/document/page-tree/index.ts
+++ b/packages/core/src/document/page-tree/index.ts
@@ -1,3 +1,9 @@
+/**
+ * ページツリー（`/Pages` ノード）を走査し、継承属性（MediaBox/Resources 等）を解決するモジュール群を公開するバレル。
+ *
+ * @module
+ */
+
 export type {
   InheritedAttrs,
   ResolveInheritedOutcome,

--- a/packages/core/src/pdf/index.ts
+++ b/packages/core/src/pdf/index.ts
@@ -1,3 +1,9 @@
+/**
+ * PDFのエラー型・フィルタ・座標系（TextSpace）・基本型・バージョン情報など、PDF処理全体で共有される基礎的な型とユーティリティを束ねるバレル。
+ *
+ * @module
+ */
+
 export * from "./errors/index";
 export * from "./filter/index";
 export { TextSpace } from "./text-space/index";

--- a/packages/core/src/pdf/types/index.ts
+++ b/packages/core/src/pdf/types/index.ts
@@ -1,3 +1,9 @@
+/**
+ * `ByteOffset` / `ObjectNumber` / `IndirectRef` などのBrand型と `PdfObject` 関連の型、トークン型を公開する基礎型のバレル。
+ *
+ * @module
+ */
+
 export { ByteOffset } from "./byte-offset/index";
 export { GenerationNumber } from "./generation-number/index";
 export { IndirectRef } from "./indirect-ref/index";

--- a/packages/core/src/utils/index.ts
+++ b/packages/core/src/utils/index.ts
@@ -1,3 +1,10 @@
+/**
+ * Brand型・Option/Result モナド・ValueOf などのユーティリティ型を集約するバレル。
+ * パッケージ全体で共通利用される汎用ヘルパーを提供する。
+ *
+ * @module
+ */
+
 export type { Brand } from "./brand/index";
 export * as Option from "./option/index";
 export * as Result from "./result/index";

--- a/packages/core/src/xref/fallback/index.ts
+++ b/packages/core/src/xref/fallback/index.ts
@@ -1,2 +1,8 @@
+/**
+ * xref テーブル/ストリームが破損・欠落している場合に、ファイル全体を走査してオブジェクトを復元する `scanFallback` を公開するバレル。
+ *
+ * @module
+ */
+
 export type { FallbackScanResult } from "./fallback-scanner";
 export { scanFallback } from "./fallback-scanner";

--- a/packages/core/src/xref/startxref/index.ts
+++ b/packages/core/src/xref/startxref/index.ts
@@ -1,1 +1,7 @@
+/**
+ * ファイル末尾から `startxref` キーワードを走査し、xref開始オフセットを取得する `scanStartXRef` を公開するバレル。
+ *
+ * @module
+ */
+
 export { scanStartXRef } from "./scanner/index";

--- a/packages/core/src/xref/stream/index.ts
+++ b/packages/core/src/xref/stream/index.ts
@@ -1,3 +1,9 @@
+/**
+ * クロスリファレンスストリーム（`/Type /XRef`, ISO 32000-1 §7.5.8）のFlateDecode展開・エントリ解析・トレーラ辞書構築を公開するバレル。
+ *
+ * @module
+ */
+
 export { decompressFlate } from "./flatedecode/index";
 export { decodeXRefStreamEntries } from "./parser/index";
 export { buildXRefStreamTrailerDict } from "./trailer/index";

--- a/packages/core/src/xref/table/index.ts
+++ b/packages/core/src/xref/table/index.ts
@@ -1,1 +1,7 @@
+/**
+ * 従来形式のクロスリファレンステーブル（`xref` キーワード, ISO 32000-1 §7.5.4）を解析する `parseXRefTable` を公開するバレル。
+ *
+ * @module
+ */
+
 export { parseXRefTable } from "./parser/index";

--- a/packages/core/src/xref/trailer/index.ts
+++ b/packages/core/src/xref/trailer/index.ts
@@ -1,2 +1,8 @@
+/**
+ * trailer 辞書の構築（`trailerDictBuilder`）と解析（`parseTrailer`）を公開するバレル。
+ *
+ * @module
+ */
+
 export { trailerDictBuilder } from "./dict-builder/index";
 export { parseTrailer } from "./parser/index";


### PR DESCRIPTION
## 概要
- objects配下のバレル（object-store, object-parser, object-stream-extractor）には役割を要約する@moduleヘッダがある一方、他のサブシステム境界バレルにはコメントが一切なく、入口ドキュメントの有無がまちまちだった問題を解消
- document・xref・pdf・utils・content-stream配下の15個のバレルファイル先頭に、再エクスポート内容に基づく1〜2行の@module要約コメントを追加し、ドキュメント方針を統一

## 変更の種類
- 📖 ドキュメント

## 詳細な変更内容
- packages/core/src/pdf/index.ts
- packages/core/src/utils/index.ts
- packages/core/src/document/index.ts
- packages/core/src/document/catalog/index.ts
- packages/core/src/document/date/index.ts
- packages/core/src/document/page-tree/index.ts
- packages/core/src/document/encoding/index.ts
- packages/core/src/document/metadata/index.ts
- packages/core/src/xref/fallback/index.ts
- packages/core/src/xref/stream/index.ts
- packages/core/src/xref/trailer/index.ts
- packages/core/src/xref/table/index.ts
- packages/core/src/xref/startxref/index.ts
- packages/core/src/content-stream/graphics-state/index.ts
- packages/core/src/pdf/types/index.ts

## 関連Issue
Closes #364

## テスト
- コメントのみの修正のため、既存の型チェック・lintが通ることを確認
- ロジック変更なし、テスト追加不要

## レビューポイント
- 15ファイル全てに@module要約コメントが追加されているか
- 各コメントの要約がそのバレルの再エクスポート内容と整合しているか