### PR TITLE
🚨 [Tests]: #505 Tf ハンドラの fontSize 境界値テスト追加

### DIFF
--- a/packages/core/src/content-stream/operators/text/tf/__tests__/tf.basic.test.ts
+++ b/packages/core/src/content-stream/operators/text/tf/__tests__/tf.basic.test.ts
@@ -122,19 +122,11 @@ test.each<[string, PdfObject, number]>([
     { type: "real", value: Number.POSITIVE_INFINITY },
     Number.POSITIVE_INFINITY,
   ],
-])(
-  "境界値 '%s' の fontSize も値域検証せず textState.fontSize に格納する",
-  (_label, sizeOperand, expected) => {
-    const ctx = buildContext([
-      { type: "name", value: "F1" },
-      sizeOperand,
-    ]);
-    const result = tfHandler(ctx);
+])("境界値 '%s' の fontSize も値域検証せず textState.fontSize に格納する", (_label, sizeOperand, expected) => {
+  const ctx = buildContext([{ type: "name", value: "F1" }, sizeOperand]);
+  const result = tfHandler(ctx);
 
-    assert(result.ok);
-    const current = GraphicsStateStack.current(
-      result.value.graphicsStateStack,
-    );
-    expect(current.textState.fontSize).toBe(expected);
-  },
-);
+  assert(result.ok);
+  const current = GraphicsStateStack.current(result.value.graphicsStateStack);
+  expect(current.textState.fontSize).toBe(expected);
+});

--- a/packages/core/src/content-stream/operators/text/tf/__tests__/tf.basic.test.ts
+++ b/packages/core/src/content-stream/operators/text/tf/__tests__/tf.basic.test.ts
@@ -112,3 +112,29 @@ test("余剰 operand は残り、Tf は末尾 2 個のみ消費する", () => {
   assert(top.some);
   expect(top.value).toEqual(surplus);
 });
+
+test.each<[string, PdfObject, number]>([
+  ["0", { type: "integer", value: 0 }, 0],
+  ["負値", { type: "real", value: -1.5 }, -1.5],
+  ["NaN", { type: "real", value: Number.NaN }, Number.NaN],
+  [
+    "Infinity",
+    { type: "real", value: Number.POSITIVE_INFINITY },
+    Number.POSITIVE_INFINITY,
+  ],
+])(
+  "境界値 '%s' の fontSize も値域検証せず textState.fontSize に格納する",
+  (_label, sizeOperand, expected) => {
+    const ctx = buildContext([
+      { type: "name", value: "F1" },
+      sizeOperand,
+    ]);
+    const result = tfHandler(ctx);
+
+    assert(result.ok);
+    const current = GraphicsStateStack.current(
+      result.value.graphicsStateStack,
+    );
+    expect(current.textState.fontSize).toBe(expected);
+  },
+);


### PR DESCRIPTION
## 概要

Tf ハンドラの fontSize に対する境界値透過テスト（0, 負値, NaN, +Infinity）を `tf.basic.test.ts` に追記し、tc/tl/tw との一貫性を回復する。

## 変更内容

### 🎯 変更の種類

- [x] 🚨 テスト追加/修正 (Tests)

### 📝 詳細な変更内容

#### 追加された機能・修正

- `tf.basic.test.ts` 末尾に `test.each<[string, PdfObject, number]>` ブロックを追加
  - fontSize=0（ゼロサイズ）: `{ type: "integer", value: 0 }`
  - fontSize=負値（-1.5）: `{ type: "real", value: -1.5 }`
  - fontSize=NaN: `{ type: "real", value: Number.NaN }`
  - fontSize=+Infinity: `{ type: "real", value: Number.POSITIVE_INFINITY }`
- font オペランドは `{ type: "name", value: "F1" }` で固定し、size のみ変動

#### 変更されたファイル

- `packages/core/src/content-stream/operators/text/tf/__tests__/tf.basic.test.ts`（26行追加）

#### 削除されたファイル・機能

- なし

## 📊 システム図

```mermaid
flowchart TD
    A["Operands: [font, size]"] --> B["Pop size"]
    B --> C{"NumericPdfObject.is(size)?"}
    C -->|No| ERR1["Error: size not numeric"]
    C -->|Yes| D["Pop font"]
    D --> E{"PdfName.is(font)?"}
    E -->|No| ERR2["Error: font not name"]
    E -->|Yes| F["Update textState"]
    F --> G["fontSize = size.value"]
    G --> H["fontName = Some(font.value)"]
    H --> I["Replace current GraphicsState"]
    I --> J["Result.ok"]

    style G fill:#ffe4b5,stroke:#d97706,stroke-width:2px
    style C fill:#e8f4e8,stroke:#2d8a2d
```

> 黄色のノード: 今回のテストで検証するポイント（境界値がそのまま格納される）
> 緑色のノード: 型チェックのみ、値域検証なし

## 📋 関連 Issue

- Closes #505

## 🧪 テスト

### テスト実行方法

```bash
pnpm --filter @pdfmod/core test -- tf.basic
```

### テスト項目

- [x] 単体テスト (Unit tests)

### テスト結果

- 全 3304 テストパス（tf.basic.test.ts: 10テスト = 既存6 + 追加4）
- tf.error.test.ts: 12テスト（影響なし）
- Codex CLI レビュー: Findings なし

## 🔍 レビューポイント

- tc/tl/tw の境界値テストと同じタプル形式・命名パターンに従っているか
- NaN を test.each 内に含めている（tz の分離パターンは不採用）
- Negative Infinity を含めていない（text state ハンドラ群との一貫性）

## ⚠️ 破壊的変更

- [ ] この変更は既存の API に破壊的変更を含みます

## ✅ チェックリスト

- [x] コードレビューの準備ができている
- [x] テストが正常に実行される
- [x] ドキュメントが更新されている（必要に応じて）
- [x] コミットメッセージが適切な形式で書かれている
- [x] 関連する Issue が PR の「Development」に Linked されている
- [x] PR 本文に `Closes #` / `Fixes #` / `Refs #` などで Issue が記載されている
- [x] セルフレビューを実施した
- [x] 破壊的変更がある場合は明記されている