### PR TITLE
🧪 [Tests]: #495 xref-pipeline統合テストにxrefストリーム経路・/Prevマージ経路・fallback経路のE2Eを追加

### DIFF
--- a/packages/core/src/xref/__tests__/xref-pipeline.integration.test.ts
+++ b/packages/core/src/xref/__tests__/xref-pipeline.integration.test.ts
@@ -194,13 +194,17 @@ test("scanStartXRef -> parseIndirectObject -> decompressFlate -> decodeXRefStrea
 
 test("scanStartXRef -> mergeXRefChainで/Prevチェーンをまたいでend-to-endにマージする（テキストxref表とxrefストリームの混在）", async () => {
   const header = "%PDF-1.7\n";
+  // obj3は新revisionのxrefストリーム（/Index [0 3 7 1]）に含まれない旧revision専有のエントリ。
+  // /Prevチェーンを実際に辿らないとmergedXRefに現れないため、マージ経路自体の実行を検証できる。
   const oldSection =
     "xref\n" +
     "0 2\n" +
     "0000000000 65535 f\r\n" +
     "0000000100 00000 n\r\n" +
+    "3 1\n" +
+    "0000000150 00000 n\r\n" +
     "trailer\n" +
-    "<< /Root 1 0 R /Size 2 >>\n";
+    "<< /Root 1 0 R /Size 4 >>\n";
   const oldOffset = header.length;
 
   const newOffset = header.length + oldSection.length;
@@ -208,10 +212,10 @@ test("scanStartXRef -> mergeXRefChainで/Prevチェーンをまたいでend-to-e
   // 解凍後の生エントリ（/Index [0 3 7 1]）:
   // obj0=free(nextFree=0,gen=0) obj1=used(offset=999,gen=0、旧revisionのoffset=100を上書き)
   // obj2=used(offset=1000,gen=0、新revisionで追加) obj7=used(offset=newOffset,gen=0、自己無矛盾)
-  // zlib.deflateSync(Buffer.from([0,0,0,0, 1,3,0xe7,0, 1,3,0xe8,0, 1,0,92,0])) の結果
+  // zlib.deflateSync(Buffer.from([0,0,0,0, 1,3,0xe7,0, 1,3,0xe8,0, 1,0,116,0])) の結果
   const newCompressed = new Uint8Array([
     120, 156, 99, 96, 96, 96, 96, 100, 126, 206, 192, 200, 252, 130, 129, 145,
-    33, 134, 1, 0, 15, 140, 2, 53,
+    161, 132, 1, 0, 15, 188, 2, 77,
   ]);
 
   const newObjHeader =
@@ -276,7 +280,7 @@ test("scanStartXRef -> mergeXRefChainで/Prevチェーンをまたいでend-to-e
   );
   assert(mergeResult.ok);
 
-  expect(mergeResult.value.mergedXRef.entries.size).toBe(4);
+  expect(mergeResult.value.mergedXRef.entries.size).toBe(5);
 
   const entry1 = mergeResult.value.mergedXRef.entries.get(ObjectNumber.of(1));
   assert(entry1 !== undefined && entry1.type === 1);
@@ -285,6 +289,11 @@ test("scanStartXRef -> mergeXRefChainで/Prevチェーンをまたいでend-to-e
   const entry2 = mergeResult.value.mergedXRef.entries.get(ObjectNumber.of(2));
   assert(entry2 !== undefined && entry2.type === 1);
   expect(entry2.offset).toBe(1000);
+
+  // obj3は旧revisionにしか存在しないため、/Prevチェーンが実際に辿られた場合のみ現れる
+  const entry3 = mergeResult.value.mergedXRef.entries.get(ObjectNumber.of(3));
+  assert(entry3 !== undefined && entry3.type === 1);
+  expect(entry3.offset).toBe(150);
 
   const entry7 = mergeResult.value.mergedXRef.entries.get(ObjectNumber.of(7));
   assert(entry7 !== undefined && entry7.type === 1);

--- a/packages/core/src/xref/__tests__/xref-pipeline.integration.test.ts
+++ b/packages/core/src/xref/__tests__/xref-pipeline.integration.test.ts
@@ -113,18 +113,21 @@ test("scanStartXRef -> parseXRefTable -> parseTrailerのend-to-endパイプラ�
 });
 
 test("scanStartXRef -> parseIndirectObject -> decompressFlate -> decodeXRefStreamEntries -> buildXRefStreamTrailerDictのend-to-endパイプライン（xrefストリーム経路）", async () => {
-  // 解凍後の生エントリ: obj0=free(nextFree=0,gen=0) obj1=used(offset=9,gen=0) obj2=used(offset=74,gen=0)
-  // zlib.deflateSync(Buffer.from([0,0,0,0, 1,0,9,0, 1,0,74,0])) の結果
-  const compressed = new Uint8Array([
-    120, 156, 99, 96, 96, 96, 96, 100, 224, 100, 96, 100, 240, 98, 0, 0, 0, 226,
-    0, 86,
-  ]);
-
   const header = "%PDF-1.7\n";
   const objOffset = header.length;
+  // 解凍後の生エントリ（/Index [0 3 7 1]）:
+  // obj0=free(nextFree=0,gen=0) obj1=used(offset=200,gen=0) obj2=used(offset=300,gen=0)
+  // obj7=used(offset=objOffset,gen=0) ※xrefストリーム自身のオブジェクトも自己無矛盾に含める
+  // zlib.deflateSync(Buffer.from([0,0,0,0, 1,0,200,0, 1,1,44,0, 1,0,9,0])) の結果
+  const compressed = new Uint8Array([
+    120, 156, 99, 96, 96, 96, 96, 100, 56, 193, 192, 200, 168, 195, 192, 200,
+    192, 201, 0, 0, 9, 25, 1, 2,
+  ]);
+
   const objHeader =
     "7 0 obj\n" +
-    `<< /Type /XRef /Filter /FlateDecode /W [1 2 1] /Size 3 /Root 1 0 R /Length ${compressed.length} >>\n` +
+    "<< /Type /XRef /Filter /FlateDecode /W [1 2 1] /Size 8 " +
+    `/Index [0 3 7 1] /Root 1 0 R /Length ${compressed.length} >>\n` +
     "stream\n";
   const footer = `startxref\n${objOffset}\n%%EOF\n`;
 
@@ -152,24 +155,31 @@ test("scanStartXRef -> parseIndirectObject -> decompressFlate -> decodeXRefStrea
   assert(decompressResult.ok);
 
   const w = pdfIntArray(stream.dictionary.entries.get("W"));
+  const index = pdfIntArray(stream.dictionary.entries.get("Index"));
   const size = pdfInt(stream.dictionary.entries.get("Size"));
 
   const xrefResult = decodeXRefStreamEntries({
     data: decompressResult.value,
     w: [w[0], w[1], w[2]],
+    index,
     size,
   });
   assert(xrefResult.ok);
 
-  expect(xrefResult.value.size).toBe(3);
+  expect(xrefResult.value.size).toBe(8);
   expect(xrefResult.value.entries.get(ObjectNumber.of(1))).toEqual({
     type: 1,
-    offset: ByteOffset.of(9),
+    offset: ByteOffset.of(200),
     generationNumber: GenerationNumber.of(0),
   });
   expect(xrefResult.value.entries.get(ObjectNumber.of(2))).toEqual({
     type: 1,
-    offset: ByteOffset.of(74),
+    offset: ByteOffset.of(300),
+    generationNumber: GenerationNumber.of(0),
+  });
+  expect(xrefResult.value.entries.get(ObjectNumber.of(7))).toEqual({
+    type: 1,
+    offset: ByteOffset.of(objOffset),
     generationNumber: GenerationNumber.of(0),
   });
 
@@ -179,7 +189,7 @@ test("scanStartXRef -> parseIndirectObject -> decompressFlate -> decodeXRefStrea
     objectNumber: ObjectNumber.of(1),
     generationNumber: GenerationNumber.of(0),
   });
-  expect(trailerResult.value.size).toBe(3);
+  expect(trailerResult.value.size).toBe(8);
 });
 
 test("scanStartXRef -> mergeXRefChainで/Prevチェーンをまたいでend-to-endにマージする（テキストxref表とxrefストリームの混在）", async () => {
@@ -193,18 +203,21 @@ test("scanStartXRef -> mergeXRefChainで/Prevチェーンをまたいでend-to-e
     "<< /Root 1 0 R /Size 2 >>\n";
   const oldOffset = header.length;
 
-  // 解凍後の生エントリ: obj0=free(nextFree=0,gen=0) obj1=used(offset=999,gen=0、旧revisionのoffset=100を上書き) obj2=used(offset=1000,gen=0、新revisionで追加)
-  // zlib.deflateSync(Buffer.from([0,0,0,0, 1,3,0xe7,0, 1,3,0xe8,0])) の結果
+  const newOffset = header.length + oldSection.length;
+
+  // 解凍後の生エントリ（/Index [0 3 7 1]）:
+  // obj0=free(nextFree=0,gen=0) obj1=used(offset=999,gen=0、旧revisionのoffset=100を上書き)
+  // obj2=used(offset=1000,gen=0、新revisionで追加) obj7=used(offset=newOffset,gen=0、自己無矛盾)
+  // zlib.deflateSync(Buffer.from([0,0,0,0, 1,3,0xe7,0, 1,3,0xe8,0, 1,0,92,0])) の結果
   const newCompressed = new Uint8Array([
-    120, 156, 99, 96, 96, 96, 96, 100, 126, 206, 192, 200, 252, 130, 1, 0, 7,
-    112, 1, 216,
+    120, 156, 99, 96, 96, 96, 96, 100, 126, 206, 192, 200, 252, 130, 129, 145,
+    33, 134, 1, 0, 15, 140, 2, 53,
   ]);
 
-  const newOffset = header.length + oldSection.length;
   const newObjHeader =
     "7 0 obj\n" +
-    "<< /Type /XRef /Filter /FlateDecode /W [1 2 1] /Size 3 " +
-    `/Root 1 0 R /Prev ${oldOffset} /Length ${newCompressed.length} >>\n` +
+    "<< /Type /XRef /Filter /FlateDecode /W [1 2 1] /Size 8 " +
+    `/Index [0 3 7 1] /Root 1 0 R /Prev ${oldOffset} /Length ${newCompressed.length} >>\n` +
     "stream\n";
   const footer = `startxref\n${newOffset}\n%%EOF\n`;
 
@@ -231,11 +244,13 @@ test("scanStartXRef -> mergeXRefChainで/Prevチェーンをまたいでend-to-e
   assert(decompressResult.ok);
 
   const w = pdfIntArray(stream.dictionary.entries.get("W"));
+  const index = pdfIntArray(stream.dictionary.entries.get("Index"));
   const size = pdfInt(stream.dictionary.entries.get("Size"));
 
   const newXrefResult = decodeXRefStreamEntries({
     data: decompressResult.value,
     w: [w[0], w[1], w[2]],
+    index,
     size,
   });
   assert(newXrefResult.ok);
@@ -261,7 +276,7 @@ test("scanStartXRef -> mergeXRefChainで/Prevチェーンをまたいでend-to-e
   );
   assert(mergeResult.ok);
 
-  expect(mergeResult.value.mergedXRef.entries.size).toBe(3);
+  expect(mergeResult.value.mergedXRef.entries.size).toBe(4);
 
   const entry1 = mergeResult.value.mergedXRef.entries.get(ObjectNumber.of(1));
   assert(entry1 !== undefined && entry1.type === 1);
@@ -271,11 +286,15 @@ test("scanStartXRef -> mergeXRefChainで/Prevチェーンをまたいでend-to-e
   assert(entry2 !== undefined && entry2.type === 1);
   expect(entry2.offset).toBe(1000);
 
+  const entry7 = mergeResult.value.mergedXRef.entries.get(ObjectNumber.of(7));
+  assert(entry7 !== undefined && entry7.type === 1);
+  expect(entry7.offset).toBe(newOffset);
+
   expect(mergeResult.value.latestTrailer.root).toEqual({
     objectNumber: ObjectNumber.of(1),
     generationNumber: GenerationNumber.of(0),
   });
-  expect(mergeResult.value.latestTrailer.size).toBe(3);
+  expect(mergeResult.value.latestTrailer.size).toBe(8);
 });
 
 test("scanStartXRef -> parseXRefTable失敗 -> scanFallbackでend-to-endにtrailerを再構成する（xref破損時のfallback経路）", () => {

--- a/packages/core/src/xref/__tests__/xref-pipeline.integration.test.ts
+++ b/packages/core/src/xref/__tests__/xref-pipeline.integration.test.ts
@@ -1,10 +1,50 @@
 import { assert, expect, test } from "vitest";
+import { ObjectParser } from "../../objects/object-parser/index";
+import type { PdfParseError } from "../../pdf/errors/index";
 import { ByteOffset } from "../../pdf/types/byte-offset/index";
 import { GenerationNumber } from "../../pdf/types/generation-number/index";
+import type { PdfValue, TrailerDict, XRefTable } from "../../pdf/types/index";
 import { ObjectNumber } from "../../pdf/types/object-number/index";
+import type { Result } from "../../utils/result/index";
+import { flatMap, ok } from "../../utils/result/index";
+import { scanFallback } from "../fallback/index";
+import { mergeXRefChain } from "../merger/index";
 import { scanStartXRef } from "../startxref/scanner/index";
+import {
+  buildXRefStreamTrailerDict,
+  decodeXRefStreamEntries,
+  decompressFlate,
+} from "../stream/index";
 import { parseXRefTable } from "../table/parser/index";
 import { parseTrailer } from "../trailer/parser/index";
+
+function encode(s: string): Uint8Array {
+  return new TextEncoder().encode(s);
+}
+
+function concatBytes(chunks: readonly Uint8Array[]): Uint8Array {
+  const total = chunks.reduce((sum, c) => sum + c.length, 0);
+  const result = new Uint8Array(total);
+  let offset = 0;
+  for (const chunk of chunks) {
+    result.set(chunk, offset);
+    offset += chunk.length;
+  }
+  return result;
+}
+
+function pdfIntArray(value: PdfValue | undefined): number[] {
+  assert(value !== undefined && value.type === "array");
+  return value.elements.map((el) => {
+    assert(el.type === "integer");
+    return el.value;
+  });
+}
+
+function pdfInt(value: PdfValue | undefined): number {
+  assert(value !== undefined && value.type === "integer");
+  return value.value;
+}
 
 test("scanStartXRefの結果をparseXRefTableに渡してend-to-endで解析する", () => {
   const pdf =
@@ -70,4 +110,224 @@ test("scanStartXRef -> parseXRefTable -> parseTrailerのend-to-endパイプラ�
     generationNumber: GenerationNumber.of(0),
   });
   expect(trailerResult.value.size).toBe(2);
+});
+
+test("scanStartXRef -> parseIndirectObject -> decompressFlate -> decodeXRefStreamEntries -> buildXRefStreamTrailerDictのend-to-endパイプライン（xrefストリーム経路）", async () => {
+  // 解凍後の生エントリ: obj0=free(nextFree=0,gen=0) obj1=used(offset=9,gen=0) obj2=used(offset=74,gen=0)
+  // zlib.deflateSync(Buffer.from([0,0,0,0, 1,0,9,0, 1,0,74,0])) の結果
+  const compressed = new Uint8Array([
+    120, 156, 99, 96, 96, 96, 96, 100, 224, 100, 96, 100, 240, 98, 0, 0, 0, 226,
+    0, 86,
+  ]);
+
+  const header = "%PDF-1.7\n";
+  const objOffset = header.length;
+  const objHeader =
+    "7 0 obj\n" +
+    `<< /Type /XRef /Filter /FlateDecode /W [1 2 1] /Size 3 /Root 1 0 R /Length ${compressed.length} >>\n` +
+    "stream\n";
+  const footer = `startxref\n${objOffset}\n%%EOF\n`;
+
+  const data = concatBytes([
+    encode(header),
+    encode(objHeader),
+    compressed,
+    encode("\nendstream\nendobj\n"),
+    encode(footer),
+  ]);
+
+  const scanResult = scanStartXRef(data);
+  assert(scanResult.ok);
+  expect(scanResult.value).toBe(objOffset);
+
+  const objectResult = await ObjectParser.parseIndirectObject(
+    data,
+    scanResult.value,
+  );
+  assert(objectResult.ok);
+  assert(objectResult.value.body.type === "stream");
+  const stream = objectResult.value.body;
+
+  const decompressResult = await decompressFlate(stream.data);
+  assert(decompressResult.ok);
+
+  const w = pdfIntArray(stream.dictionary.entries.get("W"));
+  const size = pdfInt(stream.dictionary.entries.get("Size"));
+
+  const xrefResult = decodeXRefStreamEntries({
+    data: decompressResult.value,
+    w: [w[0], w[1], w[2]],
+    size,
+  });
+  assert(xrefResult.ok);
+
+  expect(xrefResult.value.size).toBe(3);
+  expect(xrefResult.value.entries.get(ObjectNumber.of(1))).toEqual({
+    type: 1,
+    offset: ByteOffset.of(9),
+    generationNumber: GenerationNumber.of(0),
+  });
+  expect(xrefResult.value.entries.get(ObjectNumber.of(2))).toEqual({
+    type: 1,
+    offset: ByteOffset.of(74),
+    generationNumber: GenerationNumber.of(0),
+  });
+
+  const trailerResult = buildXRefStreamTrailerDict(stream.dictionary.entries);
+  assert(trailerResult.ok);
+  expect(trailerResult.value.root).toEqual({
+    objectNumber: ObjectNumber.of(1),
+    generationNumber: GenerationNumber.of(0),
+  });
+  expect(trailerResult.value.size).toBe(3);
+});
+
+test("scanStartXRef -> mergeXRefChainで/Prevチェーンをまたいでend-to-endにマージする（テキストxref表とxrefストリームの混在）", async () => {
+  const header = "%PDF-1.7\n";
+  const oldSection =
+    "xref\n" +
+    "0 2\n" +
+    "0000000000 65535 f\r\n" +
+    "0000000100 00000 n\r\n" +
+    "trailer\n" +
+    "<< /Root 1 0 R /Size 2 >>\n";
+  const oldOffset = header.length;
+
+  // 解凍後の生エントリ: obj0=free(nextFree=0,gen=0) obj1=used(offset=999,gen=0、旧revisionのoffset=100を上書き) obj2=used(offset=1000,gen=0、新revisionで追加)
+  // zlib.deflateSync(Buffer.from([0,0,0,0, 1,3,0xe7,0, 1,3,0xe8,0])) の結果
+  const newCompressed = new Uint8Array([
+    120, 156, 99, 96, 96, 96, 96, 100, 126, 206, 192, 200, 252, 130, 1, 0, 7,
+    112, 1, 216,
+  ]);
+
+  const newOffset = header.length + oldSection.length;
+  const newObjHeader =
+    "7 0 obj\n" +
+    "<< /Type /XRef /Filter /FlateDecode /W [1 2 1] /Size 3 " +
+    `/Root 1 0 R /Prev ${oldOffset} /Length ${newCompressed.length} >>\n` +
+    "stream\n";
+  const footer = `startxref\n${newOffset}\n%%EOF\n`;
+
+  const data = concatBytes([
+    encode(header),
+    encode(oldSection),
+    encode(newObjHeader),
+    newCompressed,
+    encode("\nendstream\nendobj\n"),
+    encode(footer),
+  ]);
+
+  const scanResult = scanStartXRef(data);
+  assert(scanResult.ok);
+  expect(scanResult.value).toBe(newOffset);
+  const NEW_OFFSET = scanResult.value;
+
+  const objectResult = await ObjectParser.parseIndirectObject(data, NEW_OFFSET);
+  assert(objectResult.ok);
+  assert(objectResult.value.body.type === "stream");
+  const stream = objectResult.value.body;
+
+  const decompressResult = await decompressFlate(stream.data);
+  assert(decompressResult.ok);
+
+  const w = pdfIntArray(stream.dictionary.entries.get("W"));
+  const size = pdfInt(stream.dictionary.entries.get("Size"));
+
+  const newXrefResult = decodeXRefStreamEntries({
+    data: decompressResult.value,
+    w: [w[0], w[1], w[2]],
+    size,
+  });
+  assert(newXrefResult.ok);
+
+  const newTrailerResult = buildXRefStreamTrailerDict(
+    stream.dictionary.entries,
+  );
+  assert(newTrailerResult.ok);
+
+  const parseOldSectionAt = (
+    offset: ByteOffset,
+  ): Result<{ xref: XRefTable; trailer: TrailerDict }, PdfParseError> =>
+    flatMap(parseXRefTable(data, offset), (table) =>
+      flatMap(parseTrailer(data, table.trailerOffset), (trailer) =>
+        ok({ xref: table.xref, trailer }),
+      ),
+    );
+
+  const mergeResult = mergeXRefChain(NEW_OFFSET, (offset) =>
+    offset === NEW_OFFSET
+      ? ok({ xref: newXrefResult.value, trailer: newTrailerResult.value })
+      : parseOldSectionAt(offset),
+  );
+  assert(mergeResult.ok);
+
+  expect(mergeResult.value.mergedXRef.entries.size).toBe(3);
+
+  const entry1 = mergeResult.value.mergedXRef.entries.get(ObjectNumber.of(1));
+  assert(entry1 !== undefined && entry1.type === 1);
+  expect(entry1.offset).toBe(999);
+
+  const entry2 = mergeResult.value.mergedXRef.entries.get(ObjectNumber.of(2));
+  assert(entry2 !== undefined && entry2.type === 1);
+  expect(entry2.offset).toBe(1000);
+
+  expect(mergeResult.value.latestTrailer.root).toEqual({
+    objectNumber: ObjectNumber.of(1),
+    generationNumber: GenerationNumber.of(0),
+  });
+  expect(mergeResult.value.latestTrailer.size).toBe(3);
+});
+
+test("scanStartXRef -> parseXRefTable失敗 -> scanFallbackでend-to-endにtrailerを再構成する（xref破損時のfallback経路）", () => {
+  const header = "%PDF-1.7\n";
+  const obj1 = "1 0 obj\n<< /Type /Catalog /Pages 2 0 R >>\nendobj\n";
+  const obj2 = "2 0 obj\n<< /Type /Pages /Kids [] /Count 0 >>\nendobj\n";
+  // xrefサブセクションの状態フラグが不正 ('x') であり parseXRefTable は必ず失敗する
+  const corruptedXref =
+    "xref\n0 1\n0000000100 00000 x\r\ntrailer\n<< /Root 1 0 R /Size 3 >>\n";
+
+  const obj1Offset = header.length;
+  const obj2Offset = obj1Offset + obj1.length;
+  const corruptedOffset = obj2Offset + obj2.length;
+  const footer = `startxref\n${corruptedOffset}\n%%EOF\n`;
+
+  const pdf = header + obj1 + obj2 + corruptedXref + footer;
+  const data = encode(pdf);
+
+  const scanResult = scanStartXRef(data);
+  assert(scanResult.ok);
+  expect(scanResult.value).toBe(corruptedOffset);
+
+  const tableResult = parseXRefTable(data, scanResult.value);
+  assert(!tableResult.ok);
+  expect(tableResult.error.code).toBe("XREF_TABLE_INVALID");
+
+  const fallbackResult = scanFallback(data);
+  assert(fallbackResult.ok);
+
+  expect(fallbackResult.value.trailer.some).toBe(true);
+  assert(fallbackResult.value.trailer.some);
+  expect(fallbackResult.value.trailer.value.root).toEqual({
+    objectNumber: ObjectNumber.of(1),
+    generationNumber: GenerationNumber.of(0),
+  });
+  expect(fallbackResult.value.trailer.value.size).toBe(3);
+
+  expect(
+    fallbackResult.value.xrefTable.entries.get(ObjectNumber.of(1)),
+  ).toEqual({
+    type: 1,
+    offset: ByteOffset.of(obj1Offset),
+    generationNumber: GenerationNumber.of(0),
+  });
+  expect(
+    fallbackResult.value.xrefTable.entries.get(ObjectNumber.of(2)),
+  ).toEqual({
+    type: 1,
+    offset: ByteOffset.of(obj2Offset),
+    generationNumber: GenerationNumber.of(0),
+  });
+
+  expect(fallbackResult.value.warnings).toHaveLength(1);
+  expect(fallbackResult.value.warnings[0].code).toBe("XREF_REBUILD");
 });


### PR DESCRIPTION
## 概要

`xref-pipeline.integration.test.ts` に、既存2テスト（xrefテーブル経路）では未カバーだった3つのend-to-end経路のテストを追加する。

## 変更内容

### 🎯 変更の種類

- [x] 🚨 テスト追加/修正 (Tests)

### 📝 詳細な変更内容

#### 追加された機能・修正

- **xrefストリーム経路**: `scanStartXRef` → `ObjectParser.parseIndirectObject`（実際のオブジェクト/辞書/ストリーム抽出パーサーを使用）→ `decompressFlate` → `decodeXRefStreamEntries` → `buildXRefStreamTrailerDict` を、実際にzlib圧縮したxrefストリームオブジェクトを含むPDFバイト列で通しで検証するテストを追加
- **/Prevチェーンをまたぐマージ経路（テキスト・ストリーム混在）**: 旧revisionをテキストxref表、新revisionをxrefストリームとして構築し、`mergeXRefChain` が実パーサーの結果（新revisionは非同期で事前解決した結果、旧revisionは`parseXRefTable`+`parseTrailer`を`flatMap`でチェーンしたコールバック）を使って正しくマージ（新エントリでの上書き・新規追加・sizeの統合）することを検証するテストを追加
- **fallback経路**: `parseXRefTable` が必ず失敗する破損xref表を含むPDFを構築し、`scanStartXRef`成功→`parseXRefTable`失敗→`scanFallback`によるオブジェクトスキャンとtrailer再構成、というend-to-endフローを検証するテストを追加

#### 変更されたファイル

- `packages/core/src/xref/__tests__/xref-pipeline.integration.test.ts`

## 📋 関連 Issue

- Closes #495

## 🧪 テスト

### テスト実行方法

```bash
pnpm --filter @pdfmod/core run typecheck
pnpm --filter @pdfmod/core exec vitest run
```

### テスト項目

- [x] 単体テスト (Unit tests)
- [x] 統合テスト (Integration tests)

### テスト結果

- `pnpm --filter @pdfmod/core run typecheck`: エラーなし
- `pnpm --filter @pdfmod/core exec vitest run`: 255 test files / 3173 tests すべて成功
- `biome check` / `oxlint`: 対象ファイルで警告・エラーなし

## 🔍 レビューポイント

- xrefストリームのdictはテキストから手動で組み立てず、実際の `ObjectParser.parseIndirectObject` でパースした結果（`stream.dictionary.entries` / `stream.data`）をそのまま `decompressFlate` / `decodeXRefStreamEntries` / `buildXRefStreamTrailerDict` に渡している点
- `mergeXRefChain` のコールバックは本リポジトリのテストルール（if/else/switch禁止）に従い `flatMap` と三項演算子でResultをチェーンしている点
- 圧縮データは `zlib.deflateSync` の出力をハードコードしたバイト列（コメントに元の生エントリと生成コマンドを明記）を使用しており、実行時にNode専用APIへ依存しない

## ⚠️ 破壊的変更

- [ ] この変更は既存の API に破壊的変更を含みます

## ✅ チェックリスト

- [x] コードレビューの準備ができている
- [x] テストが正常に実行される
- [x] ドキュメントが更新されている（必要に応じて、本PRは対象なし）
- [x] コミットメッセージが適切な形式で書かれている
- [x] 関連する Issue が PR の「Development」に Linked されている
- [x] PR 本文に `Closes #` で Issue が記載されている
- [x] セルフレビューを実施した
- [x] 破壊的変更がある場合は明記されている（該当なし）