### PR TITLE
🚨 [Tests]: #507 MarkedContentStack の PdfName プロパティ・深度3+ネスト・BT BT E2E の未検証パターンを追加

### DIFF
--- a/packages/core/src/content-stream/interpreter/__tests__/interpreter.marked-content-properties.test.ts
+++ b/packages/core/src/content-stream/interpreter/__tests__/interpreter.marked-content-properties.test.ts
@@ -1,0 +1,195 @@
+// 本ファイルは 2 観点を担当する:
+//   (i)  probe handler で実行途中の markedContentStack を捕捉し、interpreter 経由で
+//        組み立てられた entry の properties（3 バリアント）を観測する
+//   (ii) 深度 3 のネストが interpreter 経由で完走することを検証する
+// (ii) を本ファイルに含めるのは要件確定時の方針。
+// 3 観点目が必要になった時点でファイル分割を検討すること。
+//
+// interpreter.marked-content.test.ts は depth と error message のみを観測し
+// entry の中身は一度も見ていない（ネストも深度 2 まで）。本ファイルは
+// 「interpreter 経由で組み立てられた entry の中身」と「深度 3 ネスト」を担当する。
+//
+// probe を使う test では captured[0] にアクセスする前に必ず
+// expect(captured).toHaveLength(1) を置く（noUncheckedIndexedAccess 未設定のため
+// probe 未発火時に型エラーにならず読めない TypeError になるのを防ぐ）。
+import { assert, expect, test } from "vitest";
+import { ok } from "../../../utils/result/index";
+import { MarkedContentStack } from "../../marked-content/stack";
+import {
+  type OperatorHandler,
+  OperatorRegistry,
+} from "../../operator-registry/index";
+import { registerMarkedContentOperators } from "../../operators/marked-content/marked-content-operators/index";
+import { ContentStreamInterpreter } from "../index";
+
+const encode = (value: string): Uint8Array => new TextEncoder().encode(value);
+
+// interpreter.dispatch.test.ts / interpreter.dict-operand.test.ts /
+// interpreter.inline-image.test.ts と完全同一シグネチャのヘルパ。
+// 共有モジュール化は本 PR のスコープ外のため、独自シグネチャを作らず踏襲する。
+function registerOperator(
+  registry: ReturnType<typeof OperatorRegistry.create>,
+  name: string,
+  handler: OperatorHandler,
+): ReturnType<typeof OperatorRegistry.create> {
+  const result = OperatorRegistry.register(registry, name, handler);
+  assert(result.ok);
+  return result.value;
+}
+
+/**
+ * marked-content operator に加えて、実行途中の markedContentStack を
+ * クロージャへ捕捉する `probe` operator を登録した registry を生成する。
+ *
+ * execute の戻り値からは BDC が積んだ entry を観測できない
+ * （EMC で閉じれば消え、閉じなければ EOF 検査の err で context 自体が返らない）。
+ * そのため実行途中に割り込む probe handler で観測する。
+ * probe は context をそのまま ok で返すため後続の EMC / EOF 検査に影響しない。
+ * `probe` は BMC / EMC / BDC / MP / DP のいずれとも衝突しない名前を選んでいる。
+ */
+const buildRegistryWithProbe = (
+  captured: MarkedContentStack[],
+): OperatorRegistry => {
+  const registered = registerMarkedContentOperators(OperatorRegistry.create());
+  assert(registered.ok);
+  return registerOperator(registered.value, "probe", (context) => {
+    captured.push(context.markedContentStack);
+    return ok(context);
+  });
+};
+
+test("`/Span /P1 BDC probe EMC` の probe 時点で entry の tag が /Span・properties が some(/P1)", () => {
+  // tokenizer → operand stack → bdcHandler の経路を通しても
+  // 名前参照形 properties が resource 解決されず /P1 のまま積まれること
+  const captured: MarkedContentStack[] = [];
+  const result = ContentStreamInterpreter.execute({
+    data: encode("/Span /P1 BDC probe EMC"),
+    registry: buildRegistryWithProbe(captured),
+  });
+
+  assert(result.ok);
+  expect(captured).toHaveLength(1);
+  const popped = MarkedContentStack.pop(captured[0]);
+  assert(popped.some);
+  expect(popped.value.popped.tag).toEqual({ type: "name", value: "Span" });
+  assert(popped.value.popped.properties.some);
+  expect(popped.value.popped.properties.value).toEqual({
+    type: "name",
+    value: "P1",
+  });
+});
+
+test("`/Span /P1 BDC probe EMC` は probe がちょうど 1 回発火し probe 時 depth 1・完走時 depth 0", () => {
+  // BDC が 1 件だけ積み EMC が確実に閉じること（probe 自体は depth に影響しない）
+  // 完走時 depth 0 / warnings 空という観測自体は interpreter.marked-content.test.ts が
+  // 既に持っている。本 test の新規性は「probe がちょうど 1 回発火する」ことと
+  // 「probe 時点（EMC 前）の depth が 1 である」ことの 2 点にある。
+  const captured: MarkedContentStack[] = [];
+  const result = ContentStreamInterpreter.execute({
+    data: encode("/Span /P1 BDC probe EMC"),
+    registry: buildRegistryWithProbe(captured),
+  });
+
+  assert(result.ok);
+  expect(captured).toHaveLength(1);
+  expect(MarkedContentStack.depth(captured[0])).toBe(1);
+  expect(
+    MarkedContentStack.depth(result.value.context.markedContentStack),
+  ).toBe(0);
+});
+
+test("`/Span <</MCID 0>> BDC probe EMC` の probe 時点で properties が dictionary バリアント", () => {
+  // 辞書形と名前形が dispatch 経路で正しく分岐すること（名前形テストの対照）
+  const captured: MarkedContentStack[] = [];
+  const result = ContentStreamInterpreter.execute({
+    data: encode("/Span <</MCID 0>> BDC probe EMC"),
+    registry: buildRegistryWithProbe(captured),
+  });
+
+  assert(result.ok);
+  expect(captured).toHaveLength(1);
+  const popped = MarkedContentStack.pop(captured[0]);
+  assert(popped.some);
+  assert(popped.value.popped.properties.some);
+  expect(popped.value.popped.properties.value.type).toBe("dictionary");
+});
+
+test("`/Span BMC probe EMC` の probe 時点で properties が none", () => {
+  // BMC 由来 entry は properties を持たないこと（3 バリアント目の対照）
+  const captured: MarkedContentStack[] = [];
+  const result = ContentStreamInterpreter.execute({
+    data: encode("/Span BMC probe EMC"),
+    registry: buildRegistryWithProbe(captured),
+  });
+
+  assert(result.ok);
+  expect(captured).toHaveLength(1);
+  const popped = MarkedContentStack.pop(captured[0]);
+  assert(popped.some);
+  expect(popped.value.popped.properties).toEqual({ some: false });
+});
+
+test("3 段ネスト `/A BMC /B BMC /C BMC EMC EMC EMC` で初期状態に復帰する", () => {
+  // 深度 3 のネストが interpreter 経由でも過不足なく開閉し、末尾 depth 0・
+  // warnings 空になること（graphics-state-operators.integration.test.ts の
+  // 3 段ネスト test と同型のシナリオを marked content 側で行う）
+  // この test は stream に probe を含めないため捕捉先の配列は空のまま使わない。
+  const result = ContentStreamInterpreter.execute({
+    data: encode("/A BMC /B BMC /C BMC EMC EMC EMC"),
+    registry: buildRegistryWithProbe([]),
+  });
+
+  assert(result.ok);
+  expect(result.value.warnings).toEqual([]);
+  expect(
+    MarkedContentStack.depth(result.value.context.markedContentStack),
+  ).toBe(0);
+});
+
+test("深度 3 混在ネストの probe 時点で depth 3・LIFO で /C(some name) → /B(some dict) → /A(none)", () => {
+  // `/A BMC /B <<>> BDC /C /P1 BDC probe EMC EMC EMC` で
+  // 3 バリアントが積まれた順に対応して取り出せること（stack 単体の深度 3 検証の E2E 対応）
+  const captured: MarkedContentStack[] = [];
+  const result = ContentStreamInterpreter.execute({
+    data: encode("/A BMC /B <<>> BDC /C /P1 BDC probe EMC EMC EMC"),
+    registry: buildRegistryWithProbe(captured),
+  });
+
+  assert(result.ok);
+  expect(captured).toHaveLength(1);
+  expect(MarkedContentStack.depth(captured[0])).toBe(3);
+
+  const inner = MarkedContentStack.pop(captured[0]);
+  assert(inner.some);
+  expect(inner.value.popped.tag.value).toBe("C");
+  assert(inner.value.popped.properties.some);
+  expect(inner.value.popped.properties.value).toEqual({
+    type: "name",
+    value: "P1",
+  });
+
+  const middle = MarkedContentStack.pop(inner.value.stack);
+  assert(middle.some);
+  expect(middle.value.popped.tag.value).toBe("B");
+  assert(middle.value.popped.properties.some);
+  expect(middle.value.popped.properties.value.type).toBe("dictionary");
+
+  const outer = MarkedContentStack.pop(middle.value.stack);
+  assert(outer.some);
+  expect(outer.value.popped.tag.value).toBe("A");
+  expect(outer.value.popped.properties).toEqual({ some: false });
+});
+
+test("`/Span /P1 BDC EMC probe` の probe 時点では depth 0 で pop が none", () => {
+  // EMC が確実に pop していること = probe 方式が古い stack 参照を見ていないことの確証
+  const captured: MarkedContentStack[] = [];
+  const result = ContentStreamInterpreter.execute({
+    data: encode("/Span /P1 BDC EMC probe"),
+    registry: buildRegistryWithProbe(captured),
+  });
+
+  assert(result.ok);
+  expect(captured).toHaveLength(1);
+  expect(MarkedContentStack.depth(captured[0])).toBe(0);
+  expect(MarkedContentStack.pop(captured[0])).toEqual({ some: false });
+});

--- a/packages/core/src/content-stream/interpreter/__tests__/interpreter.text-object.test.ts
+++ b/packages/core/src/content-stream/interpreter/__tests__/interpreter.text-object.test.ts
@@ -1,0 +1,98 @@
+// 本ファイルは ContentStreamInterpreter.execute（tokenizer → dispatch → registry
+// → handler）を通した text object の二重開始と 2 周目ライフサイクルのみを担当する。
+// handler 層の BT BT と 2 周目 BT ET は et.integration.test.ts が検証済みで、
+// 本ファイルはそこを通らない E2E 経路だけを見る。
+// また text-state-operators.integration.test.ts は BT / BT ET の正常系のみを
+// E2E で担当しており、異常系（BT BT）は本ファイルが初めて E2E で固定する。
+import { assert, expect, test } from "vitest";
+import { GraphicsStateStack, TextObject } from "../../graphics-state/index";
+import { OperatorRegistry } from "../../operator-registry/index";
+import { registerTextStateOperators } from "../../operators/text/text-state-operators/index";
+import type { ContentStreamInterpreterResult } from "../index";
+import { ContentStreamInterpreter } from "../index";
+
+const encode = (value: string): Uint8Array => new TextEncoder().encode(value);
+
+/**
+ * text state operator (BT / ET を含む) を registerTextStateOperators で
+ * 登録した registry を生成する。登録失敗は assert で即座に検出する。
+ */
+const buildRegistry = (): OperatorRegistry => {
+  const registered = registerTextStateOperators(OperatorRegistry.create());
+  assert(registered.ok);
+  return registered.value;
+};
+
+/**
+ * 正常系用: content stream を実行し、成功結果を返すヘルパ（失敗時は assert で
+ * 即座に検出）。異常系（BT BT → Err）はこのヘルパを使わず
+ * ContentStreamInterpreter.execute を直接呼んで Err を検証する。
+ * text-positioning-operators.integration.test.ts と同じ構成。
+ *
+ * なお execute が err を返す場合、戻り値に warnings は載らないため
+ * 異常系では warnings の検証を行わない（できない）。
+ */
+const execute = (stream: string): ContentStreamInterpreterResult => {
+  const result = ContentStreamInterpreter.execute({
+    data: encode(stream),
+    registry: buildRegistry(),
+  });
+  assert(result.ok);
+  return result.value;
+};
+
+test("`BT BT` で execute が OPERATOR_ILLEGAL_STATE の err を返す（operatorName / message も pin down）", () => {
+  // 未 ET のまま 2 回目の BT を bytes から流すと、dispatch 層が握りつぶさず
+  // btHandler の Err がそのまま execute の戻り値へ伝播すること
+  // （handler を直接 2 回呼ぶ版は et.integration.test.ts にあり、本 test は
+  //   tokenizer / dispatch / registry を通る経路のみを見る）
+  const result = ContentStreamInterpreter.execute({
+    data: encode("BT BT"),
+    registry: buildRegistry(),
+  });
+
+  assert(!result.ok);
+  assert(result.error.code === "OPERATOR_ILLEGAL_STATE");
+  expect(result.error.operatorName).toBe("BT");
+  expect(result.error.message).toBe(
+    "BT: text object already active (nested BT/ET is not allowed)",
+  );
+});
+
+test("`BT ET BT ET` は ok で完走し末尾の textObject が非 active", () => {
+  // ET で閉じれば 2 周目の BT が通る = BT BT の err がガードの誤発火ではないことの対照
+  // 2 周目ライフサイクル自体は et.integration.test.ts が handler 層で検証済み。
+  // 本 test は同じ経路が interpreter の E2E でも成立することだけを担当する。
+  const executed = execute("BT ET BT ET");
+
+  expect(executed.warnings).toEqual([]);
+  const current = GraphicsStateStack.current(
+    executed.context.graphicsStateStack,
+  );
+  expect(TextObject.isActive(current.textObject)).toBe(false);
+});
+
+test("`BT ET BT BT` でも 2 周目の二重 BT が OPERATOR_ILLEGAL_STATE になる", () => {
+  // 1 周閉じた後でも active 検査が再び効くこと（ガードの状態リークがない）
+  const result = ContentStreamInterpreter.execute({
+    data: encode("BT ET BT BT"),
+    registry: buildRegistry(),
+  });
+
+  assert(!result.ok);
+  assert(result.error.code === "OPERATOR_ILLEGAL_STATE");
+  expect(result.error.operatorName).toBe("BT");
+});
+
+test("`BT foo BT` のように未登録 operator を挟んでも 2 回目の BT が err になる", () => {
+  // UNKNOWN_OPERATOR warning を出して継続する経路を通っても
+  // graphics state の textObject が active のまま維持されること
+  const result = ContentStreamInterpreter.execute({
+    data: encode("BT foo BT"),
+    registry: buildRegistry(),
+  });
+
+  assert(!result.ok);
+  assert(result.error.code === "OPERATOR_ILLEGAL_STATE");
+  expect(result.error.operatorName).toBe("BT");
+});

--- a/packages/core/src/content-stream/marked-content/stack/__tests__/stack.name-properties.test.ts
+++ b/packages/core/src/content-stream/marked-content/stack/__tests__/stack.name-properties.test.ts
@@ -33,7 +33,9 @@ const bdcSpanName: MarkedContentEntry = {
   tag: spanTag,
   properties: some(propertyName),
 };
-// `/Span // BDC` 由来: 空文字 name（境界値。bdcHandler は空文字 name を受理する）
+// `/Span / BDC` 由来: 空文字 name（境界値。bdcHandler は空文字 name を受理する）
+// name は `/` 1 個で始まり次の区切り文字までが名前のため、空文字 name の表記は
+// `/` 単独になる。`//` と書くと空文字 name 2 個にトークナイズされ operand 数が変わる。
 const bdcSpanEmptyName: MarkedContentEntry = {
   tag: spanTag,
   properties: some(emptyPropertyName),
@@ -67,7 +69,7 @@ test("properties が some(name) の entry を push→pop すると同一参照�
   });
 });
 
-test("properties が空文字 name（//）でも some のまま保持される", () => {
+test("properties が空文字 name（`/` 単独）でも some のまま保持される", () => {
   // 空文字 name は falsy だが Option としては some のまま扱われる境界値。
   // bdc.name.test.ts は同じ境界入力を「handler が受理するか」の観点で見ている。
   // 本 test は「stack が some のまま保持するか」の観点で見る点が差分。

--- a/packages/core/src/content-stream/marked-content/stack/__tests__/stack.name-properties.test.ts
+++ b/packages/core/src/content-stream/marked-content/stack/__tests__/stack.name-properties.test.ts
@@ -1,0 +1,124 @@
+// 本ファイルは MarkedContentStack.push を直接呼び、some(PdfName) の entry が
+// push→pop の往復で参照・内容とも保持されること、および 3 バリアント
+// (none / some(dictionary) / some(name)) が取り違えられないことを検証する。
+// bdc.name.test.ts は bdcHandler が entry を「組み立てる」責務のテストで、
+// その過程で stack 往復も間接的に通っている。本ファイルは handler を介さず
+// stack 単体の「保持する」責務のみを見る点が差分。
+import { assert, expect, test } from "vitest";
+import type {
+  PdfDictionary,
+  PdfName,
+} from "../../../../pdf/types/pdf-types/index";
+import { none, some } from "../../../../utils/option/index";
+import { type MarkedContentEntry, MarkedContentStack } from "../index";
+
+// フィクスチャはモジュールスコープの const で定義する（beforeEach は使わない）
+const spanTag: PdfName = { type: "name", value: "Span" };
+const propertyName: PdfName = { type: "name", value: "P1" };
+const emptyPropertyName: PdfName = { type: "name", value: "" };
+const mcidDict: PdfDictionary = {
+  type: "dictionary",
+  entries: new Map([["MCID", { type: "integer", value: 0 }]]),
+};
+
+// `/Span BMC` 由来: properties なし
+const bmcSpan: MarkedContentEntry = { tag: spanTag, properties: none };
+// `/Span <</MCID 0>> BDC` 由来: インライン辞書
+const bdcSpanDict: MarkedContentEntry = {
+  tag: spanTag,
+  properties: some(mcidDict),
+};
+// `/Span /P1 BDC` 由来: 名前参照（本ファイルの主対象。既存 fixture に存在しない）
+const bdcSpanName: MarkedContentEntry = {
+  tag: spanTag,
+  properties: some(propertyName),
+};
+// `/Span // BDC` 由来: 空文字 name（境界値。bdcHandler は空文字 name を受理する）
+const bdcSpanEmptyName: MarkedContentEntry = {
+  tag: spanTag,
+  properties: some(emptyPropertyName),
+};
+
+test("properties が some(name) の entry を push→pop すると同一参照で tag・properties とも保持される", () => {
+  // 名前参照形 BDC entry が stack を往復しても浅いコピーされず同一参照で返り、
+  // tag が /Span・properties が some(/P1) のまま（正規化も resource 解決もされない）こと。
+  // popped の toBe / properties.value の toBe / tag・properties の内容 toEqual を
+  // 1 test にまとめる（toBe が成立すれば内容一致は自動的に従うため、
+  // 別 test に分けても独立に落ちることがなく分割の意味がないため）。
+  // 同じ toBe 検証は dict バリアントでは stack.basic.test.ts / bdc.dict.test.ts が
+  // 済ませており、name バリアントだけが未検証というギャップを埋める。
+  // bdc.name.test.ts は同じ観測を handler 経由（bdcHandler が push した stack）で
+  // 行っている。本 test は MarkedContentStack.push を直接呼ぶ点が差分。
+  const stack = MarkedContentStack.push(
+    MarkedContentStack.create(),
+    bdcSpanName,
+  );
+
+  const result = MarkedContentStack.pop(stack);
+
+  assert(result.some);
+  expect(result.value.popped).toBe(bdcSpanName);
+  assert(result.value.popped.properties.some);
+  expect(result.value.popped.properties.value).toBe(propertyName);
+  expect(result.value.popped.tag).toEqual({ type: "name", value: "Span" });
+  expect(result.value.popped.properties.value).toEqual({
+    type: "name",
+    value: "P1",
+  });
+});
+
+test("properties が空文字 name（//）でも some のまま保持される", () => {
+  // 空文字 name は falsy だが Option としては some のまま扱われる境界値。
+  // bdc.name.test.ts は同じ境界入力を「handler が受理するか」の観点で見ている。
+  // 本 test は「stack が some のまま保持するか」の観点で見る点が差分。
+  const stack = MarkedContentStack.push(
+    MarkedContentStack.create(),
+    bdcSpanEmptyName,
+  );
+
+  const result = MarkedContentStack.pop(stack);
+
+  assert(result.some);
+  assert(result.value.popped.properties.some);
+  expect(result.value.popped.properties.value).toEqual({
+    type: "name",
+    value: "",
+  });
+});
+
+test("同一 tag で none と some(name) を積んでも pop 時に properties を取り違えない", () => {
+  // tag が同一でも properties バリアントが entry ごとに独立して保持されること
+  const s1 = MarkedContentStack.push(MarkedContentStack.create(), bmcSpan);
+  const s2 = MarkedContentStack.push(s1, bdcSpanName);
+
+  const first = MarkedContentStack.pop(s2);
+
+  assert(first.some);
+  expect(first.value.popped).toBe(bdcSpanName);
+  assert(first.value.popped.properties.some);
+  expect(first.value.popped.properties.value).toBe(propertyName);
+
+  const second = MarkedContentStack.pop(first.value.stack);
+
+  assert(second.some);
+  expect(second.value.popped).toBe(bmcSpan);
+  expect(second.value.popped.properties).toEqual({ some: false });
+});
+
+test("some(dict) と some(name) を隣接して積んでも pop 時に properties の型が入れ替わらない", () => {
+  // dictionary バリアントと name バリアントが LIFO 位置ごとに正しく対応すること
+  const s1 = MarkedContentStack.push(MarkedContentStack.create(), bdcSpanDict);
+  const s2 = MarkedContentStack.push(s1, bdcSpanName);
+
+  const upper = MarkedContentStack.pop(s2);
+
+  assert(upper.some);
+  assert(upper.value.popped.properties.some);
+  expect(upper.value.popped.properties.value.type).toBe("name");
+
+  const lower = MarkedContentStack.pop(upper.value.stack);
+
+  assert(lower.some);
+  assert(lower.value.popped.properties.some);
+  expect(lower.value.popped.properties.value.type).toBe("dictionary");
+});

--- a/packages/core/src/content-stream/marked-content/stack/__tests__/stack.nested.test.ts
+++ b/packages/core/src/content-stream/marked-content/stack/__tests__/stack.nested.test.ts
@@ -1,0 +1,179 @@
+// 本ファイルは深度 3 以上のネスト（none / some(dictionary) / some(name) 混在）で
+// MarkedContentStack の LIFO 順序・全件取り出し・元 stack 不変・永続性が
+// 維持されることを検証する。
+// stack.basic.test.ts は深度 2 まで、stack.pop-empty.test.ts は深度 0 起点の
+// pop = none を担当済み。本ファイルは深度 3 を全件 pop し切った結果としての
+// none と、深度 4 による三角測量を担当する点が差分。
+import { assert, expect, test } from "vitest";
+import type {
+  PdfDictionary,
+  PdfName,
+} from "../../../../pdf/types/pdf-types/index";
+import { none, some } from "../../../../utils/option/index";
+import { type MarkedContentEntry, MarkedContentStack } from "../index";
+
+const artifactTag: PdfName = { type: "name", value: "Artifact" };
+const spanTag: PdfName = { type: "name", value: "Span" };
+const linkTag: PdfName = { type: "name", value: "Link" };
+const figureTag: PdfName = { type: "name", value: "Figure" };
+const propertyName: PdfName = { type: "name", value: "P1" };
+const mcidDict: PdfDictionary = {
+  type: "dictionary",
+  entries: new Map([["MCID", { type: "integer", value: 0 }]]),
+};
+
+// 実 PDF の 3 段ネストを模した 3 バリアント混在の entry 群
+// 積む順（外側 → 内側）: outer(none) → middle(dict) → inner(name)
+const outerBmc: MarkedContentEntry = { tag: artifactTag, properties: none };
+const middleBdcDict: MarkedContentEntry = {
+  tag: spanTag,
+  properties: some(mcidDict),
+};
+const innerBdcName: MarkedContentEntry = {
+  tag: linkTag,
+  properties: some(propertyName),
+};
+// 深度 4 の三角測量用（3 が特別扱いされていないことの確認）
+const fourthBmc: MarkedContentEntry = { tag: figureTag, properties: none };
+
+/**
+ * entries を先頭から順に push した stack を返す（外側 → 内側の順で渡す）。
+ * 中間 stack は返さないため、中間 stack の検査が必要な test では
+ * push を直接連鎖させる。
+ *
+ * ループの書き方は emc.basic.test.ts の buildContext（let で受けた stack を
+ * for...of で push し直す形）を踏襲する。ただし同ヘルパは properties: none
+ * 固定で 3 バリアント混在を表現できないため、MarkedContentEntry を直接
+ * 受け取る形で新規定義する。
+ */
+const pushAll = (
+  entries: ReadonlyArray<MarkedContentEntry>,
+): MarkedContentStack => {
+  let stack = MarkedContentStack.create();
+  for (const entry of entries) {
+    stack = MarkedContentStack.push(stack, entry);
+  }
+  return stack;
+};
+
+test("3 バリアント混在の entry を 3 回 push すると depth が 3 になる", () => {
+  // BMC(none) → BDC(dict) → BDC(name) の 3 段ネストで depth が 3 まで積み上がること
+  const s3 = pushAll([outerBmc, middleBdcDict, innerBdcName]);
+
+  expect(MarkedContentStack.depth(s3)).toBe(3);
+});
+
+test("深度 3 の pop は LIFO で inner → middle → outer の順に全件取り出せる", () => {
+  // 3 段ネストの巻き戻しが逆順になり、各段で push した entry の同一参照が返ること
+  const s3 = pushAll([outerBmc, middleBdcDict, innerBdcName]);
+
+  const first = MarkedContentStack.pop(s3);
+  assert(first.some);
+  expect(first.value.popped).toBe(innerBdcName);
+
+  const second = MarkedContentStack.pop(first.value.stack);
+  assert(second.some);
+  expect(second.value.popped).toBe(middleBdcDict);
+
+  const third = MarkedContentStack.pop(second.value.stack);
+  assert(third.some);
+  expect(third.value.popped).toBe(outerBmc);
+});
+
+test("深度 3 を全件 pop し切った stack は depth 0 で pop が none を返す", () => {
+  // 3 回の pop で過不足なく空になり、4 回目の pop が none になること
+  const s3 = pushAll([outerBmc, middleBdcDict, innerBdcName]);
+
+  const first = MarkedContentStack.pop(s3);
+  assert(first.some);
+  const second = MarkedContentStack.pop(first.value.stack);
+  assert(second.some);
+  const third = MarkedContentStack.pop(second.value.stack);
+  assert(third.some);
+
+  expect(MarkedContentStack.depth(third.value.stack)).toBe(0);
+  expect(MarkedContentStack.pop(third.value.stack)).toEqual({ some: false });
+});
+
+test("深度 4 まで積んでも depth が 4 で pop の LIFO 順が保たれる", () => {
+  // 深度 3 が特別扱いされていないこと（三角測量による一般化の確認）
+  const s4 = pushAll([outerBmc, middleBdcDict, innerBdcName, fourthBmc]);
+  expect(MarkedContentStack.depth(s4)).toBe(4);
+
+  const first = MarkedContentStack.pop(s4);
+  assert(first.some);
+  expect(first.value.popped.tag.value).toBe("Figure");
+
+  const second = MarkedContentStack.pop(first.value.stack);
+  assert(second.some);
+  expect(second.value.popped.tag.value).toBe("Link");
+
+  const third = MarkedContentStack.pop(second.value.stack);
+  assert(third.some);
+  expect(third.value.popped.tag.value).toBe("Span");
+
+  const fourth = MarkedContentStack.pop(third.value.stack);
+  assert(fourth.some);
+  expect(fourth.value.popped.tag.value).toBe("Artifact");
+});
+
+test("深度 3 の pop 系列を通しても元 stack と中間 stack の depth が変化しない", () => {
+  // pop が非破壊であり、s1=1 / s2=2 / s3=3 が pop 後も維持されること
+  const s1 = MarkedContentStack.push(MarkedContentStack.create(), outerBmc);
+  const s2 = MarkedContentStack.push(s1, middleBdcDict);
+  const s3 = MarkedContentStack.push(s2, innerBdcName);
+
+  const first = MarkedContentStack.pop(s3);
+  assert(first.some);
+  const second = MarkedContentStack.pop(first.value.stack);
+  assert(second.some);
+  const third = MarkedContentStack.pop(second.value.stack);
+  assert(third.some);
+
+  expect(MarkedContentStack.depth(s1)).toBe(1);
+  expect(MarkedContentStack.depth(s2)).toBe(2);
+  expect(MarkedContentStack.depth(s3)).toBe(3);
+});
+
+test("深度 3 の各 pop は入力 stack と別参照の stack を返す", () => {
+  // 各段の pop が新しい配列を生成し、入力 stack を使い回さないこと
+  const s3 = pushAll([outerBmc, middleBdcDict, innerBdcName]);
+
+  const first = MarkedContentStack.pop(s3);
+  assert(first.some);
+  expect(first.value.stack).not.toBe(s3);
+
+  const second = MarkedContentStack.pop(first.value.stack);
+  assert(second.some);
+  expect(second.value.stack).not.toBe(first.value.stack);
+
+  const third = MarkedContentStack.pop(second.value.stack);
+  assert(third.some);
+  expect(third.value.stack).not.toBe(second.value.stack);
+});
+
+test("深度 2 の stack に 3 件目を push しても元 stack は depth 2 のまま別参照", () => {
+  // push が深度 3 でも非破壊であること
+  const s1 = MarkedContentStack.push(MarkedContentStack.create(), outerBmc);
+  const s2 = MarkedContentStack.push(s1, middleBdcDict);
+
+  const s3 = MarkedContentStack.push(s2, innerBdcName);
+
+  expect(MarkedContentStack.depth(s2)).toBe(2);
+  expect(s3).not.toBe(s2);
+});
+
+test("深度 3 から 1 回 pop した中間 stack に別 entry を push しても元の系列は影響を受けない", () => {
+  // 永続データ構造としての分岐独立性（分岐先 depth 3 かつ元 s3 の pop は元 entry を返す）
+  const s3 = pushAll([outerBmc, middleBdcDict, innerBdcName]);
+  const popped = MarkedContentStack.pop(s3);
+  assert(popped.some);
+
+  const branched = MarkedContentStack.push(popped.value.stack, fourthBmc);
+
+  expect(MarkedContentStack.depth(branched)).toBe(3);
+  expect(MarkedContentStack.depth(s3)).toBe(3);
+  const reread = MarkedContentStack.pop(s3);
+  assert(reread.some);
+  expect(reread.value.popped).toBe(innerBdcName);
+});


### PR DESCRIPTION
## 概要

Issue #507 で挙がっていた `MarkedContentStack` 周辺の未検証パターン 3 件を、新規テストファイル 4 本（計 23 テスト）で埋めます。

**プロダクションコードの差分は 0 行**です。追加は `*.test.ts` 4 ファイルのみで、public API・ビルド成果物・実行時挙動への影響はありません。ロールバックはファイル削除で完結します。

対象実装（`MarkedContentStack` / `btHandler` / `bdcHandler`）は完成済みのため、TDD の Red は「テストを追加して実行し、未検証領域を確かに通ることを確認する」に読み替えています。

## 変更内容

### 🎯 変更の種類

- [x] 🚨 テスト追加/修正 (Tests)

### 📝 詳細な変更内容

#### 追加されたテスト

| ファイル | 件数 | 埋めた未検証領域 |
|---|---|---|
| `stack.name-properties.test.ts` | 4 | `properties` の `some(PdfName)` バリアントが push→pop の往復で参照・内容とも保持されること。空文字 name の境界値、3 バリアント混在時の取り違え防止 |
| `stack.nested.test.ts` | 8 | 深度 3 / 4 のネストでの LIFO 全件取り出し、元 stack・中間 stack の `depth` 不変、返却 stack の別参照、分岐後の永続性 |
| `interpreter.text-object.test.ts` | 4 | `ContentStreamInterpreter.execute` 経由の `BT BT` が `OPERATOR_ILLEGAL_STATE` になること（`code` / `operatorName` / `message` を完全一致で pin down） |
| `interpreter.marked-content-properties.test.ts` | 7 | probe handler で実行途中の `markedContentStack` を捕捉し、interpreter 経由で組み立てられた entry の `properties` 3 バリアントと深度 3 ネストの LIFO 順を観測 |

#### 変更されたファイル

なし（既存テスト・プロダクションコードへの差分 0 行）

#### 削除されたファイル・機能

なし

## 📊 システム図

### 未検証領域と本 PR のカバー範囲

```mermaid
flowchart TD
    subgraph stack["MarkedContentStack (unit)"]
        D1["depth 1<br/>properties: none"]
        D2["depth 2<br/>some(PdfDictionary)"]
        D3["depth 3+ 混在<br/>none / dict / name"]:::new
        NM["some(PdfName)"]:::new
        D1 --> D2 --> D3
        D1 -.->|"既存 fixture に無い"| NM
    end

    subgraph e2e["ContentStreamInterpreter.execute (E2E)"]
        BT1["BT: INACTIVE → ACTIVE"]
        BT2["未 ET のまま 2 回目の BT"]:::new
        ERR["err OPERATOR_ILLEGAL_STATE<br/>operatorName=BT"]:::new
        BT1 --> BT2 --> ERR
    end

    classDef new fill:#ffe4b5,stroke:#d97706,stroke-width:2px
```

### probe handler 方式のデータフロー

`execute` の戻り値からは BDC が積んだ entry を観測できないため、観測用 operator を registry に追加登録して実行途中の context を捕捉します。

```
  採用: "/Span /P1 BDC probe EMC"
  ─────────────────────────────────────────────────────
    bytes → tokenizer → OperandStack[/Span, /P1] → bdcHandler
                                                      │ push (depth 1)
                                                      ▼
                              probe handler ◀── context.markedContentStack   [NEW]
                                   │ （クロージャで捕捉・ok(context) で素通し）
                                   ▼
                              captured: MarkedContentStack[]  ⇒ 観測 可能
                                   │
                                 EMC (pop)
                                   ▼
                              EOF / depth 0 → ok({ context, warnings })
                                              ⇒ entry は消えており観測 不可

  不採用: "/Span /P1 BDC"（EMC 省略）
  ─────────────────────────────────────────────────────
    EOF 検査が未閉じを検出 → err(OBJECT_PARSE_UNTERMINATED)
                            ⇒ context 自体が返らず観測 不可
```

## 📋 関連 Issue

- Closes #507

Issue 記載の 3 チェックボックス（`some(PdfName)` バリアント / 深度 3 以上のネスト / interpreter 経由の `BT BT` E2E）をすべてカバーしています。

## 🧪 テスト

### テスト実行方法

```bash
pnpm lint
pnpm typecheck
pnpm test:run
```

> `pnpm test` は watch モードで停止しないため使用していません。

### テスト項目

- [x] 単体テスト (Unit tests) — `stack.name-properties.test.ts` / `stack.nested.test.ts`
- [x] 統合テスト (Integration tests) — `interpreter.text-object.test.ts` / `interpreter.marked-content-properties.test.ts`
- [x] 手動テスト (Manual testing) — 下記の手動検証 1〜9

### テスト結果

| 項目 | 実装前 | 実装後 |
|---|---|---|
| `pnpm test:run` | 274 files / 3340 tests | **278 files / 3363 tests**（失敗 0・skip 0） |
| `pnpm lint`（biome） | 476 files / 0 error | 480 files / 0 error |
| `pnpm lint`（oxlint） | 466 files / 0 warning・0 error | 470 files / 0 warning・0 error |
| `pnpm typecheck` | 成功 | 成功 |

**ミューテーション的チェック（テストの実効性確認）**

対象実装が完成済みで「失敗する Red」を作れないため、補償としてプロダクションコードを一時的に壊し、新規テストが実際に落ちることを確認しました。

- `MarkedContentStack.pop` の `slice(0, lastIndex)` を壊す → `stack.nested.test.ts` の 8 件中 **6 件**が失敗
- `MarkedContentStack.push` を破壊的更新に変更 → 不変性の **2 件**が失敗
- 両方で落ちたのは 1 件のみで、壊した箇所ごとに検出するテストがほぼ分かれている
- 実施後にプロダクションコードを完全復元し、`git diff` が空であることを確認済み

## 🔍 レビューポイント

- **probe handler 方式の妥当性**: `execute` の戻り値から entry を観測できない（`EMC` で閉じれば消え、閉じなければ `OBJECT_PARSE_UNTERMINATED` で `context` が返らない）ため、`ok(context)` で素通しする観測用 operator を追加登録する方式を採りました。後続の `EMC` / EOF 検査に影響しないことは「完走時 `depth` 0」で担保しています。
- **`captured[0]` アクセス前の発火回数アサート**: `noUncheckedIndexedAccess` が未設定のため、probe 未発火時に型エラーにならず読めない `TypeError` になります。これを防ぐため probe を使う全 test で `expect(captured).toHaveLength(1)` を先に置いています。
- **既存テストとの重複回避**: 部分重複する 4 箇所（`bdc.name.test.ts` の 2 箇所 / `et.integration.test.ts` の 2 周目ライフサイクル / `interpreter.marked-content.test.ts` の完走時 `depth` 0）は、**既存テストを削除・改変せず**、新規ファイル側のコメントで観点差を書き分けています。
- **既存前例の踏襲**: `pushAll` のループ形は `emc.basic.test.ts`、ヘルパ 3 分割は `text-positioning-operators.integration.test.ts`、`registerOperator` のシグネチャは `interpreter.dispatch.test.ts` 系 3 ファイル、3 段ネストのテスト名は `graphics-state-operators.integration.test.ts` に揃えています（独自流儀を発明していません）。
- **`BT foo BT` の期待値が成立する根拠**: 未登録 operator は `UNKNOWN_OPERATOR` 警告を積んで operand stack をクリアしたうえで context をそのまま返して継続するため、`textObject` が active のまま維持されます。この既存挙動に依存しています。
- **異常系で `warnings` を検証していない理由**: `execute` が `err` を返す場合、戻り値に `warnings` は載らないためです（成功側の型にしか含まれない）。

## ⚠️ 破壊的変更

- [ ] この変更は既存の API に破壊的変更を含みます

なし。テスト追加のみで実行時挙動への影響はありません。

## 📚 追加情報

### 注意事項

- 既存テストとプロダクションコードへの差分は 0 行です（`git status --short` が新規 4 ファイルの `??` のみ、`git diff --stat -- packages` が空であることを確認済み）。
- テストがプロダクション実装のバグを検出した場合は本 PR で修正せず別 Issue として報告する方針でしたが、**バグは検出されませんでした**。

## ✅ チェックリスト

- [x] コードレビューの準備ができている
- [x] テストが正常に実行される
- [ ] ドキュメントが更新されている（テスト追加のみのため対象外）
- [x] コミットメッセージが適切な形式で書かれている
- [x] 関連する Issue が PR の「Development」に Linked されている
- [x] PR 本文に `Closes #507` で Issue が記載されている
- [x] セルフレビューを実施した（Codex CLI によるレビューも実施し「問題なし」）
- [x] 破壊的変更がある場合は明記されている（該当なし）

## 🤝 レビュアーへのお願い

- probe handler 方式が「観測のために測定対象を壊していないか」の観点で見ていただけると助かります。
- 既存テストとの重複回避をコメントでの書き分けに留めた判断（既存テストを消していない点）についてご意見があればお願いします。

🤖 Generated with [Claude Code](https://claude.com/claude-code)