### PR TITLE
✨ [New Feature]: #509 ObjectStore の世代番号不一致時に GENERATION_MISMATCH 警告を発火 (OR-009)

### DIFF
--- a/packages/core/src/document/pdf-document/index.ts
+++ b/packages/core/src/document/pdf-document/index.ts
@@ -334,7 +334,10 @@ export class PdfDocument {
 
     const storeResult = ObjectStore.create(
       { xref, data },
-      { cacheCapacity: options?.cacheCapacity },
+      {
+        cacheCapacity: options?.cacheCapacity,
+        onWarning: options?.onWarning,
+      },
     );
     if (!storeResult.ok) {
       return storeResult;

--- a/packages/core/src/objects/object-store/__tests__/object-store.basic.test.ts
+++ b/packages/core/src/objects/object-store/__tests__/object-store.basic.test.ts
@@ -1,5 +1,8 @@
 import { expect, test, vi } from "vitest";
-import type { PdfTypeMismatchError } from "../../../pdf/errors/index";
+import type {
+  PdfTypeMismatchError,
+  PdfWarning,
+} from "../../../pdf/errors/index";
 import { ByteOffset } from "../../../pdf/types/byte-offset/index";
 import { GenerationNumber } from "../../../pdf/types/generation-number/index";
 import { ObjectNumber } from "../../../pdf/types/object-number/index";
@@ -81,27 +84,55 @@ test("type=0 の XRefFreeEntry で get すると PdfNull が返る", async () =>
   expect(resolved).toEqual({ ok: true, value: { type: "null" } });
 });
 
-test("type=1 の XRefUsedEntry で get するとオブジェクトがパースされる", async () => {
+test("type=1 の XRefUsedEntry で get するとオブジェクトがパースされ onWarning は呼ばれない", async () => {
   const pdfData = new TextEncoder().encode("7 0 obj\n42\nendobj");
   const usedEntry: XRefUsedEntry = {
     type: 1,
     offset: ByteOffset.of(0),
     generationNumber: GenerationNumber.of(0),
   };
+  const seen: PdfWarning[] = [];
   const store = unwrapOk(
     ObjectStore.create(
       makeStoreSource({
         xref: makeXRefTable([[7, usedEntry]]),
         data: pdfData,
       }),
+      { onWarning: (w) => seen.push(w) },
     ),
   );
   const resolved = await store.get(makeRef(7));
   const value = unwrapOk(resolved);
   expect(value).toEqual({ type: "integer", value: 42 });
+  expect(seen).toHaveLength(0);
 });
 
-test("type=1 で generation mismatch の場合は PdfNull が返る", async () => {
+test("type=1 で generation mismatch の場合 onWarning に GENERATION_MISMATCH が渡る", async () => {
+  const usedEntry: XRefUsedEntry = {
+    type: 1,
+    offset: ByteOffset.of(100),
+    generationNumber: GenerationNumber.of(2),
+  };
+  const seen: PdfWarning[] = [];
+  const store = unwrapOk(
+    ObjectStore.create(
+      makeStoreSource({ xref: makeXRefTable([[7, usedEntry]]) }),
+      { onWarning: (w) => seen.push(w) },
+    ),
+  );
+  const resolved = await store.get(makeRef(7, 0));
+
+  expect(resolved).toEqual({ ok: true, value: { type: "null" } });
+  expect(seen).toEqual([
+    {
+      code: "GENERATION_MISMATCH",
+      message: "Object 7: generation mismatch (expected 2, got 0)",
+      offset: 100,
+    },
+  ]);
+});
+
+test("type=1 で generation mismatch でも onWarning 未指定なら例外にならない", async () => {
   const usedEntry: XRefUsedEntry = {
     type: 1,
     offset: ByteOffset.of(100),
@@ -114,6 +145,76 @@ test("type=1 で generation mismatch の場合は PdfNull が返る", async () =
   );
   const resolved = await store.get(makeRef(7, 0));
   expect(resolved).toEqual({ ok: true, value: { type: "null" } });
+});
+
+test("type=1 で generation mismatch の場合、2回目の get では onWarning が再発火しない", async () => {
+  const usedEntry: XRefUsedEntry = {
+    type: 1,
+    offset: ByteOffset.of(100),
+    generationNumber: GenerationNumber.of(2),
+  };
+  const seen: PdfWarning[] = [];
+  const store = unwrapOk(
+    ObjectStore.create(
+      makeStoreSource({ xref: makeXRefTable([[7, usedEntry]]) }),
+      { onWarning: (w) => seen.push(w) },
+    ),
+  );
+
+  await store.get(makeRef(7, 0));
+  expect(seen).toHaveLength(1);
+
+  await store.get(makeRef(7, 0));
+  expect(seen).toHaveLength(1);
+});
+
+test.each([
+  {
+    entryGen: 1,
+    refGen: 0,
+    label: "entry世代1・ref世代0（境界値: refが最小値0）",
+  },
+  {
+    entryGen: 0,
+    refGen: 1,
+    label: "entry世代0・ref世代1（境界値: entryが最小値0）",
+  },
+  {
+    entryGen: 65535,
+    refGen: 0,
+    label: "entry世代65535・ref世代0（境界値: GenerationNumber許容最大値）",
+  },
+  {
+    entryGen: 5,
+    refGen: 3,
+    label: "entry世代5・ref世代3（正常系バリエーション: 非ゼロ同士の不一致）",
+  },
+])("type=1 で世代不一致 $label のとき onWarning に期待/実際の値を含む GENERATION_MISMATCH が渡る", async ({
+  entryGen,
+  refGen,
+}) => {
+  const usedEntry: XRefUsedEntry = {
+    type: 1,
+    offset: ByteOffset.of(100),
+    generationNumber: GenerationNumber.of(entryGen),
+  };
+  const seen: PdfWarning[] = [];
+  const store = unwrapOk(
+    ObjectStore.create(
+      makeStoreSource({ xref: makeXRefTable([[7, usedEntry]]) }),
+      { onWarning: (w) => seen.push(w) },
+    ),
+  );
+  const resolved = await store.get(makeRef(7, refGen));
+
+  expect(resolved).toEqual({ ok: true, value: { type: "null" } });
+  expect(seen).toEqual([
+    {
+      code: "GENERATION_MISMATCH",
+      message: `Object 7: generation mismatch (expected ${entryGen}, got ${refGen})`,
+      offset: 100,
+    },
+  ]);
 });
 
 test("type=1 で obj ヘッダの objNum が xref と不一致の場合エラーが返る", async () => {

--- a/packages/core/src/objects/object-store/index.ts
+++ b/packages/core/src/objects/object-store/index.ts
@@ -5,7 +5,7 @@
  * @module
  */
 
-import type { PdfError } from "../../pdf/errors/index";
+import type { PdfError, PdfWarning } from "../../pdf/errors/index";
 import { GenerationNumber } from "../../pdf/types/generation-number/index";
 import type { ObjectNumber } from "../../pdf/types/object-number/index";
 import type { IndirectRef, PdfObject } from "../../pdf/types/pdf-types/index";
@@ -30,6 +30,7 @@ export class ObjectStore {
   private readonly source: ObjectStoreSource;
   private readonly cache: LRUCache<string, PdfObject>;
   private readonly streamCache: LRUCache<ObjectNumber, Uint8Array> | undefined;
+  private readonly onWarning: ((warning: PdfWarning) => void) | undefined;
   private readonly inFlight = new Map<
     string,
     Promise<Result<PdfObject, PdfError>>
@@ -39,15 +40,18 @@ export class ObjectStore {
    * @param source - データソース（xref, data）
    * @param cache - 解決結果キャッシュ
    * @param streamCache - ObjStm 展開済みデータキャッシュ
+   * @param onWarning - 回復可能な警告を受け取るコールバック
    */
   private constructor(
     source: ObjectStoreSource,
     cache: LRUCache<string, PdfObject>,
     streamCache: LRUCache<ObjectNumber, Uint8Array> | undefined,
+    onWarning: ((warning: PdfWarning) => void) | undefined,
   ) {
     this.source = source;
     this.cache = cache;
     this.streamCache = streamCache;
+    this.onWarning = onWarning;
   }
 
   /**
@@ -79,7 +83,14 @@ export class ObjectStore {
       streamCache = streamCacheResult.value;
     }
 
-    return ok(new ObjectStore(source, cacheResult.value, streamCache));
+    return ok(
+      new ObjectStore(
+        source,
+        cacheResult.value,
+        streamCache,
+        options?.onWarning,
+      ),
+    );
   }
 
   /**
@@ -194,6 +205,15 @@ export class ObjectStore {
         if (entry.generationNumber !== ref.generationNumber) {
           // ISO 32000-1 §7.3.10: 世代番号が一致しない参照は未定義オブジェクトとみなし
           // null オブジェクトとして解決する
+          this.onWarning?.({
+            code: "GENERATION_MISMATCH",
+            message: `Object ${ref.objectNumber}: generation mismatch (expected ${entry.generationNumber}, got ${ref.generationNumber})`,
+            offset: entry.offset,
+          });
+          // 警告の重複発火防止: mismatch 結果は他の成功パス（inline/ObjStm 読み取り）と
+          // 異なりキャッシュされないため、cache.set しないと再 get() のたびに
+          // dispatch() が再実行され警告も再発火してしまう
+          this.cache.set(cacheKey, { type: "null" });
           return ok({ type: "null" });
         }
         const resolver: ObjectResolver = (

--- a/packages/core/src/objects/object-store/index.ts
+++ b/packages/core/src/objects/object-store/index.ts
@@ -46,7 +46,7 @@ export class ObjectStore {
     source: ObjectStoreSource,
     cache: LRUCache<string, PdfObject>,
     streamCache: LRUCache<ObjectNumber, Uint8Array> | undefined,
-    onWarning: ((warning: PdfWarning) => void) | undefined,
+    onWarning: undefined | ((warning: PdfWarning) => void),
   ) {
     this.source = source;
     this.cache = cache;

--- a/packages/core/src/objects/object-store/types.ts
+++ b/packages/core/src/objects/object-store/types.ts
@@ -1,3 +1,4 @@
+import type { PdfWarning } from "../../pdf/errors/index";
 import type { XRefTable } from "../../pdf/types/pdf-types/index";
 
 /**
@@ -19,4 +20,6 @@ export interface ObjectStoreOptions {
   readonly cacheCapacity?: number;
   /** ObjStm 展開済みデータキャッシュ容量（デフォルト 64、false で無効化） */
   readonly streamCacheCapacity?: number | false;
+  /** 回復可能な警告を受け取るコールバック（未指定時は警告を破棄する） */
+  readonly onWarning?: (warning: PdfWarning) => void;
 }

--- a/packages/core/src/pdf/errors/warning/__tests__/warning.type.test.ts
+++ b/packages/core/src/pdf/errors/warning/__tests__/warning.type.test.ts
@@ -50,3 +50,8 @@ test("PdfWarningCode に UNBALANCED_RESTORE が含まれる", () => {
   const code: PdfWarningCode = "UNBALANCED_RESTORE";
   expect(code).toBe("UNBALANCED_RESTORE");
 });
+
+test("PdfWarningCode に GENERATION_MISMATCH が含まれる", () => {
+  const code: PdfWarningCode = "GENERATION_MISMATCH";
+  expect(code).toBe("GENERATION_MISMATCH");
+});

--- a/packages/core/src/pdf/errors/warning/index.ts
+++ b/packages/core/src/pdf/errors/warning/index.ts
@@ -4,7 +4,7 @@
  *
  * @example
  * ```ts
- * const code: PdfWarningCode = "CATALOG_VERSION_INVALID";
+ * const code: PdfWarningCode = "GENERATION_MISMATCH";
  * ```
  */
 export type PdfWarningCode =
@@ -28,7 +28,8 @@ export type PdfWarningCode =
   | "TRAPPED_INVALID"
   | "UNKNOWN_OPERATOR"
   | "CATALOG_VERSION_INVALID"
-  | "UNBALANCED_RESTORE";
+  | "UNBALANCED_RESTORE"
+  | "GENERATION_MISMATCH";
 
 /**
  * 回復可能なPDF問題の警告。


### PR DESCRIPTION
## 概要

`docs/pdf-parsing-pipeline/object-resolver-spec.md` OR-009 は「参照の世代番号が xref エントリの世代番号と不一致の場合、PdfNull を返却し `GENERATION_MISMATCH` 警告を通知する」と規定しているが、`ObjectStore`（type=1経路）は PdfNull 返却のみで警告を発火しておらず、`GENERATION_MISMATCH` コード自体も `PdfWarningCode` に未定義だった。仕様と実装の乖離（関連: #345 同系統issue）を解消する。

## 変更の種類

- [x] 🐛 バグ修正 (Bug fix) — 仕様と実装の乖離解消
- [x] ✨ 新機能 (New feature) — `GENERATION_MISMATCH` 警告コード / `onWarning` オプションの追加

## 詳細な変更内容

### 追加された機能・修正

- `PdfWarningCode` に `GENERATION_MISMATCH` を追加
- `ObjectStoreOptions` に `onWarning?: (warning: PdfWarning) => void` コールバックを追加
- `ObjectStore.dispatch()` の type=1（`XRefUsedEntry`）世代不一致経路で `onWarning` を発火し、`GENERATION_MISMATCH` 警告を通知
  - mismatch 結果は他の成功パスと同様に `cache.set` し、同一 ref の再 `get()` での警告重複発火を防止
- `PdfDocument.load` の `ObjectStore.create` 呼び出しに `onWarning: options?.onWarning` を配線し、`LoadOptions.onWarning` 経由でも観測可能に

### 変更されたファイル

- `packages/core/src/pdf/errors/warning/index.ts` / `__tests__/warning.type.test.ts`
- `packages/core/src/objects/object-store/{index,types}.ts` / `__tests__/object-store.basic.test.ts`
- `packages/core/src/document/pdf-document/index.ts`

### スコープ外（意図的に変更なし）

- type=0（free エントリ）・type=2（ObjStm）の世代不一致
- `entry-readers/{inline,object-stream}`
- `dispatch()` メソッド自体の分割リファクタ

## 📊 システム図

### データフロー

```mermaid
flowchart TD
    A["store.get(ref) / store.getAs(ref, type)"] --> B{"xref.entries.get(objectNumber)"}
    B -->|type=1| C{"entry.generationNumber !== ref.generationNumber ?"}
    C -->|一致| D["readInlineEntry() → 通常解決"]
    C -->|不一致| E["onWarning?.(GENERATION_MISMATCH) [NEW]"]
    E --> F["cache.set(cacheKey, null) [NEW]"]
    F --> G["ok({type: null}) を返す（戻り値は従来どおり）"]

    H["PdfDocument.load(data, options)"] -->|"onWarning: options?.onWarning [NEW]"| I["ObjectStore.create"]
    I --> A

    classDef new fill:#ffe4b5,stroke:#d97706,stroke-width:2px
    class E,F,I new
```

2回目以降の同一 ref への `get()` は、上記 cache.set 済みの結果によって resolveImpl 先頭の既存キャッシュヒット判定で早期returnするため、`dispatch()` 自体に到達せず警告は再発火しない。

## 📋 関連 Issue

- Closes #509

## 🧪 テスト

### テスト実行方法

```bash
pnpm --filter @pdfmod/core exec vitest run
pnpm --filter @pdfmod/core typecheck
pnpm lint
```

### テスト項目

- [x] 単体テスト (Unit tests)
- [x] 手動テスト (Manual testing)

### テスト結果

- 自動テスト: 全265ファイル・3266件パス
- 型チェック・lint: エラーなし
- 手動検証: 世代不一致PDFを `onWarning` 指定で load すると `GENERATION_MISMATCH` が観測され `Ok` を返す／未指定でも例外にならず `Ok` を返すことを確認
- 既存の `pdf-document.warning.test.ts` / `object-store.edge.test.ts` / `object-store.type-export.test.ts` にリグレッションなし

## 🔍 レビューポイント

- `ObjectStore.dispatch()` case 1 の mismatch 分岐で `cache.set` を追加し、警告の重複発火を防止している点（`resolveImpl` 先頭の既存キャッシュ判定に乗る形で成立）
- 警告伝搬に既存の「戻り値に warnings 配列を含める」方式ではなく `onWarning` コールバック方式を採用した理由（`ResolveRef` 型の3消費箇所への波及回避）

## ⚠️ 破壊的変更

- [ ] この変更は既存の API に破壊的変更を含みます

`ObjectStoreOptions.onWarning` は optional field のため、既存呼び出し（`ObjectStore.create(source)` 等）は無変更で動作する。

## ✅ チェックリスト

- [x] コードレビューの準備ができている
- [x] テストが正常に実行される
- [x] コミットメッセージが適切な形式で書かれている
- [x] 関連する Issue が PR の「Development」に Linked されている
- [x] PR 本文に Issue が記載されている（Closes #509）
- [x] セルフレビューを実施した（Codex CLI によるレビューで「問題なし」）
- [x] 破壊的変更はない