### PR TITLE
🧪 [Tests]: #496 flate-decompressorに本物のFlateDecode経路を通すテストを追加

### DIFF
--- a/packages/core/src/objects/object-stream-extractor/flate-decompressor/__tests__/flate-decompressor.decompress.test.ts
+++ b/packages/core/src/objects/object-stream-extractor/flate-decompressor/__tests__/flate-decompressor.decompress.test.ts
@@ -1,0 +1,16 @@
+import { assert, expect, test } from "vitest";
+import { createFlateDecompressor } from "../index";
+
+test("正常なzlibデータを展開してデコード後の内容が一致する", async () => {
+  // zlib.deflateSync(Buffer.from("Hello, PDF!"))
+  const compressed = new Uint8Array([
+    120, 156, 243, 72, 205, 201, 201, 215, 81, 8, 112, 113, 83, 4, 0, 21, 171,
+    3, 60,
+  ]);
+  const decompressor = createFlateDecompressor();
+
+  const result = await decompressor.decompress(compressed);
+
+  assert(result.ok);
+  expect(new TextDecoder().decode(result.value)).toBe("Hello, PDF!");
+});

--- a/packages/core/src/objects/object-stream-extractor/flate-decompressor/__tests__/flate-decompressor.limit.test.ts
+++ b/packages/core/src/objects/object-stream-extractor/flate-decompressor/__tests__/flate-decompressor.limit.test.ts
@@ -1,0 +1,53 @@
+import { assert, expect, test } from "vitest";
+import {
+  createFlateDecompressor,
+  DEFAULT_OBJECT_STREAM_MAX_DECOMPRESSED_SIZE,
+} from "../index";
+import { buildStoredZlib } from "./flate-decompressor.test.helpers";
+
+const OVERSIZED_PAYLOAD_FILL_BYTE = 0x41;
+
+test("デフォルトオプション使用時は8MB上限を超えるデータの展開がエラーになる", async () => {
+  const payload = new Uint8Array(
+    DEFAULT_OBJECT_STREAM_MAX_DECOMPRESSED_SIZE + 1,
+  ).fill(OVERSIZED_PAYLOAD_FILL_BYTE);
+  const compressed = buildStoredZlib(payload);
+  const decompressor = createFlateDecompressor();
+
+  const result = await decompressor.decompress(compressed);
+
+  expect(result.ok).toBe(false);
+  assert(!result.ok);
+  expect(result.error.code).toBe("FLATEDECODE_FAILED");
+});
+
+test("maxDecompressedSizeオプションで上限を上書きすると8MBを超えるデータも展開できる", async () => {
+  const payload = new Uint8Array(
+    DEFAULT_OBJECT_STREAM_MAX_DECOMPRESSED_SIZE + 1,
+  ).fill(OVERSIZED_PAYLOAD_FILL_BYTE);
+  const compressed = buildStoredZlib(payload);
+  const decompressor = createFlateDecompressor({
+    maxDecompressedSize: DEFAULT_OBJECT_STREAM_MAX_DECOMPRESSED_SIZE * 2,
+  });
+
+  const result = await decompressor.decompress(compressed);
+
+  assert(result.ok);
+  expect(result.value.length).toBe(payload.length);
+});
+
+test("上限超過時に下位のdecompressFlateのエラーがそのまま伝播する", async () => {
+  // zlib.deflateSync(Buffer.from("Hello, PDF!")) -> 展開後11バイト
+  const compressed = new Uint8Array([
+    120, 156, 243, 72, 205, 201, 201, 215, 81, 8, 112, 113, 83, 4, 0, 21, 171,
+    3, 60,
+  ]);
+  const decompressor = createFlateDecompressor({ maxDecompressedSize: 5 });
+
+  const result = await decompressor.decompress(compressed);
+
+  expect(result.ok).toBe(false);
+  assert(!result.ok);
+  expect(result.error.code).toBe("FLATEDECODE_FAILED");
+  expect(result.error.message).toContain("exceeds limit of 5 bytes");
+});

--- a/packages/core/src/objects/object-stream-extractor/flate-decompressor/__tests__/flate-decompressor.test.helpers.ts
+++ b/packages/core/src/objects/object-stream-extractor/flate-decompressor/__tests__/flate-decompressor.test.helpers.ts
@@ -1,0 +1,111 @@
+const BYTE_MASK = 0xff;
+const BITS_PER_BYTE = 8;
+const UINT16_MASK = 0xffff;
+const UINT16_BYTE_LENGTH = 2;
+const ZLIB_CMF_DEFLATE_32K_WINDOW = 0x78;
+const ZLIB_FLG_DEFAULT_LEVEL = 0x9c;
+const ZLIB_HEADER: readonly number[] = [
+  ZLIB_CMF_DEFLATE_32K_WINDOW,
+  ZLIB_FLG_DEFAULT_LEVEL,
+];
+const STORED_BLOCK_MAX_LENGTH = UINT16_MASK;
+const STORED_BLOCK_CONTROL_BYTES = 1;
+const STORED_BLOCK_HEADER_BYTES =
+  STORED_BLOCK_CONTROL_BYTES + UINT16_BYTE_LENGTH * 2;
+const ADLER32_TRAILER_BYTES = 4;
+const ADLER32_MODULO = 65521;
+const ADLER32_B_SHIFT = 16;
+
+/**
+ * 16bit値をリトルエンディアンで書き込む。
+ *
+ * @param target - 書き込み先バイト列
+ * @param offset - 書き込み開始位置
+ * @param value - 書き込む16bit値
+ */
+function writeUint16LE(
+  target: Uint8Array,
+  offset: number,
+  value: number,
+): void {
+  target[offset] = value & BYTE_MASK;
+  target[offset + 1] = (value >> BITS_PER_BYTE) & BYTE_MASK;
+}
+
+/**
+ * Adler-32チェックサムを計算する（zlibトレーラー用）。
+ *
+ * @param data - チェックサム対象のバイト列
+ * @returns Adler-32チェックサム値
+ */
+function adler32(data: Uint8Array): number {
+  let a = 1;
+  let b = 0;
+  for (let i = 0; i < data.length; i++) {
+    a = (a + data[i]) % ADLER32_MODULO;
+    b = (b + a) % ADLER32_MODULO;
+  }
+  return ((b << ADLER32_B_SHIFT) | a) >>> 0;
+}
+
+/**
+ * 非圧縮（stored）DEFLATEブロックのみで構成される正当なzlibストリームを組み立てる。
+ * サイズ上限テスト用の巨大なペイロードをソースコードへ literal 配列として
+ * 埋め込まずに実行時生成するためのテストヘルパー。
+ *
+ * @param payload - 展開後データとして復元されるべき元バイト列
+ * @returns zlib形式（RFC 1950）の圧縮バイト列
+ */
+export function buildStoredZlib(payload: Uint8Array): Uint8Array {
+  const blockCount = Math.max(
+    1,
+    Math.ceil(payload.length / STORED_BLOCK_MAX_LENGTH),
+  );
+  const totalSize =
+    ZLIB_HEADER.length +
+    blockCount * STORED_BLOCK_HEADER_BYTES +
+    payload.length +
+    ADLER32_TRAILER_BYTES;
+
+  const output = new Uint8Array(totalSize);
+  output.set(ZLIB_HEADER, 0);
+
+  let writeOffset = ZLIB_HEADER.length;
+  let readOffset = 0;
+  for (let i = 0; i < blockCount; i++) {
+    const chunkLength = Math.min(
+      STORED_BLOCK_MAX_LENGTH,
+      payload.length - readOffset,
+    );
+    const isFinalBlock = i === blockCount - 1;
+    const complement = ~chunkLength & UINT16_MASK;
+
+    output[writeOffset] = isFinalBlock ? 1 : 0;
+    writeUint16LE(
+      output,
+      writeOffset + STORED_BLOCK_CONTROL_BYTES,
+      chunkLength,
+    );
+    writeUint16LE(
+      output,
+      writeOffset + STORED_BLOCK_CONTROL_BYTES + UINT16_BYTE_LENGTH,
+      complement,
+    );
+    writeOffset += STORED_BLOCK_HEADER_BYTES;
+
+    output.set(
+      payload.subarray(readOffset, readOffset + chunkLength),
+      writeOffset,
+    );
+    writeOffset += chunkLength;
+    readOffset += chunkLength;
+  }
+
+  const checksum = adler32(payload);
+  for (let byteIndex = 0; byteIndex < ADLER32_TRAILER_BYTES; byteIndex++) {
+    const shift = (ADLER32_TRAILER_BYTES - 1 - byteIndex) * BITS_PER_BYTE;
+    output[writeOffset + byteIndex] = (checksum >>> shift) & BYTE_MASK;
+  }
+
+  return output;
+}


### PR DESCRIPTION
## 概要

`createFlateDecompressor`（`packages/core/src/objects/object-stream-extractor/flate-decompressor/index.ts`）のテストが皆無で、関数カバレッジ0%・文カバレッジ43.75%だった。既存のObjStm展開テストはすべてモックのdecompressorを注入しており、本物のFlateDecode経路（`decompressFlate`/`DecompressionStream`）が一度も実行されていなかった。

## 変更の種類

- [x] 🚨 テスト追加/修正 (Tests)

## 詳細な変更内容

### 追加された機能・修正

- `__tests__/flate-decompressor.decompress.test.ts`: 正常なzlibデータの展開成功（実際のdecompressFlate経路を実行）
- `__tests__/flate-decompressor.limit.test.ts`:
  - `DEFAULT_OBJECT_STREAM_MAX_DECOMPRESSED_SIZE`（8MB）のデフォルト上限が適用されること
  - `maxDecompressedSize` オプションで上限を上書きできること
  - 上限超過時に下位（decompressFlate）のエラーがそのまま伝播すること
- `__tests__/flate-decompressor.test.helpers.ts`: 非圧縮（stored）DEFLATEブロックのみで構成される正当なzlibストリームを実行時生成するヘルパー。8MB超のフィクスチャをソースへliteral配列として埋め込まずに済むようにするため（`node:zlib`は本リポジトリに`@types/node`が無く型チェックが通らないため不採用）

### 変更されたファイル

なし（新規追加のみ）

### 削除されたファイル・機能

なし

## 📋 関連 Issue

Closes #496

## 🧪 テスト

### テスト実行方法

```bash
pnpm run test:run
pnpm run lint
pnpm run typecheck
```

### テスト項目

- [x] 単体テスト (Unit tests)

### テスト結果

- 追加した4テストすべてパス
- `flate-decompressor/index.ts` は関数・文・分岐・行すべてカバレッジ100%達成
- 全体テスト（3194テスト / 261ファイル）・lint・typecheckすべて通過、既存テストへの回帰なし

## 🔍 レビューポイント

- `flate-decompressor.test.helpers.ts` の stored-block zlib生成ロジック（Adler-32計算含む）が正しいことは、実際の`DecompressionStream`で正常展開できることをテストで検証済み
- 8MB超のデータはUint8Arrayを実行時に確保して生成しており、ソースファイル自体には巨大なリテラルを埋め込んでいない

## ✅ チェックリスト

- [x] コードレビューの準備ができている
- [x] テストが正常に実行される
- [x] コミットメッセージが適切な形式で書かれている
- [x] 関連するIssueがPRの「Development」にLinkされている（Closes #496）
- [x] セルフレビューを実施した
- [ ] 破壊的変更はなし

🤖 Generated with [Claude Code](https://claude.com/claude-code)