### PR TITLE
🚨 [Tests]: #506 content-stream tokenizer のコメントスキップを層内で検証するテストを追加

### DIFF
--- a/packages/core/src/content-stream/tokenizer/__tests__/tokenizer.basic.test.ts
+++ b/packages/core/src/content-stream/tokenizer/__tests__/tokenizer.basic.test.ts
@@ -135,3 +135,394 @@ test("inline imageを1つのtokenとして返す", () => {
     offset: ByteOffset.of(17),
   });
 });
+
+// --- コメントスキップ ---
+
+test("LF終端のコメントをスキップし後続トークンのByteOffsetが進む", () => {
+  // "10 % xxx\n 20 m" = 14 bytes / 20 は index 10 / m は index 13
+  const tokenizer = new ContentStreamTokenizer(encode("10 % xxx\n 20 m"));
+
+  const result = tokenizer.tokenize();
+  assert(result.ok);
+  const tokens = result.value;
+
+  expect(tokenTypesWithoutEof(tokens)).toEqual([
+    TokenType.Integer,
+    TokenType.Integer,
+    TokenType.Operator,
+  ]);
+  expect(tokens[0]).toEqual({
+    type: TokenType.Integer,
+    value: 10,
+    offset: ByteOffset.of(0),
+  });
+  expect(tokens[1]).toEqual({
+    type: TokenType.Integer,
+    value: 20,
+    offset: ByteOffset.of(10),
+  });
+  expect(tokens[2]).toEqual(Operator.of("m", ByteOffset.of(13)));
+  expect(tokens[3]).toEqual({
+    type: TokenType.EOF,
+    value: null,
+    offset: ByteOffset.of(14),
+  });
+});
+
+test("CR終端のコメントをスキップし後続トークンのByteOffsetが進む", () => {
+  // "10 % xxx\r 20 m" = 14 bytes / CR は 1 byte なので LF 版と同じ offset
+  const tokenizer = new ContentStreamTokenizer(encode("10 % xxx\r 20 m"));
+
+  const result = tokenizer.tokenize();
+  assert(result.ok);
+  const tokens = result.value;
+
+  expect(tokenTypesWithoutEof(tokens)).toEqual([
+    TokenType.Integer,
+    TokenType.Integer,
+    TokenType.Operator,
+  ]);
+  expect(tokens[1]).toEqual({
+    type: TokenType.Integer,
+    value: 20,
+    offset: ByteOffset.of(10),
+  });
+  expect(tokens[2]).toEqual(Operator.of("m", ByteOffset.of(13)));
+  expect(tokens[3]).toEqual({
+    type: TokenType.EOF,
+    value: null,
+    offset: ByteOffset.of(14),
+  });
+});
+
+test("CRLF終端のコメントはLF終端より1バイト多く進んだByteOffsetになる", () => {
+  // "10 % xxx\r\n 20 m" = 15 bytes / CRLF は 2 bytes 消費するため LF 版 +1
+  const tokenizer = new ContentStreamTokenizer(encode("10 % xxx\r\n 20 m"));
+
+  const result = tokenizer.tokenize();
+  assert(result.ok);
+  const tokens = result.value;
+
+  expect(tokenTypesWithoutEof(tokens)).toEqual([
+    TokenType.Integer,
+    TokenType.Integer,
+    TokenType.Operator,
+  ]);
+  expect(tokens[1]).toEqual({
+    type: TokenType.Integer,
+    value: 20,
+    offset: ByteOffset.of(11),
+  });
+  expect(tokens[2]).toEqual(Operator.of("m", ByteOffset.of(14)));
+  expect(tokens[3]).toEqual({
+    type: TokenType.EOF,
+    value: null,
+    offset: ByteOffset.of(15),
+  });
+});
+
+test("コメント本文のdelimiterをトークン化せず丸ごと破棄する", () => {
+  // "10 % ( ) < > [ ] /\n 20 m" = 24 bytes / 20 は index 20 / m は index 23
+  const tokenizer = new ContentStreamTokenizer(
+    encode("10 % ( ) < > [ ] /\n 20 m"),
+  );
+
+  const result = tokenizer.tokenize();
+  assert(result.ok);
+  const tokens = result.value;
+
+  expect(tokenTypesWithoutEof(tokens)).toEqual([
+    TokenType.Integer,
+    TokenType.Integer,
+    TokenType.Operator,
+  ]);
+  expect(tokens[1]).toEqual({
+    type: TokenType.Integer,
+    value: 20,
+    offset: ByteOffset.of(20),
+  });
+  expect(tokens[2]).toEqual(Operator.of("m", ByteOffset.of(23)));
+  expect(tokens[3]).toEqual({
+    type: TokenType.EOF,
+    value: null,
+    offset: ByteOffset.of(24),
+  });
+});
+
+test("改行なしでEOFに達するコメントはdata長のEOF tokenで終わる", () => {
+  // "10 20 m % trailing" = 18 bytes / EOF offset は data.length と一致する
+  const tokenizer = new ContentStreamTokenizer(encode("10 20 m % trailing"));
+
+  const result = tokenizer.tokenize();
+  assert(result.ok);
+  const tokens = result.value;
+
+  expect(tokenTypesWithoutEof(tokens)).toEqual([
+    TokenType.Integer,
+    TokenType.Integer,
+    TokenType.Operator,
+  ]);
+  expect(tokens[2]).toEqual(Operator.of("m", ByteOffset.of(6)));
+  expect(tokens[3]).toEqual({
+    type: TokenType.EOF,
+    value: null,
+    offset: ByteOffset.of(18),
+  });
+});
+
+test("nextTokenでもコメントを跨いだ後のByteOffsetが正しい", () => {
+  // "10 % xxx\n 20 m" を 1 token ずつ読む
+  const tokenizer = new ContentStreamTokenizer(encode("10 % xxx\n 20 m"));
+
+  const first = tokenizer.nextToken();
+  const second = tokenizer.nextToken();
+  const third = tokenizer.nextToken();
+  const fourth = tokenizer.nextToken();
+
+  assert(first.ok);
+  assert(second.ok);
+  assert(third.ok);
+  assert(fourth.ok);
+  expect(first.value).toEqual({
+    type: TokenType.Integer,
+    value: 10,
+    offset: ByteOffset.of(0),
+  });
+  expect(second.value).toEqual({
+    type: TokenType.Integer,
+    value: 20,
+    offset: ByteOffset.of(10),
+  });
+  expect(third.value).toEqual(Operator.of("m", ByteOffset.of(13)));
+  expect(fourth.value).toEqual({
+    type: TokenType.EOF,
+    value: null,
+    offset: ByteOffset.of(14),
+  });
+});
+
+test("リテラル文字列内の%はコメント開始として扱わない", () => {
+  // "(50% off) Tj" = 12 bytes / Tj は index 10
+  const tokenizer = new ContentStreamTokenizer(encode("(50% off) Tj"));
+
+  const result = tokenizer.tokenize();
+  assert(result.ok);
+  const tokens = result.value;
+
+  expect(tokenTypesWithoutEof(tokens)).toEqual([
+    TokenType.LiteralString,
+    TokenType.Operator,
+  ]);
+  expect(tokens[0]).toEqual({
+    type: TokenType.LiteralString,
+    value: "50% off",
+    offset: ByteOffset.of(0),
+  });
+  expect(tokens[1]).toEqual(Operator.of("Tj", ByteOffset.of(10)));
+  expect(tokens[2]).toEqual({
+    type: TokenType.EOF,
+    value: null,
+    offset: ByteOffset.of(12),
+  });
+});
+
+test("空白を挟まない%も数値の直後でコメント開始として扱う", () => {
+  // "10% xxx\n 20 m" = 13 bytes / % が delimiter なので 10 で数値が切れる
+  const tokenizer = new ContentStreamTokenizer(encode("10% xxx\n 20 m"));
+
+  const result = tokenizer.tokenize();
+  assert(result.ok);
+  const tokens = result.value;
+
+  expect(tokenTypesWithoutEof(tokens)).toEqual([
+    TokenType.Integer,
+    TokenType.Integer,
+    TokenType.Operator,
+  ]);
+  expect(tokens[0]).toEqual({
+    type: TokenType.Integer,
+    value: 10,
+    offset: ByteOffset.of(0),
+  });
+  expect(tokens[1]).toEqual({
+    type: TokenType.Integer,
+    value: 20,
+    offset: ByteOffset.of(9),
+  });
+  expect(tokens[2]).toEqual(Operator.of("m", ByteOffset.of(12)));
+  expect(tokens[3]).toEqual({
+    type: TokenType.EOF,
+    value: null,
+    offset: ByteOffset.of(13),
+  });
+});
+
+test("本文が空のコメントをスキップする", () => {
+  // "10 %\n 20 m" = 10 bytes / % の直後が即 EOL（本文長 0）
+  const tokenizer = new ContentStreamTokenizer(encode("10 %\n 20 m"));
+
+  const result = tokenizer.tokenize();
+  assert(result.ok);
+  const tokens = result.value;
+
+  expect(tokenTypesWithoutEof(tokens)).toEqual([
+    TokenType.Integer,
+    TokenType.Integer,
+    TokenType.Operator,
+  ]);
+  expect(tokens[1]).toEqual({
+    type: TokenType.Integer,
+    value: 20,
+    offset: ByteOffset.of(6),
+  });
+  expect(tokens[2]).toEqual(Operator.of("m", ByteOffset.of(9)));
+  expect(tokens[3]).toEqual({
+    type: TokenType.EOF,
+    value: null,
+    offset: ByteOffset.of(10),
+  });
+});
+
+test("最終バイトが%だけの入力でもEOF tokenで終わる", () => {
+  // "10 20 m %" = 9 bytes / % が最終バイト（コメント本文が存在しない）
+  const tokenizer = new ContentStreamTokenizer(encode("10 20 m %"));
+
+  const result = tokenizer.tokenize();
+  assert(result.ok);
+  const tokens = result.value;
+
+  expect(tokenTypesWithoutEof(tokens)).toEqual([
+    TokenType.Integer,
+    TokenType.Integer,
+    TokenType.Operator,
+  ]);
+  expect(tokens[2]).toEqual(Operator.of("m", ByteOffset.of(6)));
+  expect(tokens[3]).toEqual({
+    type: TokenType.EOF,
+    value: null,
+    offset: ByteOffset.of(9),
+  });
+});
+
+test("連続するコメント行をまとめてスキップする", () => {
+  // "10 % a\n% b\n 20 m" = 16 bytes / コメント分岐を 2 周する
+  const tokenizer = new ContentStreamTokenizer(encode("10 % a\n% b\n 20 m"));
+
+  const result = tokenizer.tokenize();
+  assert(result.ok);
+  const tokens = result.value;
+
+  expect(tokenTypesWithoutEof(tokens)).toEqual([
+    TokenType.Integer,
+    TokenType.Integer,
+    TokenType.Operator,
+  ]);
+  expect(tokens[1]).toEqual({
+    type: TokenType.Integer,
+    value: 20,
+    offset: ByteOffset.of(12),
+  });
+  expect(tokens[2]).toEqual(Operator.of("m", ByteOffset.of(15)));
+  expect(tokens[3]).toEqual({
+    type: TokenType.EOF,
+    value: null,
+    offset: ByteOffset.of(16),
+  });
+});
+
+test("ストリーム先頭のコメントをスキップし最初のtokenのByteOffsetが0にならない", () => {
+  // "% header\n10 20 m" = 16 bytes / 最初の Integer は index 9 から始まる
+  const tokenizer = new ContentStreamTokenizer(encode("% header\n10 20 m"));
+
+  const result = tokenizer.tokenize();
+  assert(result.ok);
+  const tokens = result.value;
+
+  expect(tokenTypesWithoutEof(tokens)).toEqual([
+    TokenType.Integer,
+    TokenType.Integer,
+    TokenType.Operator,
+  ]);
+  expect(tokens[0]).toEqual({
+    type: TokenType.Integer,
+    value: 10,
+    offset: ByteOffset.of(9),
+  });
+  expect(tokens[1]).toEqual({
+    type: TokenType.Integer,
+    value: 20,
+    offset: ByteOffset.of(12),
+  });
+  expect(tokens[2]).toEqual(Operator.of("m", ByteOffset.of(15)));
+  expect(tokens[3]).toEqual({
+    type: TokenType.EOF,
+    value: null,
+    offset: ByteOffset.of(16),
+  });
+});
+
+test("配列オペランド内のコメントをスキップしTJだけをOperatorに変換する", () => {
+  // "[ 1 % c\n 2 ] TJ" = 15 bytes / ] は index 11 / TJ は index 13
+  const tokenizer = new ContentStreamTokenizer(encode("[ 1 % c\n 2 ] TJ"));
+
+  const result = tokenizer.tokenize();
+  assert(result.ok);
+  const tokens = result.value;
+
+  expect(tokenTypesWithoutEof(tokens)).toEqual([
+    TokenType.ArrayBegin,
+    TokenType.Integer,
+    TokenType.Integer,
+    TokenType.ArrayEnd,
+    TokenType.Operator,
+  ]);
+  expect(tokens[2]).toEqual({
+    type: TokenType.Integer,
+    value: 2,
+    offset: ByteOffset.of(9),
+  });
+  expect(tokens[3]).toEqual({
+    type: TokenType.ArrayEnd,
+    value: "]",
+    offset: ByteOffset.of(11),
+  });
+  expect(tokens[4]).toEqual(Operator.of("TJ", ByteOffset.of(13)));
+  expect(tokens[5]).toEqual({
+    type: TokenType.EOF,
+    value: null,
+    offset: ByteOffset.of(15),
+  });
+});
+
+test("辞書オペランド内のコメントをスキップしBDCだけをOperatorに変換する", () => {
+  // "<< /A 1 % c\n >> BDC" = 19 bytes / >> は index 13 / BDC は index 16
+  const tokenizer = new ContentStreamTokenizer(encode("<< /A 1 % c\n >> BDC"));
+
+  const result = tokenizer.tokenize();
+  assert(result.ok);
+  const tokens = result.value;
+
+  expect(tokenTypesWithoutEof(tokens)).toEqual([
+    TokenType.DictBegin,
+    TokenType.Name,
+    TokenType.Integer,
+    TokenType.DictEnd,
+    TokenType.Operator,
+  ]);
+  expect(tokens[2]).toEqual({
+    type: TokenType.Integer,
+    value: 1,
+    offset: ByteOffset.of(6),
+  });
+  expect(tokens[3]).toEqual({
+    type: TokenType.DictEnd,
+    value: ">>",
+    offset: ByteOffset.of(13),
+  });
+  expect(tokens[4]).toEqual(Operator.of("BDC", ByteOffset.of(16)));
+  expect(tokens[5]).toEqual({
+    type: TokenType.EOF,
+    value: null,
+    offset: ByteOffset.of(19),
+  });
+});


### PR DESCRIPTION
## 概要

content-stream 層の `ContentStreamTokenizer` で、PDF のコメント（`% ... EOL`）が正しくスキップされ、**コメントを跨いだ後の後続トークンの `ByteOffset` がずれないこと**を検証する回帰テストを 14 件追加しました。

下位 lexer にはコメント処理のテストが存在する一方、content-stream 層としての統合確認が抜けており、オフセットずれ（＝エラー報告位置の破綻に直結）を検知できない状態でした。プロダクションコードは変更していません。

## 変更内容

### 🎯 変更の種類

- [x] 🚨 テスト追加/修正 (Tests)

### 📝 詳細な変更内容

#### 追加されたテスト

`packages/core/src/content-stream/tokenizer/__tests__/tokenizer.basic.test.ts` の末尾に `// --- コメントスキップ ---` セクションを設け、以下 14 件を追加。

| # | テスト | 入力 | 主な期待値 |
|---|--------|------|-----------|
| 1 | LF 終端コメント | `"10 % xxx\n 20 m"` (14B) | `Integer(20)@10` / `Operator("m")@13` / `EOF@14` |
| 2 | CR 終端コメント | `"10 % xxx\r 20 m"` (14B) | LF 版と同一 offset（CR は 1 バイト消費） |
| 3 | CRLF 終端コメント | `"10 % xxx\r\n 20 m"` (15B) | LF 版から一律 +1（`Integer(20)@11` / `EOF@15`） |
| 4 | 本文の delimiter 破棄 | `"10 % ( ) < > [ ] /\n 20 m"` (24B) | `LiteralString` / `Name` / `ArrayBegin` / `DictBegin` が一切現れない |
| 5 | 改行なし EOF 終端 | `"10 20 m % trailing"` (18B) | `Result.ok` で `EOF@18`（= `data.length`） |
| 6 | `nextToken()` 経路 | `"10 % xxx\n 20 m"` | 4 回の逐次読み出しが `tokenize()` と同一 offset |
| 7 | リテラル文字列内 `%` | `"(50% off) Tj"` (12B) | `LiteralString("50% off")@0`（コメント扱いしない） |
| 8 | 空白なし `%` | `"10% xxx\n 20 m"` (13B) | `Integer(10)@0` / `Integer(20)@9`（`%` がトークン境界） |
| 9 | 空コメント | `"10 %\n 20 m"` (10B) | `Integer(20)@6` / `EOF@10` |
| 10 | `%` が最終バイト | `"10 20 m %"` (9B) | `Result.ok` で `EOF@9`（範囲外アクセス・無限ループなし） |
| 11 | 連続コメント行 | `"10 % a\n% b\n 20 m"` (16B) | `Integer(20)@12` / `EOF@16` |
| 12 | 先頭コメント | `"% header\n10 20 m"` (16B) | 最初の token が `@0` ではなく `@9` |
| 13 | 配列オペランド内 | `"[ 1 % c\n 2 ] TJ"` (15B) | `ArrayEnd("]")@11` 維持 / `Operator("TJ")@13` |
| 14 | 辞書オペランド内 | `"<< /A 1 % c\n >> BDC"` (19B) | `DictEnd(">>")@13` 維持 / `Operator("BDC")@16` |

#### 変更されたファイル

- `packages/core/src/content-stream/tokenizer/__tests__/tokenizer.basic.test.ts`（**391 行追加 / 0 行削除**）

#### 削除されたファイル・機能

- なし（プロダクションコードの変更なし）

## 📊 システム図

### 状態マシン / フロー図

```mermaid
flowchart TD
    Start([tokenize / nextToken]) --> Skip[空白とコメントをスキップ]
    Skip --> IsPercent{次のバイトは %?}
    IsPercent -->|Yes| Comment[EOL または EOF まで読み飛ばす]:::covered
    IsPercent -->|No| Read[トークンを読む]
    Comment --> EolKind{終端の種類}
    EolKind -->|LF / CR: 1 バイト| Skip
    EolKind -->|CRLF: 2 バイト| Skip
    EolKind -->|EOF: 改行なし| Eof[EOF@data.length]:::covered
    Read --> InString{リテラル文字列の内側?}
    InString -->|Yes| Keep["% を本文の一部として保持"]:::covered
    InString -->|No| Reclassify[Keyword を Operator へ再分類]
    Keep --> Skip
    Reclassify --> Skip
    Eof --> End([Result.ok])

    classDef covered fill:#ffe4b5,stroke:#d97706,stroke-width:2px
```

オレンジのノードが今回テストで固定した経路（[NEW] = 検証を追加した挙動）。

### データフロー

```
入力バイト列 (Uint8Array)
    ↓
ContentStreamTokenizer.tokenize() / nextToken()
    ↓
下位 lexer: 空白・コメントのスキップ + ByteOffset の伝播
    ↓
content-stream 層: Keyword → Operator の再分類
    ↓
Token[]  ── 検証 [NEW] ──┬─→ tokenTypesWithoutEof(tokens) : 余計な token が無いこと
                         ├─→ toEqual({ type, value, offset }) : 完全一致
                         └─→ toEqual(Operator.of(name, ByteOffset.of(n))) : 完全一致
```

## 📋 関連 Issue

- Closes #506

## 🧪 テスト

### テスト実行方法

```bash
# 対象ファイルのみ
pnpm vitest run packages/core/src/content-stream/tokenizer/__tests__/tokenizer.basic.test.ts

# 全体（CI と同じ）
pnpm test:run
pnpm lint
pnpm typecheck
```

### テスト項目

- [x] 単体テスト (Unit tests)

### テスト結果

- 対象ファイル: 既存 7 + 追加 14 = **21 tests passed**
- 全体: **3377 tests passed (278 files)**
- `pnpm lint`（biome + oxlint）: 0 warnings / 0 errors
- `pnpm typecheck`: 通過

**テストの効力確認**: 期待 `ByteOffset` を 1 つずらして実行すると当該 1 件のみ Red（`1 failed | 20 passed`）になることを確認し、元に戻して 21 件 Green に復帰済みです（差分に痕跡なし）。

## 🔍 レビューポイント

- **EOL 3 種を `test.each` でまとめず個別 `test()` に分割**しています。CRLF だけ期待 offset が LF 版から +1 されるため、タプルに期待値を畳み込むと offset の根拠が追えなくなるためです。
- **空白なし `10%` のケースが回帰網の要**です。`%` の PDF デリミタ判定が失われれば必ず Red になります。
- offset はすべて `toEqual` + `ByteOffset.of(n)` の**完全一致**で検証しており、`toMatchObject` による部分検証は使っていません。
- 新規ヘルパーは追加せず、既存のローカルヘルパー（`encode` / `tokenTypesWithoutEof`）のみを再利用しています。import 文の追加も 0 行です。
- hex 文字列内の `%`（`<41 % 42>` が不正 hex 値になる）は挙動が疑わしいものの、本 PR のスコープ外として意図的に含めていません。

## ⚠️ 破壊的変更

- [ ] この変更は既存の API に破壊的変更を含みます

なし（テストの追加のみ）。

## ✅ チェックリスト

- [x] コードレビューの準備ができている
- [x] テストが正常に実行される
- [x] ドキュメントが更新されている（該当なし）
- [x] コミットメッセージが適切な形式で書かれている
- [x] PR 本文に Issue が記載されている
- [x] セルフレビューを実施した（AI レビュー 2 巡で最終「指摘なし」）
- [x] 破壊的変更なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)