### PR TITLE
🔧 [Config]: プロジェクト設定のenabledPluginsを実際の稼働状態に同期

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -10,7 +10,7 @@
     "typescript-rules-plugin@d-market-typescript": true,
     "react-rules-plugin@d-market-react": true,
     "spec-plugin@d-market-spec": true,
-    "spec-review-plugin@d-market-spec": true,
+    "spec-based-code-review-plugin@d-market-spec": true,
     "git-workflow-plugin@d-market-git": true,
     "spec-to-issues-plugin@d-market-git": true,
     "workflow-automation-plugin@d-market-git": true,
@@ -20,7 +20,12 @@
     "marketplace-template@d-market-skill": true,
     "skill-grower@d-market-skill": true,
     "rust-workflow-plugin@d-market-rust": true,
-    "typescript-lsp@claude-plugins-official": true
+    "rust-rules-plugin@d-market-rust": true,
+    "rust-hooks-plugin@d-market-rust": true,
+    "typescript-lsp@claude-plugins-official": true,
+    "rust-analyzer-lsp@claude-plugins-official": true,
+    "code-intent-layering-guard@d-market-workflow": true,
+    "discord-notifier@d-market-workflow": true
   },
   "extraKnownMarketplaces": {
     "d-market-typescript": {
@@ -74,6 +79,12 @@
       "source": {
         "source": "github",
         "repo": "DIO0550/d-market-rust"
+      }
+    },
+    "d-market-workflow": {
+      "source": {
+        "source": "git",
+        "url": "https://github.com/DIO0550/d-market-workflow.git"
       }
     }
   }


### PR DESCRIPTION
## 概要

プロジェクト設定 (`.claude/settings.json`) の `enabledPlugins` を、実際に稼働している状態と一致するように同期した。

### 🎯 変更の種類

- [x] 🔧 設定変更 (Configuration)

### 📝 詳細な変更内容

#### 変更されたファイル

- `.claude/settings.json`
  - 誤った名称 `spec-review-plugin@d-market-spec` を、実際にインストール・稼働しているプラグインID `spec-based-code-review-plugin@d-market-spec` に修正
  - ユーザー設定側 (`~/.claude/settings.json`) でのみ有効化されていて、プロジェクト設定に未反映だったプラグインを追加
    - `rust-rules-plugin@d-market-rust`
    - `rust-hooks-plugin@d-market-rust`
    - `rust-analyzer-lsp@claude-plugins-official`
    - `code-intent-layering-guard@d-market-workflow`
    - `discord-notifier@d-market-workflow`
  - 上記2件の提供元である `d-market-workflow` マーケットプレイスを `extraKnownMarketplaces` に追加

## 🧪 テスト

### テスト実行方法

```bash
python3 -m json.tool .claude/settings.json
```

### テスト結果

- JSON構文の妥当性を確認済み

## 🔍 レビューポイント

- 追加したプラグイン（特にRust関連）をチーム共有のプロジェクト設定に含めることが適切か