### PR TITLE
♻️ [Refactoring]: #391 標準変換トレイト (From / Display) の実装を型間で統一

### DIFF
--- a/rust/crates/core/src/byte_offset.rs
+++ b/rust/crates/core/src/byte_offset.rs
@@ -4,6 +4,8 @@
 //! 構成要素として用いる。生成は無検証（infallible）で、0（ファイル先頭）や `u64::MAX` も
 //! 無条件に受理する。値の妥当性検証（ファイルサイズ超過等）は xref レイヤ（R2）に委譲する。
 
+use std::fmt;
+
 /// PDF ファイル内のバイトオフセット。ファイル先頭からの位置を表す非負整数のラッパ。
 ///
 /// 内部表現は `u64`（Issue #257 指定）。
@@ -25,6 +27,48 @@ impl ByteOffset {
     }
 }
 
+impl From<u64> for ByteOffset {
+    /// `u64` から `ByteOffset` を生成する慣習的な変換経路。
+    ///
+    /// `u64` の定義域が `ByteOffset` の定義域と完全に一致するロスレスな全域変換であり、
+    /// panic する経路を持たないため `TryFrom` ではなく `From` を採用する。既存の
+    /// `new` は非破壊で残しており本変換は唯一の構築経路ではないが、`42u64.into()` /
+    /// `ByteOffset::from(42)` という標準的な書き方と、`impl Into<ByteOffset>` を
+    /// 受け取るジェネリック API を可能にする目的で併設する。
+    fn from(n: u64) -> ByteOffset {
+        ByteOffset(n)
+    }
+}
+
+impl From<ByteOffset> for u64 {
+    /// `ByteOffset` から内部の `u64` を取り出す逆方向の変換経路。
+    ///
+    /// ロスレスな変換は双方向に `From` を提供するのが Rust API Guidelines (C-CONV) の
+    /// 推奨であるため、入力方向とあわせて実装する。既存の `value()` と結果は等価。
+    /// 本型は `Copy` なので本変換に渡したあとも元の値は使い続けられる。`value()` は
+    /// `&ByteOffset` しか手元にない場面で自動参照外しにより値だけ取り出せる経路として
+    /// 引き続き提供する（どちらも残す）。
+    fn from(offset: ByteOffset) -> u64 {
+        offset.0
+    }
+}
+
+/// 内部のバイトオフセットを装飾なしで出力する（型名などを付け足さない）。
+///
+/// `" at byte {}"` のような文脈は書式化の呼び出し側が持つため、型側は値だけを出す。
+/// 実装は内部 `u64` の `Display` へ**委譲**する。`write!(f, "{}", self.0)` と書くと
+/// 呼び出し側が `Formatter` に載せた書式指定（幅・ゼロ埋め・寄せ）が捨てられ、
+/// `format!("{:010}", offset)` が `"42"` になってしまう。xref エントリは
+/// オフセット 10 桁・世代番号 5 桁のゼロ埋め固定長（ISO 32000-1 §7.5.4）であり、
+/// 書式指定が黙って無視されると壊れた出力を静かに生む。委譲すれば既定の `{}` は
+/// 従来どおり `"42"` のまま、`{:010}` は `"0000000042"` と期待どおりに働く。
+/// `Debug` は derive のまま（`ByteOffset(42)`）とし、開発者向けダンプとの役割分離を保つ。
+impl fmt::Display for ByteOffset {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Display::fmt(&self.0, f)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -37,6 +81,110 @@ mod tests {
         for n in [0, 1, 42, u64::MAX] {
             assert_eq!(ByteOffset::new(n).value(), n);
         }
+    }
+
+    #[test]
+    fn from_u64_builds_offset() {
+        // u64 から From で変換した結果が new で生成した ByteOffset と等価になることを確認する
+        assert_eq!(ByteOffset::from(42), ByteOffset::new(42));
+    }
+
+    #[test]
+    fn into_offset_from_u64() {
+        // u64 側から .into() を呼ぶ経路でも同じ ByteOffset が得られることを確認する
+        let offset: ByteOffset = 42u64.into();
+        assert_eq!(offset, ByteOffset::new(42));
+    }
+
+    #[test]
+    fn unsuffixed_integer_literal_into_resolves_uniquely() {
+        // サフィックスなし整数リテラルの .into() が候補一意で u64 に推論されることを確認する
+        // （From<u32> 等を後から足すと E0283 でコンパイルが落ちる回帰ガード）
+        let offset: ByteOffset = 42.into();
+        assert_eq!(offset, ByteOffset::new(42));
+    }
+
+    #[test]
+    fn into_u64_returns_inner_value() {
+        // ByteOffset から u64 への逆方向 From が内部の生値を返すことを確認する
+        let offset = ByteOffset::new(42);
+        assert_eq!(u64::from(offset), 42);
+    }
+
+    #[test]
+    fn from_matches_new() {
+        // 新設の From と既存 new が同じ値の ByteOffset を作ることを確認する
+        assert_eq!(ByteOffset::from(7), ByteOffset::new(7));
+    }
+
+    #[test]
+    fn into_u64_matches_value() {
+        // 逆方向 From と既存 value() がどちらも同じ生値を返すことを確認する
+        let offset = ByteOffset::new(7);
+        assert_eq!(u64::from(offset), offset.value());
+    }
+
+    #[test]
+    fn from_then_into_roundtrips() {
+        // 代表値（0 / 1 / 42 / u64::MAX）を u64 → ByteOffset → u64 と往復させても
+        // 入力と一致する（双方向 From が無損失である）ことを確認する
+        for n in [0, 1, 42, u64::MAX] {
+            assert_eq!(u64::from(ByteOffset::from(n)), n);
+        }
+    }
+
+    #[test]
+    fn from_zero_builds_offset() {
+        // ファイル先頭を表す 0 を From で変換しても値が保持されることを確認する
+        assert_eq!(ByteOffset::from(0), ByteOffset::new(0));
+    }
+
+    #[test]
+    fn from_u64_max_builds_offset() {
+        // 上限 u64::MAX を From で変換しても値が保持されることを確認する
+        assert_eq!(ByteOffset::from(u64::MAX), ByteOffset::new(u64::MAX));
+    }
+
+    #[test]
+    fn display_renders_decimal() {
+        // Display が内部値の 10 進表記のみを出力することを確認する
+        assert_eq!(format!("{}", ByteOffset::new(42)), "42");
+    }
+
+    #[test]
+    fn display_renders_zero() {
+        // 0 の書式化が空文字列にならず "0" になることを確認する
+        assert_eq!(format!("{}", ByteOffset::new(0)), "0");
+    }
+
+    #[test]
+    fn display_renders_one() {
+        // 1 の書式化が "1" になることを確認する
+        assert_eq!(format!("{}", ByteOffset::new(1)), "1");
+    }
+
+    #[test]
+    fn display_renders_u64_max() {
+        // 上限 u64::MAX が桁落ちせず 10 進表記されることを確認する
+        assert_eq!(
+            format!("{}", ByteOffset::new(u64::MAX)),
+            "18446744073709551615"
+        );
+    }
+
+    #[test]
+    fn display_omits_type_name_decoration() {
+        // Display は値のみ、Debug は型名付きという役割分離を固定する
+        let offset = ByteOffset::new(42);
+        assert_eq!(format!("{offset}"), "42");
+        assert_eq!(format!("{offset:?}"), "ByteOffset(42)");
+    }
+
+    #[test]
+    fn display_respects_width_and_zero_pad() {
+        // 呼び出し側が指定した幅・ゼロ埋めが握り潰されず内部 u64 の Display へ渡ることを確認する
+        // （xref エントリのオフセットは 10 桁ゼロ埋め固定長・ISO 32000-1 §7.5.4）
+        assert_eq!(format!("{:010}", ByteOffset::new(42)), "0000000042");
     }
 
     #[test]

--- a/rust/crates/core/src/error/pdf_error.rs
+++ b/rust/crates/core/src/error/pdf_error.rs
@@ -85,7 +85,7 @@ impl fmt::Display for PdfError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", self.code)?;
         if let Some(position) = self.position {
-            write!(f, " at byte {}", position.value())?;
+            write!(f, " at byte {}", position)?;
         }
         if let Some(message) = &self.message {
             write!(f, ": {}", message)?;

--- a/rust/crates/core/src/object/generation_number.rs
+++ b/rust/crates/core/src/object/generation_number.rs
@@ -5,6 +5,8 @@
 //! 生成は無検証（infallible）で、0 や `u16::MAX`（= 65535）も無条件に受理する。
 //! 0（フリーリスト先頭の予約世代）の特別扱い・世代不一致判定は xref レイヤ（後続）に委譲する。
 
+use std::fmt;
+
 /// PDF 世代番号。間接オブジェクトの世代（削除・再利用の管理）を表す整数のラッパ。
 ///
 /// 内部表現は `u16`。仕様範囲 `0..=65535`（ISO 32000-1 §7.5.4）が `u16` の定義域と
@@ -27,6 +29,48 @@ impl GenerationNumber {
     }
 }
 
+impl From<u16> for GenerationNumber {
+    /// `u16` から `GenerationNumber` を生成する慣習的な変換経路。
+    ///
+    /// 仕様範囲 `0..=65535`（ISO 32000-1 §7.5.4）が `u16` の定義域と一致するため、
+    /// 範囲外の入力は型レベルで表現できない。よって失敗しうる変換ではなく `From` を採用する。
+    /// 既存の `new` は非破壊で残しており本変換は唯一の構築経路ではないが、`42u16.into()` /
+    /// `GenerationNumber::from(42)` という標準的な書き方と、`impl Into<GenerationNumber>` を
+    /// 受け取るジェネリック API を可能にする目的で併設する。
+    fn from(n: u16) -> GenerationNumber {
+        GenerationNumber(n)
+    }
+}
+
+impl From<GenerationNumber> for u16 {
+    /// `GenerationNumber` から内部の `u16` を取り出す逆方向の変換経路。
+    ///
+    /// ロスレスな変換は双方向に `From` を提供するのが Rust API Guidelines (C-CONV) の
+    /// 推奨であるため、入力方向とあわせて実装する。既存の `value()` と結果は等価。
+    /// 本型は `Copy` なので本変換に渡したあとも元の値は使い続けられる。`value()` は
+    /// `&GenerationNumber` しか手元にない場面で自動参照外しにより値だけ取り出せる経路として
+    /// 引き続き提供する（どちらも残す）。
+    fn from(number: GenerationNumber) -> u16 {
+        number.0
+    }
+}
+
+/// 内部の世代番号を装飾なしで出力する（型名などを付け足さない）。
+///
+/// 現時点でクレート内に書式化の呼び出し元はないが、値ラッパ newtype 3 型で同じ変換集合を
+/// 持たせるために実装する（型ごとに標準変換が不揃いな状態を解消する）。実装は内部 `u16` の
+/// `Display` へ**委譲**する。xref エントリの世代番号は 5 桁ゼロ埋め（ISO 32000-1 §7.5.4）
+/// であり、`write!(f, "{}", self.0)` と書くと呼び出し側が `Formatter` に載せた書式指定
+/// （幅・ゼロ埋め・寄せ）が捨てられ、`format!("{:05}", generation)` が `"0"` になって
+/// 壊れた固定長を静かに生む。委譲すれば既定の `{}` は従来どおりゼロ埋めなしの `"0"` を、
+/// `{:05}` は `"00000"` を返す。`Debug` は derive のまま（`GenerationNumber(42)`）とし、
+/// 開発者向けダンプとの役割分離を保つ。
+impl fmt::Display for GenerationNumber {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Display::fmt(&self.0, f)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -40,6 +84,110 @@ mod tests {
         for n in [0, 1, 42, u16::MAX] {
             assert_eq!(GenerationNumber::new(n).value(), n);
         }
+    }
+
+    #[test]
+    fn from_u16_builds_generation_number() {
+        // u16 から From で変換した結果が new で生成した GenerationNumber と等価になることを確認する
+        assert_eq!(GenerationNumber::from(42), GenerationNumber::new(42));
+    }
+
+    #[test]
+    fn into_generation_number_from_u16() {
+        // u16 側から .into() を呼ぶ経路でも同じ GenerationNumber が得られることを確認する
+        let generation: GenerationNumber = 42u16.into();
+        assert_eq!(generation, GenerationNumber::new(42));
+    }
+
+    #[test]
+    fn unsuffixed_integer_literal_into_resolves_uniquely() {
+        // サフィックスなし整数リテラルの .into() が候補一意で u16 に推論されることを確認する
+        // （候補が一意なので i32 フォールバックは起きない。From<u32> 等を後から足すと壊れる回帰ガード）
+        let generation: GenerationNumber = 42.into();
+        assert_eq!(generation, GenerationNumber::new(42));
+    }
+
+    #[test]
+    fn into_u16_returns_inner_value() {
+        // GenerationNumber から u16 への逆方向 From が内部の生値を返すことを確認する
+        let generation = GenerationNumber::new(42);
+        assert_eq!(u16::from(generation), 42);
+    }
+
+    #[test]
+    fn from_matches_new() {
+        // 新設の From と既存 new が同じ値の GenerationNumber を作ることを確認する
+        assert_eq!(GenerationNumber::from(7), GenerationNumber::new(7));
+    }
+
+    #[test]
+    fn into_u16_matches_value() {
+        // 逆方向 From と既存 value() がどちらも同じ生値を返すことを確認する
+        let generation = GenerationNumber::new(7);
+        assert_eq!(u16::from(generation), generation.value());
+    }
+
+    #[test]
+    fn from_then_into_roundtrips() {
+        // 代表値（0 / 1 / 42 / u16::MAX）を u16 → GenerationNumber → u16 と往復させても
+        // 入力と一致する（双方向 From が無損失である）ことを確認する
+        for n in [0, 1, 42, u16::MAX] {
+            assert_eq!(u16::from(GenerationNumber::from(n)), n);
+        }
+    }
+
+    #[test]
+    fn from_zero_builds_generation_number() {
+        // フリーリスト先頭の予約世代 0 を From で変換しても値が保持されることを確認する
+        assert_eq!(GenerationNumber::from(0), GenerationNumber::new(0));
+    }
+
+    #[test]
+    fn from_u16_max_builds_generation_number() {
+        // 仕様上限 u16::MAX（= 65535）を From で変換しても値が保持されることを確認する
+        assert_eq!(
+            GenerationNumber::from(u16::MAX),
+            GenerationNumber::new(u16::MAX)
+        );
+    }
+
+    #[test]
+    fn display_renders_decimal() {
+        // Display が内部値の 10 進表記のみを出力することを確認する
+        assert_eq!(format!("{}", GenerationNumber::new(42)), "42");
+    }
+
+    #[test]
+    fn display_renders_zero() {
+        // 書式指定なしの 0 は既定ではゼロ埋めせず "0" になることを確認する
+        assert_eq!(format!("{}", GenerationNumber::new(0)), "0");
+    }
+
+    #[test]
+    fn display_renders_one() {
+        // 1 の書式化が "1" になることを確認する
+        assert_eq!(format!("{}", GenerationNumber::new(1)), "1");
+    }
+
+    #[test]
+    fn display_renders_u16_max() {
+        // 仕様上限 u16::MAX（= 65535）が桁落ちせず 10 進表記されることを確認する
+        assert_eq!(format!("{}", GenerationNumber::new(u16::MAX)), "65535");
+    }
+
+    #[test]
+    fn display_omits_type_name_decoration() {
+        // Display は値のみ、Debug は型名付きという役割分離を固定する
+        let generation = GenerationNumber::new(42);
+        assert_eq!(format!("{generation}"), "42");
+        assert_eq!(format!("{generation:?}"), "GenerationNumber(42)");
+    }
+
+    #[test]
+    fn display_respects_width_and_zero_pad() {
+        // 呼び出し側が指定した幅・ゼロ埋めが握り潰されず内部 u16 の Display へ渡ることを確認する
+        // （xref エントリの世代番号は 5 桁ゼロ埋め固定長・ISO 32000-1 §7.5.4）
+        assert_eq!(format!("{:05}", GenerationNumber::new(0)), "00000");
     }
 
     #[test]

--- a/rust/crates/core/src/object/name.rs
+++ b/rust/crates/core/src/object/name.rs
@@ -56,6 +56,40 @@ impl From<&str> for PdfName {
     }
 }
 
+impl From<String> for PdfName {
+    /// 所有された `String` から `PdfName` を生成する変換経路。
+    ///
+    /// `into_bytes()` によりバッファをそのままムーブするため、`From<&str>` の
+    /// `to_vec()` と違ってコピーが発生しない。UTF-8 妥当性の検査はしない
+    /// （`String` は常に妥当な UTF-8 であり、本型はさらに広いバイト列を受理する）。
+    fn from(s: String) -> PdfName {
+        PdfName(s.into_bytes())
+    }
+}
+
+impl From<Vec<u8>> for PdfName {
+    /// 所有されたバイト列から `PdfName` を生成する変換経路。
+    ///
+    /// レクサーが `#XX` デコード後に組み立てた `Vec<u8>` をそのままムーブで受け取る
+    /// 想定の主経路。無検証（infallible）であり、空バイト列・NUL・非 UTF-8 バイトを
+    /// 無条件に受理する（`new` と同一の契約）。
+    fn from(bytes: Vec<u8>) -> PdfName {
+        PdfName(bytes)
+    }
+}
+
+impl From<&[u8]> for PdfName {
+    /// 借用したバイトスライスから `PdfName` を生成する変換経路（1 回コピーする）。
+    ///
+    /// なお `From` にはデリファレンス強制が効かないため、`b"Length"`（`&[u8; N]`）や
+    /// `&Vec<u8>` は本 impl では受理できない。バイト列リテラルからは `new(b"Length")`
+    /// を使うか、`b"Length".as_slice()` のようにスライスへ明示的に変換する。
+    /// `From<&[u8; N]>` は今回実装しないが、後から非破壊で追加できる。
+    fn from(bytes: &[u8]) -> PdfName {
+        PdfName(bytes.to_vec())
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -73,6 +107,129 @@ mod tests {
     fn from_str_builds_name() {
         // &str リテラルから From で生成すると as_bytes がそのバイト列に一致することを確認する
         assert_eq!(PdfName::from("Type").as_bytes(), b"Type");
+    }
+
+    #[test]
+    fn from_string_builds_name() {
+        // 所有された String から From で生成すると as_bytes がそのバイト列に一致することを確認する
+        assert_eq!(PdfName::from(String::from("Type")).as_bytes(), b"Type");
+    }
+
+    #[test]
+    fn from_vec_u8_builds_name() {
+        // 所有された Vec<u8> から From で生成すると as_bytes がそのバイト列に一致することを確認する
+        assert_eq!(PdfName::from(b"Type".to_vec()).as_bytes(), b"Type");
+    }
+
+    #[test]
+    fn from_slice_builds_name() {
+        // 借用バイトスライスから From で生成すると as_bytes がそのバイト列に一致することを確認する
+        let bytes = b"Type".to_vec();
+        assert_eq!(PdfName::from(bytes.as_slice()).as_bytes(), b"Type");
+    }
+
+    #[test]
+    fn from_slice_matches_from_vec() {
+        // 借用経路と所有経路が同一の PdfName を作ることを確認する
+        let bytes = b"Type".to_vec();
+        assert_eq!(
+            PdfName::from(bytes.as_slice()),
+            PdfName::from(bytes.clone())
+        );
+    }
+
+    #[test]
+    fn from_empty_slice_builds_empty_name() {
+        // 空スライスを無検証で受理し as_bytes が空になることを確認する
+        let empty: &[u8] = &[];
+        assert!(PdfName::from(empty).as_bytes().is_empty());
+    }
+
+    #[test]
+    fn from_slice_preserves_nul_byte() {
+        // #00 デコード結果の NUL バイトが借用経路でも無検証に保持されることを確認する
+        let bytes: &[u8] = &[0x00];
+        assert_eq!(PdfName::from(bytes).as_bytes(), &[0x00]);
+    }
+
+    #[test]
+    fn from_slice_preserves_non_utf8_byte() {
+        // 非 UTF-8 バイト（0x80）が借用経路でも保持され、as_str が None を返すことを確認する
+        let bytes: &[u8] = &[0x80];
+        let name = PdfName::from(bytes);
+        assert_eq!(name.as_bytes(), &[0x80]);
+        assert_eq!(name.as_str(), None);
+    }
+
+    #[test]
+    fn from_byte_literal_slice_builds_name() {
+        // b"..."（&[u8; N]）は From に deref 強制が効かず直接渡せないため、
+        // .as_slice() を挟む回避策が機能することを確認する
+        assert_eq!(PdfName::from(b"Length".as_slice()).as_bytes(), b"Length");
+    }
+
+    #[test]
+    fn from_vec_reference_requires_as_slice() {
+        // &Vec<u8> も deref 強制が効かず From では受理されないため、
+        // .as_slice() を挟む回避策が所有経路と等価になることを確認する
+        let bytes = b"Length".to_vec();
+        assert_eq!(
+            PdfName::from(bytes.as_slice()),
+            PdfName::from(bytes.clone())
+        );
+    }
+
+    #[test]
+    fn from_vec_matches_new() {
+        // 新設 From<Vec<u8>> と既存 new が同一の PdfName を作ることを確認する
+        assert_eq!(
+            PdfName::from(b"Type".to_vec()),
+            PdfName::new(b"Type".to_vec())
+        );
+    }
+
+    #[test]
+    fn from_empty_vec_builds_empty_name() {
+        // 空 Vec<u8> を無検証で受理し as_bytes が空になることを確認する
+        assert!(PdfName::from(Vec::new()).as_bytes().is_empty());
+    }
+
+    #[test]
+    fn from_vec_preserves_nul_byte() {
+        // #00 デコード結果の NUL バイトが所有経路で無検証に保持されることを確認する
+        assert_eq!(PdfName::from(vec![0x00]).as_bytes(), &[0x00]);
+    }
+
+    #[test]
+    fn from_vec_preserves_non_utf8_byte() {
+        // 非 UTF-8 バイト（0x80）が所有経路で保持され、as_str が None を返すことを確認する
+        let name = PdfName::from(vec![0x80]);
+        assert_eq!(name.as_bytes(), &[0x80]);
+        assert_eq!(name.as_str(), None);
+    }
+
+    #[test]
+    fn from_string_matches_from_str() {
+        // String 経路と既存 &str 経路が同一の PdfName を作ることを確認する
+        assert_eq!(PdfName::from(String::from("Type")), PdfName::from("Type"));
+    }
+
+    #[test]
+    fn from_empty_string_builds_empty_name() {
+        // 空 String（PDF 仕様上有効な空名 `/`）を無検証で受理し as_bytes が空になることを確認する
+        assert!(PdfName::from(String::new()).as_bytes().is_empty());
+    }
+
+    #[test]
+    fn from_string_preserves_multibyte_utf8() {
+        // 多バイト UTF-8（日本語）の名前が String 経路でも忠実に保持されることを確認する
+        assert_eq!(PdfName::from(String::from("名前")).as_str(), Some("名前"));
+    }
+
+    #[test]
+    fn from_string_preserves_nul_byte() {
+        // String も NUL を保持できるため、String 経路でも無検証で NUL が残ることを確認する
+        assert_eq!(PdfName::from(String::from("\u{0}")).as_bytes(), &[0x00]);
     }
 
     #[test]

--- a/rust/crates/core/src/object/object_number.rs
+++ b/rust/crates/core/src/object/object_number.rs
@@ -4,6 +4,8 @@
 //! 構成要素として用いる。生成は無検証（infallible）で、0 や `u64::MAX` も無条件に受理する。
 //! 0（フリーリスト先頭の予約番号）の特別扱いは xref レイヤ（R2）に委譲する。
 
+use std::fmt;
+
 /// PDF オブジェクト番号。間接オブジェクトを一意に識別する非負整数のラッパ。
 ///
 /// 内部表現は `u64`（docs/specs/01_lexical_conventions.md §4.4 の u32 とは意図的に乖離。Issue #255 指定）。
@@ -25,6 +27,47 @@ impl ObjectNumber {
     }
 }
 
+impl From<u64> for ObjectNumber {
+    /// `u64` から `ObjectNumber` を生成する慣習的な変換経路。
+    ///
+    /// `u64` の定義域が `ObjectNumber` の定義域と完全に一致するロスレスな全域変換であり、
+    /// panic する経路を持たないため `TryFrom` ではなく `From` を採用する。既存の `new` は
+    /// 非破壊で残しており本変換は唯一の構築経路ではないが、`42u64.into()` /
+    /// `ObjectNumber::from(42)` という標準的な書き方と、`impl Into<ObjectNumber>` を
+    /// 受け取るジェネリック API を可能にする目的で併設する。
+    fn from(n: u64) -> ObjectNumber {
+        ObjectNumber(n)
+    }
+}
+
+impl From<ObjectNumber> for u64 {
+    /// `ObjectNumber` から内部の `u64` を取り出す逆方向の変換経路。
+    ///
+    /// ロスレスな変換は双方向に `From` を提供するのが Rust API Guidelines (C-CONV) の
+    /// 推奨であるため、入力方向とあわせて実装する。既存の `value()` と結果は等価。
+    /// 本型は `Copy` なので本変換に渡したあとも元の値は使い続けられる。`value()` は
+    /// `&ObjectNumber` しか手元にない場面で自動参照外しにより値だけ取り出せる経路として
+    /// 引き続き提供する（どちらも残す）。
+    fn from(number: ObjectNumber) -> u64 {
+        number.0
+    }
+}
+
+/// 内部のオブジェクト番号を装飾なしで出力する（型名などを付け足さない）。
+///
+/// 現時点でクレート内に書式化の呼び出し元はないが、値ラッパ newtype 3 型で同じ変換集合を
+/// 持たせるために実装する（型ごとに標準変換が不揃いな状態を解消する）。実装は内部 `u64` の
+/// `Display` へ**委譲**する。`write!(f, "{}", self.0)` と書くと呼び出し側が `Formatter` に
+/// 載せた書式指定（幅・ゼロ埋め・寄せ）が捨てられ、`format!("{:06}", number)` が `"42"` に
+/// なってしまう。委譲すれば既定の `{}` は `"42"` のまま、`{:06}` は `"000042"` と
+/// 期待どおりに働く。`Debug` は derive のまま（`ObjectNumber(42)`）とし、開発者向け
+/// ダンプとの役割分離を保つ。
+impl fmt::Display for ObjectNumber {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Display::fmt(&self.0, f)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -37,6 +80,109 @@ mod tests {
         for n in [0, 1, 42, u64::MAX] {
             assert_eq!(ObjectNumber::new(n).value(), n);
         }
+    }
+
+    #[test]
+    fn from_u64_builds_object_number() {
+        // u64 から From で変換した結果が new で生成した ObjectNumber と等価になることを確認する
+        assert_eq!(ObjectNumber::from(42), ObjectNumber::new(42));
+    }
+
+    #[test]
+    fn into_object_number_from_u64() {
+        // u64 側から .into() を呼ぶ経路でも同じ ObjectNumber が得られることを確認する
+        let number: ObjectNumber = 42u64.into();
+        assert_eq!(number, ObjectNumber::new(42));
+    }
+
+    #[test]
+    fn unsuffixed_integer_literal_into_resolves_uniquely() {
+        // サフィックスなし整数リテラルの .into() が候補一意で u64 に推論されることを確認する
+        // （From<u32> 等を後から足すと E0283 でコンパイルが落ちる回帰ガード）
+        let number: ObjectNumber = 42.into();
+        assert_eq!(number, ObjectNumber::new(42));
+    }
+
+    #[test]
+    fn into_u64_returns_inner_value() {
+        // ObjectNumber から u64 への逆方向 From が内部の生値を返すことを確認する
+        let number = ObjectNumber::new(42);
+        assert_eq!(u64::from(number), 42);
+    }
+
+    #[test]
+    fn from_matches_new() {
+        // 新設の From と既存 new が同じ値の ObjectNumber を作ることを確認する
+        assert_eq!(ObjectNumber::from(7), ObjectNumber::new(7));
+    }
+
+    #[test]
+    fn into_u64_matches_value() {
+        // 逆方向 From と既存 value() がどちらも同じ生値を返すことを確認する
+        let number = ObjectNumber::new(7);
+        assert_eq!(u64::from(number), number.value());
+    }
+
+    #[test]
+    fn from_then_into_roundtrips() {
+        // 代表値（0 / 1 / 42 / u64::MAX）を u64 → ObjectNumber → u64 と往復させても
+        // 入力と一致する（双方向 From が無損失である）ことを確認する
+        for n in [0, 1, 42, u64::MAX] {
+            assert_eq!(u64::from(ObjectNumber::from(n)), n);
+        }
+    }
+
+    #[test]
+    fn from_zero_builds_object_number() {
+        // フリーリスト先頭の予約番号 0 を From で変換しても値が保持されることを確認する
+        assert_eq!(ObjectNumber::from(0), ObjectNumber::new(0));
+    }
+
+    #[test]
+    fn from_u64_max_builds_object_number() {
+        // 上限 u64::MAX を From で変換しても値が保持されることを確認する
+        assert_eq!(ObjectNumber::from(u64::MAX), ObjectNumber::new(u64::MAX));
+    }
+
+    #[test]
+    fn display_renders_decimal() {
+        // Display が内部値の 10 進表記のみを出力することを確認する
+        assert_eq!(format!("{}", ObjectNumber::new(42)), "42");
+    }
+
+    #[test]
+    fn display_renders_zero() {
+        // 0 の書式化が空文字列にならず "0" になることを確認する
+        assert_eq!(format!("{}", ObjectNumber::new(0)), "0");
+    }
+
+    #[test]
+    fn display_renders_one() {
+        // 1 の書式化が "1" になることを確認する
+        assert_eq!(format!("{}", ObjectNumber::new(1)), "1");
+    }
+
+    #[test]
+    fn display_renders_u64_max() {
+        // 上限 u64::MAX が桁落ちせず 10 進表記されることを確認する
+        assert_eq!(
+            format!("{}", ObjectNumber::new(u64::MAX)),
+            "18446744073709551615"
+        );
+    }
+
+    #[test]
+    fn display_omits_type_name_decoration() {
+        // Display は値のみ、Debug は型名付きという役割分離を固定する
+        let number = ObjectNumber::new(42);
+        assert_eq!(format!("{number}"), "42");
+        assert_eq!(format!("{number:?}"), "ObjectNumber(42)");
+    }
+
+    #[test]
+    fn display_respects_width_and_zero_pad() {
+        // 呼び出し側が指定した幅・ゼロ埋めが握り潰されず内部 u64 の Display へ渡ることを確認する
+        assert_eq!(format!("{:06}", ObjectNumber::new(42)), "000042");
     }
 
     #[test]

--- a/rust/crates/core/src/object/pdf_object.rs
+++ b/rust/crates/core/src/object/pdf_object.rs
@@ -160,5 +160,101 @@ impl PdfObject {
     }
 }
 
+impl From<bool> for PdfObject {
+    /// `bool` から `Boolean` バリアントを構築する変換経路。
+    ///
+    /// バリアント名を明示せずに `true.into()` と書け、`impl Into<PdfObject>` を
+    /// 受け取る汎用 API を設計できるようにする目的で提供する。
+    fn from(value: bool) -> PdfObject {
+        PdfObject::Boolean(value)
+    }
+}
+
+impl From<i64> for PdfObject {
+    /// `i64` から `Integer` バリアントを構築する変換経路。
+    ///
+    /// 整数からの変換は `i64` のみを提供する。整数リテラルの `.into()` は現在
+    /// 適用可能な impl が 1 つだけであるために一意に解決するが、`From<i32>` や
+    /// `From<u32>` を追加すると候補が複数になり、既存の `42.into()` が
+    /// 「type annotations needed」で壊れる。よって整数型の追加実装はしない。
+    fn from(value: i64) -> PdfObject {
+        PdfObject::Integer(value)
+    }
+}
+
+impl From<f64> for PdfObject {
+    /// `f64` から `Real` バリアントを構築する変換経路。
+    ///
+    /// 無検証であり、`NaN` / `±0.0` / `Inf` もそのまま保持する（正規化しない）。
+    fn from(value: f64) -> PdfObject {
+        PdfObject::Real(value)
+    }
+}
+
+impl From<Vec<u8>> for PdfObject {
+    /// 復号後の生バイト列から `String` バリアントを構築する変換経路。
+    ///
+    /// テキストエンコーディングを仮定せず、空バイト列・NUL・非 UTF-8 バイトを
+    /// 無検証で忠実に保持する。
+    ///
+    /// `Vec<PdfObject>` からの変換と併存するため、要素型が未確定の空ベクタ
+    /// （`vec![].into()` / `Vec::new().into()`）は候補が 2 つになり
+    /// 「type annotations needed」で失敗する。空の文字列オブジェクトを作るときは
+    /// `Vec::<u8>::new().into()` と要素型を明示するか、`PdfObject::String(Vec::new())`
+    /// とバリアントを直接書く。
+    fn from(bytes: Vec<u8>) -> PdfObject {
+        PdfObject::String(bytes)
+    }
+}
+
+impl From<PdfName> for PdfObject {
+    /// `PdfName` から `Name` バリアントを構築する変換経路。
+    ///
+    /// `&str` からの変換は提供しない。`&str` は `String` バリアント（テキスト）と
+    /// `Name` バリアント（`/Name` 本体）のどちらにも解釈でき、暗黙に一方を選ぶと
+    /// 誤用を招くため。また `From` は連鎖しないので、`From<&str> for PdfName` が
+    /// あっても `"Type".into()` は `PdfObject` にならない。名前オブジェクトは
+    /// `PdfObject::from(PdfName::from("Type"))` と 2 段で明示的に書く。
+    fn from(name: PdfName) -> PdfObject {
+        PdfObject::Name(name)
+    }
+}
+
+impl From<Vec<PdfObject>> for PdfObject {
+    /// 要素列から `Array` バリアントを構築する変換経路。
+    ///
+    /// `Vec<u8>` からの変換と併存するため、要素型が未確定の空ベクタは
+    /// 「type annotations needed」で失敗する。空配列は
+    /// `Vec::<PdfObject>::new().into()` と要素型を明示するか、
+    /// `PdfObject::Array(vec![])` とバリアントを直接書く。
+    fn from(items: Vec<PdfObject>) -> PdfObject {
+        PdfObject::Array(items)
+    }
+}
+
+impl From<PdfDictionary> for PdfObject {
+    /// `PdfDictionary` から `Dictionary` バリアントを構築する変換経路。
+    fn from(dict: PdfDictionary) -> PdfObject {
+        PdfObject::Dictionary(dict)
+    }
+}
+
+impl From<PdfStream> for PdfObject {
+    /// `PdfStream` から `Stream` バリアントを構築する変換経路。
+    fn from(stream: PdfStream) -> PdfObject {
+        PdfObject::Stream(stream)
+    }
+}
+
+impl From<IndirectRef> for PdfObject {
+    /// `IndirectRef` から `Reference` バリアントを構築する変換経路。
+    ///
+    /// 内包型を持たない `Null` にだけは `From` を提供できないため、構築用の
+    /// 変換は本 impl を含む 9 バリアント分で全数となる。
+    fn from(reference: IndirectRef) -> PdfObject {
+        PdfObject::Reference(reference)
+    }
+}
+
 #[cfg(test)]
 mod tests;

--- a/rust/crates/core/src/object/pdf_object/tests.rs
+++ b/rust/crates/core/src/object/pdf_object/tests.rs
@@ -1,4 +1,5 @@
 mod array_dictionary;
+mod conversion;
 mod eq_clone_debug;
 mod primitive_variants;
 mod reference;

--- a/rust/crates/core/src/object/pdf_object/tests/conversion.rs
+++ b/rust/crates/core/src/object/pdf_object/tests/conversion.rs
@@ -1,0 +1,114 @@
+use super::super::*;
+use super::{make_ref, make_stream};
+
+#[test]
+fn from_bool_builds_boolean_variant() {
+    // bool から From で変換すると Boolean バリアントになり、値が保持されることを確認する
+    assert_eq!(PdfObject::from(true), PdfObject::Boolean(true));
+}
+
+#[test]
+fn from_i64_builds_integer_variant() {
+    // i64 から From で変換すると Integer バリアントになり、値が保持されることを確認する
+    assert_eq!(PdfObject::from(42i64), PdfObject::Integer(42));
+}
+
+#[test]
+fn from_f64_builds_real_variant() {
+    // f64 から From で変換すると Real バリアントになり、値が保持されることを確認する
+    assert_eq!(PdfObject::from(1.5f64), PdfObject::Real(1.5));
+}
+
+#[test]
+fn from_vec_u8_builds_string_variant() {
+    // 復号済みバイト列から From で変換すると String バリアントになることを確認する
+    assert_eq!(
+        PdfObject::from(b"abc".to_vec()),
+        PdfObject::String(b"abc".to_vec())
+    );
+}
+
+#[test]
+fn from_pdf_name_builds_name_variant() {
+    // PdfName から From で変換すると Name バリアントになることを確認する
+    assert_eq!(
+        PdfObject::from(PdfName::from("Type")),
+        PdfObject::Name(PdfName::from("Type"))
+    );
+}
+
+#[test]
+fn from_vec_pdf_object_builds_array_variant() {
+    // 要素列から From で変換すると Array バリアントになることを確認する
+    assert_eq!(
+        PdfObject::from(vec![PdfObject::Integer(1)]),
+        PdfObject::Array(vec![PdfObject::Integer(1)])
+    );
+}
+
+#[test]
+fn from_dictionary_builds_dictionary_variant() {
+    // PdfDictionary から From で変換すると Dictionary バリアントになることを確認する
+    assert_eq!(
+        PdfObject::from(PdfDictionary::new()),
+        PdfObject::Dictionary(PdfDictionary::new())
+    );
+}
+
+#[test]
+fn from_stream_builds_stream_variant() {
+    // PdfStream から From で変換すると Stream バリアントになることを確認する
+    assert_eq!(
+        PdfObject::from(make_stream(b"data")),
+        PdfObject::Stream(make_stream(b"data"))
+    );
+}
+
+#[test]
+fn from_indirect_ref_builds_reference_variant() {
+    // IndirectRef から From で変換すると Reference バリアントになることを確認する
+    assert_eq!(
+        PdfObject::from(make_ref(1, 0)),
+        PdfObject::Reference(make_ref(1, 0))
+    );
+}
+
+#[test]
+fn integer_literal_into_resolves_to_integer_variant() {
+    // 整数リテラルの .into() が From<i64> に一意解決し Integer になることを確認する
+    // （追加の整数型 From を実装しない判断が守られていることの回帰ガード）
+    let obj: PdfObject = 42.into();
+    assert_eq!(obj, PdfObject::Integer(42));
+}
+
+#[test]
+fn float_literal_into_resolves_to_real_variant() {
+    // 浮動小数点リテラルの .into() が From<f64> に一意解決し Real になることを確認する
+    // （追加の浮動小数点型 From を実装しない判断が守られていることの回帰ガード）
+    let obj: PdfObject = 1.5.into();
+    assert_eq!(obj, PdfObject::Real(1.5));
+}
+
+#[test]
+fn from_f64_negative_zero_preserves_sign() {
+    // -0.0 の符号ビットが落ちずに Real へ保持されることを確認する
+    // （== では +0.0 と等価になってしまうため is_sign_negative() で判定する）
+    let obj = PdfObject::from(-0.0);
+    assert!(obj.as_real().is_some_and(f64::is_sign_negative));
+}
+
+#[test]
+fn from_empty_vec_u8_builds_string_variant() {
+    // 要素型を明示した空 Vec<u8> なら曖昧さなく String バリアントへ変換できることを確認する
+    // （空 vec![].into() は候補 2 件で E0283 になるため、要素型明示が回避策として機能する）
+    let obj: PdfObject = Vec::<u8>::new().into();
+    assert_eq!(obj, PdfObject::String(Vec::new()));
+}
+
+#[test]
+fn from_empty_vec_pdf_object_builds_array_variant() {
+    // 要素型を明示した空 Vec<PdfObject> なら曖昧さなく Array バリアントへ変換できることを確認する
+    // （同じく E0283 の回避策が機能することの固定）
+    let obj: PdfObject = Vec::<PdfObject>::new().into();
+    assert_eq!(obj, PdfObject::Array(Vec::new()));
+}


### PR DESCRIPTION
## 概要

`pdfmod-core` の型間で不揃いだった標準変換トレイト（`From` / `Display`）の実装を揃える、**純粋な追加リファクタリング**です。振る舞い（既存の出力文字列・既存 API のシグネチャ）は一切変えていません。

差分中の**削除行は 1 行だけ**（`pdf_error.rs` の手剥がし解消）で、残りはすべて追加行です。

## 変更内容

### 🎯 変更の種類

- [x] ♻️ リファクタリング (Refactoring)
- [x] 🚨 テスト追加/修正 (Tests)

### 📝 詳細な変更内容

#### 追加された機能・修正

- **数値系 newtype 3 型**（`ByteOffset` / `ObjectNumber` / `GenerationNumber`）に双方向 `From` と `Display` を追加
  - `Display` は `write!(f, "{}", self.0)` ではなく **`fmt::Display::fmt(&self.0, f)` で内部型へ委譲**。前者は呼び出し側が `Formatter` に載せた書式指定（幅・ゼロ埋め・寄せ）を捨てるため、xref エントリのオフセット 10 桁・世代番号 5 桁のゼロ埋め固定長（ISO 32000-1 §7.5.4）を、コンパイルもテストも通ったまま静かに壊す
  - 既定の `{}` 出力は従来どおり装飾なしの 10 進表記（`"42"` / `"0"`）
- **`PdfName`** に `From<String>` / `From<Vec<u8>>` / `From<&[u8]>` を追加（`Display` は非 UTF-8 バイトの表示仕様設計が別途必要なため実装しない）
- **`PdfObject`** に 9 バリアント分の構築用 `From` を追加（内包型を持たない `Null` 以外は全数）
- **`PdfError`** の位置表示を `position.value()` から `position` へ置き換え（本番コードの置換はここ 1 箇所のみ）

#### 将来を縛る判断（rustdoc に確約）

| 判断 | 理由 |
|---|---|
| `PdfObject` の整数変換は `From<i64>` のみ | `From<i32>` / `From<u32>` を足すと候補が複数になり、既存の `42.into()` が E0283 で**呼び出しごと壊れる** |
| `From<&str> for PdfObject` は実装しない | `String` バリアントと `Name` バリアントのどちらにも解釈でき曖昧。`From` は連鎖しないため `PdfObject::from(PdfName::from("Type"))` と 2 段で書く |
| 空 `vec![].into()` は E0283 | `Vec<u8>` と `Vec<PdfObject>` の変換が併存するため。回避策（要素型の明示）を両 rustdoc に明記 |
| `PdfName::from(b"...")` は不可 | `From` にデリファレンス強制が効かない。`new` を使うか `.as_slice()` を挟む |

#### 変更されたファイル

| ファイル | 内容 |
|---|---|
| `rust/crates/core/src/byte_offset.rs` | `From<u64>` / `From<ByteOffset> for u64` / `Display` + 新規 15 テスト |
| `rust/crates/core/src/object/object_number.rs` | 同上（`u64`）+ 新規 15 テスト |
| `rust/crates/core/src/object/generation_number.rs` | 同上（`u16`）+ 新規 15 テスト |
| `rust/crates/core/src/object/name.rs` | `From<String>` / `From<Vec<u8>>` / `From<&[u8]>` + 新規 17 テスト |
| `rust/crates/core/src/object/pdf_object.rs` | 9 バリアント分の `From` |
| `rust/crates/core/src/object/pdf_object/tests.rs` | `mod conversion;` 追加（1 行） |
| `rust/crates/core/src/object/pdf_object/tests/conversion.rs` | **[NEW]** 変換観点の 14 テスト |
| `rust/crates/core/src/error/pdf_error.rs` | `position.value()` → `position`（**1 行のみ**） |

#### 削除されたファイル・機能

なし（既存 `new` / `value` / `as_bytes` / `as_str` は非破壊で残す）

## 📊 システム図

### 型変換のフロー

```mermaid
flowchart TD
    P["u64 / u16 (プリミティブ)"] -->|"From&lt;u64&gt; / From&lt;u16&gt; [NEW]"| NT
    P -->|"既存 new(n)"| NT
    NT["newtype (無検証・infallible・Copy)<br/>ByteOffset / ObjectNumber / GenerationNumber"]
    NT -->|"From&lt;NT&gt; for u64 / u16 [NEW]"| P2["u64 / u16 (ロスレス往復)"]
    NT -->|"既存 value()"| P2
    NT -->|"Display::fmt [NEW]<br/>内部型へ委譲"| S["10 進表記<br/>{} → &quot;42&quot; / {:010} → &quot;0000000042&quot;"]
    S --> E["&quot;… at byte 42&quot; (PdfError)<br/>出力文字列は完全に不変"]

    style NT fill:#ffe4b5,stroke:#d97706,stroke-width:2px
    style S fill:#ffe4b5,stroke:#d97706,stroke-width:2px
```

### PdfObject の構築経路（9 バリアント + 実装しない 3 経路）

```mermaid
flowchart LR
    B["bool"] --> O
    I["i64"] --> O
    F["f64"] --> O
    V["Vec&lt;u8&gt;"] --> O
    N["PdfName"] --> O
    A["Vec&lt;PdfObject&gt;"] --> O
    D["PdfDictionary"] --> O
    ST["PdfStream"] --> O
    R["IndirectRef"] --> O
    O["PdfObject の対応バリアント<br/>ムーブ格納・追加アロケーションなし"]

    X1["&quot;Type&quot;.into()"] -.->|"✗ E0277 未実装<br/>String/Name が曖昧"| O
    X2["vec![].into()"] -.->|"✗ E0283 要素型未確定<br/>回避: Vec::&lt;u8&gt;::new()"| O
    X3["Null"] -.->|"✗ 内包型なし"| O

    style O fill:#ffe4b5,stroke:#d97706,stroke-width:2px
```

### エラー書式化のデータフロー

```
PdfError::fmt
    ↓
write!(f, " at byte {}", position)      ← [CHANGED] .value() の手剥がしを解消
    ↓
impl fmt::Display for ByteOffset        ← [NEW]
    ↓
fmt::Display::fmt(&self.0, f)           ← 内部 u64 へ委譲（書式指定をそのまま渡す）
    ↓
"unexpected end of file at byte 12"     ← 出力文字列は完全に不変
```

## 📋 関連 Issue

- Closes #391

## 🧪 テスト

### テスト実行方法

```bash
cd rust
cargo test --workspace
cargo test --doc --workspace
cargo fmt --all -- --check
cargo clippy --workspace --all-targets -- -D warnings
```

### テスト項目

- [x] 単体テスト (Unit tests)
- [x] 手動テスト (Manual testing)

### テスト結果

| 項目 | 実装前 | 実装後 |
|---|---|---|
| `cargo test --workspace` | 1134 passed | **1210 passed / 0 failed**（+76、想定と一致） |
| `cargo test --doc --workspace` | running 0 tests | **running 0 tests / exit 0** |
| `cargo fmt --all -- --check` | exit 0 | **exit 0** |
| `cargo clippy --workspace --all-targets -- -D warnings` | 無警告 | **無警告** |

**既存 1134 テストは 1 件も修正していません。** 新規 76 件の内訳は数値系 3 型 各 15（= 45）／`name.rs` 17／`conversion.rs` 14 です。

t-wada 式 TDD（Red-Green-Refactor）で 22 サイクルを回しました。`ByteOffset` の `Display` では 2 段目の RED として `write!` 形の実装に対し `left: "42" / right: "0000000042"` の失敗を実際に観測してから委譲形へ変えています。

## 🔍 レビューポイント

- **`Display` の委譲形**（3 型とも `fmt::Display::fmt(&self.0, f)`）— ここが `write!(f, "{}", self.0)` に戻ると、`format!("{:010}", ...)` が黙って `"42"` を返す状態に逆戻りします
- **`From<i64>` 一本化の確約** — `From<i32>` / `From<u32>` を追加すると `conversion.rs` の型推論ガード 2 件がコンパイルエラーになります（＝実効的な回帰ガード）
- **`PdfName` の受理集合の非対称性** — `new(b"Length")` は通るが `PdfName::from(b"Length")` は通りません。これは既存 `new(impl Into<Vec<u8>>)` のシグネチャ由来で、今回の追加で生まれたものではありません
- **`conversion.rs` のテスト範囲** — 値域の保持（`i64` 境界 / `NaN` / ±`Inf` / 非 UTF-8 / 多段ネスト）は既存テストが同じ値域でカバー済みのため重複させていません。`-0.0` の符号保持だけは既存の等値比較テストが符号落ちを検出できないため新規に追加しています

## ⚠️ 破壊的変更

- [ ] この変更は既存の API に破壊的変更を含みます

破壊的変更はありません。追加のみで、既存 `new` / `value` / `as_bytes` / `as_str` のシグネチャは変えていません。

## 📚 追加情報

### 注意事項

以下は本 PR のスコープ外として**コードを変更せず記録のみ**に留めています。

- **R-1**: `parser.rs` の `primitive_to_object` は今回追加した `From` 群の合成に相当しますが、`Primitive` という別入力型からの変換でパーサーの挙動に影響しうるため触っていません
- **R-2**: `From` 追加後に冗長化するテストヘルパー（4 系統・5 箇所）は 1 行も変更していません。ただし新規 `conversion.rs` は既存 `make_ref` / `make_stream` を再利用し、同型ヘルパの 5 コピー目を作っていません
- **R-3**: 同じ基準が当てはまる `IndirectRef` / `ObjectId` への横展開は行っていません（意図的なスコープ限定）

`cargo doc` が出す rustdoc 警告 5 件は `lexer/` `parser.rs` および `pdf_error.rs:83` の**既存**記述に対するもので、本 PR で追加した rustdoc 由来ではありません。

## ✅ チェックリスト

- [x] コードレビューの準備ができている
- [x] テストが正常に実行される
- [x] ドキュメントが更新されている（各 `impl` の rustdoc に「なぜ提供するか」と「提供しない 4 判断の根拠」を記載）
- [x] コミットメッセージが適切な形式で書かれている（関心ごとに 6 コミットへ分割）
- [x] 関連する Issue が PR の「Development」に Linked されている
- [x] PR 本文に Issue が記載されている
- [x] セルフレビューを実施した（codex による AI レビューも実施 → **指摘なし**）
- [x] 破壊的変更がある場合は明記されている（該当なし）

🤖 Generated with [Claude Code](https://claude.com/claude-code)