### PR TITLE
🧪 [Tests]: #381 #392 #508 #361 Rust コアのテスト不足・テストコメントスタイル不統一を解消

### DIFF
--- a/rust/crates/core/src/error/pdf_error.rs
+++ b/rust/crates/core/src/error/pdf_error.rs
@@ -102,34 +102,34 @@ impl Error for PdfError {
 mod tests {
     use super::*;
 
-    // 正常系: new(code) のみで構築すると code() は指定種別を返し、position()/message() は None。
     #[test]
     fn new_sets_code_and_leaves_position_and_message_none() {
+        // new(code) のみで構築すると code() は指定種別を返し、position()/message() は None。
         let err = PdfError::new(PdfErrorCode::UnexpectedEof);
         assert_eq!(err.code(), PdfErrorCode::UnexpectedEof);
         assert_eq!(err.position(), None);
         assert_eq!(err.message(), None);
     }
 
-    // 正常系: with_position で位置を付与すると position() が Some(指定 ByteOffset) を返す。
     #[test]
     fn with_position_sets_position() {
+        // with_position で位置を付与すると position() が Some(指定 ByteOffset) を返す。
         let err = PdfError::new(PdfErrorCode::UnexpectedToken).with_position(ByteOffset::new(12));
         assert_eq!(err.position(), Some(ByteOffset::new(12)));
         assert_eq!(err.message(), None);
     }
 
-    // 正常系: with_message でメッセージを付与すると message() が Some(指定文字列) を返す。
     #[test]
     fn with_message_sets_message() {
+        // with_message でメッセージを付与すると message() が Some(指定文字列) を返す。
         let err = PdfError::new(PdfErrorCode::InvalidNumber).with_message("bad number");
         assert_eq!(err.message(), Some("bad number"));
         assert_eq!(err.position(), None);
     }
 
-    // 正常系: with_position と with_message を連鎖すると全フィールドが指定値を返す。
     #[test]
     fn builder_chain_sets_all_fields() {
+        // with_position と with_message を連鎖すると全フィールドが指定値を返す。
         let err = PdfError::new(PdfErrorCode::InvalidSyntax)
             .with_position(ByteOffset::new(7))
             .with_message("oops");
@@ -138,9 +138,9 @@ mod tests {
         assert_eq!(err.message(), Some("oops"));
     }
 
-    // 正常系: with_message は &str / String / format! 結果（impl Into<String>）を受理できる。
     #[test]
     fn with_message_accepts_into_string_sources() {
+        // with_message は &str / String / format! 結果（impl Into<String>）を受理できる。
         let from_str = PdfError::new(PdfErrorCode::UnexpectedEof).with_message("literal");
         let from_string =
             PdfError::new(PdfErrorCode::UnexpectedEof).with_message(String::from("owned"));
@@ -151,9 +151,9 @@ mod tests {
         assert_eq!(from_format.message(), Some("tok=1"));
     }
 
-    // 正常系（上書き）: with_position/with_message を複数回呼ぶと後勝ちで最後の値が残る。
     #[test]
     fn builder_methods_overwrite_with_last_value() {
+        // with_position/with_message を複数回呼ぶと後勝ちで最後の値が残る。
         let err = PdfError::new(PdfErrorCode::UnexpectedEof)
             .with_position(ByteOffset::new(1))
             .with_position(ByteOffset::new(2))
@@ -163,55 +163,55 @@ mod tests {
         assert_eq!(err.message(), Some("last"));
     }
 
-    // 正常系（Display）: position/message なしのときは種別名のみを出力し、余分な記号を出さない。
     #[test]
     fn display_with_code_only() {
+        // position/message なしのときは種別名のみを出力し、余分な記号を出さない。
         let err = PdfError::new(PdfErrorCode::UnexpectedEof);
         assert_eq!(format!("{}", err), "unexpected end of file");
     }
 
-    // 正常系（Display）: position ありのときは " at byte N" を連結する。
     #[test]
     fn display_with_position() {
+        // position ありのときは " at byte N" を連結する。
         let err = PdfError::new(PdfErrorCode::UnexpectedEof).with_position(ByteOffset::new(12));
         assert_eq!(format!("{}", err), "unexpected end of file at byte 12");
     }
 
-    // 正常系（Display）: message のみのときは ": <message>" を連結し、" at byte" は出さない。
     #[test]
     fn display_with_message_only() {
+        // message のみのときは ": <message>" を連結し、" at byte" は出さない。
         let err = PdfError::new(PdfErrorCode::UnexpectedToken).with_message("unexpected");
         assert_eq!(format!("{}", err), "unexpected token: unexpected");
     }
 
-    // 正常系（Display）: 全要素ありのときは "{code} at byte N: <message>" 形式になる。
     #[test]
     fn display_with_all_fields() {
+        // 全要素ありのときは "{code} at byte N: <message>" 形式になる。
         let err = PdfError::new(PdfErrorCode::UnexpectedEof)
             .with_position(ByteOffset::new(12))
             .with_message("eof");
         assert_eq!(format!("{}", err), "unexpected end of file at byte 12: eof");
     }
 
-    // 境界値（Display）: 空文字列メッセージ Some("") を無検証で受理し ":" の後が空になる。
     #[test]
     fn display_with_empty_message() {
+        // 空文字列メッセージ Some("") を無検証で受理し ":" の後が空になる。
         let err = PdfError::new(PdfErrorCode::UnexpectedEof).with_message("");
         assert_eq!(err.message(), Some(""));
         assert_eq!(format!("{}", err), "unexpected end of file: ");
     }
 
-    // 正常系（等価）: 同一の code/position/message を持つ 2 値は == で等価になる。
     #[test]
     fn equal_errors_are_equal() {
+        // 同一の code/position/message を持つ 2 値は == で等価になる。
         let a = PdfError::new(PdfErrorCode::InvalidSyntax).with_position(ByteOffset::new(1));
         let b = PdfError::new(PdfErrorCode::InvalidSyntax).with_position(ByteOffset::new(1));
         assert_eq!(a, b);
     }
 
-    // 異常系（非等価）: code / position / message のいずれかが異なれば != で非等価になる。
     #[test]
     fn errors_differing_in_any_field_are_not_equal() {
+        // code / position / message のいずれかが異なれば != で非等価になる。
         let base = PdfError::new(PdfErrorCode::InvalidSyntax)
             .with_position(ByteOffset::new(1))
             .with_message("m");
@@ -248,34 +248,34 @@ mod tests {
         );
     }
 
-    // エッジケース（trait）: &dyn std::error::Error として扱え、Display 経由で文字列化できる。
     #[test]
     fn usable_as_dyn_error_ref() {
+        // &dyn std::error::Error として扱え、Display 経由で文字列化できる。
         let err = PdfError::new(PdfErrorCode::UnexpectedEof);
         let dyn_err: &dyn std::error::Error = &err;
         assert!(!dyn_err.to_string().is_empty());
     }
 
-    // エッジケース（trait）: Box<dyn std::error::Error> へアップキャストでき to_string() が Display と一致する。
     #[test]
     fn usable_as_boxed_dyn_error() {
+        // Box<dyn std::error::Error> へアップキャストでき to_string() が Display と一致する。
         let err = PdfError::new(PdfErrorCode::UnexpectedEof).with_position(ByteOffset::new(12));
         let expected = err.to_string();
         let boxed: Box<dyn std::error::Error> = Box::new(err);
         assert_eq!(boxed.to_string(), expected);
     }
 
-    // エッジケース（trait）: 下位エラー連鎖は当面ないため source() は None を返す。
     #[test]
     fn source_is_none() {
+        // 下位エラー連鎖は当面ないため source() は None を返す。
         use std::error::Error;
         let err = PdfError::new(PdfErrorCode::UnexpectedEof);
         assert!(err.source().is_none());
     }
 
-    // エッジケース（trait）: Result<(), Box<dyn Error>> の中で ? 演算子により PdfError が自動変換されて伝播する。
     #[test]
     fn propagates_via_question_mark_into_boxed_error() {
+        // Result<(), Box<dyn Error>> の中で ? 演算子により PdfError が自動変換されて伝播する。
         fn do_parse() -> Result<(), Box<dyn std::error::Error>> {
             Err(PdfError::new(PdfErrorCode::UnexpectedEof).with_position(ByteOffset::new(3)))?;
             Ok(())

--- a/rust/crates/core/src/lexer/tests/lexer_skip_comment.rs
+++ b/rust/crates/core/src/lexer/tests/lexer_skip_comment.rs
@@ -118,3 +118,12 @@ fn skip_comment_body_outlives_subsequent_peek_call() {
     assert_eq!(lexer.peek(), Some(b'r'));
     assert_eq!(body, Some(b"hello".as_slice()));
 }
+
+#[test]
+fn skip_comment_consumes_body_containing_pdf_delimiters() {
+    // コメント本文に PDF デリミタ ( ) / < > を含んでもトークン化されず EOL まで丸ごと本文として
+    // 消費され、次トークンの読み取り位置が正しく EOL 直後になることを確認する
+    let mut lexer = Lexer::new(b"%foo(bar)/Baz<01>\nrest");
+    assert_eq!(lexer.skip_comment(), Some(b"foo(bar)/Baz<01>".as_slice()));
+    assert_eq!(lexer.peek(), Some(b'r'));
+}

--- a/rust/crates/core/src/object/generation_number.rs
+++ b/rust/crates/core/src/object/generation_number.rs
@@ -33,55 +33,55 @@ mod tests {
     use std::collections::HashMap;
     use std::collections::HashSet;
 
-    // 正常系（往復）: new(n) で包んだ値を value() で取り出すと入力 n と一致する。
-    // 代表値 [0, 1, 42, u16::MAX] で生成と取り出しが無損失（ラウンドトリップ）であることを確認する。
     #[test]
     fn new_then_value_roundtrips() {
+        // new(n) で包んだ値を value() で取り出すと入力 n と一致する。
+        // 代表値 [0, 1, 42, u16::MAX] で生成と取り出しが無損失（ラウンドトリップ）であることを確認する。
         for n in [0, 1, 42, u16::MAX] {
             assert_eq!(GenerationNumber::new(n).value(), n);
         }
     }
 
-    // 境界値: 0（フリーオブジェクトの予約世代）を無検証で受理し、value() が 0 を返す。
     #[test]
     fn accepts_zero() {
+        // 0（フリーオブジェクトの予約世代）を無検証で受理し、value() が 0 を返す。
         assert_eq!(GenerationNumber::new(0).value(), 0);
     }
 
-    // 境界値: 1（最小の「使用中」通常世代）を受理し、value() が 1 を返す。
     #[test]
     fn accepts_one() {
+        // 1（最小の「使用中」通常世代）を受理し、value() が 1 を返す。
         assert_eq!(GenerationNumber::new(1).value(), 1);
     }
 
-    // 境界値: u16::MAX（= 65535、ISO 32000-1 §7.5.4 の世代上限）を受理し、範囲上限を取り出せる。
     #[test]
     fn accepts_u16_max() {
+        // u16::MAX（= 65535、ISO 32000-1 §7.5.4 の世代上限）を受理し、範囲上限を取り出せる。
         assert_eq!(GenerationNumber::new(u16::MAX).value(), u16::MAX);
     }
 
-    // 正常系（等価）: 同じ u16 から生成した 2 値は == で等価になる（PartialEq/Eq が内部値に委譲）。
     #[test]
     fn equal_numbers_are_equal() {
+        // 同じ u16 から生成した 2 値は == で等価になる（PartialEq/Eq が内部値に委譲）。
         assert_eq!(GenerationNumber::new(7), GenerationNumber::new(7));
     }
 
-    // 正常系（非等価）: 異なる u16 から生成した 2 値は != で非等価になる。
     #[test]
     fn different_numbers_are_not_equal() {
+        // 異なる u16 から生成した 2 値は != で非等価になる。
         assert_ne!(GenerationNumber::new(7), GenerationNumber::new(8));
     }
 
-    // 正常系（順序）: < / > による大小比較が内部 u16 の大小と一致する（PartialOrd/Ord が内部値に委譲）。
     #[test]
     fn orders_by_inner_value() {
+        // < / > による大小比較が内部 u16 の大小と一致する（PartialOrd/Ord が内部値に委譲）。
         assert!(GenerationNumber::new(1) < GenerationNumber::new(2));
         assert!(GenerationNumber::new(3) > GenerationNumber::new(2));
     }
 
-    // 正常系（ソート）: 配列を sort() すると内部 u16 の昇順に並ぶ（Ord により [3,1,2] → [1,2,3]）。
     #[test]
     fn sorts_in_ascending_order() {
+        // 配列を sort() すると内部 u16 の昇順に並ぶ（Ord により [3,1,2] → [1,2,3]）。
         let mut numbers = [
             GenerationNumber::new(3),
             GenerationNumber::new(1),
@@ -98,26 +98,26 @@ mod tests {
         );
     }
 
-    // エッジケース（Copy）: 代入でコピーしても元の値はムーブされず、コピーと等価のまま使い続けられる。
     #[test]
     fn is_copy_so_original_stays_usable() {
+        // 代入でコピーしても元の値はムーブされず、コピーと等価のまま使い続けられる。
         let original = GenerationNumber::new(5);
         let copied = original;
         assert_eq!(original.value(), 5);
         assert_eq!(original, copied);
     }
 
-    // 正常系（HashMap キー）: HashMap のキーとして使え、同値キーで get すると挿入値を取得できる（Hash + Eq）。
     #[test]
     fn works_as_hash_map_key() {
+        // HashMap のキーとして使え、同値キーで get すると挿入値を取得できる（Hash + Eq）。
         let mut map = HashMap::new();
         map.insert(GenerationNumber::new(10), "ten");
         assert_eq!(map.get(&GenerationNumber::new(10)), Some(&"ten"));
     }
 
-    // エッジケース（HashSet 折りたたみ）: 同値を 2 回挿入しても要素数は 1 になる（同値が 1 つに折りたたまれる）。
     #[test]
     fn equal_keys_collapse_in_hash_set() {
+        // 同値を 2 回挿入しても要素数は 1 になる（同値が 1 つに折りたたまれる）。
         let mut set = HashSet::new();
         set.insert(GenerationNumber::new(3));
         set.insert(GenerationNumber::new(3));

--- a/rust/crates/core/src/object/indirect_object.rs
+++ b/rust/crates/core/src/object/indirect_object.rs
@@ -64,17 +64,17 @@ mod tests {
         ObjectId::new(ObjectNumber::new(n), GenerationNumber::new(g))
     }
 
-    /// 代表 `(n,g)` + Integer content を `new` に包み `id()`/`object()` で取り出すと入力と一致する（ラウンドトリップ・無損失）。
     #[test]
     fn new_then_accessors_roundtrip() {
+        // 代表 `(n,g)` + Integer content を `new` に包み `id()`/`object()` で取り出すと入力と一致する（ラウンドトリップ・無損失）。
         let io = IndirectObject::new(oid(1, 0), PdfObject::Integer(42));
         assert_eq!(io.id(), oid(1, 0));
         assert_eq!(io.object(), &PdfObject::Integer(42));
     }
 
-    /// `id()` は `Copy` 値返しのため複数回呼んでも元の `IndirectObject` を使い続けられ、両呼び出しが等価。
     #[test]
     fn id_returns_copy_and_stays_usable() {
+        // `id()` は `Copy` 値返しのため複数回呼んでも元の `IndirectObject` を使い続けられ、両呼び出しが等価。
         let io = IndirectObject::new(oid(7, 3), PdfObject::Boolean(true));
         let first = io.id();
         let second = io.id();
@@ -82,149 +82,149 @@ mod tests {
         assert_eq!(io.object(), &PdfObject::Boolean(true));
     }
 
-    /// `object()` は参照返しで、内包 content と `==` で一致する（借用経路で内容へ到達できる）。
     #[test]
     fn object_returns_reference_to_content() {
+        // `object()` は参照返しで、内包 content と `==` で一致する（借用経路で内容へ到達できる）。
         let io = IndirectObject::new(oid(2, 0), PdfObject::Integer(9));
         let reference: &PdfObject = io.object();
         assert_eq!(reference, &PdfObject::Integer(9));
     }
 
-    /// `into_parts()` で `(id, object)` を所有取り出し（消費・ムーブ）すると、構築時の入力と一致する（無損失ムーブ・clone なし）。
     #[test]
     fn into_parts_decomposes_ownership() {
+        // `into_parts()` で `(id, object)` を所有取り出し（消費・ムーブ）すると、構築時の入力と一致する（無損失ムーブ・clone なし）。
         let io = IndirectObject::new(oid(12, 0), PdfObject::String(b"body".to_vec()));
         let (id, object) = io.into_parts();
         assert_eq!(id, oid(12, 0));
         assert_eq!(object, PdfObject::String(b"body".to_vec()));
     }
 
-    /// `clone()` の複製が元と `==` 等価かつ元も引き続き使用可能（深いコピー・独立性）。
     #[test]
     fn clone_preserves_content_and_keeps_original_usable() {
+        // `clone()` の複製が元と `==` 等価かつ元も引き続き使用可能（深いコピー・独立性）。
         let original = IndirectObject::new(oid(5, 1), PdfObject::Integer(100));
         let cloned = original.clone();
         assert_eq!(cloned, original);
         assert_eq!(original.object(), &PdfObject::Integer(100));
     }
 
-    /// 同 id・同 content の 2 値は `==` で等価（`PartialEq` が両フィールドに委譲）。
     #[test]
     fn same_id_and_content_are_equal() {
+        // 同 id・同 content の 2 値は `==` で等価（`PartialEq` が両フィールドに委譲）。
         let a = IndirectObject::new(oid(3, 0), PdfObject::Integer(1));
         let b = IndirectObject::new(oid(3, 0), PdfObject::Integer(1));
         assert_eq!(a, b);
     }
 
-    /// generation・content が同一で object_number のみ異なる 2 値は `!=` 非等価（object_number 軸の差異が反映される）。
     #[test]
     fn not_equal_when_object_number_differs() {
+        // generation・content が同一で object_number のみ異なる 2 値は `!=` 非等価（object_number 軸の差異が反映される）。
         let a = IndirectObject::new(oid(3, 0), PdfObject::Integer(1));
         let b = IndirectObject::new(oid(4, 0), PdfObject::Integer(1));
         assert_ne!(a, b);
     }
 
-    /// object_number・content が同一で generation のみ異なる 2 値は `!=` 非等価（generation 軸の差異が反映される）。
     #[test]
     fn not_equal_when_generation_differs() {
+        // object_number・content が同一で generation のみ異なる 2 値は `!=` 非等価（generation 軸の差異が反映される）。
         let a = IndirectObject::new(oid(3, 0), PdfObject::Integer(1));
         let b = IndirectObject::new(oid(3, 1), PdfObject::Integer(1));
         assert_ne!(a, b);
     }
 
-    /// 同 id で content が `Integer(1)` vs `Integer(2)` の 2 値は `!=` 非等価（content 軸の差異が反映される）。
     #[test]
     fn not_equal_when_content_differs() {
+        // 同 id で content が `Integer(1)` vs `Integer(2)` の 2 値は `!=` 非等価（content 軸の差異が反映される）。
         let a = IndirectObject::new(oid(3, 0), PdfObject::Integer(1));
         let b = IndirectObject::new(oid(3, 0), PdfObject::Integer(2));
         assert_ne!(a, b);
     }
 
-    /// 同 id で content が `Real(f64::NAN)` の 2 値は `!=` 非等価（`NaN != NaN` の伝播。`Eq` 非実装の帰結）。
     #[test]
     fn nan_content_propagates_to_inequality() {
+        // 同 id で content が `Real(f64::NAN)` の 2 値は `!=` 非等価（`NaN != NaN` の伝播。`Eq` 非実装の帰結）。
         let a = IndirectObject::new(oid(3, 0), PdfObject::Real(f64::NAN));
         let b = IndirectObject::new(oid(3, 0), PdfObject::Real(f64::NAN));
         assert_ne!(a, b);
     }
 
-    /// `Debug` 出力に型名 `IndirectObject` を含む。
     #[test]
     fn debug_format_contains_type_name() {
+        // `Debug` 出力に型名 `IndirectObject` を含む。
         let io = IndirectObject::new(oid(1, 0), PdfObject::Null);
         assert!(format!("{:?}", io).contains("IndirectObject"));
     }
 
-    /// 最小境界 `ObjectId(0, 0)` を無検証で受理し、番号/世代がともに 0 でラウンドトリップが成立する。
     #[test]
     fn accepts_min_boundary_object_id() {
+        // 最小境界 `ObjectId(0, 0)` を無検証で受理し、番号/世代がともに 0 でラウンドトリップが成立する。
         let io = IndirectObject::new(oid(0, 0), PdfObject::Null);
         assert_eq!(io.id().object_number().value(), 0);
         assert_eq!(io.id().generation_number().value(), 0);
         assert_eq!(io.object(), &PdfObject::Null);
     }
 
-    /// 最大境界 `ObjectId(u64::MAX, u16::MAX)` を無検証で受理し、番号/世代がともに MAX でラウンドトリップが成立する。
     #[test]
     fn accepts_max_boundary_object_id() {
+        // 最大境界 `ObjectId(u64::MAX, u16::MAX)` を無検証で受理し、番号/世代がともに MAX でラウンドトリップが成立する。
         let io = IndirectObject::new(oid(u64::MAX, u16::MAX), PdfObject::Null);
         assert_eq!(io.id().object_number().value(), u64::MAX);
         assert_eq!(io.id().generation_number().value(), u16::MAX);
     }
 
-    /// content `Null` を無損失で保持し `object()` が `&Null` を返す。
     #[test]
     fn content_preserves_null() {
+        // content `Null` を無損失で保持し `object()` が `&Null` を返す。
         let io = IndirectObject::new(oid(1, 0), PdfObject::Null);
         assert_eq!(io.object(), &PdfObject::Null);
     }
 
-    /// content `Boolean(true)` を無損失で保持し `object()` が `&Boolean(true)` を返す。
     #[test]
     fn content_preserves_boolean() {
+        // content `Boolean(true)` を無損失で保持し `object()` が `&Boolean(true)` を返す。
         let io = IndirectObject::new(oid(1, 0), PdfObject::Boolean(true));
         assert_eq!(io.object(), &PdfObject::Boolean(true));
     }
 
-    /// content `Integer(-7)` を無損失で保持し `object()` が `&Integer(-7)` を返す。
     #[test]
     fn content_preserves_integer() {
+        // content `Integer(-7)` を無損失で保持し `object()` が `&Integer(-7)` を返す。
         let io = IndirectObject::new(oid(1, 0), PdfObject::Integer(-7));
         assert_eq!(io.object(), &PdfObject::Integer(-7));
     }
 
-    /// content `Real(2.5)` を無損失で保持し `object()` が `&Real(2.5)` を返す。
     #[test]
     fn content_preserves_real() {
+        // content `Real(2.5)` を無損失で保持し `object()` が `&Real(2.5)` を返す。
         let io = IndirectObject::new(oid(1, 0), PdfObject::Real(2.5));
         assert_eq!(io.object(), &PdfObject::Real(2.5));
     }
 
-    /// content `String(b"abc")` を無損失で保持し `object()` が同一バイト列の `&String` を返す。
     #[test]
     fn content_preserves_string() {
+        // content `String(b"abc")` を無損失で保持し `object()` が同一バイト列の `&String` を返す。
         let io = IndirectObject::new(oid(1, 0), PdfObject::String(b"abc".to_vec()));
         assert_eq!(io.object(), &PdfObject::String(b"abc".to_vec()));
     }
 
-    /// content `Name("Page")` を無損失で保持し `object()` が同名の `&Name` を返す。
     #[test]
     fn content_preserves_name() {
+        // content `Name("Page")` を無損失で保持し `object()` が同名の `&Name` を返す。
         let io = IndirectObject::new(oid(1, 0), PdfObject::Name(PdfName::from("Page")));
         assert_eq!(io.object(), &PdfObject::Name(PdfName::from("Page")));
     }
 
-    /// content `Array[Integer(1), Integer(2)]` を無損失で保持し `object()` が同一配列の `&Array` を返す。
     #[test]
     fn content_preserves_array() {
+        // content `Array[Integer(1), Integer(2)]` を無損失で保持し `object()` が同一配列の `&Array` を返す。
         let items = vec![PdfObject::Integer(1), PdfObject::Integer(2)];
         let io = IndirectObject::new(oid(1, 0), PdfObject::Array(items.clone()));
         assert_eq!(io.object(), &PdfObject::Array(items));
     }
 
-    /// content `Dictionary{/Type→Name("Page")}` を無損失で保持し `object()` が同一辞書の `&Dictionary` を返す。
     #[test]
     fn content_preserves_dictionary() {
+        // content `Dictionary{/Type→Name("Page")}` を無損失で保持し `object()` が同一辞書の `&Dictionary` を返す。
         let mut dict = PdfDictionary::new();
         dict.insert(
             PdfName::from("Type"),
@@ -234,9 +234,9 @@ mod tests {
         assert_eq!(io.object(), &PdfObject::Dictionary(dict));
     }
 
-    /// content `Reference(15, 0)` を無損失で保持し `object()` が同一参照の `&Reference` を返す。
     #[test]
     fn content_preserves_reference() {
+        // content `Reference(15, 0)` を無損失で保持し `object()` が同一参照の `&Reference` を返す。
         let reference = IndirectRef::new(oid(15, 0));
         let io = IndirectObject::new(oid(1, 0), PdfObject::Reference(reference));
         assert_eq!(io.object(), &PdfObject::Reference(reference));

--- a/rust/crates/core/src/object/indirect_ref.rs
+++ b/rust/crates/core/src/object/indirect_ref.rs
@@ -39,9 +39,9 @@ mod tests {
     use crate::object::object_number::ObjectNumber;
     use std::collections::{HashMap, HashSet};
 
-    /// 代表ペアで `ObjectId` を `new` に包み `target()` で取り出すと入力と一致する（ラウンドトリップ・無損失）。
     #[test]
     fn new_then_target_roundtrips() {
+        // 代表ペアで `ObjectId` を `new` に包み `target()` で取り出すと入力と一致する（ラウンドトリップ・無損失）。
         for (n, g) in [(0u64, 0u16), (1, 1), (42, 42)] {
             let target = ObjectId::new(ObjectNumber::new(n), GenerationNumber::new(g));
             let ir = IndirectRef::new(target);
@@ -49,27 +49,27 @@ mod tests {
         }
     }
 
-    /// `target()` 経由で内包 `ObjectId` の object_number / generation_number に到達でき、入力と一致する。
     #[test]
     fn target_reaches_object_number_and_generation_number() {
+        // `target()` 経由で内包 `ObjectId` の object_number / generation_number に到達でき、入力と一致する。
         let target = ObjectId::new(ObjectNumber::new(7), GenerationNumber::new(3));
         let ir = IndirectRef::new(target);
         assert_eq!(ir.target().object_number(), ObjectNumber::new(7));
         assert_eq!(ir.target().generation_number(), GenerationNumber::new(3));
     }
 
-    /// 同一 `ObjectId` から生成した 2 つの `IndirectRef` は == で等価（Eq が内包 ObjectId に委譲）。
     #[test]
     fn same_target_is_equal() {
+        // 同一 `ObjectId` から生成した 2 つの `IndirectRef` は == で等価（Eq が内包 ObjectId に委譲）。
         let target = ObjectId::new(ObjectNumber::new(5), GenerationNumber::new(0));
         let a = IndirectRef::new(target);
         let b = IndirectRef::new(target);
         assert_eq!(a, b);
     }
 
-    /// `Copy` のため代入でコピーされ、元値も使用可能でコピーと等価。
     #[test]
     fn is_copy_so_original_stays_usable() {
+        // `Copy` のため代入でコピーされ、元値も使用可能でコピーと等価。
         let target = ObjectId::new(ObjectNumber::new(7), GenerationNumber::new(3));
         let ir = IndirectRef::new(target);
         let copied = ir;
@@ -77,9 +77,9 @@ mod tests {
         assert_eq!(ir, copied);
     }
 
-    /// `Debug` 出力に型名 `IndirectRef` を含む。
     #[test]
     fn debug_format_contains_type_name() {
+        // `Debug` 出力に型名 `IndirectRef` を含む。
         let ir = IndirectRef::new(ObjectId::new(
             ObjectNumber::new(1),
             GenerationNumber::new(0),
@@ -87,18 +87,18 @@ mod tests {
         assert!(format!("{:?}", ir).contains("IndirectRef"));
     }
 
-    /// `HashMap<IndirectRef, _>` のキーとして使え、同値キーで挿入値を取得できる（Hash + Eq）。
     #[test]
     fn works_as_hash_map_key() {
+        // `HashMap<IndirectRef, _>` のキーとして使え、同値キーで挿入値を取得できる（Hash + Eq）。
         let target = ObjectId::new(ObjectNumber::new(10), GenerationNumber::new(0));
         let mut map = HashMap::new();
         map.insert(IndirectRef::new(target), "ref10");
         assert_eq!(map.get(&IndirectRef::new(target)), Some(&"ref10"));
     }
 
-    /// 同値 `IndirectRef` を `HashSet` に 2 回挿入すると 1 件に折りたたまれる。
     #[test]
     fn equal_keys_collapse_in_hash_set() {
+        // 同値 `IndirectRef` を `HashSet` に 2 回挿入すると 1 件に折りたたまれる。
         let target = ObjectId::new(ObjectNumber::new(3), GenerationNumber::new(0));
         let mut set = HashSet::new();
         set.insert(IndirectRef::new(target));
@@ -106,10 +106,10 @@ mod tests {
         assert_eq!(set.len(), 1);
     }
 
-    /// 内包 `ObjectId` が異なる 3 値は別キーとして `HashSet` に共存する
-    /// （generation 差異・object_number 差異の両軸で Eq により区別される）。
     #[test]
     fn distinct_keys_coexist_in_hash_set() {
+        // 内包 `ObjectId` が異なる 3 値は別キーとして `HashSet` に共存する
+        // （generation 差異・object_number 差異の両軸で Eq により区別される）。
         let mut set = HashSet::new();
         // object_number 同一・generation 差異
         set.insert(IndirectRef::new(ObjectId::new(
@@ -128,9 +128,9 @@ mod tests {
         assert_eq!(set.len(), 3);
     }
 
-    /// 最小境界 `(0, 0)` の `ObjectId` を無検証で受理し、ラウンドトリップが成立する。
     #[test]
     fn accepts_min_boundary_target() {
+        // 最小境界 `(0, 0)` の `ObjectId` を無検証で受理し、ラウンドトリップが成立する。
         let target = ObjectId::new(ObjectNumber::new(0), GenerationNumber::new(0));
         let ir = IndirectRef::new(target);
         assert_eq!(ir.target(), target);
@@ -138,9 +138,9 @@ mod tests {
         assert_eq!(ir.target().generation_number().value(), 0);
     }
 
-    /// 最大境界 `(u64::MAX, u16::MAX)` の `ObjectId` を無検証で受理し、ラウンドトリップが成立する。
     #[test]
     fn accepts_max_boundary_target() {
+        // 最大境界 `(u64::MAX, u16::MAX)` の `ObjectId` を無検証で受理し、ラウンドトリップが成立する。
         let target = ObjectId::new(ObjectNumber::new(u64::MAX), GenerationNumber::new(u16::MAX));
         let ir = IndirectRef::new(target);
         assert_eq!(ir.target(), target);
@@ -148,9 +148,9 @@ mod tests {
         assert_eq!(ir.target().generation_number().value(), u16::MAX);
     }
 
-    /// 世代は同一・object_number のみ異なる 2 値は非等価（内包 ObjectId の差異が反映される）。
     #[test]
     fn not_equal_when_object_number_differs() {
+        // 世代は同一・object_number のみ異なる 2 値は非等価（内包 ObjectId の差異が反映される）。
         let a = IndirectRef::new(ObjectId::new(
             ObjectNumber::new(5),
             GenerationNumber::new(0),
@@ -162,9 +162,9 @@ mod tests {
         assert_ne!(a, b);
     }
 
-    /// object_number は同一・generation_number のみ異なる 2 値は非等価（内包 ObjectId の差異が反映される）。
     #[test]
     fn not_equal_when_generation_number_differs() {
+        // object_number は同一・generation_number のみ異なる 2 値は非等価（内包 ObjectId の差異が反映される）。
         let a = IndirectRef::new(ObjectId::new(
             ObjectNumber::new(5),
             GenerationNumber::new(0),

--- a/rust/crates/core/src/object/object_id.rs
+++ b/rust/crates/core/src/object/object_id.rs
@@ -47,9 +47,9 @@ mod tests {
     use super::*;
     use std::collections::{HashMap, HashSet};
 
-    /// 代表ペアで `new` に包んだ値を 2 アクセサで取り出すと入力と一致する（ラウンドトリップ・無損失）。
     #[test]
     fn new_then_accessors_roundtrip() {
+        // 代表ペアで `new` に包んだ値を 2 アクセサで取り出すと入力と一致する（ラウンドトリップ・無損失）。
         for (n, g) in [(0u64, 0u16), (1, 1), (42, 42), (u64::MAX, u16::MAX)] {
             let id = ObjectId::new(ObjectNumber::new(n), GenerationNumber::new(g));
             assert_eq!(id.object_number(), ObjectNumber::new(n));
@@ -57,51 +57,51 @@ mod tests {
         }
     }
 
-    /// object_number・generation_number がともに同一なら等価（Eq が両フィールドに委譲）。
     #[test]
     fn equal_when_both_fields_match() {
+        // object_number・generation_number がともに同一なら等価（Eq が両フィールドに委譲）。
         let a = ObjectId::new(ObjectNumber::new(5), GenerationNumber::new(0));
         let b = ObjectId::new(ObjectNumber::new(5), GenerationNumber::new(0));
         assert_eq!(a, b);
     }
 
-    /// object_number 同一・generation_number のみ異なれば非等価（片フィールド依存でないことを保証）。
     #[test]
     fn not_equal_when_generation_differs() {
+        // object_number 同一・generation_number のみ異なれば非等価（片フィールド依存でないことを保証）。
         let a = ObjectId::new(ObjectNumber::new(5), GenerationNumber::new(0));
         let b = ObjectId::new(ObjectNumber::new(5), GenerationNumber::new(1));
         assert_ne!(a, b);
     }
 
-    /// generation_number 同一・object_number のみ異なれば非等価（両フィールド依存の裏付け）。
     #[test]
     fn not_equal_when_object_number_differs() {
+        // generation_number 同一・object_number のみ異なれば非等価（両フィールド依存の裏付け）。
         let a = ObjectId::new(ObjectNumber::new(5), GenerationNumber::new(0));
         let b = ObjectId::new(ObjectNumber::new(6), GenerationNumber::new(0));
         assert_ne!(a, b);
     }
 
-    /// 辞書順は object_number を第 1 キーとする（generation_number に関わらず object_number が小さい方が小）。
     #[test]
     fn orders_by_object_number_first() {
+        // 辞書順は object_number を第 1 キーとする（generation_number に関わらず object_number が小さい方が小）。
         let small = ObjectId::new(ObjectNumber::new(1), GenerationNumber::new(9));
         let large = ObjectId::new(ObjectNumber::new(2), GenerationNumber::new(0));
         assert!(small < large);
         assert!(large > small);
     }
 
-    /// object_number 同一時は第 2 キー generation_number で大小が決まる。
     #[test]
     fn orders_by_generation_when_object_number_equal() {
+        // object_number 同一時は第 2 キー generation_number で大小が決まる。
         let small = ObjectId::new(ObjectNumber::new(5), GenerationNumber::new(1));
         let large = ObjectId::new(ObjectNumber::new(5), GenerationNumber::new(2));
         assert!(small < large);
         assert!(large > small);
     }
 
-    /// `sort()` すると Ord の 2 軸（object_number 優先 → generation_number）で辞書順に並ぶ。
     #[test]
     fn sorts_in_lexicographic_order() {
+        // `sort()` すると Ord の 2 軸（object_number 優先 → generation_number）で辞書順に並ぶ。
         let mut ids = [
             ObjectId::new(ObjectNumber::new(2), GenerationNumber::new(0)),
             ObjectId::new(ObjectNumber::new(1), GenerationNumber::new(5)),
@@ -118,9 +118,9 @@ mod tests {
         );
     }
 
-    /// `Copy` のため代入でコピーされ、元値も使用可能でコピーと等価。
     #[test]
     fn is_copy_so_original_stays_usable() {
+        // `Copy` のため代入でコピーされ、元値も使用可能でコピーと等価。
         let id = ObjectId::new(ObjectNumber::new(7), GenerationNumber::new(3));
         let copied = id;
         assert_eq!(id.object_number(), ObjectNumber::new(7));
@@ -128,9 +128,9 @@ mod tests {
         assert_eq!(id, copied);
     }
 
-    /// `HashMap<ObjectId, _>` のキーとして使え、同値キーで挿入値を取得できる（Hash + Eq）。
     #[test]
     fn works_as_hash_map_key() {
+        // `HashMap<ObjectId, _>` のキーとして使え、同値キーで挿入値を取得できる（Hash + Eq）。
         let mut map = HashMap::new();
         map.insert(
             ObjectId::new(ObjectNumber::new(10), GenerationNumber::new(0)),
@@ -145,9 +145,9 @@ mod tests {
         );
     }
 
-    /// 同値 `ObjectId` を `HashSet` に 2 回挿入すると 1 件に折りたたまれる。
     #[test]
     fn equal_keys_collapse_in_hash_set() {
+        // 同値 `ObjectId` を `HashSet` に 2 回挿入すると 1 件に折りたたまれる。
         let mut set = HashSet::new();
         set.insert(ObjectId::new(
             ObjectNumber::new(3),
@@ -160,9 +160,9 @@ mod tests {
         assert_eq!(set.len(), 1);
     }
 
-    /// object_number 同一・generation 違いの 2 値は別キーとして `HashSet` に共存する（両フィールド依存）。
     #[test]
     fn distinct_keys_coexist_in_hash_set() {
+        // object_number 同一・generation 違いの 2 値は別キーとして `HashSet` に共存する（両フィールド依存）。
         let mut set = HashSet::new();
         set.insert(ObjectId::new(
             ObjectNumber::new(7),
@@ -175,25 +175,25 @@ mod tests {
         assert_eq!(set.len(), 2);
     }
 
-    /// 最小境界の組 `(0, 0)` を無検証で受理し、アクセサが `0`/`0` を返す。
     #[test]
     fn accepts_min_boundary_combo() {
+        // 最小境界の組 `(0, 0)` を無検証で受理し、アクセサが `0`/`0` を返す。
         let id = ObjectId::new(ObjectNumber::new(0), GenerationNumber::new(0));
         assert_eq!(id.object_number().value(), 0);
         assert_eq!(id.generation_number().value(), 0);
     }
 
-    /// 最大境界の組 `(u64::MAX, u16::MAX)` を無検証で受理し、アクセサが各境界値を返す。
     #[test]
     fn accepts_max_boundary_combo() {
+        // 最大境界の組 `(u64::MAX, u16::MAX)` を無検証で受理し、アクセサが各境界値を返す。
         let id = ObjectId::new(ObjectNumber::new(u64::MAX), GenerationNumber::new(u16::MAX));
         assert_eq!(id.object_number().value(), u64::MAX);
         assert_eq!(id.generation_number().value(), u16::MAX);
     }
 
-    /// 片フィールドのみ MAX の組（`(u64::MAX,0)` と `(0,u16::MAX)`）を受理し、双方は非等価。
     #[test]
     fn accepts_mixed_boundary_combo() {
+        // 片フィールドのみ MAX の組（`(u64::MAX,0)` と `(0,u16::MAX)`）を受理し、双方は非等価。
         let obj_max = ObjectId::new(ObjectNumber::new(u64::MAX), GenerationNumber::new(0));
         let gen_max = ObjectId::new(ObjectNumber::new(0), GenerationNumber::new(u16::MAX));
         assert_eq!(obj_max.object_number().value(), u64::MAX);

--- a/rust/crates/core/src/object/object_number.rs
+++ b/rust/crates/core/src/object/object_number.rs
@@ -33,6 +33,7 @@ mod tests {
 
     #[test]
     fn new_then_value_roundtrips() {
+        // 代表値（0 / 1 / 42 / u64::MAX）を new で包んで value で取り出すと、生成時の値と一致することを確認する
         for n in [0, 1, 42, u64::MAX] {
             assert_eq!(ObjectNumber::new(n).value(), n);
         }
@@ -40,37 +41,44 @@ mod tests {
 
     #[test]
     fn accepts_zero() {
+        // フリーリスト先頭の予約番号である 0 が無検証で受理され、値が保持されることを確認する
         assert_eq!(ObjectNumber::new(0).value(), 0);
     }
 
     #[test]
     fn accepts_one() {
+        // 1 が無検証で受理され、値が保持されることを確認する
         assert_eq!(ObjectNumber::new(1).value(), 1);
     }
 
     #[test]
     fn accepts_u64_max() {
+        // 最大値 u64::MAX も無検証で受理され、値が保持されることを確認する
         assert_eq!(ObjectNumber::new(u64::MAX).value(), u64::MAX);
     }
 
     #[test]
     fn equal_numbers_are_equal() {
+        // 同一値から生成した 2 つが == で等価と判定されることを確認する
         assert_eq!(ObjectNumber::new(7), ObjectNumber::new(7));
     }
 
     #[test]
     fn different_numbers_are_not_equal() {
+        // 異なる値から生成した 2 つが != で非等価と判定されることを確認する
         assert_ne!(ObjectNumber::new(7), ObjectNumber::new(8));
     }
 
     #[test]
     fn orders_by_inner_value() {
+        // 大小比較（< / >）が内部 u64 の自然順に従うことを確認する
         assert!(ObjectNumber::new(1) < ObjectNumber::new(2));
         assert!(ObjectNumber::new(3) > ObjectNumber::new(2));
     }
 
     #[test]
     fn sorts_in_ascending_order() {
+        // 順不同の配列を sort() すると内部 u64 の昇順に並ぶことを確認する
         let mut numbers = [
             ObjectNumber::new(3),
             ObjectNumber::new(1),
@@ -89,6 +97,7 @@ mod tests {
 
     #[test]
     fn is_copy_so_original_stays_usable() {
+        // Copy セマンティクスにより、別変数へ複製した後も元の変数が引き続き使用可能なことを確認する
         let original = ObjectNumber::new(5);
         let copied = original;
         assert_eq!(original.value(), 5);
@@ -97,6 +106,7 @@ mod tests {
 
     #[test]
     fn works_as_hash_map_key() {
+        // HashMap のキーとして機能し、同値キーで挿入した値を取得できることを確認する
         let mut map = HashMap::new();
         map.insert(ObjectNumber::new(10), "ten");
         assert_eq!(map.get(&ObjectNumber::new(10)), Some(&"ten"));
@@ -104,6 +114,7 @@ mod tests {
 
     #[test]
     fn equal_keys_collapse_in_hash_set() {
+        // 同値を HashSet に 2 回挿入しても等価キーが 1 件に畳まれることを確認する
         let mut set = HashSet::new();
         set.insert(ObjectNumber::new(3));
         set.insert(ObjectNumber::new(3));

--- a/rust/crates/core/src/object/pdf_object/tests/eq_clone_debug.rs
+++ b/rust/crates/core/src/object/pdf_object/tests/eq_clone_debug.rs
@@ -83,10 +83,12 @@ fn clone_preserves_value_and_keeps_original_usable() {
 
 #[test]
 fn clone_preserves_nan_real() {
-    // Real(NaN) の clone 保持は == では検証できないため as_real().is_some_and(is_nan) で確認する
+    // Real(NaN) の clone 保持は == では検証できないため as_real().is_some_and(is_nan) で確認する。
+    // 複製後も original が引き続き使用可能であることも併せて確認する
     let original = PdfObject::Real(f64::NAN);
     let cloned = original.clone();
     assert!(cloned.as_real().is_some_and(f64::is_nan));
+    assert!(original.as_real().is_some_and(f64::is_nan));
 }
 
 #[test]

--- a/rust/crates/core/src/object/stream.rs
+++ b/rust/crates/core/src/object/stream.rs
@@ -68,9 +68,9 @@ mod tests {
     use crate::object::name::PdfName;
     use crate::object::pdf_object::PdfObject;
 
-    /// 値入り辞書 + `b"stream data"` で構築し `dictionary()` / `data()` で入力と同内容が返る（ラウンドトリップ・無損失）。
     #[test]
     fn new_then_accessors_roundtrip() {
+        // 値入り辞書 + `b"stream data"` で構築し `dictionary()` / `data()` で入力と同内容が返る（ラウンドトリップ・無損失）。
         let mut dict = PdfDictionary::new();
         dict.insert(PdfName::from("Length"), PdfObject::Integer(11));
         let stream = PdfStream::new(dict.clone(), b"stream data");
@@ -78,9 +78,9 @@ mod tests {
         assert_eq!(stream.data(), b"stream data");
     }
 
-    /// `b"..."`（`&[u8; N]`）・`Vec<u8>`・`&[u8]` の 3 形いずれも受理され `data()` が同一バイト列を返す（`impl Into<Vec<u8>>` の動作確認）。
     #[test]
     fn new_accepts_into_vec_u8_variants() {
+        // `b"..."`（`&[u8; N]`）・`Vec<u8>`・`&[u8]` の 3 形いずれも受理され `data()` が同一バイト列を返す（`impl Into<Vec<u8>>` の動作確認）。
         let from_array_ref = PdfStream::new(PdfDictionary::new(), b"abc");
         let from_vec = PdfStream::new(PdfDictionary::new(), b"abc".to_vec());
         let from_slice = PdfStream::new(PdfDictionary::new(), b"abc".as_slice());
@@ -89,9 +89,9 @@ mod tests {
         assert_eq!(from_slice.data(), b"abc");
     }
 
-    /// `/Length` キーを入れた辞書で構築し `dictionary().get(&key)` で挿入した値に到達できる（後段借用経路）。
     #[test]
     fn dictionary_accessor_reaches_entries() {
+        // `/Length` キーを入れた辞書で構築し `dictionary().get(&key)` で挿入した値に到達できる（後段借用経路）。
         let mut dict = PdfDictionary::new();
         dict.insert(PdfName::from("Length"), PdfObject::Integer(3));
         let stream = PdfStream::new(dict, b"xyz");
@@ -101,41 +101,41 @@ mod tests {
         );
     }
 
-    /// 空バイト列 `b""` を無検証で受理し `data()` が空スライスを返す。
     #[test]
     fn accepts_empty_data() {
+        // 空バイト列 `b""` を無検証で受理し `data()` が空スライスを返す。
         let mut dict = PdfDictionary::new();
         dict.insert(PdfName::from("Length"), PdfObject::Integer(0));
         let stream = PdfStream::new(dict, b"");
         assert_eq!(stream.data(), b"");
     }
 
-    /// 空辞書 `PdfDictionary::new()` を無検証で受理し `dictionary().is_empty()` が真になる。
     #[test]
     fn accepts_empty_dictionary() {
+        // 空辞書 `PdfDictionary::new()` を無検証で受理し `dictionary().is_empty()` が真になる。
         let stream = PdfStream::new(PdfDictionary::new(), b"data");
         assert!(stream.dictionary().is_empty());
         assert_eq!(stream.data(), b"data");
     }
 
-    /// 空辞書 + 空バイト列の両方空でも無検証で受理され両アクセサが空を返す。
     #[test]
     fn accepts_empty_dictionary_and_empty_data() {
+        // 空辞書 + 空バイト列の両方空でも無検証で受理され両アクセサが空を返す。
         let stream = PdfStream::new(PdfDictionary::new(), b"");
         assert!(stream.dictionary().is_empty());
         assert_eq!(stream.data(), b"");
     }
 
-    /// `vec![0x00, 0x80, 0xFF]`（NUL/非UTF-8/高位バイト）がテキスト解釈されず生バイトのまま忠実に保持される（無検証保持）。
     #[test]
     fn data_preserves_nul_non_utf8_and_high_bytes() {
+        // `vec![0x00, 0x80, 0xFF]`（NUL/非UTF-8/高位バイト）がテキスト解釈されず生バイトのまま忠実に保持される（無検証保持）。
         let stream = PdfStream::new(PdfDictionary::new(), vec![0x00, 0x80, 0xFF]);
         assert_eq!(stream.data(), [0x00, 0x80, 0xFF].as_slice());
     }
 
-    /// `into_parts()` で `(PdfDictionary, Vec<u8>)` に分解でき、分解結果が構築時の入力と同内容になる（所有権ムーブ）。
     #[test]
     fn into_parts_decomposes_ownership() {
+        // `into_parts()` で `(PdfDictionary, Vec<u8>)` に分解でき、分解結果が構築時の入力と同内容になる（所有権ムーブ）。
         let mut dict = PdfDictionary::new();
         dict.insert(PdfName::from("Length"), PdfObject::Integer(4));
         let stream = PdfStream::new(dict.clone(), b"body");
@@ -144,18 +144,18 @@ mod tests {
         assert_eq!(decomposed_data, b"body".to_vec());
     }
 
-    /// 空辞書 + 空データのストリームを `into_parts()` すると空辞書と空 `Vec` が返る。
     #[test]
     fn into_parts_on_empty_stream() {
+        // 空辞書 + 空データのストリームを `into_parts()` すると空辞書と空 `Vec` が返る。
         let stream = PdfStream::new(PdfDictionary::new(), b"");
         let (decomposed_dict, decomposed_data) = stream.into_parts();
         assert!(decomposed_dict.is_empty());
         assert!(decomposed_data.is_empty());
     }
 
-    /// `clone()` の複製が元と `==` 等価かつ元も引き続き使用可能（深いコピー・独立性）。
     #[test]
     fn clone_preserves_content_and_keeps_original_usable() {
+        // `clone()` の複製が元と `==` 等価かつ元も引き続き使用可能（深いコピー・独立性）。
         let mut dict = PdfDictionary::new();
         dict.insert(PdfName::from("Length"), PdfObject::Integer(4));
         let original = PdfStream::new(dict, b"body");
@@ -164,9 +164,9 @@ mod tests {
         assert_eq!(original.data(), b"body");
     }
 
-    /// 同内容（同辞書 + 同データ）の 2 値は `==` で等価（`PartialEq` が両フィールドに委譲）。
     #[test]
     fn same_content_streams_are_equal() {
+        // 同内容（同辞書 + 同データ）の 2 値は `==` で等価（`PartialEq` が両フィールドに委譲）。
         let mut dict_a = PdfDictionary::new();
         dict_a.insert(PdfName::from("Length"), PdfObject::Integer(4));
         let mut dict_b = PdfDictionary::new();
@@ -177,18 +177,18 @@ mod tests {
         );
     }
 
-    /// dictionary は同一で data のみ異なる 2 値は `!=` 非等価（data 軸の差異が反映される）。
     #[test]
     fn not_equal_when_data_differs() {
+        // dictionary は同一で data のみ異なる 2 値は `!=` 非等価（data 軸の差異が反映される）。
         assert_ne!(
             PdfStream::new(PdfDictionary::new(), b"abc"),
             PdfStream::new(PdfDictionary::new(), b"abd")
         );
     }
 
-    /// data は同一で dictionary のみ異なる 2 値は `!=` 非等価（dictionary 軸の差異が反映される）。
     #[test]
     fn not_equal_when_dictionary_differs() {
+        // data は同一で dictionary のみ異なる 2 値は `!=` 非等価（dictionary 軸の差異が反映される）。
         let mut dict = PdfDictionary::new();
         dict.insert(PdfName::from("Length"), PdfObject::Integer(3));
         assert_ne!(
@@ -197,9 +197,9 @@ mod tests {
         );
     }
 
-    /// 辞書値に `Real(NaN)` を含む同内容ストリーム同士は `!=` 非等価（`NaN != NaN` の再帰伝播。`Eq` 非実装の根拠）。
     #[test]
     fn nan_in_dictionary_propagates_to_inequality() {
+        // 辞書値に `Real(NaN)` を含む同内容ストリーム同士は `!=` 非等価（`NaN != NaN` の再帰伝播。`Eq` 非実装の根拠）。
         let mut dict_a = PdfDictionary::new();
         dict_a.insert(PdfName::from("N"), PdfObject::Real(f64::NAN));
         let mut dict_b = PdfDictionary::new();
@@ -210,9 +210,9 @@ mod tests {
         );
     }
 
-    /// `Debug` 出力に型名 `PdfStream` を含む。
     #[test]
     fn debug_format_contains_type_name() {
+        // `Debug` 出力に型名 `PdfStream` を含む。
         let stream = PdfStream::new(PdfDictionary::new(), b"data");
         assert!(format!("{:?}", stream).contains("PdfStream"));
     }


### PR DESCRIPTION
## 概要

`area:rust-core` ラベル付きの `[Tests]` / `[Docs]` issue のうち、Rust コア（`rust/crates/core`）のテスト不足・検証不十分・テストコメントの記法不統一を指摘する4件を解消しました。

## 変更内容

### 🎯 変更の種類

- [x] 🚨 テスト追加/修正 (Tests)
- [x] 📖 ドキュメント更新 (Documentation)

### 📝 詳細な変更内容

#### 追加された機能・修正

- `object_number.rs` の全11テストに検証内容の日本語コメントを追加（`byte_offset.rs` / `generation_number.rs` と同じ粒度に統一）
- `clone_preserves_nan_real` が `clone()` 後に `original` を使っておらず `clippy::redundant_clone` の温床だったため、兄弟テストと同じ形で `original` 側の NaN 保持も検証するよう修正
- `lexer_skip_comment.rs` に、コメント本文へ PDF デリミタ `( ) / < >` を含む入力（例: `%foo(bar)/Baz<01>\n`）が EOL まで丸ごと本文として消費されることを検証するテストを追加
- テスト関数へのコメント記法が `///` doc コメント（`object_id.rs` / `stream.rs` / `indirect_object.rs` / `indirect_ref.rs`）と `#[test]` 直前・分類プレフィックス付き `//` コメント（`generation_number.rs` / `error/pdf_error.rs`）の3様式に分裂していたのを、他ファイルに揃えて「テスト本体先頭に `//` で検証内容を書く」1様式へ統一

#### 変更されたファイル

- `rust/crates/core/src/object/object_number.rs`
- `rust/crates/core/src/object/pdf_object/tests/eq_clone_debug.rs`
- `rust/crates/core/src/lexer/tests/lexer_skip_comment.rs`
- `rust/crates/core/src/object/object_id.rs`
- `rust/crates/core/src/object/stream.rs`
- `rust/crates/core/src/object/indirect_object.rs`
- `rust/crates/core/src/object/indirect_ref.rs`
- `rust/crates/core/src/object/generation_number.rs`
- `rust/crates/core/src/error/pdf_error.rs`

## 📋 関連 Issue

- Closes #381
- Closes #392
- Closes #508
- Closes #361

## 🧪 テスト

### テスト実行方法

```bash
cd rust
cargo fmt --all -- --check
cargo clippy --all-targets -- -D warnings
cargo test
```

### テスト項目

- [x] 単体テスト (Unit tests)

### テスト結果

- `cargo fmt --all -- --check`: 差分なし
- `cargo clippy --all-targets -- -D warnings`: 警告なし
- `cargo test`: 1134 件全パス（`#508` のテスト追加分を含む）

## 🔍 レビューポイント

- `#361` のコメント移動はテキストの機械的な位置変更のみで、検証内容自体（アサーション）は変更していません
- `#392` は `original` 側の検証を追加しただけで、テストが担保する振る舞い（NaN の clone 保持）自体は変更していません

## ✅ チェックリスト

- [x] コードレビューの準備ができている
- [x] テストが正常に実行される
- [x] ドキュメントが更新されている（該当なし）
- [x] コミットメッセージが適切な形式で書かれている
- [ ] 関連する Issue が PR の「Development」に Linked されている
- [x] PR 本文に `Closes #` / `Fixes #` / `Refs #` などで Issue が記載されている
- [x] セルフレビューを実施した
- [x] 破壊的変更がある場合は明記されている（該当なし）

🤖 Generated with [Claude Code](https://claude.com/claude-code)