### PR TITLE
🐛 [Bug Fix]: #073 xrefストリームの間接/Length解決をローカルスキャン方式で実装

### DIFF
--- a/packages/core/src/xref/stream/parse-xref-stream/__tests__/parse-xref-stream.decode.test.ts
+++ b/packages/core/src/xref/stream/parse-xref-stream/__tests__/parse-xref-stream.decode.test.ts
@@ -161,3 +161,38 @@ test("/Rootが無いxrefストリームはtrailer:undefinedで成功する（/XR
     generationNumber: GenerationNumber.of(0),
   });
 });
+
+test("間接参照 /Length を持つ xref ストリームをデコードする", async () => {
+  const rawEntries = new Uint8Array([1, 5, 0]);
+  const lengthObj = `10 0 obj\n${rawEntries.length}\nendobj\n`;
+  const objHeader =
+    "1 0 obj\n" +
+    "<< /Type /XRef /W [1 1 1] /Size 1 /Root 2 0 R /Length 10 0 R >>\n" +
+    "stream\n";
+  const data = concatBytes([
+    encode(HEADER),
+    encode(lengthObj),
+    encode(objHeader),
+    rawEntries,
+    encode("\nendstream\nendobj\n"),
+  ]);
+
+  const lengthObjLen = encode(lengthObj).length;
+  const result = await parseXRefStream(
+    data,
+    ByteOffset.of(HEADER_LEN + lengthObjLen),
+  );
+
+  assert(result.ok);
+  expect(result.value.xref.size).toBe(1);
+  expect(result.value.xref.entries.get(ObjectNumber.of(0))).toEqual({
+    type: 1,
+    offset: ByteOffset.of(5),
+    generationNumber: GenerationNumber.of(0),
+  });
+  assert(result.value.trailer !== undefined);
+  expect(result.value.trailer.root).toEqual({
+    objectNumber: ObjectNumber.of(2),
+    generationNumber: GenerationNumber.of(0),
+  });
+});

--- a/packages/core/src/xref/stream/parse-xref-stream/__tests__/parse-xref-stream.error.test.ts
+++ b/packages/core/src/xref/stream/parse-xref-stream/__tests__/parse-xref-stream.error.test.ts
@@ -139,3 +139,22 @@ test("/DecodeParmsの/Predictorが未サポート値の場合、Predictor由来�
   assert(!result.ok);
   expect(result.error.code).toBe("XREF_STREAM_INVALID");
 });
+
+test("間接参照 /Length の参照先が存在しない xref ストリームでエラーを返す", async () => {
+  const rawEntries = new Uint8Array([1, 5, 0]);
+  const objHeader =
+    "1 0 obj\n" +
+    "<< /Type /XRef /W [1 1 1] /Size 1 /Root 2 0 R /Length 999 0 R >>\n" +
+    "stream\n";
+  const data = concatBytes([
+    encode(HEADER),
+    encode(objHeader),
+    rawEntries,
+    encode("\nendstream\nendobj\n"),
+  ]);
+
+  const result = await parseXRefStream(data, ByteOffset.of(HEADER_LEN));
+
+  assert(!result.ok);
+  expect(result.error.code).toBe("OBJECT_PARSE_STREAM_LENGTH");
+});

--- a/packages/core/src/xref/stream/parse-xref-stream/__tests__/resolve-local-length.basic.test.ts
+++ b/packages/core/src/xref/stream/parse-xref-stream/__tests__/resolve-local-length.basic.test.ts
@@ -1,0 +1,135 @@
+import { assert, expect, test } from "vitest";
+import { GenerationNumber } from "../../../../pdf/types/generation-number/index";
+import { ObjectNumber } from "../../../../pdf/types/object-number/index";
+import { resolveLocalLength } from "../index";
+
+function encode(s: string): Uint8Array {
+  return new TextEncoder().encode(s);
+}
+
+function concatBytes(chunks: readonly Uint8Array[]): Uint8Array {
+  const total = chunks.reduce((sum, c) => sum + c.length, 0);
+  const result = new Uint8Array(total);
+  let offset = 0;
+  for (const chunk of chunks) {
+    result.set(chunk, offset);
+    offset += chunk.length;
+  }
+  return result;
+}
+
+test("直後に配置された integer オブジェクトを解決する", async () => {
+  const data = concatBytes([
+    encode("1 0 obj\n<< /Length 10 0 R >>\nendobj\n"),
+    encode("10 0 obj\n42\nendobj\n"),
+  ]);
+
+  const result = await resolveLocalLength(
+    data,
+    ObjectNumber.of(10),
+    GenerationNumber.of(0),
+  );
+
+  assert(result.ok);
+  expect(result.value).toEqual({ type: "integer", value: 42 });
+});
+
+test("直前に配置された integer オブジェクトを解決する", async () => {
+  const data = concatBytes([
+    encode("3 0 obj\n100\nendobj\n"),
+    encode("1 0 obj\n<< /Length 3 0 R >>\nendobj\n"),
+  ]);
+
+  const result = await resolveLocalLength(
+    data,
+    ObjectNumber.of(3),
+    GenerationNumber.of(0),
+  );
+
+  assert(result.ok);
+  expect(result.value).toEqual({ type: "integer", value: 100 });
+});
+
+test("generation number 0 以外のオブジェクトを解決する", async () => {
+  const data = encode("5 1 obj\n7\nendobj\n");
+
+  const result = await resolveLocalLength(
+    data,
+    ObjectNumber.of(5),
+    GenerationNumber.of(1),
+  );
+
+  assert(result.ok);
+  expect(result.value).toEqual({ type: "integer", value: 7 });
+});
+
+test("データ先頭にあるオブジェクトを解決する", async () => {
+  const data = encode("1 0 obj\n256\nendobj\n");
+
+  const result = await resolveLocalLength(
+    data,
+    ObjectNumber.of(1),
+    GenerationNumber.of(0),
+  );
+
+  assert(result.ok);
+  expect(result.value).toEqual({ type: "integer", value: 256 });
+});
+
+test("データ末尾ぎりぎりにオブジェクトヘッダがある場合", async () => {
+  const data = encode("2 0 obj\n50\nendobj");
+
+  const result = await resolveLocalLength(
+    data,
+    ObjectNumber.of(2),
+    GenerationNumber.of(0),
+  );
+
+  assert(result.ok);
+  expect(result.value).toEqual({ type: "integer", value: 50 });
+});
+
+test("objNum=0, genNum=0 の最小オブジェクト番号を解決する", async () => {
+  const data = encode("0 0 obj\n1\nendobj\n");
+
+  const result = await resolveLocalLength(
+    data,
+    ObjectNumber.of(0),
+    GenerationNumber.of(0),
+  );
+
+  assert(result.ok);
+  expect(result.value).toEqual({ type: "integer", value: 1 });
+});
+
+test("同一 objNum/genNum のオブジェクトが複数存在する場合は後方（新しい方）を優先する", async () => {
+  const data = concatBytes([
+    encode("5 0 obj\n42\nendobj\n"),
+    encode("5 0 obj\n99\nendobj\n"),
+  ]);
+
+  const result = await resolveLocalLength(
+    data,
+    ObjectNumber.of(5),
+    GenerationNumber.of(0),
+  );
+
+  assert(result.ok);
+  expect(result.value).toEqual({ type: "integer", value: 99 });
+});
+
+test("偽候補の parse 失敗時に次の候補を試す", async () => {
+  const data = concatBytes([
+    encode("5 0 obj\n<<<\nendobj\n"),
+    encode("5 0 obj\n42\nendobj\n"),
+  ]);
+
+  const result = await resolveLocalLength(
+    data,
+    ObjectNumber.of(5),
+    GenerationNumber.of(0),
+  );
+
+  assert(result.ok);
+  expect(result.value).toEqual({ type: "integer", value: 42 });
+});

--- a/packages/core/src/xref/stream/parse-xref-stream/__tests__/resolve-local-length.error.test.ts
+++ b/packages/core/src/xref/stream/parse-xref-stream/__tests__/resolve-local-length.error.test.ts
@@ -73,4 +73,5 @@ test("コメント内の N G obj パターンにマッチしない", async () =>
 
   assert(!result.ok);
   expect(result.error.code).toBe("OBJECT_PARSE_STREAM_LENGTH");
+  expect(result.error.message).toContain("Cannot locate object");
 });

--- a/packages/core/src/xref/stream/parse-xref-stream/__tests__/resolve-local-length.error.test.ts
+++ b/packages/core/src/xref/stream/parse-xref-stream/__tests__/resolve-local-length.error.test.ts
@@ -1,0 +1,76 @@
+import { assert, expect, test } from "vitest";
+import { GenerationNumber } from "../../../../pdf/types/generation-number/index";
+import { ObjectNumber } from "../../../../pdf/types/object-number/index";
+import { resolveLocalLength } from "../index";
+
+function encode(s: string): Uint8Array {
+  return new TextEncoder().encode(s);
+}
+
+test("参照先オブジェクトがデータ内に存在しない場合にエラーを返す", async () => {
+  const data = encode("1 0 obj\n42\nendobj\n");
+
+  const result = await resolveLocalLength(
+    data,
+    ObjectNumber.of(99),
+    GenerationNumber.of(0),
+  );
+
+  assert(!result.ok);
+  expect(result.error.code).toBe("OBJECT_PARSE_STREAM_LENGTH");
+  expect(result.error.message).toContain("Cannot locate object");
+});
+
+test("参照先オブジェクトのパースに失敗する場合にエラーを返す", async () => {
+  const data = encode("10 0 obj\n<<<\nendobj\n");
+
+  const result = await resolveLocalLength(
+    data,
+    ObjectNumber.of(10),
+    GenerationNumber.of(0),
+  );
+
+  assert(!result.ok);
+  expect(result.error.code).toBe("OBJECT_PARSE_STREAM_LENGTH");
+  expect(result.error.message).toContain("parse failed");
+});
+
+test("空の Uint8Array でスキャンした場合にエラーを返す", async () => {
+  const data = new Uint8Array(0);
+
+  const result = await resolveLocalLength(
+    data,
+    ObjectNumber.of(1),
+    GenerationNumber.of(0),
+  );
+
+  assert(!result.ok);
+  expect(result.error.code).toBe("OBJECT_PARSE_STREAM_LENGTH");
+  expect(result.error.message).toContain("Cannot locate object");
+});
+
+test("類似パターンがあるが token boundary で区切られていない場合にマッチしない", async () => {
+  const data = encode("150 0 obj\n42\nendobj\n");
+
+  const result = await resolveLocalLength(
+    data,
+    ObjectNumber.of(50),
+    GenerationNumber.of(0),
+  );
+
+  assert(!result.ok);
+  expect(result.error.code).toBe("OBJECT_PARSE_STREAM_LENGTH");
+});
+
+test("コメント内の N G obj パターンにマッチしない", async () => {
+  const data = encode("% 5 0 obj\n");
+
+  const result = await resolveLocalLength(
+    data,
+    ObjectNumber.of(5),
+    GenerationNumber.of(0),
+  );
+
+  assert(!result.ok);
+  expect(result.error.code).toBe("OBJECT_PARSE_STREAM_LENGTH");
+});

--- a/packages/core/src/xref/stream/parse-xref-stream/__tests__/resolve-local-length.error.test.ts
+++ b/packages/core/src/xref/stream/parse-xref-stream/__tests__/resolve-local-length.error.test.ts
@@ -19,6 +19,7 @@ test("参照先オブジェクトがデータ内に存在しない場合にエ�
   assert(!result.ok);
   expect(result.error.code).toBe("OBJECT_PARSE_STREAM_LENGTH");
   expect(result.error.message).toContain("Cannot locate object");
+  expect(result.error.message).toContain("/Length resolution");
 });
 
 test("参照先オブジェクトのパースに失敗する場合にエラーを返す", async () => {
@@ -47,6 +48,7 @@ test("空の Uint8Array でスキャンした場合にエラーを返す", async
   assert(!result.ok);
   expect(result.error.code).toBe("OBJECT_PARSE_STREAM_LENGTH");
   expect(result.error.message).toContain("Cannot locate object");
+  expect(result.error.message).toContain("/Length resolution");
 });
 
 test("類似パターンがあるが token boundary で区切られていない場合にマッチしない", async () => {
@@ -74,4 +76,5 @@ test("コメント内の N G obj パターンにマッチしない", async () =>
   assert(!result.ok);
   expect(result.error.code).toBe("OBJECT_PARSE_STREAM_LENGTH");
   expect(result.error.message).toContain("Cannot locate object");
+  expect(result.error.message).toContain("/Length resolution");
 });

--- a/packages/core/src/xref/stream/parse-xref-stream/index.ts
+++ b/packages/core/src/xref/stream/parse-xref-stream/index.ts
@@ -164,7 +164,12 @@ export async function resolveLocalLength(
   return err({
     code: "OBJECT_PARSE_STREAM_LENGTH",
     message: `/Length reference target object parse failed: ${lastError?.message ?? "unknown"}`,
-    offset: lastError?.offset ?? offsets[0] ?? ByteOffset.of(0),
+    offset:
+      (lastError !== undefined && "offset" in lastError
+        ? lastError.offset
+        : undefined) ??
+      offsets[0] ??
+      ByteOffset.of(0),
   });
 }
 

--- a/packages/core/src/xref/stream/parse-xref-stream/index.ts
+++ b/packages/core/src/xref/stream/parse-xref-stream/index.ts
@@ -164,7 +164,7 @@ export async function resolveLocalLength(
   return err({
     code: "OBJECT_PARSE_STREAM_LENGTH",
     message: `/Length reference target object parse failed: ${lastError?.message ?? "unknown"}`,
-    offset: offsets[0] ?? ByteOffset.of(0),
+    offset: lastError?.offset ?? offsets[0] ?? ByteOffset.of(0),
   });
 }
 

--- a/packages/core/src/xref/stream/parse-xref-stream/index.ts
+++ b/packages/core/src/xref/stream/parse-xref-stream/index.ts
@@ -144,7 +144,7 @@ export async function resolveLocalLength(
   if (offsets.length === 0) {
     return err({
       code: "OBJECT_PARSE_STREAM_LENGTH",
-      message: `Cannot locate object ${String(objectNumber)} ${String(generationNumber)} in data for /Length resolution`,
+      message: `/Length resolution: Cannot locate object ${String(objectNumber)} ${String(generationNumber)} in data`,
       offset: ByteOffset.of(0),
     });
   }

--- a/packages/core/src/xref/stream/parse-xref-stream/index.ts
+++ b/packages/core/src/xref/stream/parse-xref-stream/index.ts
@@ -171,9 +171,9 @@ export async function resolveLocalLength(
 /**
  * バイト列を走査して `{objNum} {genNum} obj` パターンに一致するオフセットを全て返す。
  *
- * @param _data - PDF ファイル全体のバイト配列
- * @param _objNum - 検索対象のオブジェクト番号
- * @param _genNum - 検索対象の世代番号
+ * @param data - PDF ファイル全体のバイト配列
+ * @param objNum - 検索対象のオブジェクト番号
+ * @param genNum - 検索対象の世代番号
  * @returns 一致した各候補のバイトオフセット配列（出現順）
  */
 export function scanForObjectOffsets(

--- a/packages/core/src/xref/stream/parse-xref-stream/index.ts
+++ b/packages/core/src/xref/stream/parse-xref-stream/index.ts
@@ -150,10 +150,10 @@ export async function resolveLocalLength(
   }
 
   let lastError: PdfError | undefined;
-  for (const candidateOffset of offsets.reverse()) {
+  for (let i = offsets.length - 1; i >= 0; i--) {
     const parseResult = await ObjectParser.parseIndirectObject(
       data,
-      candidateOffset,
+      offsets[i] as ByteOffset,
     );
     if (parseResult.ok) {
       return ok(parseResult.value.body);

--- a/packages/core/src/xref/stream/parse-xref-stream/index.ts
+++ b/packages/core/src/xref/stream/parse-xref-stream/index.ts
@@ -9,10 +9,14 @@
  * @module
  */
 
+import { isPdfTokenBoundary } from "../../../lexer/bytes/index";
 import { ObjectParser } from "../../../objects/object-parser/index";
 import type { PdfError } from "../../../pdf/errors/index";
-import type { ByteOffset } from "../../../pdf/types/byte-offset/index";
+import { ByteOffset } from "../../../pdf/types/byte-offset/index";
+import type { GenerationNumber } from "../../../pdf/types/generation-number/index";
 import type { TrailerDict, XRefTable } from "../../../pdf/types/index";
+import type { ObjectNumber } from "../../../pdf/types/object-number/index";
+import type { PdfObject } from "../../../pdf/types/pdf-types/index";
 import type { Result } from "../../../utils/result/index";
 import { err, ok } from "../../../utils/result/index";
 import { XRefStreamDict } from "../dict/index";
@@ -44,7 +48,16 @@ export async function parseXRefStream(
 ): Promise<
   Result<{ xref: XRefTable; trailer: TrailerDict | undefined }, PdfError>
 > {
-  const objectResult = await ObjectParser.parseIndirectObject(data, offset);
+  const resolver = (
+    objNum: ObjectNumber,
+    genNum: GenerationNumber,
+  ): Promise<Result<PdfObject, PdfError>> =>
+    resolveLocalLength(data, objNum, genNum);
+  const objectResult = await ObjectParser.parseIndirectObject(
+    data,
+    offset,
+    resolver,
+  );
   if (!objectResult.ok) {
     return objectResult;
   }
@@ -105,4 +118,103 @@ export async function parseXRefStream(
   }
 
   return ok({ xref: entriesResult.value, trailer: trailerResult.value });
+}
+
+/**
+ * バイト列全体を走査して指定オブジェクトを発見・パースし、body を返す。
+ * xref テーブル未構築段階で間接参照 `/Length` を解決するために使用する。
+ *
+ * @param data - PDF ファイル全体のバイト配列
+ * @param objectNumber - 解決対象のオブジェクト番号
+ * @param generationNumber - 解決対象の世代番号
+ * @returns 成功時は参照先オブジェクトの body、失敗時は `OBJECT_PARSE_STREAM_LENGTH` エラー
+ */
+export async function resolveLocalLength(
+  data: Uint8Array,
+  objectNumber: ObjectNumber,
+  generationNumber: GenerationNumber,
+): Promise<Result<PdfObject, PdfError>> {
+  const offsets = scanForObjectOffsets(
+    data,
+    objectNumber as number,
+    generationNumber as number,
+  );
+
+  if (offsets.length === 0) {
+    return err({
+      code: "OBJECT_PARSE_STREAM_LENGTH",
+      message: `Cannot locate object ${String(objectNumber)} ${String(generationNumber)} in data for /Length resolution`,
+      offset: ByteOffset.of(0),
+    });
+  }
+
+  let lastError: PdfError | undefined;
+  for (const candidateOffset of offsets.reverse()) {
+    const parseResult = await ObjectParser.parseIndirectObject(
+      data,
+      candidateOffset,
+    );
+    if (parseResult.ok) {
+      return ok(parseResult.value.body);
+    }
+    lastError = parseResult.error;
+  }
+
+  return err({
+    code: "OBJECT_PARSE_STREAM_LENGTH",
+    message: `/Length reference target object parse failed: ${lastError?.message ?? "unknown"}`,
+    offset: offsets[0] ?? ByteOffset.of(0),
+  });
+}
+
+/**
+ * バイト列を走査して `{objNum} {genNum} obj` パターンに一致するオフセットを全て返す。
+ *
+ * @param _data - PDF ファイル全体のバイト配列
+ * @param _objNum - 検索対象のオブジェクト番号
+ * @param _genNum - 検索対象の世代番号
+ * @returns 一致した各候補のバイトオフセット配列（出現順）
+ */
+export function scanForObjectOffsets(
+  data: Uint8Array,
+  objNum: number,
+  genNum: number,
+): ByteOffset[] {
+  const pattern = new TextEncoder().encode(
+    `${String(objNum)} ${String(genNum)} obj`,
+  );
+  const results: ByteOffset[] = [];
+
+  for (let i = 0; i <= data.length - pattern.length; i++) {
+    const prevByte = data[i - 1];
+    if (i > 0 && prevByte !== undefined && !isPdfTokenBoundary(prevByte)) {
+      continue;
+    }
+
+    let matched = true;
+    for (let j = 0; j < pattern.length; j++) {
+      if (data[i + j] !== pattern[j]) {
+        matched = false;
+        break;
+      }
+    }
+
+    if (!matched) {
+      continue;
+    }
+
+    const afterPattern = i + pattern.length;
+    const afterByte = data[afterPattern];
+    if (
+      afterPattern < data.length &&
+      afterByte !== undefined &&
+      !isPdfTokenBoundary(afterByte)
+    ) {
+      continue;
+    }
+
+    results.push(ByteOffset.of(i));
+  }
+
+  return results;
 }

--- a/packages/core/src/xref/stream/parse-xref-stream/index.ts
+++ b/packages/core/src/xref/stream/parse-xref-stream/index.ts
@@ -48,6 +48,7 @@ export async function parseXRefStream(
 ): Promise<
   Result<{ xref: XRefTable; trailer: TrailerDict | undefined }, PdfError>
 > {
+  /** @param objNum - オブジェクト番号 @param genNum - 世代番号 @returns 解決結果 */
   const resolver = (
     objNum: ObjectNumber,
     genNum: GenerationNumber,

--- a/packages/core/src/xref/stream/parse-xref-stream/index.ts
+++ b/packages/core/src/xref/stream/parse-xref-stream/index.ts
@@ -184,9 +184,25 @@ export function scanForObjectOffsets(
   const pattern = new TextEncoder().encode(
     `${String(objNum)} ${String(genNum)} obj`,
   );
+  const PERCENT = 0x25;
+  const LF = 0x0a;
+  const CR = 0x0d;
   const results: ByteOffset[] = [];
+  let inComment = false;
 
   for (let i = 0; i <= data.length - pattern.length; i++) {
+    const byte = data[i];
+    if (byte === PERCENT) {
+      inComment = true;
+      continue;
+    }
+    if (inComment) {
+      if (byte === LF || byte === CR) {
+        inComment = false;
+      }
+      continue;
+    }
+
     const prevByte = data[i - 1];
     if (i > 0 && prevByte !== undefined && !isPdfTokenBoundary(prevByte)) {
       continue;


### PR DESCRIPTION
## 概要

- `parseXRefStream` が `ObjectParser.parseIndirectObject` に `resolver` を渡していないため、xref ストリームの stream 辞書が間接参照の `/Length` を持つ場合に `OBJECT_PARSE_STREAM_LENGTH` で失敗するバグを修正
- xref テーブル未構築段階でもバイト列を直接スキャンして `/Length` の参照先オブジェクトを解決できるローカルスキャン方式の resolver（`resolveLocalLength` / `scanForObjectOffsets`）を導入

## 変更の種類

🐛 バグ修正

## 詳細な変更内容

### 追加
- `resolveLocalLength(data, objectNumber, generationNumber)` — data 全体を走査して `{objNum} {genNum} obj` パターンの全候補を列挙し、後方優先で `ObjectParser.parseIndirectObject` のパースを試行して body を返す
- `scanForObjectOffsets(data, objNum, genNum)` — token boundary を考慮したパターンマッチでオブジェクトヘッダのオフセットを全件列挙
- 正常系テスト 8 件 + エラー系テスト 5 件（`resolve-local-length.{basic,error}.test.ts`）
- 統合テスト 2 件（間接 `/Length` 正常デコード・参照先不在エラー）

### 変更
- `parseXRefStream` でインラインラムダ `(objNum, genNum) => resolveLocalLength(data, objNum, genNum)` を `ObjectParser.parseIndirectObject` の第 3 引数に渡すように変更

## システム図

```mermaid
flowchart TD
    A["parseXRefStream(data, offset)"] --> B["resolveLocalLength(data, objNum, genNum)"]
    B -->|"NEW"| C["scanForObjectOffsets(data, objNum, genNum)"]
    C -->|"全候補オフセット"| D{"候補あり?"}
    D -->|No| E["err(OBJECT_PARSE_STREAM_LENGTH)"]
    D -->|Yes| F["後方優先で ObjectParser.parseIndirectObject 試行"]
    F -->|parse成功| G["ok(body)"]
    F -->|全候補失敗| H["err(parse failed)"]
    A --> I["ObjectParser.parseIndirectObject(data, offset, resolver)"]
    I -->|"/Length が間接参照"| B

    style B fill:#d4edda,stroke:#28a745
    style C fill:#d4edda,stroke:#28a745
```

## 関連Issue

Refs #073

## テスト

- `pnpm --filter @pdfmod/core test` — 3281 テスト全件 pass
- 既存 decode テスト 5 件 + error テスト 6 件に回帰なし
- `pnpm --filter @pdfmod/core run typecheck` — 型チェックエラーなし

## レビューポイント

1. `scanForObjectOffsets` の token boundary チェック — `isPdfTokenBoundary` を使って `150 0 obj` が `50 0 obj` に誤マッチしないようガードしている点
2. `resolveLocalLength` の後方優先ロジック — 増分更新 PDF で同一オブジェクト番号が複数存在する場合に後方（新しい方）を優先する点
3. `parseXRefStream` の公開シグネチャは変更していない

## チェックリスト

- [x] セルフレビュー実施
- [x] テスト正常実行（3281 pass）
- [x] 型チェック通過
- [x] IssueがPRにLinked
- [x] 破壊的変更なし