### PR TITLE
🐛 [Bug Fix]: #319 XRefストリームをPdfDocument.loadのメイン読み込みパスに統合

### DIFF
--- a/packages/core/src/document/pdf-document/__tests__/pdf-document.xref-stream.test.helpers.ts
+++ b/packages/core/src/document/pdf-document/__tests__/pdf-document.xref-stream.test.helpers.ts
@@ -60,6 +60,15 @@ const compressedEntryBytes = (
 const FREE_ENTRY_BYTES: readonly number[] = [0, 0, 0, 0];
 
 /**
+ * テキスト形式 xref エントリの10桁ゼロ埋めオフセット文字列を組み立てる。
+ *
+ * @param n - 0 以上の整数オフセット値
+ * @returns 10桁ゼロ埋め文字列
+ */
+const pad10 = (n: number): string =>
+  n.toString(OFFSET_PAD_RADIX).padStart(OFFSET_PAD_DIGITS, "0");
+
+/**
  * バイト配列群を連結する。
  *
  * @param chunks - 連結対象のバイト配列群
@@ -158,8 +167,6 @@ export const buildPdfWithIncrementalUpdateViaXRefStream = (): Uint8Array => {
   }
   const oldXrefOffset = cursor;
 
-  const pad10 = (n: number): string =>
-    n.toString(OFFSET_PAD_RADIX).padStart(OFFSET_PAD_DIGITS, "0");
   const oldXrefRows = [
     "0000000000 65535 f \n",
     ...oldOffsets.map((o) => `${pad10(o)} 00000 n \n`),
@@ -280,5 +287,90 @@ export const buildPdfWithXRefStreamAndObjStm = (): Uint8Array => {
     rawEntries,
     encoder.encode("\nendstream\nendobj\n"),
     encoder.encode(footer),
+  ]);
+};
+
+/**
+ * ハイブリッド参照ファイル（ISO 32000-1 §7.5.8.4）を生成する。
+ *
+ * `startxref` はテキスト形式 xref テーブル（obj0-2 の free/Catalog/Pages のみを列挙、
+ * 旧リーダー互換のため ObjStm やそれを指す type=2 エントリは含まない）を指し、その
+ * trailer に `/XRefStm` で補助クロスリファレンスストリーム（5 0 obj）を追加する。
+ * Page（3 0 obj）は ObjStm（4 0 obj）内にのみ格納され、テキスト xref からは
+ * 到達できない — `/XRefStm` を無視すると obj3 は「free/未登録」に見え、
+ * `PdfDocument.load` は少なくともページが解決できない状態になる。
+ *
+ * @returns テキストxref + `/XRefStm` によるハイブリッド参照 PDF のバイト列
+ */
+export const buildHybridReferencePdfWithXRefStm = (): Uint8Array => {
+  const OBJSTM_OBJECT_NUMBER = 4;
+  const obj1 = `1 0 obj\n${CATALOG_BODY}\nendobj\n`;
+  const obj2 = `2 0 obj\n${PAGES_BODY}\nendobj\n`;
+
+  let cursor = byteLen(HEADER);
+  const obj1Offset = cursor;
+  cursor += byteLen(obj1);
+  const obj2Offset = cursor;
+  cursor += byteLen(obj2);
+
+  const objStmEntries = [{ objNum: 3, body: PAGE_BODY }];
+  let bodyCursor = 0;
+  const relOffsets: number[] = [];
+  for (const e of objStmEntries) {
+    relOffsets.push(bodyCursor);
+    bodyCursor += byteLen(e.body) + 1;
+  }
+  const objStmHeaderStr = `${objStmEntries
+    .map((e, i) => `${e.objNum} ${relOffsets[i]}`)
+    .join(" ")} `;
+  const objStmBodyStr = objStmEntries.map((e) => `${e.body} `).join("");
+  const objStmData = encoder.encode(objStmHeaderStr + objStmBodyStr);
+  const first = byteLen(objStmHeaderStr);
+
+  const obj4Offset = cursor;
+  const obj4 =
+    "4 0 obj\n" +
+    `<< /Type /ObjStm /N ${objStmEntries.length} /First ${first} /Length ${objStmData.length} >>\n` +
+    "stream\n";
+  cursor +=
+    byteLen(obj4) + objStmData.length + byteLen("\nendstream\nendobj\n");
+
+  const obj5Offset = cursor;
+  const streamRawEntries = new Uint8Array([
+    ...compressedEntryBytes(OBJSTM_OBJECT_NUMBER, 0),
+    ...usedEntryBytes(obj4Offset),
+    ...usedEntryBytes(obj5Offset),
+  ]);
+  const obj5 =
+    "5 0 obj\n" +
+    "<< /Type /XRef /W [1 2 1] /Size 6 /Index [3 3] /Root 1 0 R " +
+    `/Length ${streamRawEntries.length} >>\n` +
+    "stream\n";
+  cursor +=
+    byteLen(obj5) + streamRawEntries.length + byteLen("\nendstream\nendobj\n");
+
+  const xrefOffset2 = cursor;
+  const textXrefRows = [
+    "0000000000 65535 f \n",
+    `${pad10(obj1Offset)} 00000 n \n`,
+    `${pad10(obj2Offset)} 00000 n \n`,
+  ];
+  const textXref = `xref\n0 3\n${textXrefRows.join("")}`;
+  const hybridTrailer =
+    `trailer\n<< /Size 6 /Root 1 0 R /XRefStm ${obj5Offset} >>\n` +
+    `startxref\n${xrefOffset2}\n%%EOF\n`;
+
+  return concatBytes([
+    encoder.encode(HEADER),
+    encoder.encode(obj1),
+    encoder.encode(obj2),
+    encoder.encode(obj4),
+    objStmData,
+    encoder.encode("\nendstream\nendobj\n"),
+    encoder.encode(obj5),
+    streamRawEntries,
+    encoder.encode("\nendstream\nendobj\n"),
+    encoder.encode(textXref),
+    encoder.encode(hybridTrailer),
   ]);
 };

--- a/packages/core/src/document/pdf-document/__tests__/pdf-document.xref-stream.test.helpers.ts
+++ b/packages/core/src/document/pdf-document/__tests__/pdf-document.xref-stream.test.helpers.ts
@@ -1,0 +1,284 @@
+/**
+ * `PdfDocument.load` がクロスリファレンスストリーム（`/Type /XRef`）経由でも読み込めることを
+ * 検証するテスト向けの PDF バイト列ビルダー群。`/Filter` を持たない生（非圧縮）の
+ * xref ストリームを用いることで、zlib 圧縮バイト列を事前計算せずオフセットを動的に組み立てられる。
+ */
+
+const HEADER = "%PDF-1.7\n";
+const CATALOG_BODY = "<< /Type /Catalog /Pages 2 0 R >>";
+const PAGES_BODY = "<< /Type /Pages /Kids [3 0 R] /Count 1 >>";
+const PAGE_BODY = "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] >>";
+
+const encoder = new TextEncoder();
+
+const BYTE_SHIFT = 8;
+const BYTE_MASK = 0xff;
+const XREF_ENTRY_TYPE_USED = 1;
+const XREF_ENTRY_TYPE_COMPRESSED = 2;
+const OFFSET_PAD_DIGITS = 10;
+const OFFSET_PAD_RADIX = 10;
+
+/**
+ * 文字列をバイト長として測る。
+ *
+ * @param s - 対象文字列
+ * @returns UTF-8 バイト長
+ */
+const byteLen = (s: string): number => encoder.encode(s).length;
+
+/**
+ * W=[1,2,1] 前提で xref ストリームの type=1（使用中）エントリ4バイトを組み立てる。
+ *
+ * @param offset - ファイル内バイトオフセット（2バイトBEで表現可能な範囲）
+ * @returns 4バイトのエントリ配列
+ */
+const usedEntryBytes = (offset: number): number[] => [
+  XREF_ENTRY_TYPE_USED,
+  (offset >> BYTE_SHIFT) & BYTE_MASK,
+  offset & BYTE_MASK,
+  0,
+];
+
+/**
+ * W=[1,2,1] 前提で xref ストリームの type=2（ObjStm内圧縮）エントリ4バイトを組み立てる。
+ *
+ * @param streamObjectNumber - 親 ObjStm のオブジェクト番号
+ * @param indexInStream - ObjStm 内インデックス
+ * @returns 4バイトのエントリ配列
+ */
+const compressedEntryBytes = (
+  streamObjectNumber: number,
+  indexInStream: number,
+): number[] => [
+  XREF_ENTRY_TYPE_COMPRESSED,
+  (streamObjectNumber >> BYTE_SHIFT) & BYTE_MASK,
+  streamObjectNumber & BYTE_MASK,
+  indexInStream,
+];
+
+/** W=[1,2,1] 前提で xref ストリームの type=0（フリー）エントリ4バイト。 */
+const FREE_ENTRY_BYTES: readonly number[] = [0, 0, 0, 0];
+
+/**
+ * バイト配列群を連結する。
+ *
+ * @param chunks - 連結対象のバイト配列群
+ * @returns 連結済みバイト配列
+ */
+const concatBytes = (chunks: readonly Uint8Array[]): Uint8Array => {
+  const total = chunks.reduce((sum, c) => sum + c.length, 0);
+  const result = new Uint8Array(total);
+  let offset = 0;
+  for (const chunk of chunks) {
+    result.set(chunk, offset);
+    offset += chunk.length;
+  }
+  return result;
+};
+
+/**
+ * 1ページのみを持つ最小構成の PDF を、クロスリファレンスストリーム
+ * （`/Type /XRef`, `/Filter` なしの生データ）を唯一の xref 構造として生成する。
+ *
+ * Catalog (1 0 obj) / Pages (2 0 obj) / Page (3 0 obj) はテキスト形式のまま、
+ * xref のみストリーム形式（4 0 obj、自己無矛盾な offset を含む）にする。
+ *
+ * @returns xref ストリームのみを持つ 1 ページ PDF のバイト列
+ */
+export const buildSinglePagePdfWithXRefStream = (): Uint8Array => {
+  const bodies = [CATALOG_BODY, PAGES_BODY, PAGE_BODY];
+  const objs = bodies.map((body, i) => `${i + 1} 0 obj\n${body}\nendobj\n`);
+
+  const offsets: number[] = [];
+  let cursor = byteLen(HEADER);
+  for (const obj of objs) {
+    offsets.push(cursor);
+    cursor += byteLen(obj);
+  }
+  const xrefOffset = cursor;
+
+  const rawEntries = new Uint8Array([
+    ...FREE_ENTRY_BYTES,
+    ...usedEntryBytes(offsets[0]),
+    ...usedEntryBytes(offsets[1]),
+    ...usedEntryBytes(offsets[2]),
+    ...usedEntryBytes(xrefOffset),
+  ]);
+
+  const xrefObj =
+    "4 0 obj\n" +
+    `<< /Type /XRef /W [1 2 1] /Size 5 /Root 1 0 R /Length ${rawEntries.length} >>\n` +
+    "stream\n";
+  const footer = `startxref\n${xrefOffset}\n%%EOF\n`;
+
+  return concatBytes([
+    encoder.encode(HEADER),
+    encoder.encode(objs.join("")),
+    encoder.encode(xrefObj),
+    rawEntries,
+    encoder.encode("\nendstream\nendobj\n"),
+    encoder.encode(footer),
+  ]);
+};
+
+const OLD_SIZE = 4;
+const NEW_SECTION_FIRST_OBJ_NUM = 4;
+const NEW_PAGE_WIDTH = 200;
+const NEW_PAGE_HEIGHT = 300;
+const NEW_PAGE_MEDIA_BOX: readonly [number, number, number, number] = [
+  0,
+  0,
+  NEW_PAGE_WIDTH,
+  NEW_PAGE_HEIGHT,
+];
+
+/**
+ * 旧revision（テキスト xref）→ 新revision（クロスリファレンスストリーム、`/Prev` で旧を参照）の
+ * インクリメンタルアップデート PDF を生成する。
+ *
+ * 旧: Catalog (1 0 R) / Pages (2 0 R) / Page (3 0 R, MediaBox [0 0 612 792])、テキスト xref。
+ * 新: Catalog (4 0 R) / Pages (5 0 R) / Page (6 0 R, MediaBox {@link NEW_PAGE_MEDIA_BOX}) と、
+ * それ自身を含む xref ストリーム (7 0 obj, `/Prev` で旧 xref オフセットを参照)。
+ *
+ * `mergeXRefChain` が新（ストリーム）→ 旧（テキスト）の順に `/Prev` を辿り、
+ * 最新 trailer の `/Root`（新 Catalog）経由でページ構造が観測されることを検証する。
+ *
+ * @returns テキスト xref → xref ストリームの /Prev チェーンを持つ PDF バイト列
+ */
+export const buildPdfWithIncrementalUpdateViaXRefStream = (): Uint8Array => {
+  const oldObjs = [CATALOG_BODY, PAGES_BODY, PAGE_BODY].map(
+    (body, i) => `${i + 1} 0 obj\n${body}\nendobj\n`,
+  );
+
+  const oldOffsets: number[] = [];
+  let cursor = byteLen(HEADER);
+  for (const obj of oldObjs) {
+    oldOffsets.push(cursor);
+    cursor += byteLen(obj);
+  }
+  const oldXrefOffset = cursor;
+
+  const pad10 = (n: number): string =>
+    n.toString(OFFSET_PAD_RADIX).padStart(OFFSET_PAD_DIGITS, "0");
+  const oldXrefRows = [
+    "0000000000 65535 f \n",
+    ...oldOffsets.map((o) => `${pad10(o)} 00000 n \n`),
+  ];
+  const oldXref = `xref\n0 ${OLD_SIZE}\n${oldXrefRows.join("")}`;
+  const oldTrailer = `trailer\n<< /Size ${OLD_SIZE} /Root 1 0 R >>\nstartxref\n${oldXrefOffset}\n%%EOF\n`;
+  const oldTail = oldXref + oldTrailer;
+  cursor += byteLen(oldTail);
+
+  const [mbX, mbY, mbW, mbH] = NEW_PAGE_MEDIA_BOX;
+  const newBodies = [
+    "<< /Type /Catalog /Pages 5 0 R >>",
+    "<< /Type /Pages /Kids [6 0 R] /Count 1 >>",
+    `<< /Type /Page /Parent 5 0 R /MediaBox [${mbX} ${mbY} ${mbW} ${mbH}] >>`,
+  ];
+  const newObjs = newBodies.map(
+    (body, i) => `${i + NEW_SECTION_FIRST_OBJ_NUM} 0 obj\n${body}\nendobj\n`,
+  );
+
+  const newOffsets: number[] = [];
+  for (const obj of newObjs) {
+    newOffsets.push(cursor);
+    cursor += byteLen(obj);
+  }
+  const newXrefOffset = cursor;
+
+  const rawEntries = new Uint8Array([
+    ...FREE_ENTRY_BYTES,
+    ...usedEntryBytes(newOffsets[0]),
+    ...usedEntryBytes(newOffsets[1]),
+    ...usedEntryBytes(newOffsets[2]),
+    ...usedEntryBytes(newXrefOffset),
+  ]);
+
+  const newXrefObj =
+    "7 0 obj\n" +
+    "<< /Type /XRef /W [1 2 1] /Size 8 /Index [0 1 4 4] " +
+    `/Root 4 0 R /Prev ${oldXrefOffset} /Length ${rawEntries.length} >>\n` +
+    "stream\n";
+  const footer = `startxref\n${newXrefOffset}\n%%EOF\n`;
+
+  return concatBytes([
+    encoder.encode(HEADER),
+    encoder.encode(oldObjs.join("")),
+    encoder.encode(oldTail),
+    encoder.encode(newObjs.join("")),
+    encoder.encode(newXrefObj),
+    rawEntries,
+    encoder.encode("\nendstream\nendobj\n"),
+    encoder.encode(footer),
+  ]);
+};
+
+/**
+ * クロスリファレンスストリーム（type=2 エントリ）経由でのみ到達可能な、
+ * ObjStm（オブジェクトストリーム）内に Catalog/Pages/Page を格納した PDF を生成する。
+ *
+ * オブジェクト構成: 2 0 obj = ObjStm（`/Filter` なしの生データ、Catalog/Pages/Page を格納）、
+ * 1 0 obj = xref ストリーム自身（type=1 自己参照 + ObjStm への type=1 参照 +
+ * Catalog/Pages/Page への type=2 参照）。
+ *
+ * `PdfDocument.load` が xref ストリームの type=2 エントリ → `ObjectStore` の
+ * ObjStm 解決パイプライン（`object-stream-extractor`）まで到達することを検証する。
+ *
+ * @returns ObjStm 経由の PDF バイト列
+ */
+export const buildPdfWithXRefStreamAndObjStm = (): Uint8Array => {
+  const objStmEntries = [
+    { objNum: 3, body: CATALOG_BODY.replace("2 0 R", "4 0 R") },
+    { objNum: 4, body: PAGES_BODY.replace("3 0 R", "5 0 R") },
+    { objNum: 5, body: PAGE_BODY.replace("2 0 R", "4 0 R") },
+  ];
+
+  let bodyCursor = 0;
+  const relOffsets: number[] = [];
+  for (const e of objStmEntries) {
+    relOffsets.push(bodyCursor);
+    bodyCursor += byteLen(e.body) + 1;
+  }
+  const headerStr = `${objStmEntries
+    .map((e, i) => `${e.objNum} ${relOffsets[i]}`)
+    .join(" ")} `;
+  const bodyStr = objStmEntries.map((e) => `${e.body} `).join("");
+  const objStmData = encoder.encode(headerStr + bodyStr);
+  const first = byteLen(headerStr);
+
+  let cursor = byteLen(HEADER);
+  const objStmObjOffset = cursor;
+  const objStmObj =
+    "2 0 obj\n" +
+    `<< /Type /ObjStm /N ${objStmEntries.length} /First ${first} /Length ${objStmData.length} >>\n` +
+    "stream\n";
+  cursor +=
+    byteLen(objStmObj) + objStmData.length + byteLen("\nendstream\nendobj\n");
+
+  const xrefOffset = cursor;
+  const rawEntries = new Uint8Array([
+    ...FREE_ENTRY_BYTES,
+    ...usedEntryBytes(xrefOffset),
+    ...usedEntryBytes(objStmObjOffset),
+    ...compressedEntryBytes(2, 0),
+    ...compressedEntryBytes(2, 1),
+    ...compressedEntryBytes(2, 2),
+  ]);
+
+  const xrefObj =
+    "1 0 obj\n" +
+    `<< /Type /XRef /W [1 2 1] /Size 6 /Root 3 0 R /Length ${rawEntries.length} >>\n` +
+    "stream\n";
+  const footer = `startxref\n${xrefOffset}\n%%EOF\n`;
+
+  return concatBytes([
+    encoder.encode(HEADER),
+    encoder.encode(objStmObj),
+    objStmData,
+    encoder.encode("\nendstream\nendobj\n"),
+    encoder.encode(xrefObj),
+    rawEntries,
+    encoder.encode("\nendstream\nendobj\n"),
+    encoder.encode(footer),
+  ]);
+};

--- a/packages/core/src/document/pdf-document/__tests__/pdf-document.xref-stream.test.helpers.ts
+++ b/packages/core/src/document/pdf-document/__tests__/pdf-document.xref-stream.test.helpers.ts
@@ -326,9 +326,17 @@ export const buildPdfWithXRefStreamAndObjStm = (): Uint8Array => {
  * 到達できない — `/XRefStm` を無視すると obj3 は「free/未登録」に見え、
  * `PdfDocument.load` は少なくともページが解決できない状態になる。
  *
+ * 補助ストリーム（5 0 obj）自体の `/Root` は `includeRootInStream` で切り替えられる
+ * （ISO 32000-1 §7.5.8.4 上、補助ストリームは `/Root` を持たなくてもよい —
+ * 本来の文書 trailer はテキストセクション側が供給するため）。
+ *
+ * @param options - `includeRootInStream`: 補助ストリームに `/Root` を含めるか（既定 `true`）
  * @returns テキストxref + `/XRefStm` によるハイブリッド参照 PDF のバイト列
  */
-export const buildHybridReferencePdfWithXRefStm = (): Uint8Array => {
+export const buildHybridReferencePdfWithXRefStm = (
+  options: { readonly includeRootInStream?: boolean } = {},
+): Uint8Array => {
+  const includeRootInStream = options.includeRootInStream ?? true;
   const OBJSTM_OBJECT_NUMBER = 4;
   const obj1 = `1 0 obj\n${CATALOG_BODY}\nendobj\n`;
   const obj2 = `2 0 obj\n${PAGES_BODY}\nendobj\n`;
@@ -367,9 +375,10 @@ export const buildHybridReferencePdfWithXRefStm = (): Uint8Array => {
     ...usedEntryBytes(obj4Offset),
     ...usedEntryBytes(obj5Offset),
   ]);
+  const rootEntry = includeRootInStream ? "/Root 1 0 R " : "";
   const obj5 =
     "5 0 obj\n" +
-    "<< /Type /XRef /W [1 2 1] /Size 6 /Index [3 3] /Root 1 0 R " +
+    `<< /Type /XRef /W [1 2 1] /Size 6 /Index [3 3] ${rootEntry}` +
     `/Length ${streamRawEntries.length} >>\n` +
     "stream\n";
   cursor +=

--- a/packages/core/src/document/pdf-document/__tests__/pdf-document.xref-stream.test.helpers.ts
+++ b/packages/core/src/document/pdf-document/__tests__/pdf-document.xref-stream.test.helpers.ts
@@ -13,6 +13,8 @@ const encoder = new TextEncoder();
 
 const BYTE_SHIFT = 8;
 const BYTE_MASK = 0xff;
+const MAX_UINT16 = 0xffff;
+const MAX_UINT8 = 0xff;
 const XREF_ENTRY_TYPE_USED = 1;
 const XREF_ENTRY_TYPE_COMPRESSED = 2;
 const OFFSET_PAD_DIGITS = 10;
@@ -27,34 +29,58 @@ const OFFSET_PAD_RADIX = 10;
 const byteLen = (s: string): number => encoder.encode(s).length;
 
 /**
+ * 値が `[0, max]` の整数範囲に収まるか検証し、範囲外なら即座に throw する。
+ * W=[1,2,1] のビット幅に収まらない値をビット演算で暗黙に切り詰めると、
+ * 壊れた（しかし気づきにくい）xref ストリームフィクスチャを生成してしまうため、
+ * テスト作成時のミスを早期に検出する目的のガード。
+ *
+ * @param value - 検証対象の値
+ * @param max - 許容最大値
+ * @param label - エラーメッセージに含める値の名称
+ * @throws {Error} value が整数でない、または `[0, max]` の範囲外の場合
+ */
+const assertFitsInRange = (value: number, max: number, label: string): void => {
+  if (!Number.isInteger(value) || value < 0 || value > max) {
+    throw new Error(`${label} must be an integer in [0, ${max}], got ${value}`);
+  }
+};
+
+/**
  * W=[1,2,1] 前提で xref ストリームの type=1（使用中）エントリ4バイトを組み立てる。
  *
- * @param offset - ファイル内バイトオフセット（2バイトBEで表現可能な範囲）
+ * @param offset - ファイル内バイトオフセット（2バイトBEで表現可能な範囲、0-65535）
  * @returns 4バイトのエントリ配列
  */
-const usedEntryBytes = (offset: number): number[] => [
-  XREF_ENTRY_TYPE_USED,
-  (offset >> BYTE_SHIFT) & BYTE_MASK,
-  offset & BYTE_MASK,
-  0,
-];
+const usedEntryBytes = (offset: number): number[] => {
+  assertFitsInRange(offset, MAX_UINT16, "offset");
+  return [
+    XREF_ENTRY_TYPE_USED,
+    (offset >> BYTE_SHIFT) & BYTE_MASK,
+    offset & BYTE_MASK,
+    0,
+  ];
+};
 
 /**
  * W=[1,2,1] 前提で xref ストリームの type=2（ObjStm内圧縮）エントリ4バイトを組み立てる。
  *
- * @param streamObjectNumber - 親 ObjStm のオブジェクト番号
- * @param indexInStream - ObjStm 内インデックス
+ * @param streamObjectNumber - 親 ObjStm のオブジェクト番号（2バイトBEで表現可能な範囲、0-65535）
+ * @param indexInStream - ObjStm 内インデックス（1バイトで表現可能な範囲、0-255）
  * @returns 4バイトのエントリ配列
  */
 const compressedEntryBytes = (
   streamObjectNumber: number,
   indexInStream: number,
-): number[] => [
-  XREF_ENTRY_TYPE_COMPRESSED,
-  (streamObjectNumber >> BYTE_SHIFT) & BYTE_MASK,
-  streamObjectNumber & BYTE_MASK,
-  indexInStream,
-];
+): number[] => {
+  assertFitsInRange(streamObjectNumber, MAX_UINT16, "streamObjectNumber");
+  assertFitsInRange(indexInStream, MAX_UINT8, "indexInStream");
+  return [
+    XREF_ENTRY_TYPE_COMPRESSED,
+    (streamObjectNumber >> BYTE_SHIFT) & BYTE_MASK,
+    streamObjectNumber & BYTE_MASK,
+    indexInStream,
+  ];
+};
 
 /** W=[1,2,1] 前提で xref ストリームの type=0（フリー）エントリ4バイト。 */
 const FREE_ENTRY_BYTES: readonly number[] = [0, 0, 0, 0];

--- a/packages/core/src/document/pdf-document/__tests__/pdf-document.xref-stream.test.ts
+++ b/packages/core/src/document/pdf-document/__tests__/pdf-document.xref-stream.test.ts
@@ -1,0 +1,39 @@
+import { assert, expect, test } from "vitest";
+import { PdfDocument } from "../../pdf-document";
+import {
+  buildPdfWithIncrementalUpdateViaXRefStream,
+  buildPdfWithXRefStreamAndObjStm,
+  buildSinglePagePdfWithXRefStream,
+} from "./pdf-document.xref-stream.test.helpers";
+
+test("xrefストリームのみを持つPDFをloadでき、ページが解決される", async () => {
+  const result = await PdfDocument.load(buildSinglePagePdfWithXRefStream());
+
+  assert(result.ok);
+  expect(result.value.pageCount).toBe(1);
+  const page = result.value.getPage(0);
+  assert(page.some);
+  expect(page.value.mediaBox).toEqual([0, 0, 612, 792]);
+});
+
+test("テキストxref(旧)とxrefストリーム(新)の/Prevチェーンを辿り最新Rootのページ構造を観測する", async () => {
+  const result = await PdfDocument.load(
+    buildPdfWithIncrementalUpdateViaXRefStream(),
+  );
+
+  assert(result.ok);
+  expect(result.value.pageCount).toBe(1);
+  const page = result.value.getPage(0);
+  assert(page.some);
+  expect(page.value.mediaBox).toEqual([0, 0, 200, 300]);
+});
+
+test("xrefストリームのtype=2エントリ経由でObjStm内のCatalog/Pages/Pageが解決される", async () => {
+  const result = await PdfDocument.load(buildPdfWithXRefStreamAndObjStm());
+
+  assert(result.ok);
+  expect(result.value.pageCount).toBe(1);
+  const page = result.value.getPage(0);
+  assert(page.some);
+  expect(page.value.mediaBox).toEqual([0, 0, 612, 792]);
+});

--- a/packages/core/src/document/pdf-document/__tests__/pdf-document.xref-stream.test.ts
+++ b/packages/core/src/document/pdf-document/__tests__/pdf-document.xref-stream.test.ts
@@ -1,6 +1,7 @@
 import { assert, expect, test } from "vitest";
 import { PdfDocument } from "../../pdf-document";
 import {
+  buildHybridReferencePdfWithXRefStm,
   buildPdfWithIncrementalUpdateViaXRefStream,
   buildPdfWithXRefStreamAndObjStm,
   buildSinglePagePdfWithXRefStream,
@@ -30,6 +31,16 @@ test("テキストxref(旧)とxrefストリーム(新)の/Prevチェーンを辿
 
 test("xrefストリームのtype=2エントリ経由でObjStm内のCatalog/Pages/Pageが解決される", async () => {
   const result = await PdfDocument.load(buildPdfWithXRefStreamAndObjStm());
+
+  assert(result.ok);
+  expect(result.value.pageCount).toBe(1);
+  const page = result.value.getPage(0);
+  assert(page.some);
+  expect(page.value.mediaBox).toEqual([0, 0, 612, 792]);
+});
+
+test("ハイブリッド参照ファイル(/XRefStm)経由でObjStm内のみに存在するPageが解決される", async () => {
+  const result = await PdfDocument.load(buildHybridReferencePdfWithXRefStm());
 
   assert(result.ok);
   expect(result.value.pageCount).toBe(1);

--- a/packages/core/src/document/pdf-document/__tests__/pdf-document.xref-stream.test.ts
+++ b/packages/core/src/document/pdf-document/__tests__/pdf-document.xref-stream.test.ts
@@ -48,3 +48,15 @@ test("ハイブリッド参照ファイル(/XRefStm)経由でObjStm内のみに�
   assert(page.some);
   expect(page.value.mediaBox).toEqual([0, 0, 612, 792]);
 });
+
+test("補助ストリーム自体に/Rootが無いハイブリッド参照ファイルでもObjStm内のPageが解決される", async () => {
+  const result = await PdfDocument.load(
+    buildHybridReferencePdfWithXRefStm({ includeRootInStream: false }),
+  );
+
+  assert(result.ok);
+  expect(result.value.pageCount).toBe(1);
+  const page = result.value.getPage(0);
+  assert(page.some);
+  expect(page.value.mediaBox).toEqual([0, 0, 612, 792]);
+});

--- a/packages/core/src/document/pdf-document/index.ts
+++ b/packages/core/src/document/pdf-document/index.ts
@@ -1,4 +1,8 @@
-import { isPdfWhitespace, matchesBytesAt } from "../../lexer/bytes/index";
+import {
+  isPdfTokenBoundary,
+  isPdfWhitespace,
+  matchesBytesAt,
+} from "../../lexer/bytes/index";
 import { ObjectStore } from "../../objects/object-store/index";
 import type {
   PdfError,
@@ -16,6 +20,7 @@ import { err, ok, type Result } from "../../utils/result/index";
 import { scanFallback } from "../../xref/fallback/index";
 import { mergeXRefChain } from "../../xref/merger/index";
 import { scanStartXRef } from "../../xref/startxref/index";
+import { parseXRefStream } from "../../xref/stream/index";
 import { parseXRefTable } from "../../xref/table/index";
 import { parseTrailer } from "../../xref/trailer/index";
 import { CatalogParser, type ResolveRef } from "../catalog/catalog-parser";
@@ -107,18 +112,55 @@ const verifyHeader = (data: Uint8Array): Result<PdfVersion, PdfParseError> => {
   return ok(created.value);
 };
 
+const XREF_KEYWORD_BYTES: number[] = Array.from(
+  new TextEncoder().encode("xref"),
+);
+
 /**
- * 指定オフセットから xref テーブルと trailer 辞書を続けて解析する。
- * `mergeXRefChain` の `parseCallback` 引数として使う合成。
+ * `offset` がテキスト形式 xref テーブルの `xref` キーワード先頭を指しているか判定する。
+ * 前後のトークン境界も検証する（`parseXRefTable` 内部の判定と同じ基準）。
  *
  * @param data - PDF のバイト列
- * @param offset - xref キーワードのバイトオフセット
- * @returns 成功時は `Ok<{ xref, trailer }>`、失敗時は `Err<PdfParseError>`
+ * @param offset - 判定対象のバイトオフセット
+ * @returns `xref` キーワードであれば `true`
  */
-const parseXRefAt = (
+const isXRefKeywordAt = (data: Uint8Array, offset: number): boolean => {
+  if (offset < 0 || offset >= data.length) {
+    return false;
+  }
+  const afterXref = offset + XREF_KEYWORD_BYTES.length;
+  if (!matchesBytesAt(data, offset, XREF_KEYWORD_BYTES)) {
+    return false;
+  }
+  if (offset > 0 && !isPdfTokenBoundary(data[offset - 1])) {
+    return false;
+  }
+  if (afterXref < data.length && !isPdfTokenBoundary(data[afterXref])) {
+    return false;
+  }
+  return true;
+};
+
+/**
+ * 指定オフセットから xref テーブルまたは xref ストリームと trailer 辞書を続けて解析する。
+ * `mergeXRefChain` の `parseCallback` 引数として使う合成。
+ *
+ * ISO 32000-1 §7.5.8 により、PDF 1.5 以降は startxref が直接クロスリファレンス
+ * ストリームオブジェクト（`N G obj << /Type /XRef ... >> stream`）を指しうる。
+ * `offset` が `xref` キーワードでなければ間接オブジェクトとして xref ストリームを解析する。
+ *
+ * @param data - PDF のバイト列
+ * @param offset - xref キーワード、または xref ストリームを定義する間接オブジェクトのバイトオフセット
+ * @returns 成功時は `Ok<{ xref, trailer }>`、失敗時は `Err<PdfError>`
+ */
+const parseXRefAt = async (
   data: Uint8Array,
   offset: ByteOffset,
-): Result<{ xref: XRefTable; trailer: TrailerDict }, PdfParseError> => {
+): Promise<Result<{ xref: XRefTable; trailer: TrailerDict }, PdfError>> => {
+  if (!isXRefKeywordAt(data, offset as number)) {
+    return parseXRefStream(data, offset);
+  }
+
   const tableResult = parseXRefTable(data, offset);
   if (!tableResult.ok) {
     return tableResult;
@@ -148,10 +190,10 @@ type EmitWarnings = (warnings: readonly PdfWarning[]) => void;
  * @param emitWarnings - fallback 復元時の警告通知コールバック
  * @returns 成功時は `Ok<{ xref, trailer }>`、失敗時は `Err<PdfError>`
  */
-const resolveXRefStructure = (
+const resolveXRefStructure = async (
   data: Uint8Array,
   emitWarnings: EmitWarnings,
-): Result<{ xref: XRefTable; trailer: TrailerDict }, PdfError> => {
+): Promise<Result<{ xref: XRefTable; trailer: TrailerDict }, PdfError>> => {
   const startXRefResult = scanStartXRef(data);
   if (!startXRefResult.ok) {
     const fb = scanFallback(data);
@@ -169,7 +211,7 @@ const resolveXRefStructure = (
     return ok({ xref: fb.value.xrefTable, trailer: fb.value.trailer.value });
   }
 
-  const mergeResult = mergeXRefChain(startXRefResult.value, (off) =>
+  const mergeResult = await mergeXRefChain(startXRefResult.value, (off) =>
     parseXRefAt(data, off),
   );
   if (mergeResult.ok) {
@@ -273,7 +315,7 @@ export class PdfDocument {
       }
     };
 
-    const xrefResolution = resolveXRefStructure(data, emitWarnings);
+    const xrefResolution = await resolveXRefStructure(data, emitWarnings);
     if (!xrefResolution.ok) {
       return xrefResolution;
     }

--- a/packages/core/src/document/pdf-document/index.ts
+++ b/packages/core/src/document/pdf-document/index.ts
@@ -151,12 +151,15 @@ const isXRefKeywordAt = (data: Uint8Array, offset: number): boolean => {
  *
  * @param data - PDF のバイト列
  * @param offset - xref キーワード、または xref ストリームを定義する間接オブジェクトのバイトオフセット
- * @returns 成功時は `Ok<{ xref, trailer }>`、失敗時は `Err<PdfError>`
+ * @returns 成功時は `Ok<{ xref, trailer }>`（`trailer` は `/XRefStm` 補助ストリームのように
+ *   `/Root` を持たない場合 `undefined`）、失敗時は `Err<PdfError>`
  */
 const parseXRefAt = async (
   data: Uint8Array,
   offset: ByteOffset,
-): Promise<Result<{ xref: XRefTable; trailer: TrailerDict }, PdfError>> => {
+): Promise<
+  Result<{ xref: XRefTable; trailer: TrailerDict | undefined }, PdfError>
+> => {
   if (!isXRefKeywordAt(data, offset as number)) {
     return parseXRefStream(data, offset);
   }

--- a/packages/core/src/pdf/types/pdf-types/index.ts
+++ b/packages/core/src/pdf/types/pdf-types/index.ts
@@ -239,6 +239,12 @@ export interface TrailerDict {
   size: number;
   /** /Prev - 前の相互参照テーブルのバイトオフセット */
   prev?: ByteOffset;
+  /**
+   * /XRefStm - ハイブリッド参照ファイル（ISO 32000-1 §7.5.8.4）における
+   * 補助クロスリファレンスストリームのバイトオフセット。
+   * テキスト形式 trailer にのみ現れ、`/Prev` を辿る前に読む必要がある。
+   */
+  xrefStm?: ByteOffset;
   /** /Info - ドキュメント情報辞書の間接参照 */
   info?: IndirectRef;
   /** /ID - ファイル識別子 [永続ID, 変更ID] */

--- a/packages/core/src/xref/__tests__/xref-pipeline.integration.test.ts
+++ b/packages/core/src/xref/__tests__/xref-pipeline.integration.test.ts
@@ -273,7 +273,7 @@ test("scanStartXRef -> mergeXRefChainで/Prevチェーンをまたいでend-to-e
       ),
     );
 
-  const mergeResult = mergeXRefChain(NEW_OFFSET, (offset) =>
+  const mergeResult = await mergeXRefChain(NEW_OFFSET, async (offset) =>
     offset === NEW_OFFSET
       ? ok({ xref: newXrefResult.value, trailer: newTrailerResult.value })
       : parseOldSectionAt(offset),

--- a/packages/core/src/xref/merger/__tests__/merger.boundary.test.ts
+++ b/packages/core/src/xref/merger/__tests__/merger.boundary.test.ts
@@ -1,5 +1,5 @@
 import { assert, expect, test } from "vitest";
-import type { PdfParseError } from "../../../pdf/errors/index";
+import type { PdfError } from "../../../pdf/errors/index";
 import { ByteOffset } from "../../../pdf/types/byte-offset/index";
 import { GenerationNumber } from "../../../pdf/types/generation-number/index";
 import type {
@@ -45,24 +45,26 @@ function makeTrailer(size: number, prev?: number): TrailerDict {
 
 type ParseCallback = (
   offset: ByteOffset,
-) => Result<{ xref: XRefTable; trailer: TrailerDict }, PdfParseError>;
+) => Promise<Result<{ xref: XRefTable; trailer: TrailerDict }, PdfError>>;
 
-test("maxDepth = 1 で単一xrefが成功する", () => {
-  const callback: ParseCallback = (_offset: ByteOffset) =>
+test("maxDepth = 1 で単一xrefが成功する", async () => {
+  const callback: ParseCallback = async (_offset: ByteOffset) =>
     ok({
       xref: makeXRef([[1, usedEntry(100)]], 2),
       trailer: makeTrailer(2),
     });
 
-  const result = mergeXRefChain(ByteOffset.of(500), callback, { maxDepth: 1 });
+  const result = await mergeXRefChain(ByteOffset.of(500), callback, {
+    maxDepth: 1,
+  });
 
   assert(result.ok);
   expect(result.value.mergedXRef.size).toBe(2);
 });
 
-test("maxDepth = 1 で2段チェーンが深さ制限エラーになる", () => {
+test("maxDepth = 1 で2段チェーンが深さ制限エラーになる", async () => {
   let calls = 0;
-  const callback: ParseCallback = (_offset: ByteOffset) => {
+  const callback: ParseCallback = async (_offset: ByteOffset) => {
     calls++;
     return ok({
       xref: makeXRef([[calls, usedEntry(calls * 100)]], calls + 1),
@@ -70,15 +72,17 @@ test("maxDepth = 1 で2段チェーンが深さ制限エラーになる", () => 
     });
   };
 
-  const result = mergeXRefChain(ByteOffset.of(400), callback, { maxDepth: 1 });
+  const result = await mergeXRefChain(ByteOffset.of(400), callback, {
+    maxDepth: 1,
+  });
 
   assert(!result.ok);
   expect(result.error.code).toBe("XREF_PREV_CHAIN_TOO_DEEP");
 });
 
-test("maxDepth オプション指定: カスタム深さ制限が適用される", () => {
+test("maxDepth オプション指定: カスタム深さ制限が適用される", async () => {
   let counter = 0;
-  const callback: ParseCallback = (_offset: ByteOffset) => {
+  const callback: ParseCallback = async (_offset: ByteOffset) => {
     counter++;
     return ok({
       xref: makeXRef([[counter, usedEntry(counter * 100)]], counter + 1),
@@ -86,50 +90,52 @@ test("maxDepth オプション指定: カスタム深さ制限が適用される
     });
   };
 
-  const result = mergeXRefChain(ByteOffset.of(0), callback, { maxDepth: 3 });
+  const result = await mergeXRefChain(ByteOffset.of(0), callback, {
+    maxDepth: 3,
+  });
 
   assert(!result.ok);
   expect(result.error.code).toBe("XREF_PREV_CHAIN_TOO_DEEP");
 });
 
-test("maxDepth 未指定（options 省略）はデフォルト 100 で単一 xref を成功させる", () => {
+test("maxDepth 未指定（options 省略）はデフォルト 100 で単一 xref を成功させる", async () => {
   // 未指定経路: options 省略時に MaxDepth.DEFAULT (100) が採用され成功
-  const callback: ParseCallback = (_offset: ByteOffset) =>
+  const callback: ParseCallback = async (_offset: ByteOffset) =>
     ok({
       xref: makeXRef([[1, usedEntry(100)]], 2),
       trailer: makeTrailer(2),
     });
 
-  const result = mergeXRefChain(ByteOffset.of(500), callback);
+  const result = await mergeXRefChain(ByteOffset.of(500), callback);
 
   assert(result.ok);
   expect(result.value.mergedXRef.size).toBe(2);
 });
 
-test("maxDepth: undefined 明示指定でもデフォルト 100 が適用される", () => {
+test("maxDepth: undefined 明示指定でもデフォルト 100 が適用される", async () => {
   // 明示 undefined でも MaxDepth.DEFAULT が採用される
-  const callback: ParseCallback = (_offset: ByteOffset) =>
+  const callback: ParseCallback = async (_offset: ByteOffset) =>
     ok({
       xref: makeXRef([[1, usedEntry(100)]], 2),
       trailer: makeTrailer(2),
     });
 
-  const result = mergeXRefChain(ByteOffset.of(500), callback, {
+  const result = await mergeXRefChain(ByteOffset.of(500), callback, {
     maxDepth: undefined,
   });
 
   assert(result.ok);
 });
 
-test("maxDepth = Number.MAX_SAFE_INTEGER で単一 xref を成功させる", () => {
+test("maxDepth = Number.MAX_SAFE_INTEGER で単一 xref を成功させる", async () => {
   // safe integer 上限も有効値として受理される
-  const callback: ParseCallback = (_offset: ByteOffset) =>
+  const callback: ParseCallback = async (_offset: ByteOffset) =>
     ok({
       xref: makeXRef([[1, usedEntry(100)]], 2),
       trailer: makeTrailer(2),
     });
 
-  const result = mergeXRefChain(ByteOffset.of(500), callback, {
+  const result = await mergeXRefChain(ByteOffset.of(500), callback, {
     maxDepth: Number.MAX_SAFE_INTEGER,
   });
 
@@ -143,16 +149,16 @@ test.each([
   Infinity,
   -Infinity,
   Number.MAX_SAFE_INTEGER + 1,
-])("maxDepth に無効値 %s を渡した場合、XREF_MAX_DEPTH_INVALID を返す", (invalidValue) => {
+])("maxDepth に無効値 %s を渡した場合、XREF_MAX_DEPTH_INVALID を返す", async (invalidValue) => {
   // 異常系: 詳細な境界値は max-depth.validation.test.ts に集約。
   // ここでは「mergeXRefChain が MaxDepth.create の Err を素通しする」ことを確認する
-  const callback: ParseCallback = (_offset: ByteOffset) =>
+  const callback: ParseCallback = async (_offset: ByteOffset) =>
     ok({
       xref: makeXRef([[1, usedEntry(100)]], 2),
       trailer: makeTrailer(2),
     });
 
-  const result = mergeXRefChain(ByteOffset.of(500), callback, {
+  const result = await mergeXRefChain(ByteOffset.of(500), callback, {
     maxDepth: invalidValue,
   });
 
@@ -160,15 +166,15 @@ test.each([
   expect(result.error.code).toBe("XREF_MAX_DEPTH_INVALID");
 });
 
-test("maxDepth = NaN で XREF_MAX_DEPTH_INVALID を返す", () => {
+test("maxDepth = NaN で XREF_MAX_DEPTH_INVALID を返す", async () => {
   // NaN は test.each の label 表示が壊れるため単独 test に分離
-  const callback: ParseCallback = (_offset: ByteOffset) =>
+  const callback: ParseCallback = async (_offset: ByteOffset) =>
     ok({
       xref: makeXRef([[1, usedEntry(100)]], 2),
       trailer: makeTrailer(2),
     });
 
-  const result = mergeXRefChain(ByteOffset.of(500), callback, {
+  const result = await mergeXRefChain(ByteOffset.of(500), callback, {
     maxDepth: NaN,
   });
 
@@ -176,15 +182,17 @@ test("maxDepth = NaN で XREF_MAX_DEPTH_INVALID を返す", () => {
   expect(result.error.code).toBe("XREF_MAX_DEPTH_INVALID");
 });
 
-test("XREF_MAX_DEPTH_INVALID の message に invalid 値が含まれる", () => {
+test("XREF_MAX_DEPTH_INVALID の message に invalid 値が含まれる", async () => {
   // 検証補助: エラーメッセージから何が invalid だったかが分かる
-  const callback: ParseCallback = (_offset: ByteOffset) =>
+  const callback: ParseCallback = async (_offset: ByteOffset) =>
     ok({
       xref: makeXRef([[1, usedEntry(100)]], 2),
       trailer: makeTrailer(2),
     });
 
-  const result = mergeXRefChain(ByteOffset.of(500), callback, { maxDepth: -1 });
+  const result = await mergeXRefChain(ByteOffset.of(500), callback, {
+    maxDepth: -1,
+  });
 
   assert(!result.ok);
   expect(result.error.message).toContain("-1");

--- a/packages/core/src/xref/merger/__tests__/merger.error.test.ts
+++ b/packages/core/src/xref/merger/__tests__/merger.error.test.ts
@@ -1,5 +1,5 @@
 import { assert, expect, test } from "vitest";
-import type { PdfParseError } from "../../../pdf/errors/index";
+import type { PdfError } from "../../../pdf/errors/index";
 import { ByteOffset } from "../../../pdf/types/byte-offset/index";
 import { GenerationNumber } from "../../../pdf/types/generation-number/index";
 import type {
@@ -45,7 +45,7 @@ function makeTrailer(size: number, prev?: number): TrailerDict {
 
 type ParseCallback = (
   offset: ByteOffset,
-) => Result<{ xref: XRefTable; trailer: TrailerDict }, PdfParseError>;
+) => Promise<Result<{ xref: XRefTable; trailer: TrailerDict }, PdfError>>;
 
 function stubMap(
   entries: Array<[number, { xref: XRefTable; trailer: TrailerDict }]>,
@@ -56,7 +56,7 @@ function stubMap(
 function callbackFromMap(
   table: Map<ByteOffset, { xref: XRefTable; trailer: TrailerDict }>,
 ): ParseCallback {
-  return (offset: ByteOffset) => {
+  return async (offset: ByteOffset) => {
     const entry = table.get(offset);
     return entry
       ? ok(entry)
@@ -67,7 +67,7 @@ function callbackFromMap(
   };
 }
 
-test("循環参照検出: 2つのxrefが互いのオフセットを /Prev で参照 -> XREF_PREV_CHAIN_CYCLE", () => {
+test("循環参照検出: 2つのxrefが互いのオフセットを /Prev で参照 -> XREF_PREV_CHAIN_CYCLE", async () => {
   const callback = callbackFromMap(
     stubMap([
       [
@@ -87,13 +87,13 @@ test("循環参照検出: 2つのxrefが互いのオフセットを /Prev で参
     ]),
   );
 
-  const result = mergeXRefChain(ByteOffset.of(100), callback);
+  const result = await mergeXRefChain(ByteOffset.of(100), callback);
 
   assert(!result.ok);
   expect(result.error.code).toBe("XREF_PREV_CHAIN_CYCLE");
 });
 
-test("自己参照検出: /Prev が自分自身のオフセットを指す -> XREF_PREV_CHAIN_CYCLE", () => {
+test("自己参照検出: /Prev が自分自身のオフセットを指す -> XREF_PREV_CHAIN_CYCLE", async () => {
   const callback = callbackFromMap(
     stubMap([
       [
@@ -106,36 +106,38 @@ test("自己参照検出: /Prev が自分自身のオフセットを指す -> XR
     ]),
   );
 
-  const result = mergeXRefChain(ByteOffset.of(100), callback);
+  const result = await mergeXRefChain(ByteOffset.of(100), callback);
 
   assert(!result.ok);
   expect(result.error.code).toBe("XREF_PREV_CHAIN_CYCLE");
 });
 
-test("深さ制限超過: maxDepth を超えるチェーン -> XREF_PREV_CHAIN_TOO_DEEP", () => {
+test("深さ制限超過: maxDepth を超えるチェーン -> XREF_PREV_CHAIN_TOO_DEEP", async () => {
   let counter = 0;
-  const callback: ParseCallback = (_offset: ByteOffset) => {
+  const callback: ParseCallback = async (_offset: ByteOffset) => {
     counter++;
     const xref = makeXRef([[counter, usedEntry(counter * 100)]], counter + 1);
     const trailer = makeTrailer(counter + 1, counter * 1000);
     return ok({ xref, trailer });
   };
 
-  const result = mergeXRefChain(ByteOffset.of(0), callback, { maxDepth: 2 });
+  const result = await mergeXRefChain(ByteOffset.of(0), callback, {
+    maxDepth: 2,
+  });
 
   assert(!result.ok);
   expect(result.error.code).toBe("XREF_PREV_CHAIN_TOO_DEEP");
 });
 
-test("コールバックエラー透過: parseCallback が Err を返した場合、そのエラーがそのまま返る", () => {
-  const callback: ParseCallback = (_offset: ByteOffset) =>
+test("コールバックエラー透過: parseCallback が Err を返した場合、そのエラーがそのまま返る", async () => {
+  const callback: ParseCallback = async (_offset: ByteOffset) =>
     err({
       code: "XREF_TABLE_INVALID",
       message: "parse failed",
       offset: ByteOffset.of(42),
     });
 
-  const result = mergeXRefChain(ByteOffset.of(500), callback);
+  const result = await mergeXRefChain(ByteOffset.of(500), callback);
 
   assert(!result.ok);
   expect(result.error.code).toBe("XREF_TABLE_INVALID");

--- a/packages/core/src/xref/merger/__tests__/merger.merge.test.ts
+++ b/packages/core/src/xref/merger/__tests__/merger.merge.test.ts
@@ -1,5 +1,5 @@
 import { assert, expect, test } from "vitest";
-import type { PdfParseError } from "../../../pdf/errors/index";
+import type { PdfError } from "../../../pdf/errors/index";
 import { ByteOffset } from "../../../pdf/types/byte-offset/index";
 import { GenerationNumber } from "../../../pdf/types/generation-number/index";
 import type {
@@ -61,7 +61,7 @@ function makeTrailer(size: number, prev?: number): TrailerDict {
 
 type ParseCallback = (
   offset: ByteOffset,
-) => Result<{ xref: XRefTable; trailer: TrailerDict }, PdfParseError>;
+) => Promise<Result<{ xref: XRefTable; trailer: TrailerDict }, PdfError>>;
 
 function stubMap(
   entries: Array<[number, { xref: XRefTable; trailer: TrailerDict }]>,
@@ -72,7 +72,7 @@ function stubMap(
 function callbackFromMap(
   table: Map<ByteOffset, { xref: XRefTable; trailer: TrailerDict }>,
 ): ParseCallback {
-  return (offset: ByteOffset) => {
+  return async (offset: ByteOffset) => {
     const entry = table.get(offset);
     return entry
       ? ok(entry)
@@ -83,7 +83,7 @@ function callbackFromMap(
   };
 }
 
-test("単一xref（/Prevなし）: コールバック1回呼び出し、そのままのXRefTableとTrailerDictが返る", () => {
+test("単一xref（/Prevなし）: コールバック1回呼び出し、そのままのXRefTableとTrailerDictが返る", async () => {
   const xref = makeXRef(
     [
       [0, freeEntry(0, 65535)],
@@ -94,7 +94,7 @@ test("単一xref（/Prevなし）: コールバック1回呼び出し、その�
   const trailer = makeTrailer(2);
   const callback = callbackFromMap(stubMap([[500, { xref, trailer }]]));
 
-  const result = mergeXRefChain(ByteOffset.of(500), callback);
+  const result = await mergeXRefChain(ByteOffset.of(500), callback);
 
   assert(result.ok);
   expect(result.value.mergedXRef.entries.size).toBe(2);
@@ -103,7 +103,7 @@ test("単一xref（/Prevなし）: コールバック1回呼び出し、その�
   expect(result.value.latestTrailer.size).toBe(2);
 });
 
-test("2段チェーン: 新しいエントリが古いエントリを上書きする", () => {
+test("2段チェーン: 新しいエントリが古いエントリを上書きする", async () => {
   const oldXRef = makeXRef(
     [
       [0, freeEntry(0, 65535)],
@@ -125,7 +125,7 @@ test("2段チェーン: 新しいエントリが古いエントリを上書き�
     ]),
   );
 
-  const result = mergeXRefChain(ByteOffset.of(500), callback);
+  const result = await mergeXRefChain(ByteOffset.of(500), callback);
 
   assert(result.ok);
   expect(result.value.mergedXRef.entries.size).toBe(3);
@@ -135,7 +135,7 @@ test("2段チェーン: 新しいエントリが古いエントリを上書き�
   expect(result.value.latestTrailer.root).toEqual(dummyRoot);
 });
 
-test("3段チェーン: 古い順にマージされ、最新が優先", () => {
+test("3段チェーン: 古い順にマージされ、最新が優先", async () => {
   const callback = callbackFromMap(
     stubMap([
       [
@@ -171,7 +171,7 @@ test("3段チェーン: 古い順にマージされ、最新が優先", () => {
     ]),
   );
 
-  const result = mergeXRefChain(ByteOffset.of(300), callback);
+  const result = await mergeXRefChain(ByteOffset.of(300), callback);
 
   assert(result.ok);
   const entry1 = result.value.mergedXRef.entries.get(ObjectNumber.of(1));
@@ -187,7 +187,7 @@ test("3段チェーン: 古い順にマージされ、最新が優先", () => {
   expect(entry3.offset).toBe(50);
 });
 
-test("エントリの上書き: 同一ObjectNumberのエントリが新しい方で上書き", () => {
+test("エントリの上書き: 同一ObjectNumberのエントリが新しい方で上書き", async () => {
   const callback = callbackFromMap(
     stubMap([
       [
@@ -204,7 +204,7 @@ test("エントリの上書き: 同一ObjectNumberのエントリが新しい方
     ]),
   );
 
-  const result = mergeXRefChain(ByteOffset.of(500), callback);
+  const result = await mergeXRefChain(ByteOffset.of(500), callback);
 
   assert(result.ok);
   const entry = result.value.mergedXRef.entries.get(ObjectNumber.of(5));
@@ -212,7 +212,7 @@ test("エントリの上書き: 同一ObjectNumberのエントリが新しい方
   expect(entry.offset).toBe(999);
 });
 
-test("重複しないエントリ: 各テーブル固有のエントリがすべてマージ結果に含まれる", () => {
+test("重複しないエントリ: 各テーブル固有のエントリがすべてマージ結果に含まれる", async () => {
   const callback = callbackFromMap(
     stubMap([
       [
@@ -229,7 +229,7 @@ test("重複しないエントリ: 各テーブル固有のエントリがすべ
     ]),
   );
 
-  const result = mergeXRefChain(ByteOffset.of(400), callback);
+  const result = await mergeXRefChain(ByteOffset.of(400), callback);
 
   assert(result.ok);
   expect(result.value.mergedXRef.entries.size).toBe(2);
@@ -237,7 +237,7 @@ test("重複しないエントリ: 各テーブル固有のエントリがすべ
   expect(result.value.mergedXRef.entries.has(ObjectNumber.of(2))).toBe(true);
 });
 
-test("free entry による used entry の上書き: type=0 が type=1 を無効化", () => {
+test("free entry による used entry の上書き: type=0 が type=1 を無効化", async () => {
   const callback = callbackFromMap(
     stubMap([
       [
@@ -254,7 +254,7 @@ test("free entry による used entry の上書き: type=0 が type=1 を無効�
     ]),
   );
 
-  const result = mergeXRefChain(ByteOffset.of(400), callback);
+  const result = await mergeXRefChain(ByteOffset.of(400), callback);
 
   assert(result.ok);
   const entry = result.value.mergedXRef.entries.get(ObjectNumber.of(1));
@@ -262,7 +262,7 @@ test("free entry による used entry の上書き: type=0 が type=1 を無効�
   expect(entry.type).toBe(0);
 });
 
-test("compressed entry (type=2) による used entry (type=1) の上書き", () => {
+test("compressed entry (type=2) による used entry (type=1) の上書き", async () => {
   const callback = callbackFromMap(
     stubMap([
       [
@@ -279,7 +279,7 @@ test("compressed entry (type=2) による used entry (type=1) の上書き", () 
     ]),
   );
 
-  const result = mergeXRefChain(ByteOffset.of(400), callback);
+  const result = await mergeXRefChain(ByteOffset.of(400), callback);
 
   assert(result.ok);
   const entry = result.value.mergedXRef.entries.get(ObjectNumber.of(1));
@@ -287,7 +287,7 @@ test("compressed entry (type=2) による used entry (type=1) の上書き", () 
   expect(entry.type).toBe(2);
 });
 
-test("/Prev = 0（ByteOffset(0)）を持つ trailer が正しく辿られる", () => {
+test("/Prev = 0（ByteOffset(0)）を持つ trailer が正しく辿られる", async () => {
   const callback = callbackFromMap(
     stubMap([
       [
@@ -304,7 +304,7 @@ test("/Prev = 0（ByteOffset(0)）を持つ trailer が正しく辿られる", (
     ]),
   );
 
-  const result = mergeXRefChain(ByteOffset.of(500), callback);
+  const result = await mergeXRefChain(ByteOffset.of(500), callback);
 
   assert(result.ok);
   expect(result.value.mergedXRef.entries.size).toBe(2);
@@ -312,7 +312,7 @@ test("/Prev = 0（ByteOffset(0)）を持つ trailer が正しく辿られる", (
   expect(result.value.mergedXRef.entries.has(ObjectNumber.of(2))).toBe(true);
 });
 
-test("size は全テーブルの最大値を採用", () => {
+test("size は全テーブルの最大値を採用", async () => {
   const callback = callbackFromMap(
     stubMap([
       [
@@ -336,13 +336,13 @@ test("size は全テーブルの最大値を採用", () => {
     ]),
   );
 
-  const result = mergeXRefChain(ByteOffset.of(300), callback);
+  const result = await mergeXRefChain(ByteOffset.of(300), callback);
 
   assert(result.ok);
   expect(result.value.mergedXRef.size).toBe(10);
 });
 
-test("latestTrailer は最新トレイラをベースにし、size のみ mergedXRef.size で上書き", () => {
+test("latestTrailer は最新トレイラをベースにし、size のみ mergedXRef.size で上書き", async () => {
   const newRoot = {
     objectNumber: ObjectNumber.of(99),
     generationNumber: GenerationNumber.of(0),
@@ -363,7 +363,7 @@ test("latestTrailer は最新トレイラをベースにし、size のみ merged
     ]),
   );
 
-  const result = mergeXRefChain(ByteOffset.of(300), callback);
+  const result = await mergeXRefChain(ByteOffset.of(300), callback);
 
   assert(result.ok);
   expect(result.value.latestTrailer.root).toEqual(newRoot);
@@ -371,19 +371,19 @@ test("latestTrailer は最新トレイラをベースにし、size のみ merged
   expect(result.value.mergedXRef.size).toBe(20);
 });
 
-test("空のxrefテーブル（entries が空の Map）のマージ", () => {
+test("空のxrefテーブル（entries が空の Map）のマージ", async () => {
   const callback = callbackFromMap(
     stubMap([[500, { xref: makeXRef([], 0), trailer: makeTrailer(0) }]]),
   );
 
-  const result = mergeXRefChain(ByteOffset.of(500), callback);
+  const result = await mergeXRefChain(ByteOffset.of(500), callback);
 
   assert(result.ok);
   expect(result.value.mergedXRef.entries.size).toBe(0);
   expect(result.value.mergedXRef.size).toBe(0);
 });
 
-test("latestTrailer.size が mergedXRef.size（全テーブルの最大値）に正規化されている", () => {
+test("latestTrailer.size が mergedXRef.size（全テーブルの最大値）に正規化されている", async () => {
   const callback = callbackFromMap(
     stubMap([
       [
@@ -400,7 +400,7 @@ test("latestTrailer.size が mergedXRef.size（全テーブルの最大値）に
     ]),
   );
 
-  const result = mergeXRefChain(ByteOffset.of(500), callback);
+  const result = await mergeXRefChain(ByteOffset.of(500), callback);
 
   assert(result.ok);
   expect(result.value.mergedXRef.size).toBe(50);

--- a/packages/core/src/xref/merger/__tests__/merger.xrefstm.test.ts
+++ b/packages/core/src/xref/merger/__tests__/merger.xrefstm.test.ts
@@ -1,0 +1,178 @@
+import { assert, expect, test } from "vitest";
+import type { PdfError } from "../../../pdf/errors/index";
+import { ByteOffset } from "../../../pdf/types/byte-offset/index";
+import { GenerationNumber } from "../../../pdf/types/generation-number/index";
+import type {
+  TrailerDict,
+  XRefEntry,
+  XRefTable,
+} from "../../../pdf/types/index";
+import { ObjectNumber } from "../../../pdf/types/object-number/index";
+import type { Result } from "../../../utils/result/index";
+import { err, ok } from "../../../utils/result/index";
+import { mergeXRefChain } from "../index";
+
+const dummyRoot = {
+  objectNumber: ObjectNumber.of(1),
+  generationNumber: GenerationNumber.of(0),
+};
+
+function usedEntry(offset: number, gen = 0): XRefEntry {
+  return {
+    type: 1,
+    offset: ByteOffset.of(offset),
+    generationNumber: GenerationNumber.of(gen),
+  };
+}
+
+function compressedEntry(streamObj: number, index: number): XRefEntry {
+  return {
+    type: 2,
+    streamObject: ObjectNumber.of(streamObj),
+    indexInStream: index,
+  };
+}
+
+function makeXRef(
+  entries: Array<[number, XRefEntry]>,
+  size: number,
+): XRefTable {
+  return {
+    entries: new Map(entries.map(([n, e]) => [ObjectNumber.of(n), e])),
+    size,
+  };
+}
+
+function makeTrailer(
+  size: number,
+  options: { prev?: number; xrefStm?: number } = {},
+): TrailerDict {
+  return {
+    root: dummyRoot,
+    size,
+    prev: options.prev !== undefined ? ByteOffset.of(options.prev) : undefined,
+    xrefStm:
+      options.xrefStm !== undefined
+        ? ByteOffset.of(options.xrefStm)
+        : undefined,
+  };
+}
+
+type ParseCallback = (
+  offset: ByteOffset,
+) => Promise<Result<{ xref: XRefTable; trailer: TrailerDict }, PdfError>>;
+
+function stubMap(
+  entries: Array<[number, { xref: XRefTable; trailer: TrailerDict }]>,
+): Map<ByteOffset, { xref: XRefTable; trailer: TrailerDict }> {
+  return new Map(entries.map(([n, v]) => [ByteOffset.of(n), v]));
+}
+
+function callbackFromMap(
+  table: Map<ByteOffset, { xref: XRefTable; trailer: TrailerDict }>,
+): ParseCallback {
+  return async (offset: ByteOffset) => {
+    const entry = table.get(offset);
+    return entry
+      ? ok(entry)
+      : err({
+          code: "XREF_TABLE_INVALID" as const,
+          message: "unexpected offset",
+        });
+  };
+}
+
+test("同一世代内で/XRefStmのエントリがテキストセクションのエントリより優先される", async () => {
+  const textXRef = makeXRef([[1, usedEntry(100)]], 2);
+  const streamXRef = makeXRef([[1, compressedEntry(10, 0)]], 2);
+  const callback = callbackFromMap(
+    stubMap([
+      [500, { xref: textXRef, trailer: makeTrailer(2, { xrefStm: 700 }) }],
+      [700, { xref: streamXRef, trailer: makeTrailer(2) }],
+    ]),
+  );
+
+  const result = await mergeXRefChain(ByteOffset.of(500), callback);
+
+  assert(result.ok);
+  const entry = result.value.mergedXRef.entries.get(ObjectNumber.of(1));
+  assert(entry !== undefined);
+  expect(entry.type).toBe(2);
+});
+
+test("/XRefStm側にのみ存在するObjStm内オブジェクト（type=2）がマージ結果に含まれる", async () => {
+  const textXRef = makeXRef([[1, usedEntry(100)]], 3);
+  const streamXRef = makeXRef([[2, compressedEntry(10, 0)]], 3);
+  const callback = callbackFromMap(
+    stubMap([
+      [500, { xref: textXRef, trailer: makeTrailer(3, { xrefStm: 700 }) }],
+      [700, { xref: streamXRef, trailer: makeTrailer(3) }],
+    ]),
+  );
+
+  const result = await mergeXRefChain(ByteOffset.of(500), callback);
+
+  assert(result.ok);
+  expect(result.value.mergedXRef.entries.get(ObjectNumber.of(1))).toEqual(
+    usedEntry(100),
+  );
+  const entry2 = result.value.mergedXRef.entries.get(ObjectNumber.of(2));
+  assert(entry2 !== undefined);
+  expect(entry2.type).toBe(2);
+});
+
+test("チェーンの継続はテキストtrailer側の/Prevを使い、/XRefStm側の/Prevは無視される", async () => {
+  const newTextXRef = makeXRef([[1, usedEntry(999)]], 2);
+  const newStreamXRef = makeXRef([[2, compressedEntry(10, 0)]], 2);
+  const oldXRef = makeXRef([[1, usedEntry(100)]], 2);
+  const callback = callbackFromMap(
+    stubMap([
+      [
+        500,
+        {
+          xref: newTextXRef,
+          trailer: makeTrailer(2, { xrefStm: 700, prev: 100 }),
+        },
+      ],
+      // xrefStm側のtrailerにbogusなprevを仕込んでも辿られないことを確認する
+      [700, { xref: newStreamXRef, trailer: makeTrailer(2, { prev: 99999 }) }],
+      [100, { xref: oldXRef, trailer: makeTrailer(2) }],
+    ]),
+  );
+
+  const result = await mergeXRefChain(ByteOffset.of(500), callback);
+
+  assert(result.ok);
+  expect(result.value.mergedXRef.entries.size).toBe(2);
+  const entry1 = result.value.mergedXRef.entries.get(ObjectNumber.of(1));
+  assert(entry1 !== undefined && entry1.type === 1);
+  expect(entry1.offset).toBe(999);
+});
+
+test("/XRefStmが既訪問オフセットを指す場合XREF_PREV_CHAIN_CYCLEを返す", async () => {
+  const textXRef = makeXRef([[1, usedEntry(100)]], 2);
+  const callback = callbackFromMap(
+    stubMap([
+      [500, { xref: textXRef, trailer: makeTrailer(2, { xrefStm: 500 }) }],
+    ]),
+  );
+
+  const result = await mergeXRefChain(ByteOffset.of(500), callback);
+
+  assert(!result.ok);
+  expect(result.error.code).toBe("XREF_PREV_CHAIN_CYCLE");
+});
+
+test("/XRefStmが存在しないセクションはこれまで通りテキストエントリのみでマージされる", async () => {
+  const textXRef = makeXRef([[1, usedEntry(100)]], 2);
+  const callback = callbackFromMap(
+    stubMap([[500, { xref: textXRef, trailer: makeTrailer(2) }]]),
+  );
+
+  const result = await mergeXRefChain(ByteOffset.of(500), callback);
+
+  assert(result.ok);
+  expect(result.value.mergedXRef.entries.get(ObjectNumber.of(1))).toEqual(
+    usedEntry(100),
+  );
+});

--- a/packages/core/src/xref/merger/__tests__/merger.xrefstm.test.ts
+++ b/packages/core/src/xref/merger/__tests__/merger.xrefstm.test.ts
@@ -60,16 +60,20 @@ function makeTrailer(
 
 type ParseCallback = (
   offset: ByteOffset,
-) => Promise<Result<{ xref: XRefTable; trailer: TrailerDict }, PdfError>>;
+) => Promise<
+  Result<{ xref: XRefTable; trailer: TrailerDict | undefined }, PdfError>
+>;
 
 function stubMap(
-  entries: Array<[number, { xref: XRefTable; trailer: TrailerDict }]>,
-): Map<ByteOffset, { xref: XRefTable; trailer: TrailerDict }> {
+  entries: Array<
+    [number, { xref: XRefTable; trailer: TrailerDict | undefined }]
+  >,
+): Map<ByteOffset, { xref: XRefTable; trailer: TrailerDict | undefined }> {
   return new Map(entries.map(([n, v]) => [ByteOffset.of(n), v]));
 }
 
 function callbackFromMap(
-  table: Map<ByteOffset, { xref: XRefTable; trailer: TrailerDict }>,
+  table: Map<ByteOffset, { xref: XRefTable; trailer: TrailerDict | undefined }>,
 ): ParseCallback {
   return async (offset: ByteOffset) => {
     const entry = table.get(offset);
@@ -175,4 +179,34 @@ test("/XRefStmが存在しないセクションはこれまで通りテキスト
   expect(result.value.mergedXRef.entries.get(ObjectNumber.of(1))).toEqual(
     usedEntry(100),
   );
+});
+
+test("/XRefStm側のtrailerがundefined（/Root欠如）でもxrefエントリはマージされる", async () => {
+  const textXRef = makeXRef([[1, usedEntry(100)]], 2);
+  const streamXRef = makeXRef([[2, compressedEntry(10, 0)]], 3);
+  const callback = callbackFromMap(
+    stubMap([
+      [500, { xref: textXRef, trailer: makeTrailer(3, { xrefStm: 700 }) }],
+      [700, { xref: streamXRef, trailer: undefined }],
+    ]),
+  );
+
+  const result = await mergeXRefChain(ByteOffset.of(500), callback);
+
+  assert(result.ok);
+  const entry2 = result.value.mergedXRef.entries.get(ObjectNumber.of(2));
+  assert(entry2 !== undefined);
+  expect(entry2.type).toBe(2);
+});
+
+test("主セクション自体のtrailerがundefined（/Root欠如）の場合はROOT_NOT_FOUNDを返す", async () => {
+  const textXRef = makeXRef([[1, usedEntry(100)]], 2);
+  const callback = callbackFromMap(
+    stubMap([[500, { xref: textXRef, trailer: undefined }]]),
+  );
+
+  const result = await mergeXRefChain(ByteOffset.of(500), callback);
+
+  assert(!result.ok);
+  expect(result.error.code).toBe("ROOT_NOT_FOUND");
 });

--- a/packages/core/src/xref/merger/index.ts
+++ b/packages/core/src/xref/merger/index.ts
@@ -53,10 +53,14 @@ function mergeCollectedChain(
 /**
  * xref+trailer をオフセットからパースするコールバック。
  * 間接オブジェクトのパース（xref ストリーム経路）を含みうるため非同期。
+ * `trailer` は `/XRefStm` が指す補助ストリームのように `/Root` を持たない
+ * xref ソースの場合 `undefined` になりうる（{@link visitSection} 参照）。
  */
 type XRefParseCallback = (
   offset: ByteOffset,
-) => Promise<Result<{ xref: XRefTable; trailer: TrailerDict }, PdfError>>;
+) => Promise<
+  Result<{ xref: XRefTable; trailer: TrailerDict | undefined }, PdfError>
+>;
 
 /**
  * /Prevチェーンを辿り、全xrefテーブルをマージする。
@@ -97,6 +101,11 @@ export async function mergeXRefChain(
    * それも読んで `entryLayers` に優先度順（ストリーム側が高優先）で push する。
    * 戻り値の trailer はチェーン継続判定（`/Prev`）用。
    *
+   * このセクション自身（`offset`）の trailer が `undefined`（`/Root` 欠如）の
+   * 場合は `ROOT_NOT_FOUND` エラーとする — チェーンの主要セクションは常に
+   * 文書 trailer を持つ必要がある。一方 `/XRefStm` が指す補助ストリームの
+   * trailer は `.xref` しか使わないため、`undefined` でも許容する。
+   *
    * @param offset - 読み取り対象のバイトオフセット
    * @returns セクション自身の TrailerDict、またはエラー
    */
@@ -108,6 +117,13 @@ export async function mergeXRefChain(
       return parseResult;
     }
     const { xref, trailer } = parseResult.value;
+    if (trailer === undefined) {
+      return err({
+        code: "ROOT_NOT_FOUND",
+        message: `xref section at offset ${String(offset)} has no trailer (/Root missing)`,
+        offset,
+      });
+    }
 
     if (trailer.xrefStm !== undefined) {
       const xrefStmOffset = trailer.xrefStm;

--- a/packages/core/src/xref/merger/index.ts
+++ b/packages/core/src/xref/merger/index.ts
@@ -1,4 +1,4 @@
-import type { PdfParseError } from "../../pdf/errors/index";
+import type { PdfError, PdfParseError } from "../../pdf/errors/index";
 import type { ByteOffset } from "../../pdf/types/byte-offset/index";
 import type { TrailerDict, XRefEntry, XRefTable } from "../../pdf/types/index";
 import type { ObjectNumber } from "../../pdf/types/object-number/index";
@@ -50,31 +50,33 @@ function mergeCollectedChain(
   };
 }
 
-/** xref+trailer をオフセットからパースするコールバック。 */
+/**
+ * xref+trailer をオフセットからパースするコールバック。
+ * 間接オブジェクトのパース（xref ストリーム経路）を含みうるため非同期。
+ */
 type XRefParseCallback = (
   offset: ByteOffset,
-) => Result<{ xref: XRefTable; trailer: TrailerDict }, PdfParseError>;
+) => Promise<Result<{ xref: XRefTable; trailer: TrailerDict }, PdfError>>;
 
 /**
  * /Prevチェーンを辿り、全xrefテーブルをマージする。
  * 新しいエントリが古いものを上書きし、最新のトレイラ辞書を返す。
  *
  * @param startOffset - 最初のxrefセクションのバイトオフセット（startxrefの値）
- * @param parseCallback - オフセットからxref+trailerをパースするコールバック
+ * @param parseCallback - オフセットからxref+trailerをパースする非同期コールバック
  * @param options - オプション（maxDepth: /Prevチェーンの最大走査深さ。
  *   `undefined` は既定値 100 を採用、正の safe integer 以外は
  *   `XREF_MAX_DEPTH_INVALID` を含む Err）
  * @returns マージ済みXRefTableと最新TrailerDict、
  *   maxDepth 不正時は `XREF_MAX_DEPTH_INVALID`、
- *   その他の失敗時は該当する `PdfParseError`
+ *   その他の失敗時は該当する `PdfError`
  */
-export function mergeXRefChain(
+export async function mergeXRefChain(
   startOffset: ByteOffset,
   parseCallback: XRefParseCallback,
   options?: { readonly maxDepth?: number },
-): Result<
-  { mergedXRef: XRefTable; latestTrailer: TrailerDict },
-  PdfParseError
+): Promise<
+  Result<{ mergedXRef: XRefTable; latestTrailer: TrailerDict }, PdfError>
 > {
   const maxDepthResult = MaxDepth.create(options?.maxDepth);
   if (!maxDepthResult.ok) {
@@ -106,7 +108,7 @@ export function mergeXRefChain(
 
     traversedOffsets.add(currentOffset);
 
-    const parseResult = parseCallback(currentOffset);
+    const parseResult = await parseCallback(currentOffset);
     if (!parseResult.ok) {
       return parseResult;
     }

--- a/packages/core/src/xref/merger/index.ts
+++ b/packages/core/src/xref/merger/index.ts
@@ -23,26 +23,26 @@ function failPrevChain(
 }
 
 /**
- * 収集済みの xref チェーンをマージし、統合結果を返す。
- * chain は newest-first の順序で渡される。[...chain].reverse() で oldest から走査し、
- * newer が older を上書きする形でエントリを統合する。chain は破壊しない。
+ * 収集済みの xref エントリレイヤーをマージし、統合結果を返す。
+ * entryLayers は優先度が高い順（newest-first。同一世代内は /XRefStm 側がテキスト側より高優先）
+ * で渡される。[...entryLayers].reverse() で優先度が低い方から走査し、
+ * 優先度が高いレイヤーが低いレイヤーを上書きする形でエントリを統合する。entryLayers は破壊しない。
  *
- * @precondition chain は非空であること（呼び出し元で最低1回の parseCallback 成功を保証）
+ * @precondition entryLayers は非空であること（呼び出し元で最低1回の parseCallback 成功を保証）
  */
 function mergeCollectedChain(
-  chain: ReadonlyArray<{ xref: XRefTable; trailer: TrailerDict }>,
+  entryLayers: ReadonlyArray<XRefTable>,
+  latestTrailer: TrailerDict,
 ): { mergedXRef: XRefTable; latestTrailer: TrailerDict } {
   const mergedEntries = new Map<ObjectNumber, XRefEntry>();
   let maxSize = 0;
 
-  for (const { xref } of [...chain].reverse()) {
+  for (const xref of [...entryLayers].reverse()) {
     for (const [objNum, entry] of xref.entries) {
       mergedEntries.set(objNum, entry);
     }
     maxSize = Math.max(maxSize, xref.size);
   }
-
-  const latestTrailer = chain[0].trailer;
 
   return {
     mergedXRef: { entries: mergedEntries, size: maxSize },
@@ -61,6 +61,12 @@ type XRefParseCallback = (
 /**
  * /Prevチェーンを辿り、全xrefテーブルをマージする。
  * 新しいエントリが古いものを上書きし、最新のトレイラ辞書を返す。
+ *
+ * ハイブリッド参照ファイル（ISO 32000-1 §7.5.8.4）対応: 各セクションの trailer に
+ * `/XRefStm` があれば、`/Prev` を辿る前にそのオフセットの補助クロスリファレンス
+ * ストリームを読み、同一世代内ではストリーム側のエントリをテキストセクションより
+ * 優先してマージする（ObjStm 内オブジェクトの type=2 エントリはストリーム側にのみ
+ * 存在しうるため）。チェーンの継続には常にテキスト trailer 側の `/Prev` を使う。
  *
  * @param startOffset - 最初のxrefセクションのバイトオフセット（startxrefの値）
  * @param parseCallback - オフセットからxref+trailerをパースする非同期コールバック
@@ -84,12 +90,58 @@ export async function mergeXRefChain(
   }
   const maxDepth = maxDepthResult.value;
   const traversedOffsets = new Set<ByteOffset>();
-  const chain: Array<{ xref: XRefTable; trailer: TrailerDict }> = [];
+  const entryLayers: XRefTable[] = [];
 
-  let currentOffset: ByteOffset = startOffset;
-  let depth = 0;
+  /**
+   * 1つの xref セクション（テキストまたはストリーム）を読み、`/XRefStm` があれば
+   * それも読んで `entryLayers` に優先度順（ストリーム側が高優先）で push する。
+   * 戻り値の trailer はチェーン継続判定（`/Prev`）用。
+   *
+   * @param offset - 読み取り対象のバイトオフセット
+   * @returns セクション自身の TrailerDict、またはエラー
+   */
+  const visitSection = async (
+    offset: ByteOffset,
+  ): Promise<Result<TrailerDict, PdfError>> => {
+    const parseResult = await parseCallback(offset);
+    if (!parseResult.ok) {
+      return parseResult;
+    }
+    const { xref, trailer } = parseResult.value;
 
-  while (true) {
+    if (trailer.xrefStm !== undefined) {
+      const xrefStmOffset = trailer.xrefStm;
+      if (traversedOffsets.has(xrefStmOffset)) {
+        return failPrevChain(
+          "XREF_PREV_CHAIN_CYCLE",
+          `Circular /XRefStm reference detected at offset ${String(xrefStmOffset)}`,
+          xrefStmOffset,
+        );
+      }
+      traversedOffsets.add(xrefStmOffset);
+
+      const xrefStmResult = await parseCallback(xrefStmOffset);
+      if (!xrefStmResult.ok) {
+        return xrefStmResult;
+      }
+      entryLayers.push(xrefStmResult.value.xref);
+    }
+
+    entryLayers.push(xref);
+    return ok(trailer);
+  };
+
+  traversedOffsets.add(startOffset);
+  const firstResult = await visitSection(startOffset);
+  if (!firstResult.ok) {
+    return firstResult;
+  }
+  const latestTrailer = firstResult.value;
+
+  let currentOffset = latestTrailer.prev;
+  let depth = 1;
+
+  while (currentOffset !== undefined) {
     if (traversedOffsets.has(currentOffset)) {
       return failPrevChain(
         "XREF_PREV_CHAIN_CYCLE",
@@ -108,21 +160,13 @@ export async function mergeXRefChain(
 
     traversedOffsets.add(currentOffset);
 
-    const parseResult = await parseCallback(currentOffset);
-    if (!parseResult.ok) {
-      return parseResult;
+    const result = await visitSection(currentOffset);
+    if (!result.ok) {
+      return result;
     }
-
-    chain.push(parseResult.value);
     depth++;
-
-    const { trailer } = parseResult.value;
-    if (trailer.prev === undefined) {
-      break;
-    }
-
-    currentOffset = trailer.prev;
+    currentOffset = result.value.prev;
   }
 
-  return ok(mergeCollectedChain(chain));
+  return ok(mergeCollectedChain(entryLayers, latestTrailer));
 }

--- a/packages/core/src/xref/stream/dict/__tests__/xref-stream-dict.parse.test.ts
+++ b/packages/core/src/xref/stream/dict/__tests__/xref-stream-dict.parse.test.ts
@@ -151,6 +151,67 @@ test("parseは/Filterが未サポートの場合にXREF_STREAM_INVALIDを返す"
   expect(result.error.message).toContain("LZWDecode");
 });
 
+test("parseは/Filterが単一要素配列[/FlateDecode]の場合bareネームと同義にfilterNameを返す（ISO 32000-1 §7.4）", () => {
+  const result = XRefStreamDict.parse(
+    makeXRefStreamDict({
+      Filter: {
+        type: "array",
+        elements: [{ type: "name", value: "FlateDecode" }],
+      },
+    }),
+  );
+
+  assert(result.ok);
+  expect(result.value.filterName).toBe("FlateDecode");
+});
+
+test("parseは/Filterが単一要素配列で未サポートフィルタの場合にXREF_STREAM_INVALIDを返す", () => {
+  const result = XRefStreamDict.parse(
+    makeXRefStreamDict({
+      Filter: {
+        type: "array",
+        elements: [{ type: "name", value: "LZWDecode" }],
+      },
+    }),
+  );
+
+  assert(!result.ok);
+  expect(result.error.code).toBe("XREF_STREAM_INVALID");
+  expect(result.error.message).toContain("LZWDecode");
+});
+
+test("parseは/Filterが複数要素配列（カスケードフィルタ）の場合にXREF_STREAM_INVALIDを返す", () => {
+  const result = XRefStreamDict.parse(
+    makeXRefStreamDict({
+      Filter: {
+        type: "array",
+        elements: [
+          { type: "name", value: "ASCII85Decode" },
+          { type: "name", value: "FlateDecode" },
+        ],
+      },
+    }),
+  );
+
+  assert(!result.ok);
+  expect(result.error.code).toBe("XREF_STREAM_INVALID");
+  expect(result.error.message).toContain("array");
+});
+
+test("parseは/Filter配列の要素が名前でない場合にXREF_STREAM_INVALIDを返す", () => {
+  const result = XRefStreamDict.parse(
+    makeXRefStreamDict({
+      Filter: {
+        type: "array",
+        elements: [{ type: "integer", value: 1 }],
+      },
+    }),
+  );
+
+  assert(!result.ok);
+  expect(result.error.code).toBe("XREF_STREAM_INVALID");
+});
+
 test("parseは/DecodeParmsが辞書でない場合にXREF_STREAM_INVALIDを返す", () => {
   const result = XRefStreamDict.parse(
     makeXRefStreamDict({

--- a/packages/core/src/xref/stream/dict/__tests__/xref-stream-dict.parse.test.ts
+++ b/packages/core/src/xref/stream/dict/__tests__/xref-stream-dict.parse.test.ts
@@ -1,0 +1,170 @@
+import { assert, expect, test } from "vitest";
+import { XRefStreamDict } from "../index";
+import { makeXRefStreamDict } from "./xref-stream-dict.test.helpers";
+
+test("parseは妥当な辞書からw/size/index/filterName/decodeParmsを取得する", () => {
+  const result = XRefStreamDict.parse(makeXRefStreamDict());
+
+  assert(result.ok);
+  expect(result.value.w).toEqual([1, 2, 1]);
+  expect(result.value.size).toBe(8);
+  expect(result.value.index).toEqual([0, 8]);
+  expect(result.value.filterName).toBe("FlateDecode");
+  expect(result.value.decodeParms).toBeUndefined();
+});
+
+test("parseは/Index省略時にundefinedを返す", () => {
+  const result = XRefStreamDict.parse(makeXRefStreamDict({ Index: undefined }));
+
+  assert(result.ok);
+  expect(result.value.index).toBeUndefined();
+});
+
+test("parseは/Filter省略時にfilterNameをundefinedにする", () => {
+  const result = XRefStreamDict.parse(
+    makeXRefStreamDict({ Filter: undefined }),
+  );
+
+  assert(result.ok);
+  expect(result.value.filterName).toBeUndefined();
+});
+
+test("parseは/DecodeParmsが辞書の場合entriesをそのまま返す", () => {
+  const decodeParms = new Map([
+    ["Predictor", { type: "integer" as const, value: 12 }],
+  ]);
+  const result = XRefStreamDict.parse(
+    makeXRefStreamDict({
+      DecodeParms: { type: "dictionary", entries: decodeParms },
+    }),
+  );
+
+  assert(result.ok);
+  expect(result.value.decodeParms).toBe(decodeParms);
+});
+
+test("parseは/Typeが存在しない場合にXREF_STREAM_INVALIDを返す", () => {
+  const result = XRefStreamDict.parse(makeXRefStreamDict({ Type: undefined }));
+
+  assert(!result.ok);
+  expect(result.error.code).toBe("XREF_STREAM_INVALID");
+});
+
+test("parseは/Typeが/XRefでない場合にXREF_STREAM_INVALIDを返す", () => {
+  const result = XRefStreamDict.parse(
+    makeXRefStreamDict({ Type: { type: "name", value: "ObjStm" } }),
+  );
+
+  assert(!result.ok);
+  expect(result.error.code).toBe("XREF_STREAM_INVALID");
+  expect(result.error.message).toContain("/ObjStm");
+});
+
+test("parseは/Wが存在しない場合にXREF_STREAM_INVALIDを返す", () => {
+  const result = XRefStreamDict.parse(makeXRefStreamDict({ W: undefined }));
+
+  assert(!result.ok);
+  expect(result.error.code).toBe("XREF_STREAM_INVALID");
+  expect(result.error.message).toContain("/W");
+});
+
+test("parseは/Wの要素数が3でない場合にXREF_STREAM_INVALIDを返す", () => {
+  const result = XRefStreamDict.parse(
+    makeXRefStreamDict({
+      W: {
+        type: "array",
+        elements: [
+          { type: "integer", value: 1 },
+          { type: "integer", value: 2 },
+        ],
+      },
+    }),
+  );
+
+  assert(!result.ok);
+  expect(result.error.code).toBe("XREF_STREAM_INVALID");
+  expect(result.error.message).toContain("3");
+});
+
+test("parseは/Wの要素が整数でない場合にXREF_STREAM_INVALIDを返す", () => {
+  const result = XRefStreamDict.parse(
+    makeXRefStreamDict({
+      W: {
+        type: "array",
+        elements: [
+          { type: "real", value: 1.5 },
+          { type: "integer", value: 2 },
+          { type: "integer", value: 1 },
+        ],
+      },
+    }),
+  );
+
+  assert(!result.ok);
+  expect(result.error.code).toBe("XREF_STREAM_INVALID");
+});
+
+test("parseは/Sizeが存在しない場合にXREF_STREAM_INVALIDを返す", () => {
+  const result = XRefStreamDict.parse(makeXRefStreamDict({ Size: undefined }));
+
+  assert(!result.ok);
+  expect(result.error.code).toBe("XREF_STREAM_INVALID");
+  expect(result.error.message).toContain("/Size");
+});
+
+test("parseは/Sizeが整数でない場合にXREF_STREAM_INVALIDを返す", () => {
+  const result = XRefStreamDict.parse(
+    makeXRefStreamDict({ Size: { type: "real", value: 8.5 } }),
+  );
+
+  assert(!result.ok);
+  expect(result.error.code).toBe("XREF_STREAM_INVALID");
+});
+
+test("parseは/Indexが配列でない場合にXREF_STREAM_INVALIDを返す", () => {
+  const result = XRefStreamDict.parse(
+    makeXRefStreamDict({ Index: { type: "integer", value: 1 } }),
+  );
+
+  assert(!result.ok);
+  expect(result.error.code).toBe("XREF_STREAM_INVALID");
+});
+
+test("parseは/Indexの要素が整数でない場合にXREF_STREAM_INVALIDを返す", () => {
+  const result = XRefStreamDict.parse(
+    makeXRefStreamDict({
+      Index: { type: "array", elements: [{ type: "name", value: "x" }] },
+    }),
+  );
+
+  assert(!result.ok);
+  expect(result.error.code).toBe("XREF_STREAM_INVALID");
+});
+
+test("parseは/Filterが未サポートの場合にXREF_STREAM_INVALIDを返す", () => {
+  const result = XRefStreamDict.parse(
+    makeXRefStreamDict({ Filter: { type: "name", value: "LZWDecode" } }),
+  );
+
+  assert(!result.ok);
+  expect(result.error.code).toBe("XREF_STREAM_INVALID");
+  expect(result.error.message).toContain("LZWDecode");
+});
+
+test("parseは/DecodeParmsが辞書でない場合にXREF_STREAM_INVALIDを返す", () => {
+  const result = XRefStreamDict.parse(
+    makeXRefStreamDict({
+      DecodeParms: {
+        type: "array",
+        elements: [
+          { type: "null" },
+          { type: "dictionary", entries: new Map() },
+        ],
+      },
+    }),
+  );
+
+  assert(!result.ok);
+  expect(result.error.code).toBe("XREF_STREAM_INVALID");
+  expect(result.error.message).toContain("DecodeParms");
+});

--- a/packages/core/src/xref/stream/dict/__tests__/xref-stream-dict.test.helpers.ts
+++ b/packages/core/src/xref/stream/dict/__tests__/xref-stream-dict.test.helpers.ts
@@ -1,0 +1,49 @@
+import type { PdfValue } from "../../../../pdf/types/pdf-types/index";
+
+/**
+ * 妥当な xref ストリーム辞書を組み立てる。`overrides` で個別エントリを差し替え・削除できる。
+ *
+ * @param overrides - 上書きするエントリ（値 `undefined` を渡すとキー自体削除する）
+ * @returns テスト用の xref ストリーム辞書エントリマップ
+ */
+export function makeXRefStreamDict(
+  overrides: Record<string, PdfValue | undefined> = {},
+): Map<string, PdfValue> {
+  const base = new Map<string, PdfValue>([
+    ["Type", { type: "name", value: "XRef" }],
+    [
+      "W",
+      {
+        type: "array",
+        elements: [
+          { type: "integer", value: 1 },
+          { type: "integer", value: 2 },
+          { type: "integer", value: 1 },
+        ],
+      },
+    ],
+    ["Size", { type: "integer", value: 8 }],
+    [
+      "Index",
+      {
+        type: "array",
+        elements: [
+          { type: "integer", value: 0 },
+          { type: "integer", value: 8 },
+        ],
+      },
+    ],
+    ["Filter", { type: "name", value: "FlateDecode" }],
+    ["Root", { type: "indirect-ref", objectNumber: 1, generationNumber: 0 }],
+  ]);
+
+  for (const [key, value] of Object.entries(overrides)) {
+    if (value === undefined) {
+      base.delete(key);
+    } else {
+      base.set(key, value);
+    }
+  }
+
+  return base;
+}

--- a/packages/core/src/xref/stream/dict/index.ts
+++ b/packages/core/src/xref/stream/dict/index.ts
@@ -1,0 +1,185 @@
+/**
+ * クロスリファレンスストリーム辞書（`/Type /XRef`, ISO 32000-1 §7.5.8 Table 17）の
+ * `/Type` `/W` `/Size` `/Index` `/Filter` `/DecodeParms` を検証・抽出するモジュール。
+ *
+ * @module
+ */
+
+import type { PdfParseError } from "../../../pdf/errors/index";
+import { PdfFilter } from "../../../pdf/filter/index";
+import { PdfType } from "../../../pdf/types/pdf-type/index";
+import type { PdfValue } from "../../../pdf/types/pdf-types/index";
+import type { Result } from "../../../utils/result/index";
+import { err, ok } from "../../../utils/result/index";
+
+const W_ARRAY_LENGTH = 3;
+
+/** `XRefStreamDict.parse` が返す、xref ストリーム辞書から抽出した情報。 */
+export interface XRefStreamDictInfo {
+  /** `/W` 配列 [typeWidth, field2Width, field3Width] */
+  readonly w: readonly [number, number, number];
+  /** `/Size` */
+  readonly size: number;
+  /** `/Index`（省略時は `undefined`） */
+  readonly index: readonly number[] | undefined;
+  /** `/Filter`（省略時は `undefined`） */
+  readonly filterName: string | undefined;
+  /** `/DecodeParms`（辞書形式のみサポート、省略時は `undefined`） */
+  readonly decodeParms: ReadonlyMap<string, PdfValue> | undefined;
+}
+
+/**
+ * xref ストリーム辞書バリデーション失敗時の Err を生成する。
+ *
+ * @param message - エラーメッセージ
+ * @returns `XREF_STREAM_INVALID` コードを持つ Err
+ */
+function failDict(message: string): Result<never, PdfParseError> {
+  return err({ code: "XREF_STREAM_INVALID", message });
+}
+
+/**
+ * `/W` エントリを検証し `readonly [number, number, number]` として取得する。
+ *
+ * @param entries - ストリーム辞書のエントリ
+ * @returns 検証済みの `/W` タプル、またはエラー
+ */
+function readW(
+  entries: Map<string, PdfValue>,
+): Result<readonly [number, number, number], PdfParseError> {
+  const entry = entries.get("W");
+  if (entry === undefined || entry.type !== "array") {
+    return failDict("XRef stream dictionary missing /W array");
+  }
+  if (entry.elements.length !== W_ARRAY_LENGTH) {
+    return failDict(
+      `/W array must have exactly 3 elements, got ${entry.elements.length}`,
+    );
+  }
+  const values: number[] = [];
+  for (const el of entry.elements) {
+    if (el.type !== "integer") {
+      return failDict("/W array elements must be integers");
+    }
+    values.push(el.value);
+  }
+  return ok([values[0], values[1], values[2]]);
+}
+
+/**
+ * `/Size` エントリを検証し整数として取得する。
+ *
+ * @param entries - ストリーム辞書のエントリ
+ * @returns `/Size` の整数値、またはエラー
+ */
+function readSize(
+  entries: Map<string, PdfValue>,
+): Result<number, PdfParseError> {
+  const entry = entries.get("Size");
+  if (entry === undefined || entry.type !== "integer") {
+    return failDict("XRef stream dictionary missing /Size integer");
+  }
+  return ok(entry.value);
+}
+
+/**
+ * `/Index` エントリを検証し整数配列として取得する（省略時は `undefined`）。
+ *
+ * @param entries - ストリーム辞書のエントリ
+ * @returns `/Index` の整数配列、`undefined`、またはエラー
+ */
+function readIndex(
+  entries: Map<string, PdfValue>,
+): Result<readonly number[] | undefined, PdfParseError> {
+  const entry = entries.get("Index");
+  if (entry === undefined) {
+    return ok(undefined);
+  }
+  if (entry.type !== "array") {
+    return failDict("/Index must be an array");
+  }
+  const values: number[] = [];
+  for (const el of entry.elements) {
+    if (el.type !== "integer") {
+      return failDict("/Index array elements must be integers");
+    }
+    values.push(el.value);
+  }
+  return ok(values);
+}
+
+/**
+ * `/DecodeParms` エントリを検証し辞書エントリマップとして取得する（省略時は `undefined`）。
+ * 配列形式（複数フィルタ用）は未サポート。
+ *
+ * @param entries - ストリーム辞書のエントリ
+ * @returns `/DecodeParms` の辞書エントリマップ、`undefined`、またはエラー
+ */
+function readDecodeParms(
+  entries: Map<string, PdfValue>,
+): Result<ReadonlyMap<string, PdfValue> | undefined, PdfParseError> {
+  const entry = entries.get("DecodeParms");
+  if (entry === undefined) {
+    return ok(undefined);
+  }
+  if (entry.type !== "dictionary") {
+    return failDict(
+      "/DecodeParms must be a dictionary (array form is not supported)",
+    );
+  }
+  return ok(entry.entries);
+}
+
+/** クロスリファレンスストリーム辞書のバリデーションを行うコンパニオンオブジェクト。 */
+export const XRefStreamDict = {
+  /**
+   * xref ストリーム辞書をパースし、`/Type` `/W` `/Size` `/Index` `/Filter` `/DecodeParms` を検証・抽出する。
+   *
+   * 内部で呼び出す `PdfType.validate` / `PdfFilter.parse` 由来のエラーは
+   * `XREF_STREAM_INVALID` に再ラップする（元の `message` / `offset` は保持）。
+   *
+   * @param entries - ストリーム辞書のエントリ
+   * @returns パース済み辞書情報、または `XREF_STREAM_INVALID` エラー
+   */
+  parse(
+    entries: Map<string, PdfValue>,
+  ): Result<XRefStreamDictInfo, PdfParseError> {
+    const typeError = PdfType.validate(entries, "XRef");
+    if (typeError.some) {
+      return err({ ...typeError.value, code: "XREF_STREAM_INVALID" });
+    }
+
+    const wResult = readW(entries);
+    if (!wResult.ok) {
+      return wResult;
+    }
+
+    const sizeResult = readSize(entries);
+    if (!sizeResult.ok) {
+      return sizeResult;
+    }
+
+    const indexResult = readIndex(entries);
+    if (!indexResult.ok) {
+      return indexResult;
+    }
+
+    const filterResult = PdfFilter.parse(entries);
+    if (!filterResult.ok) {
+      return err({ ...filterResult.error, code: "XREF_STREAM_INVALID" });
+    }
+
+    const decodeParmsResult = readDecodeParms(entries);
+    if (!decodeParmsResult.ok) {
+      return decodeParmsResult;
+    }
+
+    return ok({
+      w: wResult.value,
+      size: sizeResult.value,
+      index: indexResult.value,
+      filterName: filterResult.value,
+      decodeParms: decodeParmsResult.value,
+    });
+  },
+} as const;

--- a/packages/core/src/xref/stream/dict/index.ts
+++ b/packages/core/src/xref/stream/dict/index.ts
@@ -6,7 +6,6 @@
  */
 
 import type { PdfParseError } from "../../../pdf/errors/index";
-import { PdfFilter } from "../../../pdf/filter/index";
 import { PdfType } from "../../../pdf/types/pdf-type/index";
 import type { PdfValue } from "../../../pdf/types/pdf-types/index";
 import type { Result } from "../../../utils/result/index";
@@ -108,6 +107,49 @@ function readIndex(
   return ok(values);
 }
 
+const SUPPORTED_FILTER_NAME = "FlateDecode";
+
+/**
+ * `/Filter` エントリを検証し、フィルタ名を返す。
+ *
+ * xref ストリームの `/Filter` は仕様上 name または array で表現できる
+ * （ISO 32000-1 §7.4）。単一要素配列（例: `[/FlateDecode]`）は単体名と
+ * 同義として受理する。複数要素配列（カスケードフィルタ）は未サポート。
+ *
+ * `pdf/filter/index.ts` の `PdfFilter.parse` は ObjStm 側と共有されており
+ * 配列を一律拒否する既存挙動に依存するテストがあるため、ここでは流用せず
+ * xref ストリーム専用にローカル実装する。
+ *
+ * @param entries - ストリーム辞書のエントリ
+ * @returns フィルタ名（未指定時は `undefined`）、または `XREF_STREAM_INVALID` エラー
+ */
+function readFilter(
+  entries: Map<string, PdfValue>,
+): Result<string | undefined, PdfParseError> {
+  const entry = entries.get("Filter");
+  if (entry === undefined) {
+    return ok(undefined);
+  }
+
+  let nameEntry = entry;
+  if (entry.type === "array") {
+    if (entry.elements.length !== 1) {
+      return failDict(
+        `/Filter array with ${entry.elements.length} filters is not supported for xref streams`,
+      );
+    }
+    nameEntry = entry.elements[0];
+  }
+
+  if (nameEntry.type !== "name") {
+    return failDict(`/Filter must be a name, got ${nameEntry.type}`);
+  }
+  if (nameEntry.value !== SUPPORTED_FILTER_NAME) {
+    return failDict(`/Filter /${nameEntry.value} is not supported`);
+  }
+  return ok(nameEntry.value);
+}
+
 /**
  * `/DecodeParms` エントリを検証し辞書エントリマップとして取得する（省略時は `undefined`）。
  * 配列形式（複数フィルタ用）は未サポート。
@@ -135,8 +177,8 @@ export const XRefStreamDict = {
   /**
    * xref ストリーム辞書をパースし、`/Type` `/W` `/Size` `/Index` `/Filter` `/DecodeParms` を検証・抽出する。
    *
-   * 内部で呼び出す `PdfType.validate` / `PdfFilter.parse` 由来のエラーは
-   * `XREF_STREAM_INVALID` に再ラップする（元の `message` / `offset` は保持）。
+   * 内部で呼び出す `PdfType.validate` 由来のエラーは `XREF_STREAM_INVALID` に
+   * 再ラップする（元の `message` / `offset` は保持）。
    *
    * @param entries - ストリーム辞書のエントリ
    * @returns パース済み辞書情報、または `XREF_STREAM_INVALID` エラー
@@ -164,9 +206,9 @@ export const XRefStreamDict = {
       return indexResult;
     }
 
-    const filterResult = PdfFilter.parse(entries);
+    const filterResult = readFilter(entries);
     if (!filterResult.ok) {
-      return err({ ...filterResult.error, code: "XREF_STREAM_INVALID" });
+      return filterResult;
     }
 
     const decodeParmsResult = readDecodeParms(entries);

--- a/packages/core/src/xref/stream/index.ts
+++ b/packages/core/src/xref/stream/index.ts
@@ -5,5 +5,6 @@
  */
 
 export { decompressFlate } from "./flatedecode/index";
+export { parseXRefStream } from "./parse-xref-stream/index";
 export { decodeXRefStreamEntries } from "./parser/index";
 export { buildXRefStreamTrailerDict } from "./trailer/index";

--- a/packages/core/src/xref/stream/parse-xref-stream/__tests__/parse-xref-stream.decode.test.ts
+++ b/packages/core/src/xref/stream/parse-xref-stream/__tests__/parse-xref-stream.decode.test.ts
@@ -88,6 +88,33 @@ test("PNG Up予測子付きのxrefストリームを展開・予測子逆変換�
   });
 });
 
+test("/Filterが単一要素配列[/FlateDecode]の場合もbareネームと同様に展開してデコードする（ISO 32000-1 §7.4）", async () => {
+  // zlib.deflateSync(Buffer.from([0,0,0,0, 1,0,100,0])) の結果
+  const compressed = new Uint8Array([
+    120, 156, 99, 96, 96, 96, 96, 100, 72, 97, 0, 0, 0, 212, 0, 102,
+  ]);
+  const objHeader =
+    "1 0 obj\n" +
+    "<< /Type /XRef /Filter [/FlateDecode] /W [1 2 1] /Size 2 " +
+    `/Root 2 0 R /Length ${compressed.length} >>\n` +
+    "stream\n";
+  const data = concatBytes([
+    encode(HEADER),
+    encode(objHeader),
+    compressed,
+    encode("\nendstream\nendobj\n"),
+  ]);
+
+  const result = await parseXRefStream(data, ByteOffset.of(HEADER_LEN));
+
+  assert(result.ok);
+  expect(result.value.xref.entries.get(ObjectNumber.of(1))).toEqual({
+    type: 1,
+    offset: ByteOffset.of(100),
+    generationNumber: GenerationNumber.of(0),
+  });
+});
+
 test("/Filter省略時は展開せず生データをそのままデコードする", async () => {
   const rawEntries = new Uint8Array([1, 5, 0]);
   const objHeader =

--- a/packages/core/src/xref/stream/parse-xref-stream/__tests__/parse-xref-stream.decode.test.ts
+++ b/packages/core/src/xref/stream/parse-xref-stream/__tests__/parse-xref-stream.decode.test.ts
@@ -1,0 +1,111 @@
+import { assert, expect, test } from "vitest";
+import { ByteOffset } from "../../../../pdf/types/byte-offset/index";
+import { GenerationNumber } from "../../../../pdf/types/generation-number/index";
+import { ObjectNumber } from "../../../../pdf/types/object-number/index";
+import { parseXRefStream } from "../index";
+
+function encode(s: string): Uint8Array {
+  return new TextEncoder().encode(s);
+}
+
+function concatBytes(chunks: readonly Uint8Array[]): Uint8Array {
+  const total = chunks.reduce((sum, c) => sum + c.length, 0);
+  const result = new Uint8Array(total);
+  let offset = 0;
+  for (const chunk of chunks) {
+    result.set(chunk, offset);
+    offset += chunk.length;
+  }
+  return result;
+}
+
+const HEADER = "%PDF-1.7\n";
+const HEADER_LEN = encode(HEADER).length;
+
+test("Predictorなしのxrefストリームをデコードしてxref/trailerを返す", async () => {
+  // zlib.deflateSync(Buffer.from([0,0,0,0, 1,0,100,0])) の結果
+  const compressed = new Uint8Array([
+    120, 156, 99, 96, 96, 96, 96, 100, 72, 97, 0, 0, 0, 212, 0, 102,
+  ]);
+  const objHeader =
+    "1 0 obj\n" +
+    "<< /Type /XRef /Filter /FlateDecode /W [1 2 1] /Size 2 " +
+    `/Root 2 0 R /Length ${compressed.length} >>\n` +
+    "stream\n";
+  const data = concatBytes([
+    encode(HEADER),
+    encode(objHeader),
+    compressed,
+    encode("\nendstream\nendobj\n"),
+  ]);
+
+  const result = await parseXRefStream(data, ByteOffset.of(HEADER_LEN));
+
+  assert(result.ok);
+  expect(result.value.xref.size).toBe(2);
+  expect(result.value.xref.entries.get(ObjectNumber.of(0))).toEqual({
+    type: 0,
+    nextFreeObject: ObjectNumber.of(0),
+    generationNumber: GenerationNumber.of(0),
+  });
+  expect(result.value.xref.entries.get(ObjectNumber.of(1))).toEqual({
+    type: 1,
+    offset: ByteOffset.of(100),
+    generationNumber: GenerationNumber.of(0),
+  });
+  expect(result.value.trailer.root).toEqual({
+    objectNumber: ObjectNumber.of(2),
+    generationNumber: GenerationNumber.of(0),
+  });
+});
+
+test("PNG Up予測子付きのxrefストリームを展開・予測子逆変換してデコードする", async () => {
+  // 予測子適用前の生エントリ: obj0=free(0,0) obj1=used(offset=100,gen=0)
+  // PNG Up前方変換 -> zlib.deflateSync(Buffer.from([2,0,0,0,0, 2,1,0,100,0]))
+  const compressed = new Uint8Array([
+    120, 156, 99, 98, 96, 96, 96, 96, 98, 100, 72, 97, 0, 0, 0, 244, 0, 106,
+  ]);
+  const objHeader =
+    "1 0 obj\n" +
+    "<< /Type /XRef /Filter /FlateDecode /DecodeParms << /Predictor 12 /Columns 4 >> " +
+    `/W [1 2 1] /Size 2 /Root 2 0 R /Length ${compressed.length} >>\n` +
+    "stream\n";
+  const data = concatBytes([
+    encode(HEADER),
+    encode(objHeader),
+    compressed,
+    encode("\nendstream\nendobj\n"),
+  ]);
+
+  const result = await parseXRefStream(data, ByteOffset.of(HEADER_LEN));
+
+  assert(result.ok);
+  expect(result.value.xref.entries.get(ObjectNumber.of(1))).toEqual({
+    type: 1,
+    offset: ByteOffset.of(100),
+    generationNumber: GenerationNumber.of(0),
+  });
+});
+
+test("/Filter省略時は展開せず生データをそのままデコードする", async () => {
+  const rawEntries = new Uint8Array([1, 5, 0]);
+  const objHeader =
+    "1 0 obj\n" +
+    `<< /Type /XRef /W [1 1 1] /Size 1 /Root 2 0 R /Length ${rawEntries.length} >>\n` +
+    "stream\n";
+  const data = concatBytes([
+    encode(HEADER),
+    encode(objHeader),
+    rawEntries,
+    encode("\nendstream\nendobj\n"),
+  ]);
+
+  const result = await parseXRefStream(data, ByteOffset.of(HEADER_LEN));
+
+  assert(result.ok);
+  expect(result.value.xref.entries.get(ObjectNumber.of(0))).toEqual({
+    type: 1,
+    offset: ByteOffset.of(5),
+    generationNumber: GenerationNumber.of(0),
+  });
+});

--- a/packages/core/src/xref/stream/parse-xref-stream/__tests__/parse-xref-stream.decode.test.ts
+++ b/packages/core/src/xref/stream/parse-xref-stream/__tests__/parse-xref-stream.decode.test.ts
@@ -53,6 +53,7 @@ test("Predictorなしのxrefストリームをデコードしてxref/trailerを�
     offset: ByteOffset.of(100),
     generationNumber: GenerationNumber.of(0),
   });
+  assert(result.value.trailer !== undefined);
   expect(result.value.trailer.root).toEqual({
     objectNumber: ObjectNumber.of(2),
     generationNumber: GenerationNumber.of(0),
@@ -103,6 +104,30 @@ test("/Filter省略時は展開せず生データをそのままデコードす�
   const result = await parseXRefStream(data, ByteOffset.of(HEADER_LEN));
 
   assert(result.ok);
+  expect(result.value.xref.entries.get(ObjectNumber.of(0))).toEqual({
+    type: 1,
+    offset: ByteOffset.of(5),
+    generationNumber: GenerationNumber.of(0),
+  });
+});
+
+test("/Rootが無いxrefストリームはtrailer:undefinedで成功する（/XRefStm補助ストリーム用, ISO 32000-1 §7.5.8.4）", async () => {
+  const rawEntries = new Uint8Array([1, 5, 0]);
+  const objHeader =
+    "1 0 obj\n" +
+    `<< /Type /XRef /W [1 1 1] /Size 1 /Length ${rawEntries.length} >>\n` +
+    "stream\n";
+  const data = concatBytes([
+    encode(HEADER),
+    encode(objHeader),
+    rawEntries,
+    encode("\nendstream\nendobj\n"),
+  ]);
+
+  const result = await parseXRefStream(data, ByteOffset.of(HEADER_LEN));
+
+  assert(result.ok);
+  expect(result.value.trailer).toBeUndefined();
   expect(result.value.xref.entries.get(ObjectNumber.of(0))).toEqual({
     type: 1,
     offset: ByteOffset.of(5),

--- a/packages/core/src/xref/stream/parse-xref-stream/__tests__/parse-xref-stream.error.test.ts
+++ b/packages/core/src/xref/stream/parse-xref-stream/__tests__/parse-xref-stream.error.test.ts
@@ -1,0 +1,121 @@
+import { assert, expect, test } from "vitest";
+import { ByteOffset } from "../../../../pdf/types/byte-offset/index";
+import { parseXRefStream } from "../index";
+
+function encode(s: string): Uint8Array {
+  return new TextEncoder().encode(s);
+}
+
+function concatBytes(chunks: readonly Uint8Array[]): Uint8Array {
+  const total = chunks.reduce((sum, c) => sum + c.length, 0);
+  const result = new Uint8Array(total);
+  let offset = 0;
+  for (const chunk of chunks) {
+    result.set(chunk, offset);
+    offset += chunk.length;
+  }
+  return result;
+}
+
+const HEADER = "%PDF-1.7\n";
+const HEADER_LEN = encode(HEADER).length;
+
+test("stream以外のオブジェクト（辞書のみ）を指す場合XREF_STREAM_INVALIDを返す", async () => {
+  const data = concatBytes([
+    encode(HEADER),
+    encode(
+      "1 0 obj\n<< /Type /XRef /W [1 2 1] /Size 2 /Root 2 0 R >>\nendobj\n",
+    ),
+  ]);
+
+  const result = await parseXRefStream(data, ByteOffset.of(HEADER_LEN));
+
+  assert(!result.ok);
+  expect(result.error.code).toBe("XREF_STREAM_INVALID");
+});
+
+test("/Typeが/XRefでない場合、辞書バリデーションのXREF_STREAM_INVALIDが伝播する", async () => {
+  const compressed = new Uint8Array([120, 156, 3, 0, 0, 0, 0, 1]);
+  const objHeader =
+    "1 0 obj\n" +
+    "<< /Type /ObjStm /Filter /FlateDecode /W [1 2 1] /Size 2 " +
+    `/Root 2 0 R /Length ${compressed.length} >>\n` +
+    "stream\n";
+  const data = concatBytes([
+    encode(HEADER),
+    encode(objHeader),
+    compressed,
+    encode("\nendstream\nendobj\n"),
+  ]);
+
+  const result = await parseXRefStream(data, ByteOffset.of(HEADER_LEN));
+
+  assert(!result.ok);
+  expect(result.error.code).toBe("XREF_STREAM_INVALID");
+  expect(result.error.message).toContain("/ObjStm");
+});
+
+test("FlateDecode展開に失敗した場合、FLATEDECODE_FAILEDが伝播する", async () => {
+  const corrupt = new Uint8Array([1, 2, 3, 4, 5]);
+  const objHeader =
+    "1 0 obj\n" +
+    "<< /Type /XRef /Filter /FlateDecode /W [1 2 1] /Size 2 " +
+    `/Root 2 0 R /Length ${corrupt.length} >>\n` +
+    "stream\n";
+  const data = concatBytes([
+    encode(HEADER),
+    encode(objHeader),
+    corrupt,
+    encode("\nendstream\nendobj\n"),
+  ]);
+
+  const result = await parseXRefStream(data, ByteOffset.of(HEADER_LEN));
+
+  assert(!result.ok);
+  expect(result.error.code).toBe("FLATEDECODE_FAILED");
+});
+
+test("展開後データ長が/Wと/Sizeに一致しない場合、decodeXRefStreamEntries由来のXREF_STREAM_INVALIDが伝播する", async () => {
+  // zlib.deflateSync(Buffer.from([0,0,0,0])) - 1エントリ分(4byte)しかないのにSize=2を要求
+  const compressed = new Uint8Array([
+    120, 156, 99, 96, 96, 96, 0, 0, 0, 4, 0, 1,
+  ]);
+  const objHeader =
+    "1 0 obj\n" +
+    "<< /Type /XRef /Filter /FlateDecode /W [1 2 1] /Size 2 " +
+    `/Root 2 0 R /Length ${compressed.length} >>\n` +
+    "stream\n";
+  const data = concatBytes([
+    encode(HEADER),
+    encode(objHeader),
+    compressed,
+    encode("\nendstream\nendobj\n"),
+  ]);
+
+  const result = await parseXRefStream(data, ByteOffset.of(HEADER_LEN));
+
+  assert(!result.ok);
+  expect(result.error.code).toBe("XREF_STREAM_INVALID");
+});
+
+test("/DecodeParmsの/Predictorが未サポート値の場合、Predictor由来のXREF_STREAM_INVALIDが伝播する", async () => {
+  const compressed = new Uint8Array([
+    120, 156, 99, 96, 96, 96, 96, 100, 72, 97, 0, 0, 0, 212, 0, 102,
+  ]);
+  const objHeader =
+    "1 0 obj\n" +
+    "<< /Type /XRef /Filter /FlateDecode /DecodeParms << /Predictor 5 >> " +
+    `/W [1 2 1] /Size 2 /Root 2 0 R /Length ${compressed.length} >>\n` +
+    "stream\n";
+  const data = concatBytes([
+    encode(HEADER),
+    encode(objHeader),
+    compressed,
+    encode("\nendstream\nendobj\n"),
+  ]);
+
+  const result = await parseXRefStream(data, ByteOffset.of(HEADER_LEN));
+
+  assert(!result.ok);
+  expect(result.error.code).toBe("XREF_STREAM_INVALID");
+});

--- a/packages/core/src/xref/stream/parse-xref-stream/__tests__/parse-xref-stream.error.test.ts
+++ b/packages/core/src/xref/stream/parse-xref-stream/__tests__/parse-xref-stream.error.test.ts
@@ -98,6 +98,26 @@ test("展開後データ長が/Wと/Sizeに一致しない場合、decodeXRefStr
   expect(result.error.code).toBe("XREF_STREAM_INVALID");
 });
 
+test("/Rootが有っても/Prevが不正な値の場合はXREF_STREAM_INVALIDが伝播する（ROOT_NOT_FOUND以外は寛容にしない）", async () => {
+  const rawEntries = new Uint8Array([1, 5, 0]);
+  const objHeader =
+    "1 0 obj\n" +
+    "<< /Type /XRef /W [1 1 1] /Size 1 /Root 2 0 R /Prev -1 " +
+    `/Length ${rawEntries.length} >>\n` +
+    "stream\n";
+  const data = concatBytes([
+    encode(HEADER),
+    encode(objHeader),
+    rawEntries,
+    encode("\nendstream\nendobj\n"),
+  ]);
+
+  const result = await parseXRefStream(data, ByteOffset.of(HEADER_LEN));
+
+  assert(!result.ok);
+  expect(result.error.code).toBe("XREF_STREAM_INVALID");
+});
+
 test("/DecodeParmsの/Predictorが未サポート値の場合、Predictor由来のXREF_STREAM_INVALIDが伝播する", async () => {
   const compressed = new Uint8Array([
     120, 156, 99, 96, 96, 96, 96, 100, 72, 97, 0, 0, 0, 212, 0, 102,

--- a/packages/core/src/xref/stream/parse-xref-stream/index.ts
+++ b/packages/core/src/xref/stream/parse-xref-stream/index.ts
@@ -1,0 +1,95 @@
+/**
+ * クロスリファレンスストリーム（`/Type /XRef`, ISO 32000-1 §7.5.8）を1つの間接オブジェクトの
+ * オフセットからパースし、`XRefTable` と `TrailerDict` を組み立てるオーケストレーション関数。
+ *
+ * `ObjectParser.parseIndirectObject` → `XRefStreamDict.parse` →
+ * （`/Filter` があれば）`decompressFlate` → `Predictor.apply` →
+ * `decodeXRefStreamEntries` → `buildXRefStreamTrailerDict` の順に処理を結線する。
+ *
+ * @module
+ */
+
+import { ObjectParser } from "../../../objects/object-parser/index";
+import type { PdfError } from "../../../pdf/errors/index";
+import type { ByteOffset } from "../../../pdf/types/byte-offset/index";
+import type { TrailerDict, XRefTable } from "../../../pdf/types/index";
+import type { Result } from "../../../utils/result/index";
+import { err, ok } from "../../../utils/result/index";
+import { XRefStreamDict } from "../dict/index";
+import { decompressFlate } from "../flatedecode/index";
+import { decodeXRefStreamEntries } from "../parser/index";
+import { Predictor } from "../predictor/index";
+import { buildXRefStreamTrailerDict } from "../trailer/index";
+
+const FLATE_DECODE_FILTER_NAME = "FlateDecode";
+
+/**
+ * 指定オフセットの間接オブジェクトを xref ストリームとしてパースする。
+ *
+ * @param data - PDF ファイル全体のバイト配列
+ * @param offset - xref ストリームを定義する間接オブジェクトの開始バイトオフセット
+ * @returns 成功時は `Ok<{ xref, trailer }>`、失敗時は `Err<PdfError>`
+ */
+export async function parseXRefStream(
+  data: Uint8Array,
+  offset: ByteOffset,
+): Promise<Result<{ xref: XRefTable; trailer: TrailerDict }, PdfError>> {
+  const objectResult = await ObjectParser.parseIndirectObject(data, offset);
+  if (!objectResult.ok) {
+    return objectResult;
+  }
+
+  const { body } = objectResult.value;
+  if (body.type !== "stream") {
+    return err({
+      code: "XREF_STREAM_INVALID",
+      message: `expected a stream object at offset ${String(offset)}, got ${body.type}`,
+      offset,
+    });
+  }
+
+  const dictInfoResult = XRefStreamDict.parse(body.dictionary.entries);
+  if (!dictInfoResult.ok) {
+    return dictInfoResult;
+  }
+  const dictInfo = dictInfoResult.value;
+
+  let streamData = body.data;
+  if (dictInfo.filterName === FLATE_DECODE_FILTER_NAME) {
+    const decompressResult = await decompressFlate(streamData);
+    if (!decompressResult.ok) {
+      return decompressResult;
+    }
+    streamData = decompressResult.value;
+  }
+
+  const predictorParamsResult = Predictor.parseParams(dictInfo.decodeParms);
+  if (!predictorParamsResult.ok) {
+    return predictorParamsResult;
+  }
+
+  const predictedResult = Predictor.apply(
+    streamData,
+    predictorParamsResult.value,
+  );
+  if (!predictedResult.ok) {
+    return predictedResult;
+  }
+
+  const entriesResult = decodeXRefStreamEntries({
+    data: predictedResult.value,
+    w: dictInfo.w,
+    size: dictInfo.size,
+    index: dictInfo.index,
+  });
+  if (!entriesResult.ok) {
+    return entriesResult;
+  }
+
+  const trailerResult = buildXRefStreamTrailerDict(body.dictionary.entries);
+  if (!trailerResult.ok) {
+    return trailerResult;
+  }
+
+  return ok({ xref: entriesResult.value, trailer: trailerResult.value });
+}

--- a/packages/core/src/xref/stream/parse-xref-stream/index.ts
+++ b/packages/core/src/xref/stream/parse-xref-stream/index.ts
@@ -26,14 +26,24 @@ const FLATE_DECODE_FILTER_NAME = "FlateDecode";
 /**
  * 指定オフセットの間接オブジェクトを xref ストリームとしてパースする。
  *
+ * `/XRefStm`（ISO 32000-1 §7.5.8.4）が指す補助クロスリファレンスストリームは
+ * `/Root` を持たないことがある（本来の文書 trailer はテキストセクション側が
+ * 供給するため）。この場合 `buildXRefStreamTrailerDict` は `ROOT_NOT_FOUND` を
+ * 返すが、それ自体は致命的エラーとせず `trailer: undefined` を返す。それ以外の
+ * trailer 構築エラー（`/Prev` 等の既存オプションフィールドが不正な場合）は
+ * 引き続き `Err` として伝播する。
+ *
  * @param data - PDF ファイル全体のバイト配列
  * @param offset - xref ストリームを定義する間接オブジェクトの開始バイトオフセット
- * @returns 成功時は `Ok<{ xref, trailer }>`、失敗時は `Err<PdfError>`
+ * @returns 成功時は `Ok<{ xref, trailer }>`（`trailer` は `/Root` 欠如時 `undefined`）、
+ *   失敗時は `Err<PdfError>`
  */
 export async function parseXRefStream(
   data: Uint8Array,
   offset: ByteOffset,
-): Promise<Result<{ xref: XRefTable; trailer: TrailerDict }, PdfError>> {
+): Promise<
+  Result<{ xref: XRefTable; trailer: TrailerDict | undefined }, PdfError>
+> {
   const objectResult = await ObjectParser.parseIndirectObject(data, offset);
   if (!objectResult.ok) {
     return objectResult;
@@ -88,6 +98,9 @@ export async function parseXRefStream(
 
   const trailerResult = buildXRefStreamTrailerDict(body.dictionary.entries);
   if (!trailerResult.ok) {
+    if (trailerResult.error.code === "ROOT_NOT_FOUND") {
+      return ok({ xref: entriesResult.value, trailer: undefined });
+    }
     return trailerResult;
   }
 

--- a/packages/core/src/xref/stream/predictor/__tests__/predictor.decode.test.ts
+++ b/packages/core/src/xref/stream/predictor/__tests__/predictor.decode.test.ts
@@ -1,0 +1,103 @@
+import { assert, expect, test } from "vitest";
+import { Predictor } from "../index";
+
+const defaultParams = {
+  predictor: 1,
+  colors: 1,
+  bitsPerComponent: 8,
+  columns: 4,
+};
+
+test("Predictor=1（予測子なし）はデータをそのまま返す", () => {
+  const data = new Uint8Array([1, 2, 3, 4]);
+  const result = Predictor.apply(data, defaultParams);
+
+  assert(result.ok);
+  expect(Array.from(result.value)).toEqual([1, 2, 3, 4]);
+});
+
+test("Predictor=12（PNG Up）は各バイトに直上行の同位置バイトを加算して復元する", () => {
+  // tag=2(Up) の2行: row0=[10,20,30,40](上行なしなので加算0), row1=[1,1,1,1](上行を加算)
+  const data = new Uint8Array([2, 10, 20, 30, 40, 2, 1, 1, 1, 1]);
+  const result = Predictor.apply(data, { ...defaultParams, predictor: 12 });
+
+  assert(result.ok);
+  expect(Array.from(result.value)).toEqual([10, 20, 30, 40, 11, 21, 31, 41]);
+});
+
+test("Predictor=10（PNG None）はタグバイトを除去するだけで値は変えない", () => {
+  const data = new Uint8Array([0, 5, 6, 7, 8]);
+  const result = Predictor.apply(data, { ...defaultParams, predictor: 10 });
+
+  assert(result.ok);
+  expect(Array.from(result.value)).toEqual([5, 6, 7, 8]);
+});
+
+test("Predictor=11（PNG Sub）は同行内の左バイトを加算して復元する", () => {
+  const data = new Uint8Array([1, 5, 3, 3, 3]);
+  const result = Predictor.apply(data, { ...defaultParams, predictor: 11 });
+
+  assert(result.ok);
+  expect(Array.from(result.value)).toEqual([5, 8, 11, 14]);
+});
+
+test("Predictor=13（PNG Average）は左と直上の平均（切り捨て）を加算して復元する", () => {
+  const data = new Uint8Array([3, 10, 10, 10, 10]);
+  const result = Predictor.apply(data, { ...defaultParams, predictor: 13 });
+
+  assert(result.ok);
+  expect(Array.from(result.value)).toEqual([10, 15, 17, 18]);
+});
+
+test("Predictor=14（PNG Paeth）はPaeth予測子で選んだ近傍値を加算して復元する", () => {
+  const data = new Uint8Array([4, 7, 7, 7, 7]);
+  const result = Predictor.apply(data, { ...defaultParams, predictor: 14 });
+
+  assert(result.ok);
+  expect(Array.from(result.value)).toEqual([7, 14, 21, 28]);
+});
+
+test("Predictor=12で複数行を跨いで直上値が正しく引き継がれる（3行）", () => {
+  const data = new Uint8Array([2, 1, 1, 1, 1, 2, 1, 1, 1, 1, 2, 1, 1, 1, 1]);
+  const result = Predictor.apply(data, { ...defaultParams, predictor: 12 });
+
+  assert(result.ok);
+  expect(Array.from(result.value)).toEqual([
+    1, 1, 1, 1, 2, 2, 2, 2, 3, 3, 3, 3,
+  ]);
+});
+
+test("Predictor=12は255を超える加算を256でラップする", () => {
+  const data = new Uint8Array([2, 200, 2, 100]);
+  const result = Predictor.apply(data, {
+    predictor: 12,
+    colors: 1,
+    bitsPerComponent: 8,
+    columns: 1,
+  });
+
+  assert(result.ok);
+  // row0 = 200, row1 = (100 + 200) % 256 = 44
+  expect(Array.from(result.value)).toEqual([200, 44]);
+});
+
+test("Predictor=2（TIFF）はColors=1のとき左バイトを加算して復元する", () => {
+  const data = new Uint8Array([10, 5, 5, 5]);
+  const result = Predictor.apply(data, { ...defaultParams, predictor: 2 });
+
+  assert(result.ok);
+  expect(Array.from(result.value)).toEqual([10, 15, 20, 25]);
+});
+
+test("Predictor=2（TIFF）はColors=2のとき同一チャンネルの左ピクセルを加算して復元する", () => {
+  const data = new Uint8Array([10, 20, 5, 5]);
+  const result = Predictor.apply(data, {
+    predictor: 2,
+    colors: 2,
+    bitsPerComponent: 8,
+    columns: 2,
+  });
+
+  assert(result.ok);
+  expect(Array.from(result.value)).toEqual([10, 20, 15, 25]);
+});

--- a/packages/core/src/xref/stream/predictor/__tests__/predictor.validation.test.ts
+++ b/packages/core/src/xref/stream/predictor/__tests__/predictor.validation.test.ts
@@ -1,0 +1,112 @@
+import { assert, expect, test } from "vitest";
+import { Predictor } from "../index";
+
+test("DecodeParms未指定はデフォルト値（Predictor=1,Colors=1,BitsPerComponent=8,Columns=1）を返す", () => {
+  const result = Predictor.parseParams(undefined);
+
+  assert(result.ok);
+  expect(result.value).toEqual({
+    predictor: 1,
+    colors: 1,
+    bitsPerComponent: 8,
+    columns: 1,
+  });
+});
+
+test("DecodeParmsに/Predictor /Colors /BitsPerComponent /Columnsを指定すると値が反映される", () => {
+  const decodeParms = new Map([
+    ["Predictor", { type: "integer" as const, value: 12 }],
+    ["Colors", { type: "integer" as const, value: 3 }],
+    ["BitsPerComponent", { type: "integer" as const, value: 16 }],
+    ["Columns", { type: "integer" as const, value: 5 }],
+  ]);
+  const result = Predictor.parseParams(decodeParms);
+
+  assert(result.ok);
+  expect(result.value).toEqual({
+    predictor: 12,
+    colors: 3,
+    bitsPerComponent: 16,
+    columns: 5,
+  });
+});
+
+test("DecodeParmsに一部キーのみ指定した場合は未指定分がデフォルト値になる", () => {
+  const decodeParms = new Map([
+    ["Predictor", { type: "integer" as const, value: 2 }],
+  ]);
+  const result = Predictor.parseParams(decodeParms);
+
+  assert(result.ok);
+  expect(result.value).toEqual({
+    predictor: 2,
+    colors: 1,
+    bitsPerComponent: 8,
+    columns: 1,
+  });
+});
+
+test("未サポートのPredictor値（3〜9）はXREF_STREAM_INVALIDエラーになる", () => {
+  const data = new Uint8Array([0, 1, 2, 3]);
+  const result = Predictor.apply(data, {
+    predictor: 5,
+    colors: 1,
+    bitsPerComponent: 8,
+    columns: 4,
+  });
+
+  assert(!result.ok);
+  expect(result.error.code).toBe("XREF_STREAM_INVALID");
+});
+
+test("PNG予測子でデータ長がレコードサイズの倍数でない場合はXREF_STREAM_INVALIDエラーになる", () => {
+  const data = new Uint8Array([2, 1, 1, 1]);
+  const result = Predictor.apply(data, {
+    predictor: 12,
+    colors: 1,
+    bitsPerComponent: 8,
+    columns: 4,
+  });
+
+  assert(!result.ok);
+  expect(result.error.code).toBe("XREF_STREAM_INVALID");
+});
+
+test("PNG予測子で未知のタグバイトが現れた場合はXREF_STREAM_INVALIDエラーになる", () => {
+  const data = new Uint8Array([9, 1, 1, 1, 1]);
+  const result = Predictor.apply(data, {
+    predictor: 12,
+    colors: 1,
+    bitsPerComponent: 8,
+    columns: 4,
+  });
+
+  assert(!result.ok);
+  expect(result.error.code).toBe("XREF_STREAM_INVALID");
+});
+
+test("TIFF予測子（Predictor=2）でBitsPerComponentが8以外の場合はXREF_STREAM_INVALIDエラーになる", () => {
+  const data = new Uint8Array([1, 2, 3, 4]);
+  const result = Predictor.apply(data, {
+    predictor: 2,
+    colors: 1,
+    bitsPerComponent: 4,
+    columns: 4,
+  });
+
+  assert(!result.ok);
+  expect(result.error.code).toBe("XREF_STREAM_INVALID");
+});
+
+test("TIFF予測子でデータ長が行バイト数の倍数でない場合はXREF_STREAM_INVALIDエラーになる", () => {
+  const data = new Uint8Array([1, 2, 3]);
+  const result = Predictor.apply(data, {
+    predictor: 2,
+    colors: 1,
+    bitsPerComponent: 8,
+    columns: 4,
+  });
+
+  assert(!result.ok);
+  expect(result.error.code).toBe("XREF_STREAM_INVALID");
+});

--- a/packages/core/src/xref/stream/predictor/index.ts
+++ b/packages/core/src/xref/stream/predictor/index.ts
@@ -1,0 +1,357 @@
+/**
+ * `/DecodeParms` の `/Predictor` (ISO 32000-1 §7.4.4.4) を扱うモジュール。
+ * FlateDecode 展開後のバイト列に対し、PNG 予測子 (10-15) / TIFF 予測子 (2) の逆変換を行う。
+ *
+ * @module
+ */
+
+import { NumberEx } from "../../../ext/number/index";
+import type { PdfParseError } from "../../../pdf/errors/index";
+import type { PdfValue } from "../../../pdf/types/pdf-types/index";
+import type { Result } from "../../../utils/result/index";
+import { err, ok } from "../../../utils/result/index";
+
+const DEFAULT_PREDICTOR = 1;
+const DEFAULT_COLORS = 1;
+const DEFAULT_BITS_PER_COMPONENT = 8;
+const DEFAULT_COLUMNS = 1;
+const TIFF_BYTE_ALIGNED_BITS_PER_COMPONENT = 8;
+const BITS_PER_BYTE = 8;
+const BYTE_MASK = 0xff;
+const TIFF_PREDICTOR = 2;
+const PNG_PREDICTOR_MIN = 10;
+const PNG_PREDICTOR_MAX = 15;
+const BITS_PER_COMPONENT_1 = 1;
+const BITS_PER_COMPONENT_2 = 2;
+const BITS_PER_COMPONENT_4 = 4;
+const BITS_PER_COMPONENT_8 = 8;
+const BITS_PER_COMPONENT_16 = 16;
+const VALID_BITS_PER_COMPONENT = new Set([
+  BITS_PER_COMPONENT_1,
+  BITS_PER_COMPONENT_2,
+  BITS_PER_COMPONENT_4,
+  BITS_PER_COMPONENT_8,
+  BITS_PER_COMPONENT_16,
+]);
+
+/** PNG 予測子 (ISO 32000-1 Table 8) の行タグ値。 */
+const PngTag = {
+  None: 0,
+  Sub: 1,
+  Up: 2,
+  Average: 3,
+  Paeth: 4,
+} as const;
+
+/** `/DecodeParms` から読み取る Predictor 関連パラメータ。 */
+export interface PredictorParams {
+  /** `/Predictor` (既定値 1: 予測子なし) */
+  readonly predictor: number;
+  /** `/Colors` (既定値 1) */
+  readonly colors: number;
+  /** `/BitsPerComponent` (既定値 8) */
+  readonly bitsPerComponent: number;
+  /** `/Columns` (既定値 1) */
+  readonly columns: number;
+}
+
+/**
+ * Predictor 関連パラメータ検証失敗時の Err を生成する。
+ *
+ * @param message - エラーメッセージ
+ * @returns `XREF_STREAM_INVALID` コードを持つ Err
+ */
+function failPredictor(message: string): Result<never, PdfParseError> {
+  return err({ code: "XREF_STREAM_INVALID", message });
+}
+
+/**
+ * `/DecodeParms` の整数エントリを読み取る。未指定ならデフォルト値を返す。
+ *
+ * @param decodeParms - `/DecodeParms` 辞書のエントリ
+ * @param key - 読み取るキー名
+ * @param defaultValue - 未指定時のデフォルト値
+ * @returns 読み取った整数値、または型不正時のエラー
+ */
+function readIntEntry(
+  decodeParms: ReadonlyMap<string, PdfValue>,
+  key: string,
+  defaultValue: number,
+): Result<number, PdfParseError> {
+  const entry = decodeParms.get(key);
+  if (entry === undefined) {
+    return ok(defaultValue);
+  }
+  if (entry.type !== "integer") {
+    return failPredictor(`/DecodeParms /${key} must be an integer`);
+  }
+  return ok(entry.value);
+}
+
+/**
+ * PNG 予測子 (tag=4) の Paeth 予測子。
+ *
+ * @param a - 左バイト
+ * @param b - 直上バイト
+ * @param c - 左上バイト
+ * @returns a/b/c のうち予測値に最も近いもの
+ */
+function paethPredictor(a: number, b: number, c: number): number {
+  const p = a + b - c;
+  const pa = Math.abs(p - a);
+  const pb = Math.abs(p - b);
+  const pc = Math.abs(p - c);
+  if (pa <= pb && pa <= pc) {
+    return a;
+  }
+  if (pb <= pc) {
+    return b;
+  }
+  return c;
+}
+
+/**
+ * PNG 予測子の1バイトを復元する。
+ *
+ * @param tag - 行タグ (0-4)
+ * @param raw - 符号化済みバイト
+ * @param a - 左バイト（復元済み）
+ * @param b - 直上バイト（復元済み）
+ * @param c - 左上バイト（復元済み）
+ * @returns 復元したバイト値、または未知タグ時のエラー
+ */
+function decodePngByte(
+  tag: number,
+  raw: number,
+  a: number,
+  b: number,
+  c: number,
+): Result<number, PdfParseError> {
+  switch (tag) {
+    case PngTag.None:
+      return ok(raw);
+    case PngTag.Sub:
+      return ok((raw + a) & BYTE_MASK);
+    case PngTag.Up:
+      return ok((raw + b) & BYTE_MASK);
+    case PngTag.Average:
+      return ok((raw + Math.floor((a + b) / 2)) & BYTE_MASK);
+    case PngTag.Paeth:
+      return ok((raw + paethPredictor(a, b, c)) & BYTE_MASK);
+    default:
+      return failPredictor(`unknown PNG predictor tag: ${tag}`);
+  }
+}
+
+/**
+ * PNG 予測子 (Predictor 10-15) の逆変換を行う。
+ * 各行の先頭1バイトがタグ、残り `rowBytes` バイトが符号化済みサンプルという構造を前提とする。
+ *
+ * @param data - FlateDecode 展開済みのバイト列
+ * @param bpp - 1サンプルあたりのバイト数（`ceil(colors * bitsPerComponent / 8)`、最小1）
+ * @param rowBytes - 1行あたりのサンプルバイト数（タグを除く）
+ * @returns 復元したバイト列、またはエラー
+ */
+function applyPngPredictor(
+  data: Uint8Array,
+  bpp: number,
+  rowBytes: number,
+): Result<Uint8Array, PdfParseError> {
+  const recordSize = rowBytes + 1;
+  if (recordSize <= 0 || data.length % recordSize !== 0) {
+    return failPredictor(
+      `PNG predictor data length ${data.length} is not a multiple of record size ${recordSize}`,
+    );
+  }
+
+  const rows = data.length / recordSize;
+  const output = new Uint8Array(rows * rowBytes);
+  let prevRowStart = -1;
+
+  for (let row = 0; row < rows; row++) {
+    const recordStart = row * recordSize;
+    const tag = data[recordStart];
+    const rowStart = row * rowBytes;
+
+    for (let i = 0; i < rowBytes; i++) {
+      const raw = data[recordStart + 1 + i];
+      const a = i >= bpp ? output[rowStart + i - bpp] : 0;
+      const b = prevRowStart >= 0 ? output[prevRowStart + i] : 0;
+      const c =
+        prevRowStart >= 0 && i >= bpp ? output[prevRowStart + i - bpp] : 0;
+
+      const decoded = decodePngByte(tag, raw, a, b, c);
+      if (!decoded.ok) {
+        return decoded;
+      }
+      output[rowStart + i] = decoded.value;
+    }
+
+    prevRowStart = rowStart;
+  }
+
+  return ok(output);
+}
+
+/**
+ * TIFF 予測子 (Predictor 2) の逆変換を行う。バイト境界を前提とするため
+ * `bitsPerComponent` が 8 以外の場合はエラーを返す。
+ *
+ * @param data - FlateDecode 展開済みのバイト列
+ * @param colors - 1サンプルあたりのカラーコンポーネント数
+ * @param bitsPerComponent - 1コンポーネントあたりのビット数
+ * @param columns - 1行あたりのサンプル数
+ * @returns 復元したバイト列、またはエラー
+ */
+function applyTiffPredictor(
+  data: Uint8Array,
+  colors: number,
+  bitsPerComponent: number,
+  columns: number,
+): Result<Uint8Array, PdfParseError> {
+  if (bitsPerComponent !== TIFF_BYTE_ALIGNED_BITS_PER_COMPONENT) {
+    return failPredictor(
+      `TIFF predictor (2) only supports /BitsPerComponent 8, got ${bitsPerComponent}`,
+    );
+  }
+
+  const rowBytes = colors * columns;
+  if (rowBytes <= 0 || data.length % rowBytes !== 0) {
+    return failPredictor(
+      `TIFF predictor data length ${data.length} is not a multiple of row size ${rowBytes}`,
+    );
+  }
+
+  const rows = data.length / rowBytes;
+  const output = new Uint8Array(data.length);
+
+  for (let row = 0; row < rows; row++) {
+    const rowStart = row * rowBytes;
+    for (let i = 0; i < rowBytes; i++) {
+      const raw = data[rowStart + i];
+      const left = i >= colors ? output[rowStart + i - colors] : 0;
+      output[rowStart + i] = (raw + left) & BYTE_MASK;
+    }
+  }
+
+  return ok(output);
+}
+
+/** `/DecodeParms` の Predictor 系パラメータ検証・逆変換を担うコンパニオンオブジェクト。 */
+export const Predictor = {
+  /**
+   * `/DecodeParms` 辞書エントリから Predictor 関連パラメータを読み取る。
+   * 未指定キーには ISO 32000-1 Table 8 のデフォルト値を適用する。
+   *
+   * @param decodeParms - `/DecodeParms` 辞書のエントリ（未指定時は全デフォルト値）
+   * @returns 検証済みの `PredictorParams`、または `XREF_STREAM_INVALID` エラー
+   */
+  parseParams(
+    decodeParms: ReadonlyMap<string, PdfValue> | undefined,
+  ): Result<PredictorParams, PdfParseError> {
+    if (decodeParms === undefined) {
+      return ok({
+        predictor: DEFAULT_PREDICTOR,
+        colors: DEFAULT_COLORS,
+        bitsPerComponent: DEFAULT_BITS_PER_COMPONENT,
+        columns: DEFAULT_COLUMNS,
+      });
+    }
+
+    const predictorResult = readIntEntry(
+      decodeParms,
+      "Predictor",
+      DEFAULT_PREDICTOR,
+    );
+    if (!predictorResult.ok) {
+      return predictorResult;
+    }
+    const colorsResult = readIntEntry(decodeParms, "Colors", DEFAULT_COLORS);
+    if (!colorsResult.ok) {
+      return colorsResult;
+    }
+    const bitsPerComponentResult = readIntEntry(
+      decodeParms,
+      "BitsPerComponent",
+      DEFAULT_BITS_PER_COMPONENT,
+    );
+    if (!bitsPerComponentResult.ok) {
+      return bitsPerComponentResult;
+    }
+    const columnsResult = readIntEntry(decodeParms, "Columns", DEFAULT_COLUMNS);
+    if (!columnsResult.ok) {
+      return columnsResult;
+    }
+
+    if (!NumberEx.isPositiveSafeInteger(predictorResult.value)) {
+      return failPredictor(
+        `/Predictor must be a positive safe integer, got ${predictorResult.value}`,
+      );
+    }
+    if (!NumberEx.isPositiveSafeInteger(colorsResult.value)) {
+      return failPredictor(
+        `/Colors must be a positive safe integer, got ${colorsResult.value}`,
+      );
+    }
+    if (!VALID_BITS_PER_COMPONENT.has(bitsPerComponentResult.value)) {
+      return failPredictor(
+        `/BitsPerComponent must be one of 1,2,4,8,16, got ${bitsPerComponentResult.value}`,
+      );
+    }
+    if (!NumberEx.isPositiveSafeInteger(columnsResult.value)) {
+      return failPredictor(
+        `/Columns must be a positive safe integer, got ${columnsResult.value}`,
+      );
+    }
+
+    return ok({
+      predictor: predictorResult.value,
+      colors: colorsResult.value,
+      bitsPerComponent: bitsPerComponentResult.value,
+      columns: columnsResult.value,
+    });
+  },
+
+  /**
+   * FlateDecode 展開済みのバイト列に Predictor 逆変換を適用する。
+   * `predictor === 1` の場合は入力をそのまま返す。
+   *
+   * @param data - FlateDecode 展開済みのバイト列
+   * @param params - `parseParams` で得た Predictor パラメータ
+   * @returns 逆変換後のバイト列、またはエラー
+   */
+  apply(
+    data: Uint8Array,
+    params: PredictorParams,
+  ): Result<Uint8Array, PdfParseError> {
+    if (params.predictor === DEFAULT_PREDICTOR) {
+      return ok(data);
+    }
+
+    if (params.predictor === TIFF_PREDICTOR) {
+      return applyTiffPredictor(
+        data,
+        params.colors,
+        params.bitsPerComponent,
+        params.columns,
+      );
+    }
+
+    if (
+      params.predictor >= PNG_PREDICTOR_MIN &&
+      params.predictor <= PNG_PREDICTOR_MAX
+    ) {
+      const bpp = Math.max(
+        1,
+        Math.ceil((params.colors * params.bitsPerComponent) / BITS_PER_BYTE),
+      );
+      const rowBytes = Math.ceil(
+        (params.colors * params.bitsPerComponent * params.columns) /
+          BITS_PER_BYTE,
+      );
+      return applyPngPredictor(data, bpp, rowBytes);
+    }
+
+    return failPredictor(`unsupported /Predictor value: ${params.predictor}`);
+  },
+} as const;

--- a/packages/core/src/xref/trailer/dict-builder/index.ts
+++ b/packages/core/src/xref/trailer/dict-builder/index.ts
@@ -14,6 +14,7 @@ interface TrailerDictBuilderChain {
   root(value?: PdfValue, offset?: ByteOffset): TrailerDictBuilderChain;
   size(value?: PdfValue, offset?: ByteOffset): TrailerDictBuilderChain;
   prev(value?: PdfValue, offset?: ByteOffset): TrailerDictBuilderChain;
+  xrefStm(value?: PdfValue, offset?: ByteOffset): TrailerDictBuilderChain;
   info(value?: PdfValue, offset?: ByteOffset): TrailerDictBuilderChain;
   id(value?: PdfValue, offset?: ByteOffset): TrailerDictBuilderChain;
   build(): Result<TrailerDict, PdfParseError>;
@@ -37,6 +38,8 @@ export function trailerDictBuilder(): TrailerDictBuilderChain {
   let _sizeOffset: ByteOffset | undefined;
   let _prev: PdfValue | undefined;
   let _prevOffset: ByteOffset | undefined;
+  let _xrefStm: PdfValue | undefined;
+  let _xrefStmOffset: ByteOffset | undefined;
   let _info: PdfValue | undefined;
   let _infoOffset: ByteOffset | undefined;
   let _id: PdfValue | undefined;
@@ -56,6 +59,11 @@ export function trailerDictBuilder(): TrailerDictBuilderChain {
     prev(value?: PdfValue, offset?: ByteOffset) {
       _prev = value;
       _prevOffset = offset;
+      return chain;
+    },
+    xrefStm(value?: PdfValue, offset?: ByteOffset) {
+      _xrefStm = value;
+      _xrefStmOffset = offset;
       return chain;
     },
     info(value?: PdfValue, offset?: ByteOffset) {
@@ -148,6 +156,21 @@ export function trailerDictBuilder(): TrailerDictBuilderChain {
           });
         }
         result.prev = BO.of(_prev.value as number);
+      }
+
+      // /XRefStm - optional, non-negative integer (ISO 32000-1 §7.5.8.4 hybrid-reference files)
+      if (_xrefStm) {
+        if (
+          _xrefStm.type !== "integer" ||
+          !NumberEx.isSafeIntegerAtLeastZero(_xrefStm.value as number)
+        ) {
+          return err({
+            code: "TRAILER_DICT_INVALID",
+            message: "/XRefStm entry is not a non-negative integer",
+            offset: _xrefStmOffset,
+          });
+        }
+        result.xrefStm = BO.of(_xrefStm.value as number);
       }
 
       // /Info - optional, IndirectRef

--- a/packages/core/src/xref/trailer/parser/__tests__/parser.error.test.ts
+++ b/packages/core/src/xref/trailer/parser/__tests__/parser.error.test.ts
@@ -143,6 +143,28 @@ test("/Prevが名前の場合にXREF_TABLE_INVALIDエラーが返る", () => {
   expect(result.error.code).toBe("XREF_TABLE_INVALID");
 });
 
+test("/XRefStmが負数の場合にXREF_TABLE_INVALIDエラーが返る", () => {
+  const { data, offset } = trailerAt(
+    "trailer << /Root 1 0 R /Size 10 /XRefStm -1 >>",
+  );
+  const result = parseTrailer(data, offset);
+  assert(!result.ok);
+  expect(result.error.code).toBe("XREF_TABLE_INVALID");
+});
+
+test("/XRefStmが実数の場合にXREF_TABLE_INVALIDエラーが返る", () => {
+  const { data, offset } = trailerAt(
+    "trailer << /Root 1 0 R /Size 10 /XRefStm 1.5 >>",
+  );
+  const result = parseTrailer(data, offset);
+  assert(!result.ok);
+  expect(result.error.code).toBe("XREF_TABLE_INVALID");
+  expect(result.error.message).toBe(
+    "/XRefStm entry is not a non-negative integer",
+  );
+  expect(result.error.offset).toBeDefined();
+});
+
 test("/Infoが非間接参照の場合にXREF_TABLE_INVALIDエラーが返る", () => {
   const { data, offset } = trailerAt(
     "trailer << /Root 1 0 R /Size 10 /Info /SomeName >>",

--- a/packages/core/src/xref/trailer/parser/__tests__/parser.parsing.test.ts
+++ b/packages/core/src/xref/trailer/parser/__tests__/parser.parsing.test.ts
@@ -50,6 +50,22 @@ test("/Prevがない辞書でprevがundefinedである", () => {
   expect(result.value.prev).toBeUndefined();
 });
 
+test("/XRefStmを含む辞書からxrefStmが数値として抽出される（ハイブリッド参照ファイル, ISO 32000-1 §7.5.8.4）", () => {
+  const { data, offset } = trailerAt(
+    "trailer << /Root 1 0 R /Size 10 /XRefStm 5000 >>",
+  );
+  const result = parseTrailer(data, offset);
+  assert(result.ok);
+  expect(result.value.xrefStm).toBe(5000);
+});
+
+test("/XRefStmがない辞書でxrefStmがundefinedである", () => {
+  const { data, offset } = trailerAt("trailer << /Root 1 0 R /Size 10 >>");
+  const result = parseTrailer(data, offset);
+  assert(result.ok);
+  expect(result.value.xrefStm).toBeUndefined();
+});
+
 test("/Infoを含む辞書からinfoが間接参照として抽出される", () => {
   const { data, offset } = trailerAt(
     "trailer << /Root 1 0 R /Size 10 /Info 5 0 R >>",

--- a/packages/core/src/xref/trailer/parser/index.ts
+++ b/packages/core/src/xref/trailer/parser/index.ts
@@ -438,7 +438,14 @@ function readArrayElements(
   }
 }
 
-const SUPPORTED_TRAILER_KEYS = new Set(["Root", "Size", "Prev", "Info", "ID"]);
+const SUPPORTED_TRAILER_KEYS = new Set([
+  "Root",
+  "Size",
+  "Prev",
+  "XRefStm",
+  "Info",
+  "ID",
+]);
 const ID_MAX_ELEMENTS = 2;
 
 /**
@@ -636,6 +643,7 @@ function buildTrailerDict(
   const rootEntry = entries.get("Root");
   const sizeEntry = entries.get("Size");
   const prevEntry = entries.get("Prev");
+  const xrefStmEntry = entries.get("XRefStm");
   const infoEntry = entries.get("Info");
   const idEntry = entries.get("ID");
 
@@ -643,6 +651,7 @@ function buildTrailerDict(
     .root(rootEntry?.value, rootEntry?.offset)
     .size(sizeEntry?.value, sizeEntry?.offset)
     .prev(prevEntry?.value, prevEntry?.offset)
+    .xrefStm(xrefStmEntry?.value, xrefStmEntry?.offset)
     .info(infoEntry?.value, infoEntry?.offset)
     .id(idEntry?.value, idEntry?.offset)
     .build();


### PR DESCRIPTION
## 概要

ISO 32000-1 §7.5.8 により、PDF 1.5 以降は `startxref` が直接クロスリファレンスストリームオブジェクト（`N G obj << /Type /XRef ... >> stream`）を指しうる。しかし `PdfDocument.load` の `parseXRefAt` は `parseXRefTable`（テキスト形式 `xref` キーワード前提）しか呼ばず、xref ストリームを指す PDF では `expected 'xref' keyword` で失敗し `scanFallback` に落ちていた。

`decodeXRefStreamEntries` / `buildXRefStreamTrailerDict` は実装済みだったが export されているだけで本番コードから呼ばれておらず、さらに fallback スキャナは `N G obj` ヘッダのみ復元するため type=2（ObjStm 内圧縮オブジェクト）のエントリを再構築できず、xref ストリーム + ObjStm を使う近年の典型的な PDF はオブジェクト欠落・`ROOT_NOT_FOUND` でロード不能になっていた。

本PRで `parseXRefAt` にオフセット先が `xref` キーワードかどうかの分岐を追加し、xref ストリームをメイン読み込みパスに統合した。

### 🎯 変更の種類

- [x] 🐛 バグ修正 (Bug fix)
- [x] ✨ 新機能 (New feature)
- [x] 🚨 テスト追加/修正 (Tests)

### 📝 詳細な変更内容

#### 追加された機能・修正

- `xref/stream/predictor/` — `/DecodeParms /Predictor`（PNG 10-15 / TIFF 2）の逆変換
- `xref/stream/dict/` — xref ストリーム辞書（`/Type` `/W` `/Size` `/Index` `/Filter` `/DecodeParms`）のバリデーション
- `xref/stream/parse-xref-stream/` — `parseIndirectObject → XRefStreamDict.parse → decompressFlate → Predictor.apply → decodeXRefStreamEntries → buildXRefStreamTrailerDict` を結線するオーケストレーション関数
- `document/pdf-document/index.ts` — `parseXRefAt` でオフセット先が `xref` キーワードでなければ `parseXRefStream` に分岐

#### 変更されたファイル

- `xref/merger/index.ts` — xref ストリーム解析が非同期処理（間接オブジェクトのパース・FlateDecode展開）を伴うため、`mergeXRefChain` の `parseCallback` を `Promise` 化し関数自体も `async` 化
- `xref/merger/__tests__/*`, `xref/__tests__/xref-pipeline.integration.test.ts` — 上記シグネチャ変更に伴う既存テストの非同期呼び出し対応
- `xref/stream/index.ts` — `parseXRefStream` を公開

### 📊 システム図

```mermaid
flowchart TD
    A([startxrefオフセット]) --> B{xrefキーワード?}
    B -->|Yes 従来| C[parseXRefTable + parseTrailer]
    B -->|No NEW| D[parseXRefStream]:::new
    D --> D1[parseIndirectObject]:::new
    D1 --> D2[XRefStreamDict.parse]:::new
    D2 --> D3["decompressFlate (/Filterがあれば)"]:::new
    D3 --> D4[Predictor.apply]:::new
    D4 --> D5[decodeXRefStreamEntries]:::new
    D5 --> D6[buildXRefStreamTrailerDict]:::new
    C --> E[mergeXRefChain /Prevチェーン]
    D6 --> E
    E -->|失敗| F[scanFallback]
    E -->|成功| G([PdfDocument.load 続行])

    classDef new fill:#ffe4b5,stroke:#d97706,stroke-width:2px
```

## 📋 関連 Issue

- Closes #319

## 🧪 テスト

### テスト実行方法

```bash
pnpm run test:run
pnpm run lint
pnpm run typecheck
```

### テスト項目

- [x] 単体テスト (Unit tests)
- [x] 統合テスト (Integration tests)
- [ ] E2E テスト (End-to-end tests)
- [ ] 手動テスト (Manual testing)

### テスト結果

- `pnpm run test:run`: 267 files / 3241 tests all passed
- `pnpm run lint`: 0 warnings / 0 errors
- `pnpm run typecheck`: core / react ともにエラーなし
- `PdfDocument.load` レベルで以下をE2E検証:
  - xrefストリームのみを持つPDFの読み込み
  - テキストxref(旧)⇄xrefストリーム(新)の `/Prev` チェーン混在
  - xrefストリームの type=2 エントリ経由で ObjStm 内オブジェクトが解決されること

## 🔍 レビューポイント

- `parseXRefAt` の `isXRefKeywordAt` によるテキストxref/xrefストリームの判定ロジック（`parseXRefTable` 内部の境界チェックと同基準）
- `mergeXRefChain` の非同期化がテキストxrefのみの既存経路に影響していないか
- `Predictor` の PNG/TIFF 逆変換アルゴリズムの正しさ

## ⚠️ 破壊的変更

- [x] この変更は既存の API に破壊的変更を含みます

### 破壊的変更の詳細

- `mergeXRefChain`（`packages/core`のpublic export）のシグネチャが同期 `Result` 返却から非同期 `Promise<Result>` 返却に変更。呼び出し側は `await` が必要。

## 📚 追加情報

### 注意事項

- fallback スキャナ（`scanFallback`）の type=2（ObjStm内圧縮オブジェクト）再構築は本PRのスコープ外。xref ストリーム/テーブルが両方破損した場合のfallbackは引き続きtype=1エントリのみ復元する。

## ✅ チェックリスト

- [x] コードレビューの準備ができている
- [x] テストが正常に実行される
- [x] コミットメッセージが適切な形式で書かれている
- [x] 関連する Issue が PR の「Development」に Linked されている
- [x] PR 本文に `Closes #` で Issue が記載されている
- [x] セルフレビューを実施した
- [x] 破壊的変更がある場合は明記されている