### PR TITLE
✨ [New Feature]: #073 q/Q (save/restore graphics state) operator handler を production 実装に昇格

### DIFF
--- a/packages/core/src/content-stream/operators/graphics-state/graphics-state-operators/__tests__/graphics-state-operators.basic.test.ts
+++ b/packages/core/src/content-stream/operators/graphics-state/graphics-state-operators/__tests__/graphics-state-operators.basic.test.ts
@@ -8,6 +8,8 @@ test.each([
   ["J"],
   ["j"],
   ["M"],
+  ["q"],
+  ["Q"],
 ])("registerGraphicsStateOperators は %s を登録する", (name) => {
   const result = registerGraphicsStateOperators(OperatorRegistry.create());
   assert(result.ok);

--- a/packages/core/src/content-stream/operators/graphics-state/graphics-state-operators/__tests__/graphics-state-operators.integration.test.ts
+++ b/packages/core/src/content-stream/operators/graphics-state/graphics-state-operators/__tests__/graphics-state-operators.integration.test.ts
@@ -1,31 +1,14 @@
 import { assert, expect, test } from "vitest";
-import { ok } from "../../../../../utils/result/index";
 import {
   GraphicsState,
   GraphicsStateStack,
   Matrix,
 } from "../../../../graphics-state/index";
 import { ContentStreamInterpreter } from "../../../../interpreter/index";
-import {
-  type OperatorHandler,
-  OperatorRegistry,
-} from "../../../../operator-registry/index";
+import { OperatorRegistry } from "../../../../operator-registry/index";
 import { registerGraphicsStateOperators } from "../../graphics-state-operators";
 
 const encode = (s: string): Uint8Array => new TextEncoder().encode(s);
-
-const qHandler: OperatorHandler = (context) =>
-  ok({
-    ...context,
-    graphicsStateStack: GraphicsStateStack.save(context.graphicsStateStack),
-  });
-
-const qRestoreHandler: OperatorHandler = (context) =>
-  ok({
-    ...context,
-    graphicsStateStack: GraphicsStateStack.restore(context.graphicsStateStack)
-      .stack,
-  });
 
 test("barrel 経由で `1 0 0 1 100 200 cm 2 w` を実行すると CTM と lineWidth が更新される", () => {
   const registered = registerGraphicsStateOperators(OperatorRegistry.create());
@@ -45,18 +28,44 @@ test("barrel 経由で `1 0 0 1 100 200 cm 2 w` を実行すると CTM と lineW
 });
 
 test("`q 1 0 0 1 100 200 cm 2 w Q` を実行すると save/restore で初期 GraphicsState に戻る", () => {
-  const baseRegistered = registerGraphicsStateOperators(
-    OperatorRegistry.create(),
-  );
-  assert(baseRegistered.ok);
-  const withQ = OperatorRegistry.register(baseRegistered.value, "q", qHandler);
-  assert(withQ.ok);
-  const withQQ = OperatorRegistry.register(withQ.value, "Q", qRestoreHandler);
-  assert(withQQ.ok);
+  const registered = registerGraphicsStateOperators(OperatorRegistry.create());
+  assert(registered.ok);
 
   const result = ContentStreamInterpreter.execute({
     data: encode("q 1 0 0 1 100 200 cm 2 w Q"),
-    registry: withQQ.value,
+    registry: registered.value,
+  });
+
+  assert(result.ok);
+  const current = GraphicsStateStack.current(
+    result.value.context.graphicsStateStack,
+  );
+  expect(current).toEqual(GraphicsState.create());
+});
+
+test("3 段ネスト `q 2 w q 3 w q 4 w Q Q Q` で初期状態に復帰する", () => {
+  const registered = registerGraphicsStateOperators(OperatorRegistry.create());
+  assert(registered.ok);
+
+  const result = ContentStreamInterpreter.execute({
+    data: encode("q 2 w q 3 w q 4 w Q Q Q"),
+    registry: registered.value,
+  });
+
+  assert(result.ok);
+  const current = GraphicsStateStack.current(
+    result.value.context.graphicsStateStack,
+  );
+  expect(current).toEqual(GraphicsState.create());
+});
+
+test("unbalanced Q を interpreter 経由で実行しても ok で継続する", () => {
+  const registered = registerGraphicsStateOperators(OperatorRegistry.create());
+  assert(registered.ok);
+
+  const result = ContentStreamInterpreter.execute({
+    data: encode("Q"),
+    registry: registered.value,
   });
 
   assert(result.ok);

--- a/packages/core/src/content-stream/operators/graphics-state/graphics-state-operators/index.ts
+++ b/packages/core/src/content-stream/operators/graphics-state/graphics-state-operators/index.ts
@@ -8,12 +8,16 @@ import { lineCapHandler } from "../line-cap-handler";
 import { lineJoinHandler } from "../line-join-handler";
 import { lineWidthHandler } from "../line-width-handler";
 import { miterLimitHandler } from "../miter-limit-handler";
+import { qHandler } from "../q";
+import { qRestoreHandler } from "../q-restore";
 
 export { cmHandler } from "../cm";
 export { lineCapHandler } from "../line-cap-handler";
 export { lineJoinHandler } from "../line-join-handler";
 export { lineWidthHandler } from "../line-width-handler";
 export { miterLimitHandler } from "../miter-limit-handler";
+export { qHandler } from "../q";
+export { qRestoreHandler } from "../q-restore";
 
 const GRAPHICS_STATE_OPERATORS: ReadonlyArray<
   readonly [string, OperatorHandler]
@@ -23,6 +27,8 @@ const GRAPHICS_STATE_OPERATORS: ReadonlyArray<
   ["J", lineCapHandler],
   ["j", lineJoinHandler],
   ["M", miterLimitHandler],
+  ["q", qHandler],
+  ["Q", qRestoreHandler],
 ];
 
 /**

--- a/packages/core/src/content-stream/operators/graphics-state/graphics-state-operators/index.ts
+++ b/packages/core/src/content-stream/operators/graphics-state/graphics-state-operators/index.ts
@@ -32,7 +32,7 @@ const GRAPHICS_STATE_OPERATORS: ReadonlyArray<
 ];
 
 /**
- * Graphics State operator (cm / w / J / j / M) を OperatorRegistry に
+ * Graphics State operator (cm / w / J / j / M / q / Q) を OperatorRegistry に
  * 一括登録するヘルパ。
  *
  * fail-fast: いずれかの register が Err を返した時点で reduce 内 flatMap が

--- a/packages/core/src/content-stream/operators/graphics-state/q-restore/__tests__/q-restore.basic.test.ts
+++ b/packages/core/src/content-stream/operators/graphics-state/q-restore/__tests__/q-restore.basic.test.ts
@@ -1,0 +1,103 @@
+import { assert, expect, test } from "vitest";
+import type { PdfObject } from "../../../../../pdf/types/pdf-types/index";
+import {
+  GraphicsState,
+  GraphicsStateStack,
+} from "../../../../graphics-state/index";
+import { MarkedContentStack } from "../../../../marked-content/stack";
+import { OperandStack } from "../../../../operand-stack/index";
+import type { OperatorHandlerContext } from "../../../../operator-registry/index";
+import { qRestoreHandler } from "../../q-restore";
+
+const buildContext = (): OperatorHandlerContext => {
+  const operandStack = OperandStack.create();
+  const graphicsStateStack = GraphicsStateStack.create();
+  return {
+    operandStack,
+    graphicsStateStack,
+    markedContentStack: MarkedContentStack.create(),
+  };
+};
+
+test("Q 実行後に直前の saved state が current に復帰する", () => {
+  const ctx = buildContext();
+  const initialCurrent = GraphicsStateStack.current(ctx.graphicsStateStack);
+
+  const savedStack = GraphicsStateStack.save(ctx.graphicsStateStack);
+  const modified = GraphicsStateStack.replaceCurrent(
+    savedStack,
+    GraphicsState.update(GraphicsStateStack.current(savedStack), {
+      lineWidth: 42,
+    }),
+  );
+
+  const result = qRestoreHandler({
+    ...ctx,
+    graphicsStateStack: modified,
+  });
+
+  assert(result.ok);
+  const restoredCurrent = GraphicsStateStack.current(
+    result.value.graphicsStateStack,
+  );
+  expect(restoredCurrent).toEqual(initialCurrent);
+});
+
+test("Q 実行後に saved から 1 つ pop される", () => {
+  const ctx = buildContext();
+  const savedStack = GraphicsStateStack.save(ctx.graphicsStateStack);
+
+  const result = qRestoreHandler({
+    ...ctx,
+    graphicsStateStack: savedStack,
+  });
+
+  assert(result.ok);
+  expect(result.value.graphicsStateStack.saved).toHaveLength(0);
+});
+
+test("Q 実行後も operandStack は同一参照のまま", () => {
+  const ctx = buildContext();
+  const savedStack = GraphicsStateStack.save(ctx.graphicsStateStack);
+
+  const result = qRestoreHandler({
+    ...ctx,
+    graphicsStateStack: savedStack,
+  });
+
+  assert(result.ok);
+  expect(result.value.operandStack).toBe(ctx.operandStack);
+});
+
+test("Q 実行後も markedContentStack は同一参照のまま", () => {
+  const ctx = buildContext();
+  const savedStack = GraphicsStateStack.save(ctx.graphicsStateStack);
+
+  const result = qRestoreHandler({
+    ...ctx,
+    graphicsStateStack: savedStack,
+  });
+
+  assert(result.ok);
+  expect(result.value.markedContentStack).toBe(ctx.markedContentStack);
+});
+
+test("非空 operandStack で Q を実行しても operand が消費されない", () => {
+  const ctx = buildContext();
+  const operand1: PdfObject = { type: "integer", value: 10 };
+  const operand2: PdfObject = { type: "integer", value: 20 };
+  OperandStack.push(ctx.operandStack, operand1);
+  OperandStack.push(ctx.operandStack, operand2);
+  const savedStack = GraphicsStateStack.save(ctx.graphicsStateStack);
+
+  const result = qRestoreHandler({
+    ...ctx,
+    graphicsStateStack: savedStack,
+  });
+
+  assert(result.ok);
+  expect(OperandStack.depth(result.value.operandStack)).toBe(2);
+  const top = OperandStack.peek(result.value.operandStack);
+  assert(top.some);
+  expect(top.value).toEqual(operand2);
+});

--- a/packages/core/src/content-stream/operators/graphics-state/q-restore/__tests__/q-restore.unbalanced.test.ts
+++ b/packages/core/src/content-stream/operators/graphics-state/q-restore/__tests__/q-restore.unbalanced.test.ts
@@ -1,0 +1,99 @@
+import { assert, expect, test } from "vitest";
+import type { PdfObject } from "../../../../../pdf/types/pdf-types/index";
+import { GraphicsStateStack } from "../../../../graphics-state/index";
+import { MarkedContentStack } from "../../../../marked-content/stack";
+import { OperandStack } from "../../../../operand-stack/index";
+import type { OperatorHandlerContext } from "../../../../operator-registry/index";
+import { qRestoreHandler } from "../../q-restore";
+
+const buildContext = (): OperatorHandlerContext => {
+  const operandStack = OperandStack.create();
+  const graphicsStateStack = GraphicsStateStack.create();
+  return {
+    operandStack,
+    graphicsStateStack,
+    markedContentStack: MarkedContentStack.create(),
+  };
+};
+
+test("saved が空のときに Q を実行しても ok を返す", () => {
+  const ctx = buildContext();
+
+  const result = qRestoreHandler(ctx);
+
+  assert(result.ok);
+});
+
+test("saved が空のときに Q を実行しても current は変更されない", () => {
+  const ctx = buildContext();
+  const beforeCurrent = GraphicsStateStack.current(ctx.graphicsStateStack);
+
+  const result = qRestoreHandler(ctx);
+
+  assert(result.ok);
+  const afterCurrent = GraphicsStateStack.current(
+    result.value.graphicsStateStack,
+  );
+  expect(afterCurrent).toEqual(beforeCurrent);
+});
+
+test("q 1 回 → Q 2 回で 2 回目の Q も ok を返す", () => {
+  const ctx = buildContext();
+  const initialCurrent = GraphicsStateStack.current(ctx.graphicsStateStack);
+
+  const savedStack = GraphicsStateStack.save(ctx.graphicsStateStack);
+  const firstQ = qRestoreHandler({ ...ctx, graphicsStateStack: savedStack });
+  assert(firstQ.ok);
+
+  const secondQ = qRestoreHandler({
+    ...ctx,
+    graphicsStateStack: firstQ.value.graphicsStateStack,
+  });
+  assert(secondQ.ok);
+
+  const finalCurrent = GraphicsStateStack.current(
+    secondQ.value.graphicsStateStack,
+  );
+  expect(finalCurrent).toEqual(initialCurrent);
+});
+
+test("Q を連続 3 回実行しても毎回 ok を返し current が不変", () => {
+  const ctx = buildContext();
+  const initialCurrent = GraphicsStateStack.current(ctx.graphicsStateStack);
+
+  let currentCtx: OperatorHandlerContext = ctx;
+  for (let i = 0; i < 3; i++) {
+    const result = qRestoreHandler(currentCtx);
+    assert(result.ok);
+    currentCtx = {
+      ...currentCtx,
+      graphicsStateStack: result.value.graphicsStateStack,
+    };
+  }
+
+  const finalCurrent = GraphicsStateStack.current(
+    currentCtx.graphicsStateStack,
+  );
+  expect(finalCurrent).toEqual(initialCurrent);
+});
+
+test("連続 Q 実行後も operandStack が消費されない", () => {
+  const ctx = buildContext();
+  const operand1: PdfObject = { type: "integer", value: 10 };
+  const operand2: PdfObject = { type: "integer", value: 20 };
+  OperandStack.push(ctx.operandStack, operand1);
+  OperandStack.push(ctx.operandStack, operand2);
+
+  const first = qRestoreHandler(ctx);
+  assert(first.ok);
+  const second = qRestoreHandler({
+    ...ctx,
+    graphicsStateStack: first.value.graphicsStateStack,
+  });
+  assert(second.ok);
+
+  expect(OperandStack.depth(second.value.operandStack)).toBe(2);
+  const top = OperandStack.peek(second.value.operandStack);
+  assert(top.some);
+  expect(top.value).toEqual(operand2);
+});

--- a/packages/core/src/content-stream/operators/graphics-state/q-restore/index.ts
+++ b/packages/core/src/content-stream/operators/graphics-state/q-restore/index.ts
@@ -1,0 +1,32 @@
+import { ok } from "../../../../utils/result/index";
+import { GraphicsStateStack } from "../../../graphics-state/index";
+import type {
+  OperatorHandler,
+  OperatorHandlerContext,
+} from "../../../operator-registry/index";
+
+/**
+ * PDF §8.4.4 `Q` operator (restore graphics state) のハンドラ。
+ *
+ * saved スタックから直前の GraphicsState を pop して current に復帰する。
+ * operand は取らない。常に ok を返す。
+ *
+ * saved が空の場合（unbalanced restore）は `GraphicsStateStack.restore` が
+ * current 維持の新 stack を返すため、handler も no-op 相当で ok を返す。
+ * `RestoreResult.warning` は現時点では handler レベルで伝搬しない。
+ * 将来、interpreter の warnings 配列に追加する拡張が検討される可能性がある。
+ *
+ * @param context - 実行コンテキスト
+ * @returns 更新後コンテキスト (常に ok)
+ */
+export const qRestoreHandler: OperatorHandler = (
+  context: OperatorHandlerContext,
+) => {
+  const restoreResult = GraphicsStateStack.restore(context.graphicsStateStack);
+
+  return ok({
+    operandStack: context.operandStack,
+    graphicsStateStack: restoreResult.stack,
+    markedContentStack: context.markedContentStack,
+  });
+};

--- a/packages/core/src/content-stream/operators/graphics-state/q/__tests__/q.basic.test.ts
+++ b/packages/core/src/content-stream/operators/graphics-state/q/__tests__/q.basic.test.ts
@@ -1,0 +1,80 @@
+import { assert, expect, test } from "vitest";
+import type { PdfObject } from "../../../../../pdf/types/pdf-types/index";
+import {
+  GraphicsState,
+  GraphicsStateStack,
+} from "../../../../graphics-state/index";
+import { MarkedContentStack } from "../../../../marked-content/stack";
+import { OperandStack } from "../../../../operand-stack/index";
+import type { OperatorHandlerContext } from "../../../../operator-registry/index";
+import { qHandler } from "../../q";
+
+const buildContext = (): OperatorHandlerContext => {
+  const operandStack = OperandStack.create();
+  const graphicsStateStack = GraphicsStateStack.create();
+  return {
+    operandStack,
+    graphicsStateStack,
+    markedContentStack: MarkedContentStack.create(),
+  };
+};
+
+test("q 実行後に saved に current がプッシュされる", () => {
+  const ctx = buildContext();
+  const beforeCurrent = GraphicsStateStack.current(ctx.graphicsStateStack);
+
+  const result = qHandler(ctx);
+
+  assert(result.ok);
+  const afterStack = result.value.graphicsStateStack;
+  const saved = afterStack.saved;
+  expect(saved).toHaveLength(1);
+  expect(saved[0]).toEqual(beforeCurrent);
+});
+
+test("q 実行後の current は実行前と同じ state", () => {
+  const ctx = buildContext();
+  const beforeCurrent = GraphicsStateStack.current(ctx.graphicsStateStack);
+
+  const result = qHandler(ctx);
+
+  assert(result.ok);
+  const afterCurrent = GraphicsStateStack.current(
+    result.value.graphicsStateStack,
+  );
+  expect(afterCurrent).toEqual(beforeCurrent);
+});
+
+test("q 実行後も operandStack は同一参照のまま", () => {
+  const ctx = buildContext();
+
+  const result = qHandler(ctx);
+
+  assert(result.ok);
+  expect(result.value.operandStack).toBe(ctx.operandStack);
+});
+
+test("q 実行後も markedContentStack は同一参照のまま", () => {
+  const ctx = buildContext();
+
+  const result = qHandler(ctx);
+
+  assert(result.ok);
+  expect(result.value.markedContentStack).toBe(ctx.markedContentStack);
+});
+
+test("非空 operandStack で q を実行しても operand が消費されない", () => {
+  const ctx = buildContext();
+  const operand1: PdfObject = { type: "integer", value: 10 };
+  const operand2: PdfObject = { type: "integer", value: 20 };
+  OperandStack.push(ctx.operandStack, operand1);
+  OperandStack.push(ctx.operandStack, operand2);
+
+  const result = qHandler(ctx);
+
+  assert(result.ok);
+  expect(OperandStack.depth(result.value.operandStack)).toBe(2);
+  const top = OperandStack.peek(result.value.operandStack);
+  assert(top.some);
+  expect(top.value).toEqual(operand2);
+});

--- a/packages/core/src/content-stream/operators/graphics-state/q/__tests__/q.basic.test.ts
+++ b/packages/core/src/content-stream/operators/graphics-state/q/__tests__/q.basic.test.ts
@@ -1,9 +1,6 @@
 import { assert, expect, test } from "vitest";
 import type { PdfObject } from "../../../../../pdf/types/pdf-types/index";
-import {
-  GraphicsState,
-  GraphicsStateStack,
-} from "../../../../graphics-state/index";
+import { GraphicsStateStack } from "../../../../graphics-state/index";
 import { MarkedContentStack } from "../../../../marked-content/stack";
 import { OperandStack } from "../../../../operand-stack/index";
 import type { OperatorHandlerContext } from "../../../../operator-registry/index";

--- a/packages/core/src/content-stream/operators/graphics-state/q/index.ts
+++ b/packages/core/src/content-stream/operators/graphics-state/q/index.ts
@@ -1,0 +1,27 @@
+import { ok } from "../../../../utils/result/index";
+import { GraphicsStateStack } from "../../../graphics-state/index";
+import type {
+  OperatorHandler,
+  OperatorHandlerContext,
+} from "../../../operator-registry/index";
+
+/**
+ * PDF §8.4.4 `q` operator (save graphics state) のハンドラ。
+ *
+ * 現在の GraphicsState を saved スタックに push する。
+ * operand は取らない。常に ok を返す。
+ *
+ * @param context - 実行コンテキスト
+ * @returns 更新後コンテキスト (常に ok)
+ */
+export const qHandler: OperatorHandler = (context: OperatorHandlerContext) => {
+  const graphicsStateStack = GraphicsStateStack.save(
+    context.graphicsStateStack,
+  );
+
+  return ok({
+    operandStack: context.operandStack,
+    graphicsStateStack,
+    markedContentStack: context.markedContentStack,
+  });
+};

--- a/packages/core/src/content-stream/operators/xobject/xobject-operators/__tests__/xobject-operators.integration.test.ts
+++ b/packages/core/src/content-stream/operators/xobject/xobject-operators/__tests__/xobject-operators.integration.test.ts
@@ -1,13 +1,9 @@
 import { assert, expect, test } from "vitest";
-import { flatMap, ok } from "../../../../../utils/result/index";
-import { GraphicsStateStack } from "../../../../graphics-state/index";
+import { flatMap } from "../../../../../utils/result/index";
 import type { ContentStreamInterpreterResult } from "../../../../interpreter/index";
 import { ContentStreamInterpreter } from "../../../../interpreter/index";
 import { OperandStack } from "../../../../operand-stack/index";
-import type {
-  OperatorHandler,
-  OperatorHandlerContext,
-} from "../../../../operator-registry/index";
+import type { OperatorHandlerContext } from "../../../../operator-registry/index";
 import { OperatorRegistry } from "../../../../operator-registry/index";
 import { registerGraphicsStateOperators } from "../../../graphics-state/graphics-state-operators/index";
 import { registerTextStateOperators } from "../../../text/text-state-operators/index";
@@ -15,25 +11,6 @@ import { registerXObjectOperators } from "../index";
 
 const encode = (s: string): Uint8Array => new TextEncoder().encode(s);
 
-// NOTE: q (gsave) / Q (grestore) operator は現状コードベース全体で未実装のため、
-// integration テスト用に inline 定義する。本実装されたら inline 定義は削除し、
-// 対応する register*Operators 経由の登録に置き換える。
-const qHandler: OperatorHandler = (context) =>
-  ok({
-    ...context,
-    graphicsStateStack: GraphicsStateStack.save(context.graphicsStateStack),
-  });
-
-const qRestoreHandler: OperatorHandler = (context) =>
-  ok({
-    ...context,
-    graphicsStateStack: GraphicsStateStack.restore(context.graphicsStateStack)
-      .stack,
-  });
-
-// XObject + text-state + graphics-state (cm/w/J/j/M) + inline q/Q を併用登録した registry を作るヘルパ。
-// graphics-state barrel は q/Q を含まないため inline 定義との衝突は無い。
-// 登録失敗は assert で即座に検出する。
 const createRegistry = (): OperatorRegistry => {
   const withXObject = registerXObjectOperators(OperatorRegistry.create());
   const withTextState = flatMap(withXObject, registerTextStateOperators);
@@ -41,14 +18,8 @@ const createRegistry = (): OperatorRegistry => {
     withTextState,
     registerGraphicsStateOperators,
   );
-  const withQ = flatMap(withGraphicsState, (r) =>
-    OperatorRegistry.register(r, "q", qHandler),
-  );
-  const withQQ = flatMap(withQ, (r) =>
-    OperatorRegistry.register(r, "Q", qRestoreHandler),
-  );
-  assert(withQQ.ok);
-  return withQQ.value;
+  assert(withGraphicsState.ok);
+  return withGraphicsState.value;
 };
 
 // 正常系用: content stream を実行し成功結果を返すヘルパ（失敗時は assert で即座に検出）。


### PR DESCRIPTION
## 概要

テスト内 mock として 2 箇所に重複定義されていた `q`（save graphics state）と `Q`（restore graphics state）の handler を production 実装に昇格。`registerGraphicsStateOperators` に登録し、テスト側の重複 mock 定義を削除した。ISO 32000-1:2008 §8.4.4 準拠。

## 🎯 変更の種類

- [x] ✨ 新機能 (New feature)
- [x] ♻️ リファクタリング (Refactoring)
- [x] 🚨 テスト追加/修正 (Tests)

## 📝 詳細な変更内容

### 追加された機能・修正

- `qHandler`: `GraphicsStateStack.save` で current state を saved に push。operand なし、常に ok
- `qRestoreHandler`: `GraphicsStateStack.restore` で直前の saved state を current に復帰。unbalanced 時も ok（warning は handler レベルで伝搬しない）
- 返却値は 3 フィールド明示展開（`operandStack`, `graphicsStateStack`, `markedContentStack`）— スプレッド不使用
- `GRAPHICS_STATE_OPERATORS` 配列に `["q", qHandler]`, `["Q", qRestoreHandler]` を追加
- 3 段ネスト `q 2 w q 3 w q 4 w Q Q Q` の統合テスト
- unbalanced Q の統合テスト

### 変更されたファイル

- `graphics-state-operators/index.ts` — q/Q の import, re-export, 配列エントリ追加
- `graphics-state-operators.basic.test.ts` — test.each に `"q"` / `"Q"` 追加
- `graphics-state-operators.integration.test.ts` — inline mock 削除、registry 構築を簡素化、統合テスト追加
- `xobject-operators.integration.test.ts` — inline mock・NOTE コメント削除、createRegistry を簡素化

### 削除されたファイル・機能

- `graphics-state-operators.integration.test.ts` の inline `qHandler` / `qRestoreHandler` 定義
- `xobject-operators.integration.test.ts` の inline `qHandler` / `qRestoreHandler` 定義と NOTE コメント
- 手動 `OperatorRegistry.register` による q/Q 個別登録ステップ（withQ / withQQ）

## 📊 システム図

```mermaid
flowchart TD
    CS["Content Stream<br/>q 2 w q 3 w q 4 w Q Q Q"] --> I[ContentStreamInterpreter]
    I -->|"lookup('q')"| QH["qHandler [NEW]"]
    I -->|"lookup('Q')"| QRH["qRestoreHandler [NEW]"]
    I -->|"lookup('w')"| WH[lineWidthHandler]

    QH --> GSS_SAVE["GraphicsStateStack.save()"]
    QRH --> GSS_RESTORE["GraphicsStateStack.restore()"]
    GSS_RESTORE -->|".stack のみ取得<br/>warning 無視"| QRH

    REG["GRAPHICS_STATE_OPERATORS [CHANGED]"] -->|"cm, w, J, j, M, q, Q"| RGS[registerGraphicsStateOperators]

    classDef new fill:#d4edda,stroke:#28a745,stroke-width:2px
    classDef changed fill:#fff3cd,stroke:#ffc107,stroke-width:2px
    class QH,QRH new
    class REG changed
```

## 📋 関連 Issue

- Refs #073
- 親 Epic: #483

## 🧪 テスト

### テスト実行方法

```bash
pnpm --filter @pdfmod/core test
pnpm --filter @pdfmod/core build
```

### テスト項目

- [x] 単体テスト (Unit tests) — q.basic / q-restore.basic / q-restore.unbalanced
- [x] 統合テスト (Integration tests) — 3 段ネスト q/Q, unbalanced Q via interpreter

### テスト結果

- 全 3300 テスト green
- ビルド成功（型エラーなし）

## 🔍 レビューポイント

- `qRestoreHandler` が `RestoreResult.warning` を無視する設計判断（JSDoc に将来拡張余地を記載）
- 返却値の 3 フィールド明示展開（mock のスプレッド構文との差異）
- 既存テストへのリグレッションがないこと

## ⚠️ 破壊的変更

- [ ] この変更は既存の API に破壊的変更を含みます

## ✅ チェックリスト

- [x] コードレビューの準備ができている
- [x] テストが正常に実行される
- [x] コミットメッセージが適切な形式で書かれている
- [x] 関連する Issue が PR の「Development」に Linked されている
- [x] PR 本文に `Refs #` で Issue が記載されている
- [x] セルフレビューを実施した