### PR TITLE
📝 [Doc]: #361 Rustテストコメントのスタイルを統一

### DIFF
--- a/rust/crates/core/src/error/pdf_error.rs
+++ b/rust/crates/core/src/error/pdf_error.rs
@@ -102,34 +102,34 @@ impl Error for PdfError {
 mod tests {
     use super::*;
 
-    // 正常系: new(code) のみで構築すると code() は指定種別を返し、position()/message() は None。
     #[test]
     fn new_sets_code_and_leaves_position_and_message_none() {
+        // new(code) のみで構築すると code() は指定種別を返し、position()/message() は None
         let err = PdfError::new(PdfErrorCode::UnexpectedEof);
         assert_eq!(err.code(), PdfErrorCode::UnexpectedEof);
         assert_eq!(err.position(), None);
         assert_eq!(err.message(), None);
     }
 
-    // 正常系: with_position で位置を付与すると position() が Some(指定 ByteOffset) を返す。
     #[test]
     fn with_position_sets_position() {
+        // with_position で位置を付与すると position() が Some(指定 ByteOffset) を返す
         let err = PdfError::new(PdfErrorCode::UnexpectedToken).with_position(ByteOffset::new(12));
         assert_eq!(err.position(), Some(ByteOffset::new(12)));
         assert_eq!(err.message(), None);
     }
 
-    // 正常系: with_message でメッセージを付与すると message() が Some(指定文字列) を返す。
     #[test]
     fn with_message_sets_message() {
+        // with_message でメッセージを付与すると message() が Some(指定文字列) を返す
         let err = PdfError::new(PdfErrorCode::InvalidNumber).with_message("bad number");
         assert_eq!(err.message(), Some("bad number"));
         assert_eq!(err.position(), None);
     }
 
-    // 正常系: with_position と with_message を連鎖すると全フィールドが指定値を返す。
     #[test]
     fn builder_chain_sets_all_fields() {
+        // with_position と with_message を連鎖すると全フィールドが指定値を返す
         let err = PdfError::new(PdfErrorCode::InvalidSyntax)
             .with_position(ByteOffset::new(7))
             .with_message("oops");
@@ -138,9 +138,9 @@ mod tests {
         assert_eq!(err.message(), Some("oops"));
     }
 
-    // 正常系: with_message は &str / String / format! 結果（impl Into<String>）を受理できる。
     #[test]
     fn with_message_accepts_into_string_sources() {
+        // with_message は &str / String / format! 結果（impl Into<String>）を受理できる
         let from_str = PdfError::new(PdfErrorCode::UnexpectedEof).with_message("literal");
         let from_string =
             PdfError::new(PdfErrorCode::UnexpectedEof).with_message(String::from("owned"));
@@ -151,9 +151,9 @@ mod tests {
         assert_eq!(from_format.message(), Some("tok=1"));
     }
 
-    // 正常系（上書き）: with_position/with_message を複数回呼ぶと後勝ちで最後の値が残る。
     #[test]
     fn builder_methods_overwrite_with_last_value() {
+        // with_position/with_message を複数回呼ぶと後勝ちで最後の値が残る
         let err = PdfError::new(PdfErrorCode::UnexpectedEof)
             .with_position(ByteOffset::new(1))
             .with_position(ByteOffset::new(2))
@@ -163,55 +163,55 @@ mod tests {
         assert_eq!(err.message(), Some("last"));
     }
 
-    // 正常系（Display）: position/message なしのときは種別名のみを出力し、余分な記号を出さない。
     #[test]
     fn display_with_code_only() {
+        // position/message なしのときは種別名のみを出力し、余分な記号を出さない
         let err = PdfError::new(PdfErrorCode::UnexpectedEof);
         assert_eq!(format!("{}", err), "unexpected end of file");
     }
 
-    // 正常系（Display）: position ありのときは " at byte N" を連結する。
     #[test]
     fn display_with_position() {
+        // position ありのときは " at byte N" を連結する
         let err = PdfError::new(PdfErrorCode::UnexpectedEof).with_position(ByteOffset::new(12));
         assert_eq!(format!("{}", err), "unexpected end of file at byte 12");
     }
 
-    // 正常系（Display）: message のみのときは ": <message>" を連結し、" at byte" は出さない。
     #[test]
     fn display_with_message_only() {
+        // message のみのときは ": <message>" を連結し、" at byte" は出さない
         let err = PdfError::new(PdfErrorCode::UnexpectedToken).with_message("unexpected");
         assert_eq!(format!("{}", err), "unexpected token: unexpected");
     }
 
-    // 正常系（Display）: 全要素ありのときは "{code} at byte N: <message>" 形式になる。
     #[test]
     fn display_with_all_fields() {
+        // 全要素ありのときは "{code} at byte N: <message>" 形式になる
         let err = PdfError::new(PdfErrorCode::UnexpectedEof)
             .with_position(ByteOffset::new(12))
             .with_message("eof");
         assert_eq!(format!("{}", err), "unexpected end of file at byte 12: eof");
     }
 
-    // 境界値（Display）: 空文字列メッセージ Some("") を無検証で受理し ":" の後が空になる。
     #[test]
     fn display_with_empty_message() {
+        // 空文字列メッセージ Some("") を無検証で受理し ":" の後が空になる
         let err = PdfError::new(PdfErrorCode::UnexpectedEof).with_message("");
         assert_eq!(err.message(), Some(""));
         assert_eq!(format!("{}", err), "unexpected end of file: ");
     }
 
-    // 正常系（等価）: 同一の code/position/message を持つ 2 値は == で等価になる。
     #[test]
     fn equal_errors_are_equal() {
+        // 同一の code/position/message を持つ 2 値は == で等価になる
         let a = PdfError::new(PdfErrorCode::InvalidSyntax).with_position(ByteOffset::new(1));
         let b = PdfError::new(PdfErrorCode::InvalidSyntax).with_position(ByteOffset::new(1));
         assert_eq!(a, b);
     }
 
-    // 異常系（非等価）: code / position / message のいずれかが異なれば != で非等価になる。
     #[test]
     fn errors_differing_in_any_field_are_not_equal() {
+        // code / position / message のいずれかが異なれば != で非等価になる
         let base = PdfError::new(PdfErrorCode::InvalidSyntax)
             .with_position(ByteOffset::new(1))
             .with_message("m");
@@ -248,34 +248,34 @@ mod tests {
         );
     }
 
-    // エッジケース（trait）: &dyn std::error::Error として扱え、Display 経由で文字列化できる。
     #[test]
     fn usable_as_dyn_error_ref() {
+        // &dyn std::error::Error として扱え、Display 経由で文字列化できる
         let err = PdfError::new(PdfErrorCode::UnexpectedEof);
         let dyn_err: &dyn std::error::Error = &err;
         assert!(!dyn_err.to_string().is_empty());
     }
 
-    // エッジケース（trait）: Box<dyn std::error::Error> へアップキャストでき to_string() が Display と一致する。
     #[test]
     fn usable_as_boxed_dyn_error() {
+        // Box<dyn std::error::Error> へアップキャストでき to_string() が Display と一致する
         let err = PdfError::new(PdfErrorCode::UnexpectedEof).with_position(ByteOffset::new(12));
         let expected = err.to_string();
         let boxed: Box<dyn std::error::Error> = Box::new(err);
         assert_eq!(boxed.to_string(), expected);
     }
 
-    // エッジケース（trait）: 下位エラー連鎖は当面ないため source() は None を返す。
     #[test]
     fn source_is_none() {
+        // 下位エラー連鎖は当面ないため source() は None を返す
         use std::error::Error;
         let err = PdfError::new(PdfErrorCode::UnexpectedEof);
         assert!(err.source().is_none());
     }
 
-    // エッジケース（trait）: Result<(), Box<dyn Error>> の中で ? 演算子により PdfError が自動変換されて伝播する。
     #[test]
     fn propagates_via_question_mark_into_boxed_error() {
+        // Result<(), Box<dyn Error>> の中で ? 演算子により PdfError が自動変換されて伝播する
         fn do_parse() -> Result<(), Box<dyn std::error::Error>> {
             Err(PdfError::new(PdfErrorCode::UnexpectedEof).with_position(ByteOffset::new(3)))?;
             Ok(())

--- a/rust/crates/core/src/object/generation_number.rs
+++ b/rust/crates/core/src/object/generation_number.rs
@@ -33,55 +33,55 @@ mod tests {
     use std::collections::HashMap;
     use std::collections::HashSet;
 
-    // 正常系（往復）: new(n) で包んだ値を value() で取り出すと入力 n と一致する。
-    // 代表値 [0, 1, 42, u16::MAX] で生成と取り出しが無損失（ラウンドトリップ）であることを確認する。
     #[test]
     fn new_then_value_roundtrips() {
+        // new(n) で包んだ値を value() で取り出すと入力 n と一致する
+        // 代表値 [0, 1, 42, u16::MAX] で生成と取り出しが無損失（ラウンドトリップ）であることを確認する
         for n in [0, 1, 42, u16::MAX] {
             assert_eq!(GenerationNumber::new(n).value(), n);
         }
     }
 
-    // 境界値: 0（フリーオブジェクトの予約世代）を無検証で受理し、value() が 0 を返す。
     #[test]
     fn accepts_zero() {
+        // 0（フリーオブジェクトの予約世代）を無検証で受理し、value() が 0 を返す
         assert_eq!(GenerationNumber::new(0).value(), 0);
     }
 
-    // 境界値: 1（最小の「使用中」通常世代）を受理し、value() が 1 を返す。
     #[test]
     fn accepts_one() {
+        // 1（最小の「使用中」通常世代）を受理し、value() が 1 を返す
         assert_eq!(GenerationNumber::new(1).value(), 1);
     }
 
-    // 境界値: u16::MAX（= 65535、ISO 32000-1 §7.5.4 の世代上限）を受理し、範囲上限を取り出せる。
     #[test]
     fn accepts_u16_max() {
+        // u16::MAX（= 65535、ISO 32000-1 §7.5.4 の世代上限）を受理し、範囲上限を取り出せる
         assert_eq!(GenerationNumber::new(u16::MAX).value(), u16::MAX);
     }
 
-    // 正常系（等価）: 同じ u16 から生成した 2 値は == で等価になる（PartialEq/Eq が内部値に委譲）。
     #[test]
     fn equal_numbers_are_equal() {
+        // 同じ u16 から生成した 2 値は == で等価になる（PartialEq/Eq が内部値に委譲）
         assert_eq!(GenerationNumber::new(7), GenerationNumber::new(7));
     }
 
-    // 正常系（非等価）: 異なる u16 から生成した 2 値は != で非等価になる。
     #[test]
     fn different_numbers_are_not_equal() {
+        // 異なる u16 から生成した 2 値は != で非等価になる
         assert_ne!(GenerationNumber::new(7), GenerationNumber::new(8));
     }
 
-    // 正常系（順序）: < / > による大小比較が内部 u16 の大小と一致する（PartialOrd/Ord が内部値に委譲）。
     #[test]
     fn orders_by_inner_value() {
+        // < / > による大小比較が内部 u16 の大小と一致する（PartialOrd/Ord が内部値に委譲）
         assert!(GenerationNumber::new(1) < GenerationNumber::new(2));
         assert!(GenerationNumber::new(3) > GenerationNumber::new(2));
     }
 
-    // 正常系（ソート）: 配列を sort() すると内部 u16 の昇順に並ぶ（Ord により [3,1,2] → [1,2,3]）。
     #[test]
     fn sorts_in_ascending_order() {
+        // 配列を sort() すると内部 u16 の昇順に並ぶ（Ord により [3,1,2] → [1,2,3]）
         let mut numbers = [
             GenerationNumber::new(3),
             GenerationNumber::new(1),
@@ -98,26 +98,26 @@ mod tests {
         );
     }
 
-    // エッジケース（Copy）: 代入でコピーしても元の値はムーブされず、コピーと等価のまま使い続けられる。
     #[test]
     fn is_copy_so_original_stays_usable() {
+        // 代入でコピーしても元の値はムーブされず、コピーと等価のまま使い続けられる
         let original = GenerationNumber::new(5);
         let copied = original;
         assert_eq!(original.value(), 5);
         assert_eq!(original, copied);
     }
 
-    // 正常系（HashMap キー）: HashMap のキーとして使え、同値キーで get すると挿入値を取得できる（Hash + Eq）。
     #[test]
     fn works_as_hash_map_key() {
+        // HashMap のキーとして使え、同値キーで get すると挿入値を取得できる（Hash + Eq）
         let mut map = HashMap::new();
         map.insert(GenerationNumber::new(10), "ten");
         assert_eq!(map.get(&GenerationNumber::new(10)), Some(&"ten"));
     }
 
-    // エッジケース（HashSet 折りたたみ）: 同値を 2 回挿入しても要素数は 1 になる（同値が 1 つに折りたたまれる）。
     #[test]
     fn equal_keys_collapse_in_hash_set() {
+        // 同値を 2 回挿入しても要素数は 1 になる（同値が 1 つに折りたたまれる）
         let mut set = HashSet::new();
         set.insert(GenerationNumber::new(3));
         set.insert(GenerationNumber::new(3));

--- a/rust/crates/core/src/object/object_id.rs
+++ b/rust/crates/core/src/object/object_id.rs
@@ -47,9 +47,9 @@ mod tests {
     use super::*;
     use std::collections::{HashMap, HashSet};
 
-    /// 代表ペアで `new` に包んだ値を 2 アクセサで取り出すと入力と一致する（ラウンドトリップ・無損失）。
     #[test]
     fn new_then_accessors_roundtrip() {
+        // 代表ペアで new に包んだ値を 2 アクセサで取り出すと入力と一致する（ラウンドトリップ・無損失）
         for (n, g) in [(0u64, 0u16), (1, 1), (42, 42), (u64::MAX, u16::MAX)] {
             let id = ObjectId::new(ObjectNumber::new(n), GenerationNumber::new(g));
             assert_eq!(id.object_number(), ObjectNumber::new(n));
@@ -57,51 +57,51 @@ mod tests {
         }
     }
 
-    /// object_number・generation_number がともに同一なら等価（Eq が両フィールドに委譲）。
     #[test]
     fn equal_when_both_fields_match() {
+        // object_number・generation_number がともに同一なら等価（Eq が両フィールドに委譲）
         let a = ObjectId::new(ObjectNumber::new(5), GenerationNumber::new(0));
         let b = ObjectId::new(ObjectNumber::new(5), GenerationNumber::new(0));
         assert_eq!(a, b);
     }
 
-    /// object_number 同一・generation_number のみ異なれば非等価（片フィールド依存でないことを保証）。
     #[test]
     fn not_equal_when_generation_differs() {
+        // object_number 同一・generation_number のみ異なれば非等価（片フィールド依存でないことを保証）
         let a = ObjectId::new(ObjectNumber::new(5), GenerationNumber::new(0));
         let b = ObjectId::new(ObjectNumber::new(5), GenerationNumber::new(1));
         assert_ne!(a, b);
     }
 
-    /// generation_number 同一・object_number のみ異なれば非等価（両フィールド依存の裏付け）。
     #[test]
     fn not_equal_when_object_number_differs() {
+        // generation_number 同一・object_number のみ異なれば非等価（両フィールド依存の裏付け）
         let a = ObjectId::new(ObjectNumber::new(5), GenerationNumber::new(0));
         let b = ObjectId::new(ObjectNumber::new(6), GenerationNumber::new(0));
         assert_ne!(a, b);
     }
 
-    /// 辞書順は object_number を第 1 キーとする（generation_number に関わらず object_number が小さい方が小）。
     #[test]
     fn orders_by_object_number_first() {
+        // 辞書順は object_number を第 1 キーとする（generation_number に関わらず object_number が小さい方が小）
         let small = ObjectId::new(ObjectNumber::new(1), GenerationNumber::new(9));
         let large = ObjectId::new(ObjectNumber::new(2), GenerationNumber::new(0));
         assert!(small < large);
         assert!(large > small);
     }
 
-    /// object_number 同一時は第 2 キー generation_number で大小が決まる。
     #[test]
     fn orders_by_generation_when_object_number_equal() {
+        // object_number 同一時は第 2 キー generation_number で大小が決まる
         let small = ObjectId::new(ObjectNumber::new(5), GenerationNumber::new(1));
         let large = ObjectId::new(ObjectNumber::new(5), GenerationNumber::new(2));
         assert!(small < large);
         assert!(large > small);
     }
 
-    /// `sort()` すると Ord の 2 軸（object_number 優先 → generation_number）で辞書順に並ぶ。
     #[test]
     fn sorts_in_lexicographic_order() {
+        // sort() すると Ord の 2 軸（object_number 優先 → generation_number）で辞書順に並ぶ
         let mut ids = [
             ObjectId::new(ObjectNumber::new(2), GenerationNumber::new(0)),
             ObjectId::new(ObjectNumber::new(1), GenerationNumber::new(5)),
@@ -118,9 +118,9 @@ mod tests {
         );
     }
 
-    /// `Copy` のため代入でコピーされ、元値も使用可能でコピーと等価。
     #[test]
     fn is_copy_so_original_stays_usable() {
+        // Copy のため代入でコピーされ、元値も使用可能でコピーと等価
         let id = ObjectId::new(ObjectNumber::new(7), GenerationNumber::new(3));
         let copied = id;
         assert_eq!(id.object_number(), ObjectNumber::new(7));
@@ -128,9 +128,9 @@ mod tests {
         assert_eq!(id, copied);
     }
 
-    /// `HashMap<ObjectId, _>` のキーとして使え、同値キーで挿入値を取得できる（Hash + Eq）。
     #[test]
     fn works_as_hash_map_key() {
+        // HashMap<ObjectId, _> のキーとして使え、同値キーで挿入値を取得できる（Hash + Eq）
         let mut map = HashMap::new();
         map.insert(
             ObjectId::new(ObjectNumber::new(10), GenerationNumber::new(0)),
@@ -145,9 +145,9 @@ mod tests {
         );
     }
 
-    /// 同値 `ObjectId` を `HashSet` に 2 回挿入すると 1 件に折りたたまれる。
     #[test]
     fn equal_keys_collapse_in_hash_set() {
+        // 同値 ObjectId を HashSet に 2 回挿入すると 1 件に折りたたまれる
         let mut set = HashSet::new();
         set.insert(ObjectId::new(
             ObjectNumber::new(3),
@@ -160,9 +160,9 @@ mod tests {
         assert_eq!(set.len(), 1);
     }
 
-    /// object_number 同一・generation 違いの 2 値は別キーとして `HashSet` に共存する（両フィールド依存）。
     #[test]
     fn distinct_keys_coexist_in_hash_set() {
+        // object_number 同一・generation 違いの 2 値は別キーとして HashSet に共存する（両フィールド依存）
         let mut set = HashSet::new();
         set.insert(ObjectId::new(
             ObjectNumber::new(7),
@@ -175,25 +175,25 @@ mod tests {
         assert_eq!(set.len(), 2);
     }
 
-    /// 最小境界の組 `(0, 0)` を無検証で受理し、アクセサが `0`/`0` を返す。
     #[test]
     fn accepts_min_boundary_combo() {
+        // 最小境界の組 (0, 0) を無検証で受理し、アクセサが 0/0 を返す
         let id = ObjectId::new(ObjectNumber::new(0), GenerationNumber::new(0));
         assert_eq!(id.object_number().value(), 0);
         assert_eq!(id.generation_number().value(), 0);
     }
 
-    /// 最大境界の組 `(u64::MAX, u16::MAX)` を無検証で受理し、アクセサが各境界値を返す。
     #[test]
     fn accepts_max_boundary_combo() {
+        // 最大境界の組 (u64::MAX, u16::MAX) を無検証で受理し、アクセサが各境界値を返す
         let id = ObjectId::new(ObjectNumber::new(u64::MAX), GenerationNumber::new(u16::MAX));
         assert_eq!(id.object_number().value(), u64::MAX);
         assert_eq!(id.generation_number().value(), u16::MAX);
     }
 
-    /// 片フィールドのみ MAX の組（`(u64::MAX,0)` と `(0,u16::MAX)`）を受理し、双方は非等価。
     #[test]
     fn accepts_mixed_boundary_combo() {
+        // 片フィールドのみ MAX の組（(u64::MAX,0) と (0,u16::MAX)）を受理し、双方は非等価
         let obj_max = ObjectId::new(ObjectNumber::new(u64::MAX), GenerationNumber::new(0));
         let gen_max = ObjectId::new(ObjectNumber::new(0), GenerationNumber::new(u16::MAX));
         assert_eq!(obj_max.object_number().value(), u64::MAX);


### PR DESCRIPTION
## 概要
- Issue #361 の指摘どおり、テストコメントの配置・形式がファイルごとにバラバラだった状態を「テスト本体先頭行に `//` で検証内容を書く」スタイルに統一

## 変更の種類
- 📖 ドキュメント

## 詳細な変更内容
- `rust/crates/core/src/object/object_id.rs`: テスト関数に付与していた `///` docコメントを、テスト本体先頭行の `//` コメントへ変更（検証内容の文言は保持）
- `rust/crates/core/src/object/generation_number.rs`: `#[test]` の上にあった「正常系/境界値/エッジケース」分類プレフィックス付き `//` コメントから、プレフィックスを削りテスト本体先頭行の `//` コメントへ移動
- `rust/crates/core/src/error/pdf_error.rs`: 同様に「正常系/異常系/境界値/エッジケース」分類プレフィックス付きコメントから、プレフィックスを削りテスト本体先頭行の `//` コメントへ移動
- 既に「テスト本体先頭に `//`」スタイルだった `byte_offset.rs` / `object/dictionary.rs` / `object/name.rs` / `error/pdf_error_code.rs` は変更なし（確認のみ）
- `object/pdf_object.rs` 自体はテストを持たず `mod tests;` で `pdf_object/tests/*.rs` を参照する構成になっており、参照先は既に統一スタイルだったため変更なし
- Issue本文にある `object_number.rs` は日本語コメント自体が無い既知の例外のため対象外（Issue記載どおり）

## 関連Issue
Closes #361

## テスト
- コメントスタイルのみの修正のため、既存の cargo fmt/clippy/test が通ることを確認
- `cargo fmt --check`: 差分なし
- `cargo clippy --all-targets -- -D warnings`: warning 0件
- `cargo test`: 1133 passed; 0 failed（変更前後でテスト件数・アサーション内容に変化なし）
- ロジック変更なし

## レビューポイント
- 統一後のスタイル（テスト本体先頭行の `//` コメント、分類プレフィックスなし）が `rust-rules-plugin:testing` スキルの規定・他ファイルの慣習と一致しているか
- コメントの文言が元の検証内容から意味を変えずに保持されているか