### PR TITLE
🐛 [Bug Fix]: #550 xref fallback 時に失われる /Encrypt を検出し暗号化 PDF のすり抜けを塞ぐ

### DIFF
--- a/packages/core/src/document/pdf-document/__tests__/pdf-document.test.helpers.ts
+++ b/packages/core/src/document/pdf-document/__tests__/pdf-document.test.helpers.ts
@@ -777,3 +777,112 @@ export const buildPdfWithEncryptDict = (): Uint8Array =>
     [CATALOG_BODY, PAGES_BODY_SINGLE, PAGE_BODY, ENCRYPT_DICT_BODY],
     ["/Encrypt 4 0 R"],
   );
+
+/**
+ * `/Filter /FlateDecode` を宣言しながら zlib として展開できないストリームデータ。
+ * xref ストリームの解析を必ず失敗させ、fallback scan 経路へ落とすために使う。
+ */
+const BROKEN_FLATE_STREAM_BYTE = 0xff;
+const BROKEN_FLATE_STREAM_LENGTH = 4;
+const BROKEN_FLATE_STREAM_DATA = new Uint8Array(
+  BROKEN_FLATE_STREAM_LENGTH,
+).fill(BROKEN_FLATE_STREAM_BYTE);
+
+/** {@link buildBrokenXRefStreamPdf} が `/Encrypt` から参照する暗号化辞書のオブジェクト番号。 */
+const BROKEN_XREF_STREAM_ENCRYPT_OBJECT_NUMBER = 4;
+
+/**
+ * `/Type /XRef` を持つがストリームデータを展開できない xref ストリームを唯一の
+ * xref 構造として持つ PDF を生成する。
+ *
+ * `startxref` は xref ストリームを指すが、`/Filter /FlateDecode` の宣言に反して
+ * ストリームデータが zlib ではないため `parseXRefStream` が失敗し、
+ * `PdfDocument.load` は `scanFallback` 経路（生バイト走査による xref 再構築）へ落ちる。
+ * この経路は失敗した xref ストリームの辞書を解析しないため、`/Encrypt` の検出は
+ * fallback スキャナのバイト走査に委ねられる。
+ *
+ * `includeTextTrailer` を立てると、`/Encrypt` を持たないテキスト形式 trailer を
+ * xref ストリームの後ろに置く。fallback スキャナはこの trailer を直接採用する経路
+ * （FB-002）に入るため、xref ストリーム辞書側の `/Encrypt` を拾えるかを検証できる。
+ *
+ * @param options - `includeEncrypt`: xref ストリーム辞書に `/Encrypt` と参照先の暗号化辞書を含めるか。
+ *   `includeTextTrailer`: `/Encrypt` を持たないテキスト trailer を併置するか
+ * @returns 解析不能な xref ストリームを持つ PDF バイト列
+ */
+const buildBrokenXRefStreamPdf = (options: {
+  readonly includeEncrypt: boolean;
+  readonly includeTextTrailer?: boolean;
+}): Uint8Array => {
+  const encoder = new TextEncoder();
+  const baseBodies = [CATALOG_BODY, PAGES_BODY_SINGLE, PAGE_BODY];
+  const objectBodies = options.includeEncrypt
+    ? [...baseBodies, ENCRYPT_DICT_BODY]
+    : baseBodies;
+  const objs = formatIndirectObjects(objectBodies);
+
+  let cursor = encoder.encode(PDF_HEADER).length;
+  for (const obj of objs) {
+    cursor += encoder.encode(obj).length;
+  }
+  const xrefStreamObjNum = objectBodies.length + 1;
+  const xrefStreamOffset = cursor;
+
+  const size = xrefStreamObjNum + 1;
+  const encryptEntry = options.includeEncrypt
+    ? ` /Encrypt ${BROKEN_XREF_STREAM_ENCRYPT_OBJECT_NUMBER} 0 R`
+    : "";
+  const dict =
+    `<< /Type /XRef /Filter /FlateDecode /W [${XREF_STREAM_W.join(" ")}] ` +
+    `/Size ${size} /Root 1 0 R${encryptEntry} ` +
+    `/Length ${BROKEN_FLATE_STREAM_DATA.length} >>`;
+
+  const textTrailer =
+    options.includeTextTrailer === true
+      ? `trailer\n<< /Size ${size} /Root 1 0 R >>\n`
+      : "";
+
+  return concatUint8Arrays([
+    encoder.encode(PDF_HEADER),
+    ...objs.map((o) => encoder.encode(o)),
+    encoder.encode(`${xrefStreamObjNum} 0 obj\n${dict}\nstream\n`),
+    BROKEN_FLATE_STREAM_DATA,
+    encoder.encode("\nendstream\nendobj\n"),
+    encoder.encode(textTrailer),
+    encoder.encode(`startxref\n${xrefStreamOffset}\n%%EOF\n`),
+  ]);
+};
+
+/**
+ * 解析不能な xref ストリームの辞書に `/Encrypt` を持つ暗号化 PDF を生成する。
+ *
+ * fallback scan 経路でも xref ストリーム辞書の `/Encrypt` が拾われ、
+ * `PdfDocument.load` が `ENCRYPTED_PDF_UNSUPPORTED` を返すことを検証する fixture。
+ *
+ * @returns `/Encrypt` を持つ解析不能な xref ストリーム PDF のバイト列
+ */
+export const buildXRefStreamPdfWithEncrypt = (): Uint8Array =>
+  buildBrokenXRefStreamPdf({ includeEncrypt: true });
+
+/**
+ * 解析不能な xref ストリームを持つが `/Encrypt` は持たない非暗号化 PDF を生成する。
+ *
+ * {@link buildXRefStreamPdfWithEncrypt} の対照 fixture。fallback scan 経路が
+ * `/Encrypt` 不在の PDF を暗号化と誤判定せず、従来どおり読み込めることを検証する。
+ *
+ * @returns `/Encrypt` を持たない解析不能な xref ストリーム PDF のバイト列
+ */
+export const buildXRefStreamPdfWithoutEncrypt = (): Uint8Array =>
+  buildBrokenXRefStreamPdf({ includeEncrypt: false });
+
+/**
+ * 解析不能な xref ストリームの辞書に `/Encrypt` を持ちつつ、`/Encrypt` を持たない
+ * テキスト形式 trailer も併置した暗号化 PDF を生成する。
+ *
+ * fallback scan がテキスト trailer をそのまま採用する経路（FB-002）でも
+ * xref ストリーム辞書の `/Encrypt` が拾われ、`ENCRYPTED_PDF_UNSUPPORTED` を返す
+ * ことを検証する fixture。テキスト trailer だけを信じると暗号化検出をすり抜ける。
+ *
+ * @returns テキスト trailer と `/Encrypt` 付き xref ストリームを併せ持つ PDF バイト列
+ */
+export const buildXRefStreamPdfWithEncryptAndTextTrailer = (): Uint8Array =>
+  buildBrokenXRefStreamPdf({ includeEncrypt: true, includeTextTrailer: true });

--- a/packages/core/src/document/pdf-document/__tests__/pdf-document.xref-formats.test.ts
+++ b/packages/core/src/document/pdf-document/__tests__/pdf-document.xref-formats.test.ts
@@ -5,6 +5,9 @@ import {
   buildPdfWithEncryptDict,
   buildPdfWithHybridXRefStm,
   buildPdfWithWrongTypeXRefStream,
+  buildXRefStreamPdfWithEncrypt,
+  buildXRefStreamPdfWithEncryptAndTextTrailer,
+  buildXRefStreamPdfWithoutEncrypt,
 } from "./pdf-document.test.helpers";
 
 test("xrefストリーム形式のみのPDFはfallback scanを経由せず（XREF_REBUILD warningなしで）loadされる", async () => {
@@ -52,6 +55,41 @@ test("trailerに/Encryptを持つPDFをloadするとENCRYPTED_PDF_UNSUPPORTEDを
   assert(!result.ok);
   assert(!(result.error instanceof RangeError));
   expect(result.error.code).toBe("ENCRYPTED_PDF_UNSUPPORTED");
+});
+
+test("xrefストリーム辞書に/Encryptを持つPDFはfallback scan経由でもENCRYPTED_PDF_UNSUPPORTEDを返す", async () => {
+  const seen: string[] = [];
+  const result = await PdfDocument.load(buildXRefStreamPdfWithEncrypt(), {
+    onWarning: (w) => seen.push(w.code),
+  });
+
+  expect(seen).toContain("XREF_REBUILD");
+  assert(!result.ok);
+  assert(!(result.error instanceof RangeError));
+  expect(result.error.code).toBe("ENCRYPTED_PDF_UNSUPPORTED");
+});
+
+test("/Encryptを持たないテキストtrailerが併存していてもxrefストリーム辞書の/EncryptでENCRYPTED_PDF_UNSUPPORTEDを返す", async () => {
+  const seen: string[] = [];
+  const result = await PdfDocument.load(
+    buildXRefStreamPdfWithEncryptAndTextTrailer(),
+    { onWarning: (w) => seen.push(w.code) },
+  );
+
+  expect(seen).toContain("XREF_REBUILD");
+  assert(!result.ok);
+  assert(!(result.error instanceof RangeError));
+  expect(result.error.code).toBe("ENCRYPTED_PDF_UNSUPPORTED");
+});
+
+test("/Encryptを持たない解析不能なxrefストリームのPDFはfallback scan経由でXREF_REBUILD warningを伴ってOkになる", async () => {
+  const seen: string[] = [];
+  const result = await PdfDocument.load(buildXRefStreamPdfWithoutEncrypt(), {
+    onWarning: (w) => seen.push(w.code),
+  });
+
+  assert(result.ok);
+  expect(seen).toContain("XREF_REBUILD");
 });
 
 test("/TypeがXRefでないストリームがxrefストリーム位置にあるPDFはXREF_STREAM_INVALIDでfallback scanへ移行しXREF_REBUILD warningを伴ってOkになる", async () => {

--- a/packages/core/src/xref/fallback/fallback-scanner/__tests__/fallback-scanner.behavior.test.ts
+++ b/packages/core/src/xref/fallback/fallback-scanner/__tests__/fallback-scanner.behavior.test.ts
@@ -297,3 +297,149 @@ test.each([
   const result = scanFallback(data);
   expect(result.ok).toBe(true);
 });
+
+test("/Type /XRef obj 内に /Encrypt があるとき合成 trailer に encrypt を付与する", () => {
+  const body =
+    "5 0 obj\n<< /Type /XRef /Size 6 /Encrypt 4 0 R >>\nendobj\n" +
+    "1 0 obj\n<< /Type /Catalog >>\nendobj\n";
+  const data = encode(body);
+  const result = scanFallback(data);
+  assert(result.ok);
+  assert(result.value.trailer.some);
+  expect(result.value.trailer.value.encrypt).toBeDefined();
+});
+
+test("/Type /XRef obj に /Encrypt が無いとき合成 trailer に encrypt を付与しない", () => {
+  const body =
+    "5 0 obj\n<< /Type /XRef /Size 6 >>\nendobj\n" +
+    "1 0 obj\n<< /Type /Catalog >>\nendobj\n";
+  const data = encode(body);
+  const result = scanFallback(data);
+  assert(result.ok);
+  assert(result.value.trailer.some);
+  expect(result.value.trailer.value.encrypt).toBeUndefined();
+});
+
+test("/Type/XRef（スペース無し派生）+ /Encrypt も暗号化として検出する", () => {
+  const body =
+    "5 0 obj\n<</Type/XRef/Size 6/Encrypt 4 0 R>>\nendobj\n" +
+    "1 0 obj\n<< /Type /Catalog >>\nendobj\n";
+  const data = encode(body);
+  const result = scanFallback(data);
+  assert(result.ok);
+  assert(result.value.trailer.some);
+  expect(result.value.trailer.value.encrypt).toBeDefined();
+});
+
+test("/Type/XRef（スペース無し派生）に /Encrypt が無ければ encrypt を付与しない", () => {
+  const body =
+    "5 0 obj\n<</Type/XRef/Size 6>>\nendobj\n" +
+    "1 0 obj\n<< /Type /Catalog >>\nendobj\n";
+  const data = encode(body);
+  const result = scanFallback(data);
+  assert(result.ok);
+  assert(result.value.trailer.some);
+  expect(result.value.trailer.value.encrypt).toBeUndefined();
+});
+
+test("ストリームデータ内の `/Encrypt` バイト列は暗号化として検出しない", () => {
+  const body =
+    "5 0 obj\n<< /Type /XRef /Length 14 >>\nstream\n/Encrypt 4 0 R\nendstream\nendobj\n" +
+    "1 0 obj\n<< /Type /Catalog >>\nendobj\n";
+  const data = encode(body);
+  const result = scanFallback(data);
+  assert(result.ok);
+  assert(result.value.trailer.some);
+  expect(result.value.trailer.value.encrypt).toBeUndefined();
+});
+
+test("ストリームデータ内の `/Type /XRef` バイト列は xref ストリーム obj として扱わない", () => {
+  const body =
+    "5 0 obj\n<< /Encrypt 4 0 R /Length 11 >>\nstream\n/Type /XRef\nendstream\nendobj\n" +
+    "1 0 obj\n<< /Type /Catalog >>\nendobj\n";
+  const data = encode(body);
+  const result = scanFallback(data);
+  assert(result.ok);
+  assert(result.value.trailer.some);
+  expect(result.value.trailer.value.encrypt).toBeUndefined();
+});
+
+test("/Encrypt が /Type /XRef と別 obj にある場合は暗号化として検出しない", () => {
+  const body =
+    "5 0 obj\n<< /Type /XRef /Size 6 >>\nendobj\n" +
+    "4 0 obj\n<< /Encrypt 3 0 R >>\nendobj\n" +
+    "1 0 obj\n<< /Type /Catalog >>\nendobj\n";
+  const data = encode(body);
+  const result = scanFallback(data);
+  assert(result.ok);
+  assert(result.value.trailer.some);
+  expect(result.value.trailer.value.encrypt).toBeUndefined();
+});
+
+test("`endobj` 後の `garbage /Type /XRef /Encrypt` は obj scope 外のため検出しない", () => {
+  const body =
+    "1 0 obj\n<< /Type /Catalog >>\nendobj\n" +
+    "garbage /Type /XRef /Encrypt 4 0 R\n";
+  const data = encode(body);
+  const result = scanFallback(data);
+  assert(result.ok);
+  assert(result.value.trailer.some);
+  expect(result.value.trailer.value.encrypt).toBeUndefined();
+});
+
+test("/Type /XRef obj が複数あり片方だけ /Encrypt を持つ場合も検出する", () => {
+  const body =
+    "5 0 obj\n<< /Type /XRef /Size 7 >>\nendobj\n" +
+    "6 0 obj\n<< /Type /XRef /Encrypt 4 0 R >>\nendobj\n" +
+    "1 0 obj\n<< /Type /Catalog >>\nendobj\n";
+  const data = encode(body);
+  const result = scanFallback(data);
+  assert(result.ok);
+  assert(result.value.trailer.some);
+  expect(result.value.trailer.value.encrypt).toBeDefined();
+});
+
+test("obj が 1 件も無いデータでは /Type /XRef /Encrypt があっても trailer は None", () => {
+  const data = encode("%PDF-1.7\n/Type /XRef /Encrypt 4 0 R\n%%EOF\n");
+  const result = scanFallback(data);
+  assert(result.ok);
+  expect(result.value.trailer.some).toBe(false);
+});
+
+test("/Encrypt を持たないテキスト trailer 採用時も /Type /XRef obj の /Encrypt を検出する (FB-002)", () => {
+  const body =
+    "1 0 obj\n<< /Type /Catalog >>\nendobj\n" +
+    "trailer\n<< /Root 1 0 R /Size 6 >>\n" +
+    "5 0 obj\n<< /Type /XRef /Size 6 /Encrypt 4 0 R >>\nendobj\n";
+  const data = encode(body);
+  const result = scanFallback(data);
+  assert(result.ok);
+  assert(result.value.trailer.some);
+  expect(result.value.trailer.value.encrypt).toBeDefined();
+});
+
+test("テキスト trailer 自身の /Encrypt はマーカーで上書きされず間接参照のまま保たれる (FB-002)", () => {
+  const body =
+    "1 0 obj\n<< /Type /Catalog >>\nendobj\n" +
+    "trailer\n<< /Root 1 0 R /Size 6 /Encrypt 4 0 R >>\n" +
+    "5 0 obj\n<< /Type /XRef /Size 6 /Encrypt 4 0 R >>\nendobj\n";
+  const data = encode(body);
+  const result = scanFallback(data);
+  assert(result.ok);
+  assert(result.value.trailer.some);
+  expect(result.value.trailer.value.encrypt).toEqual({
+    objectNumber: ObjectNumber.of(4),
+    generationNumber: GenerationNumber.of(0),
+  });
+});
+
+test("テキスト trailer 採用時に /Type /XRef obj が無ければ encrypt を付与しない (FB-002)", () => {
+  const body =
+    "1 0 obj\n<< /Type /Catalog >>\nendobj\n" +
+    "trailer\n<< /Root 1 0 R /Size 6 >>\n";
+  const data = encode(body);
+  const result = scanFallback(data);
+  assert(result.ok);
+  assert(result.value.trailer.some);
+  expect(result.value.trailer.value.encrypt).toBeUndefined();
+});

--- a/packages/core/src/xref/fallback/fallback-scanner/index.ts
+++ b/packages/core/src/xref/fallback/fallback-scanner/index.ts
@@ -43,6 +43,13 @@ const CATALOG_SPACED_BYTES = Array.from(
 const CATALOG_COMPACT_BYTES = Array.from(
   new TextEncoder().encode("/Type/Catalog"),
 );
+const XREF_TYPE_SPACED_BYTES = Array.from(
+  new TextEncoder().encode("/Type /XRef"),
+);
+const XREF_TYPE_COMPACT_BYTES = Array.from(
+  new TextEncoder().encode("/Type/XRef"),
+);
+const ENCRYPT_BYTES = Array.from(new TextEncoder().encode("/Encrypt"));
 const PERCENT = 0x25;
 const LF = 0x0a;
 const CR = 0x0d;
@@ -569,9 +576,110 @@ function inferCatalogRoot(
 }
 
 /**
+ * 2 つのバイト位置が同一 obj 本体スコープに属するか判定する。
+ * どちらかがどの scope にも含まれない場合は `false`。
+ * ObjectHit の同一性は `objectNumber` / `generation` / `offset` の三つ組で比較する
+ * （同一オブジェクト番号が複数回出現する壊れた PDF でも別 obj として扱うため）。
+ *
+ * @param scopes - obj 本体スコープ列（buildObjectScopes 由来）
+ * @param posA - 比較する一方のバイト位置
+ * @param posB - 比較するもう一方のバイト位置
+ * @returns 同一 obj スコープ内であれば `true`
+ */
+function areInSameScope(
+  scopes: readonly ObjectScope[],
+  posA: number,
+  posB: number,
+): boolean {
+  const hitA = findScopeContaining(scopes, posA);
+  const hitB = findScopeContaining(scopes, posB);
+  if (!hitA.some || !hitB.some) {
+    return false;
+  }
+  return (
+    hitA.value.objectNumber === hitB.value.objectNumber &&
+    hitA.value.generation === hitB.value.generation &&
+    hitA.value.offset === hitB.value.offset
+  );
+}
+
+/**
+ * xref ストリーム obj（`/Type /XRef`）の辞書に `/Encrypt` が含まれるか判定する。
+ * `parseXRefStream` が失敗して辞書を得られない場合でも、生バイト走査で
+ * 暗号化 PDF であることを検出するために用いる。
+ * `/Type /XRef` と `/Type/XRef` の双方を候補に含め、stream 領域内の偶発一致は除外し、
+ * `/Encrypt` が同一 obj スコープに属する場合のみ検出とみなす。
+ *
+ * @param data - PDF ファイル全体
+ * @param scopes - obj 本体スコープ列（buildObjectScopes 由来）
+ * @param streamRegions - stream 領域列（findStreamRegions 由来）
+ * @returns `/Encrypt` を持つ xref ストリーム obj が存在すれば `true`
+ */
+function hasEncryptInXRefStream(
+  data: Uint8Array,
+  scopes: readonly ObjectScope[],
+  streamRegions: readonly ByteRange[],
+): boolean {
+  const encryptPositions = findCatalogPositions(data, ENCRYPT_BYTES).filter(
+    (pos) => !isInsideAnyRange(streamRegions, pos),
+  );
+  if (encryptPositions.length === 0) {
+    return false;
+  }
+  const xrefPositions = [
+    ...findCatalogPositions(data, XREF_TYPE_SPACED_BYTES),
+    ...findCatalogPositions(data, XREF_TYPE_COMPACT_BYTES),
+  ];
+  for (const xrefPos of xrefPositions) {
+    if (isInsideAnyRange(streamRegions, xrefPos)) {
+      continue;
+    }
+    for (const encryptPos of encryptPositions) {
+      if (areInSameScope(scopes, xrefPos, encryptPos)) {
+        return true;
+      }
+    }
+  }
+  return false;
+}
+
+/**
+ * trailer に `/Encrypt` が無く、かつ xref ストリーム obj が `/Encrypt` を持つ場合に限り、
+ * 暗号化 PDF の早期検出用マーカーとして空の辞書を `encrypt` に設定した trailer を返す。
+ * trailer が既に `/Encrypt` を持つ場合は、解析済みの値を保つためそのまま返す。
+ *
+ * @param trailer - 補完対象の TrailerDict（FB-002 の直接取得 / FB-004 の合成のいずれか）
+ * @param data - PDF ファイル全体
+ * @param scopes - obj 本体スコープ列（buildObjectScopes 由来）
+ * @param streamRegions - stream 領域列（findStreamRegions 由来）
+ * @returns 必要に応じて `encrypt` を補完した TrailerDict
+ */
+function withXRefStreamEncrypt(
+  trailer: TrailerDict,
+  data: Uint8Array,
+  scopes: readonly ObjectScope[],
+  streamRegions: readonly ByteRange[],
+): TrailerDict {
+  if (trailer.encrypt !== undefined) {
+    return trailer;
+  }
+  if (!hasEncryptInXRefStream(data, scopes, streamRegions)) {
+    return trailer;
+  }
+  return {
+    ...trailer,
+    encrypt: { type: "dictionary", entries: new Map() },
+  };
+}
+
+/**
  * xref 通常パース失敗時のフォールバックスキャナ (#19)。
  * FB-001/003 で XRefTable を再構築し、FB-002 で trailer を直接取得、
  * trailer 不在時は FB-004 で `/Type /Catalog` から最小 trailer を合成する。
+ * どちらの経路で得た trailer にも、`/Encrypt` を欠いていて xref ストリーム obj 側に
+ * `/Encrypt` がある場合は、暗号化 PDF の早期検出のためのマーカーとして
+ * 空の `encrypt` 辞書を付与する（呼び出し側は `encrypt` の有無のみを見るため、
+ * 辞書の中身は復元しない）。
  *
  * @param data - PDF ファイル全体のバイト配列
  * @returns 復元した XRef テーブル / trailer / `XREF_REBUILD` warning 1 件
@@ -588,7 +696,9 @@ export function scanFallback(
   if (directTrailer.some) {
     return ok({
       xrefTable,
-      trailer: directTrailer,
+      trailer: some(
+        withXRefStreamEncrypt(directTrailer.value, data, scopes, streamRegions),
+      ),
       warnings: [warning],
     });
   }
@@ -598,5 +708,14 @@ export function scanFallback(
     streamRegions,
     xrefTable.size,
   );
-  return ok({ xrefTable, trailer: synthTrailer, warnings: [warning] });
+  if (!synthTrailer.some) {
+    return ok({ xrefTable, trailer: synthTrailer, warnings: [warning] });
+  }
+  return ok({
+    xrefTable,
+    trailer: some(
+      withXRefStreamEncrypt(synthTrailer.value, data, scopes, streamRegions),
+    ),
+    warnings: [warning],
+  });
 }


### PR DESCRIPTION
## 概要

xref ストリームの解析に失敗して fallback scan に落ちると、**暗号化された PDF が「暗号化されていない PDF」として読み込みを継続**し、`ENCRYPTED_PDF_UNSUPPORTED` による早期検出をすり抜けていた。

`scanFallback` は失敗した xref ストリームの辞書を一切参照せず、生バイト走査で `/Type /Catalog` を探して最小 trailer を組み立てるため、`/Encrypt` が丸ごと失われることが原因。

fallback の走査に「`/Type /XRef` を持つオブジェクトの中に `/Encrypt` があるか」の判定を追加し、検出時は trailer に暗号化マーカーを載せるようにした。

## 変更内容

### 🎯 変更の種類

- [x] 🐛 バグ修正 (Bug fix)
- [ ] ✨ 新機能 (New feature)
- [ ] ♻️ リファクタリング (Refactoring)
- [ ] 🎨 UI/UX 改善 (UI/UX improvement)
- [ ] 🐎 パフォーマンス改善 (Performance improvement)
- [x] 🚨 テスト追加/修正 (Tests)
- [ ] 📖 ドキュメント更新 (Documentation)
- [ ] 🔧 設定変更 (Configuration)
- [ ] 🗑️ 削除 (Removal)

### 📝 詳細な変更内容

#### 追加された機能・修正

- `/Type /XRef`・`/Type/XRef`（スペース無し派生）・`/Encrypt` のバイトパターン走査を追加
- `/Type /XRef` と `/Encrypt` が**同一オブジェクト範囲**にあるときのみ暗号化と判定する検出処理を追加
  - オブジェクトの同一性は「オブジェクト番号 + 世代番号 + ファイル内オフセット」の三つ組で比較（壊れた PDF では同じオブジェクト番号が複数回現れるため）
  - `stream`〜`endstream` 領域内の偶発一致は既存の除外処理で弾く
- 検出時に trailer へ暗号化マーカー（空の辞書）を補完する処理を追加
  - fallback は辞書をパースしない設計のため、値は復元せず**存在の有無だけ**を表す
  - trailer に既に `/Encrypt` がある場合は、解析済みの間接参照を捨てないよう**上書きしない**
- テキスト trailer を直接採用する経路（FB-002）と、Catalog から合成する経路（FB-004）の**両方**に適用

#### 変更されたファイル

- `packages/core/src/xref/fallback/fallback-scanner/index.ts`
- `packages/core/src/xref/fallback/fallback-scanner/__tests__/fallback-scanner.behavior.test.ts`
- `packages/core/src/document/pdf-document/__tests__/pdf-document.test.helpers.ts`
- `packages/core/src/document/pdf-document/__tests__/pdf-document.xref-formats.test.ts`

#### 削除されたファイル・機能

- なし

## 📊 システム図

### フロー図

```mermaid
flowchart TD
    Start([scanFallback]) --> FB1[FB-001/003: obj 走査と XRefTable 再構築]
    FB1 --> Scope[stream 領域とオブジェクト範囲を構築]
    Scope --> FB2{"FB-002: テキスト trailer が見つかるか"}

    FB2 -->|見つかる| Direct[テキスト trailer を採用]
    FB2 -->|見つからない| FB4{"FB-004: /Type /Catalog から合成できるか"}

    FB4 -->|できる| Synth[最小 trailer を合成]
    FB4 -->|できない| None[trailer = None]

    Direct --> Supp["暗号化マーカーの補完<br/>(withXRefStreamEncrypt)"]:::new
    Synth --> Supp

    Supp --> Has{"trailer に /Encrypt が既にあるか"}:::new
    Has -->|ある| AsIs[解析済みの値をそのまま保持]:::new
    Has -->|ない| Detect{"/Type /XRef obj 内に /Encrypt があるか"}:::new

    Detect -->|ある| Marker[空の辞書をマーカーとして付与]:::new
    Detect -->|ない| Plain[encrypt なしのまま]:::new

    AsIs --> Ret([FallbackScanResult を返す])
    Marker --> Ret
    Plain --> Ret
    None --> Ret

    classDef new fill:#ffe4b5,stroke:#d97706,stroke-width:2px
```

検出時の除外条件:

- `/Type /XRef` または `/Encrypt` が `stream`〜`endstream` 領域内 → 除外（偽陽性回避）
- どちらかがオブジェクト範囲の外（ゴミ領域） → 除外
- 両者が別々のオブジェクトにある → 除外

### データフロー

```
PDF byte array
    |
    +-- startxref → xref ストリームの解析に失敗
    |
    +-- scanFallback
    |       |
    |   FB-001/003: obj ヘッダー走査 → XRefTable 再構築
    |       |
    |   findStreamRegions / buildObjectScopes
    |       |
    |   FB-002 findValidTrailer ──┐
    |   FB-004 inferCatalogRoot ──┤
    |                             |
    |   withXRefStreamEncrypt <───┘  [NEW] 両経路に適用
    |       |
    |   hasEncryptInXRefStream      [NEW]
    |       |  /Type /XRef と /Encrypt が同一 obj 範囲か
    |       |  （stream 領域内・範囲外は除外）
    |       ↓
    |   TrailerDict { root, size, encrypt? }
    |
    +-- resolveXRefStructure（変更なし）
    |       |
    |   XREF_REBUILD warning を通知 → Ok を返す
    |
    +-- PdfDocument.load（変更なし）
            |
        trailer.encrypt !== undefined
            |
        → ENCRYPTED_PDF_UNSUPPORTED
```

## 📋 関連 Issue

- Closes #550

## 🧪 テスト

### テスト実行方法

```bash
pnpm --filter @pdfmod/core test
pnpm run lint
pnpm run typecheck
pnpm --filter @pdfmod/core build
```

### テスト項目

- [x] 単体テスト (Unit tests)
- [x] 統合テスト (Integration tests)
- [ ] E2E テスト (End-to-end tests)
- [ ] 手動テスト (Manual testing)

### テスト結果

- `pnpm --filter @pdfmod/core test` — **3316 tests / 270 files 全 green**
- `pnpm run lint`（biome + oxlint）— 0 errors / 0 warnings
- `pnpm run typecheck` — core / react ともに成功
- `pnpm --filter @pdfmod/core build` — 成功

追加したテスト（ユニット 13 件 / 統合 3 件）:

| 種別 | 観点 |
|:-|:-|
| 正常系 | `/Type /XRef` + `/Encrypt` で `encrypt` が付与される |
| 正常系 | `/Type/XRef`（スペース無し派生）でも検出される |
| 正常系 | `/Type /XRef` obj が複数あり片方だけ `/Encrypt` を持つ場合も検出 |
| 正常系 | `/Encrypt` を持たないテキスト trailer 採用時も検出（FB-002） |
| 退行防止 | `/Encrypt` 無しでは `encrypt` が `undefined`（spaced / compact 別ケース） |
| 退行防止 | テキスト trailer 自身の `/Encrypt` が間接参照のまま保たれる |
| 退行防止 | テキスト trailer 採用時に `/Type /XRef` が無ければ付与しない |
| エッジ | `/Encrypt` が stream 領域内 → 検出しない |
| エッジ | `/Type /XRef` が stream 領域内 → xref ストリームとして扱わない |
| エッジ | `/Encrypt` が別オブジェクト → 検出しない |
| エッジ | 両者がオブジェクト範囲外（ゴミ領域） → 検出しない |
| 境界値 | obj が 1 件も無いデータで trailer は None |
| 統合 | 暗号化 xref ストリームが fallback 経由で `ENCRYPTED_PDF_UNSUPPORTED` |
| 統合 | テキスト trailer 併存でも `ENCRYPTED_PDF_UNSUPPORTED` |
| 統合 | 非暗号化 xref ストリームは `XREF_REBUILD` 警告付きで Ok |

統合テストは `ENCRYPTED_PDF_UNSUPPORTED` に加えて `XREF_REBUILD` 警告も検証している。これを確認しないと、xref ストリームが正常に解析されて辞書から `/Encrypt` を得た場合にもテストが通ってしまい、fallback 経路を通った証明にならないため。

## 🔍 レビューポイント

- **FB-002 経路も対象にした判断**: 当初計画では「xref ストリームのみの PDF では FB-002 は失敗する」という理由で FB-004 経路のみを対象にしていた。実装中のレビューで、`/Encrypt` を持たないテキスト trailer と暗号化された xref ストリームが同居する PDF では FB-002 が採用されて検出をすり抜けることが判明し（一時テストで実測）、両経路に広げた
- **マーカーの妥当性**: `PdfDocument.load` は `trailer.encrypt !== undefined` の存在チェックのみを行うため、値は空の辞書で足りる。fallback は失敗した xref ストリームの辞書をパースしないため、`/Encrypt` の参照先を解決する手段がそもそも無い
- **検出条件の絞り込み**: 誤検出（非暗号化 PDF を暗号化と誤判定）を避けるため、stream 領域内の偶発一致と、オブジェクト範囲外・別オブジェクトの `/Encrypt` を除外している
- **`resolveXRefStructure` は無変更**: trailer に `encrypt` が載れば下流の暗号化検出は既存ロジックのまま動くため、呼び出し側に手を入れていない

## ⚠️ 破壊的変更

- [ ] この変更は既存の API に破壊的変更を含みます

型定義（`TrailerDict` / `FallbackScanResult`）の変更は無し。非暗号化 PDF の fallback 挙動も従来どおり。

## 📚 追加情報

### 注意事項

fallback スキャナはバイトレベル走査のベストエフォートであり、以下は今回のスコープ外の既知の制約:

- `/Type\n/XRef` のように `/Type` と `/XRef` の間に改行・複数空白・コメントが入るケースは検出できない（既存の `/Type /Catalog` 検出も同じ制約）
- `/En#63rypt` のような `#xx` エスケープ済み Name は検出できない
- stream 領域は `/Length` ではなく「最初に見つかった `endstream`」で閉じる推定のため、ストリームデータ内に偶発的な `endstream` があると領域が早く閉じ、その後ろの `/Encrypt` が「ストリーム外」と扱われる余地がある（誤りの向きは false positive で、セキュリティ上の穴ではない）
- `/ID` 等 `/Encrypt` 以外のエントリの保全はスコープ外

正常な xref 解析経路では `parseXRefStream` がデコード済みの辞書キーから正確に `/Encrypt` を取得するため、これらの制約は fallback 経路に限られる。

## ✅ チェックリスト

- [x] コードレビューの準備ができている
- [x] テストが正常に実行される
- [x] ドキュメントが更新されている（必要に応じて）
- [x] コミットメッセージが適切な形式で書かれている
- [ ] 関連する Issue が PR の「Development」に Linked されている
- [x] PR 本文に `Closes #` などで Issue が記載されている
- [x] セルフレビューを実施した
- [x] 破壊的変更がある場合は明記されている

## 🤝 レビュアーへのお願い

- 検出条件（同一オブジェクト範囲 + stream 領域除外）に、非暗号化 PDF を誤検出しうる抜けが無いかを重点的に見てほしい
- 逆に、暗号化 PDF がすり抜ける経路が他に残っていないか（FB-002 / FB-004 以外の返却パス）も確認してほしい

🤖 Generated with [Claude Code](https://claude.com/claude-code)