### PR TITLE
📝 [Doc]: #354 パッケージ外公開/横断利用される型にJSDocを追加

### DIFF
--- a/packages/core/src/content-stream/graphics-state/color/index.ts
+++ b/packages/core/src/content-stream/graphics-state/color/index.ts
@@ -1,15 +1,16 @@
 import { ColorSpace } from "../color-space";
 
 /**
- * PDF spec §8.6 のデバイス色値。
- * DeviceGray / DeviceRGB / DeviceCMYK を discriminated union で表現する。
- * 値域 (0.0〜1.0) の検証はここでは行わない (Issue #208 仕様)。
+ * DeviceGray の色値。
  */
 export type GrayColor = {
   readonly kind: "gray";
   readonly g: number;
 };
 
+/**
+ * DeviceRGB の色値。
+ */
 export type RgbColor = {
   readonly kind: "rgb";
   readonly r: number;
@@ -17,6 +18,9 @@ export type RgbColor = {
   readonly b: number;
 };
 
+/**
+ * DeviceCMYK の色値。
+ */
 export type CmykColor = {
   readonly kind: "cmyk";
   readonly c: number;
@@ -25,6 +29,11 @@ export type CmykColor = {
   readonly k: number;
 };
 
+/**
+ * PDF spec §8.6 のデバイス色値。
+ * DeviceGray / DeviceRGB / DeviceCMYK を discriminated union で表現する。
+ * 値域 (0.0〜1.0) の検証はここでは行わない (Issue #208 仕様)。
+ */
 export type Color = GrayColor | RgbColor | CmykColor;
 
 export const Color = {

--- a/packages/core/src/content-stream/graphics-state/path-segment/index.ts
+++ b/packages/core/src/content-stream/graphics-state/path-segment/index.ts
@@ -1,6 +1,5 @@
 /**
- * PDF spec §4.1 path construction operator が生成する 1 segment。
- * discriminated union + companion object (factory + is*).
+ * `m` operator (moveto) が生成する segment。新しいサブパスを現在点として開始する。
  */
 export type MoveToSegment = {
   readonly kind: "moveTo";
@@ -8,12 +7,18 @@ export type MoveToSegment = {
   readonly y: number;
 };
 
+/**
+ * `l` operator (lineto) が生成する segment。現在点から直線を追加する。
+ */
 export type LineToSegment = {
   readonly kind: "lineTo";
   readonly x: number;
   readonly y: number;
 };
 
+/**
+ * `c` operator (curveto) が生成する segment。2 つの制御点を持つ 3 次 Bezier 曲線を追加する。
+ */
 export type CurveToSegment = {
   readonly kind: "curveTo";
   readonly x1: number;
@@ -24,10 +29,16 @@ export type CurveToSegment = {
   readonly y3: number;
 };
 
+/**
+ * `h` operator (closepath) が生成する segment。現在のサブパスを開始点へ直線で閉じる。
+ */
 export type CloseSegment = {
   readonly kind: "close";
 };
 
+/**
+ * `re` operator (rectangle) が生成する segment。矩形の独立したサブパスを追加する。
+ */
 export type RectSegment = {
   readonly kind: "rect";
   readonly x: number;
@@ -36,6 +47,10 @@ export type RectSegment = {
   readonly height: number;
 };
 
+/**
+ * PDF spec §4.1 path construction operator が生成する 1 segment。
+ * discriminated union + companion object (factory + is*).
+ */
 export type PathSegment =
   | MoveToSegment
   | LineToSegment

--- a/packages/core/src/content-stream/interpreter/index.ts
+++ b/packages/core/src/content-stream/interpreter/index.ts
@@ -18,14 +18,25 @@ import {
 import { ContentStreamTokenizer } from "../tokenizer/index";
 import { readArrayOperand, readDictOperand } from "./composite-operand/index";
 
+/**
+ * `ContentStreamInterpreter.execute` の入力パラメータ。
+ */
 export type ContentStreamInterpreterExecuteOptions = {
+  /** 実行対象の content stream バイト列 */
   readonly data: Uint8Array;
+  /** operator handler の登録簿 */
   readonly registry: OperatorRegistry;
+  /** 呼び出し側が指定する任意の初期 context（省略時は新規生成される） */
   readonly initialContext?: OperatorHandlerContext;
 };
 
+/**
+ * `ContentStreamInterpreter.execute` の実行結果。
+ */
 export type ContentStreamInterpreterResult = {
+  /** 実行完了時点の最終 context */
   readonly context: OperatorHandlerContext;
+  /** 実行中に収集された warning の一覧 */
   readonly warnings: readonly PdfWarning[];
 };
 
@@ -37,6 +48,10 @@ type InterpreterStep =
   | { readonly type: "continue"; readonly context: OperatorHandlerContext }
   | { readonly type: "done"; readonly result: InterpreterDoneResult };
 
+/**
+ * Content stream (RPN 命令列) を解釈実行するインタプリタ。
+ * Operator dispatch・inline image・複合オペランド (array/dict) の読み取りを統括する。
+ */
 export const ContentStreamInterpreter = {
   /**
    * Content stream の token 列をRPNとしてEOFまで逐次実行する。

--- a/packages/core/src/xref/fallback/object-scanner/index.ts
+++ b/packages/core/src/xref/fallback/object-scanner/index.ts
@@ -35,6 +35,10 @@ export interface ObjectScanSkipped {
   readonly reason: "object-number-invalid" | "generation-invalid";
 }
 
+/**
+ * `scanObjectHeaders` による走査結果。
+ * 検出できた `ObjectHit` と、検証で弾かれた `ObjectScanSkipped` の両方を含む。
+ */
 export interface ObjectScanReport {
   readonly hits: readonly ObjectHit[];
   readonly skipped: readonly ObjectScanSkipped[];


### PR DESCRIPTION
## 概要
- interpreter/path-segment/color/object-scannerの各型にJSDocを追加し、IDEホバーで説明が表示されるようにした

## 変更の種類
- 📖 ドキュメント

## 詳細な変更内容
- `content-stream/interpreter/index.ts`: `ContentStreamInterpreterExecuteOptions` / `ContentStreamInterpreterResult` とそのフィールド、`ContentStreamInterpreter` 本体にJSDocを追加
- `content-stream/graphics-state/path-segment/index.ts`: union全体の説明を `PathSegment` 型に移し、`MoveToSegment` / `LineToSegment` / `CurveToSegment` / `CloseSegment` / `RectSegment` それぞれに1行JSDocを追加
- `content-stream/graphics-state/color/index.ts`: 同様にunion全体の説明を `Color` 型に移し、`GrayColor` / `RgbColor` / `CmykColor` それぞれに1行JSDocを追加
- `xref/fallback/object-scanner/index.ts`: 同ファイル内の他interface (`ObjectHit` / `ObjectScanSkipped`) のスタイルに合わせて `ObjectScanReport` にJSDocを追加

## 関連Issue
Closes #354

## テスト
- コメントのみの修正のため、既存の型チェック・lintが通ることを確認
- ロジック変更なし、テスト追加不要

## レビューポイント
- (JSDocの内容が実装と一致しているか)