### PR TITLE
🚨 [Tests]: #497 xref/trailer/dict-builder に専用ユニットテストを新設し build() の全バリデーション分岐を直接網羅

### DIFF
--- a/packages/core/src/xref/trailer/dict-builder/__tests__/dict-builder.basic.test.ts
+++ b/packages/core/src/xref/trailer/dict-builder/__tests__/dict-builder.basic.test.ts
@@ -1,0 +1,170 @@
+// 担当範囲: trailerDictBuilder().build() の正常系（成功パス）。
+// 必須・オプションの各フィールドが TrailerDict に正しくマッピングされることを検証する。
+// 異常系は必須フィールドが validation、オプションフィールドが error を参照。
+
+import { assert, expect, test } from "vitest";
+import { ByteOffset } from "../../../../pdf/types/byte-offset/index";
+import { GenerationNumber } from "../../../../pdf/types/generation-number/index";
+import type { PdfValue } from "../../../../pdf/types/index";
+import { ObjectNumber } from "../../../../pdf/types/object-number/index";
+import { trailerDictBuilder } from "../index";
+
+const validRoot: PdfValue = {
+  type: "indirect-ref",
+  objectNumber: 1,
+  generationNumber: 0,
+};
+const validSize: PdfValue = { type: "integer", value: 10 };
+
+test("/Root と /Size のみを設定した最小構成で TrailerDict を返す", () => {
+  // 正常系: 必須 2 フィールドのみ。オプションは result に現れない
+  const result = trailerDictBuilder().root(validRoot).size(validSize).build();
+
+  assert(result.ok);
+  expect(result.value.root).toEqual({
+    objectNumber: ObjectNumber.of(1),
+    generationNumber: GenerationNumber.of(0),
+  });
+  expect(result.value.size).toBe(10);
+  expect(result.value.prev).toBeUndefined();
+  expect(result.value.info).toBeUndefined();
+  expect(result.value.id).toBeUndefined();
+  expect(result.value.encrypt).toBeUndefined();
+  expect(result.value.xrefStm).toBeUndefined();
+});
+
+test("/XRefStm を含む全フィールドを設定した場合に全項目が TrailerDict に載る", () => {
+  // 正常系: xref ストリーム経路からは到達不能な全部入りパス
+  const result = trailerDictBuilder()
+    .root(validRoot)
+    .size(validSize)
+    .prev({ type: "integer", value: 512 })
+    .info({ type: "indirect-ref", objectNumber: 2, generationNumber: 0 })
+    .id({
+      type: "array",
+      elements: [
+        { type: "string", value: new Uint8Array([0x01]), encoding: "hex" },
+        { type: "string", value: new Uint8Array([0x02]), encoding: "hex" },
+      ],
+    })
+    .encrypt({ type: "indirect-ref", objectNumber: 3, generationNumber: 0 })
+    .xrefStm({ type: "integer", value: 1024 })
+    .build();
+
+  assert(result.ok);
+  expect(result.value.root).toEqual({
+    objectNumber: ObjectNumber.of(1),
+    generationNumber: GenerationNumber.of(0),
+  });
+  expect(result.value.size).toBe(10);
+  expect(result.value.prev).toBe(ByteOffset.of(512));
+  expect(result.value.info).toEqual({
+    objectNumber: ObjectNumber.of(2),
+    generationNumber: GenerationNumber.of(0),
+  });
+  expect(result.value.id?.[0]).toEqual(new Uint8Array([0x01]));
+  expect(result.value.id?.[1]).toEqual(new Uint8Array([0x02]));
+  expect(result.value.encrypt).toEqual({
+    objectNumber: ObjectNumber.of(3),
+    generationNumber: GenerationNumber.of(0),
+  });
+  expect(result.value.xrefStm).toBe(ByteOffset.of(1024));
+});
+
+test("/Prev のみを追加設定した場合に prev が ByteOffset として載る", () => {
+  // 正常系: 増分更新 PDF で前世代 xref のオフセットが存在するケース
+  const result = trailerDictBuilder()
+    .root(validRoot)
+    .size(validSize)
+    .prev({ type: "integer", value: 512 })
+    .build();
+
+  assert(result.ok);
+  expect(result.value.prev).toBe(ByteOffset.of(512));
+});
+
+test("/XRefStm のみを追加設定した場合に xrefStm が ByteOffset として載る", () => {
+  // 正常系: ハイブリッド参照 PDF。
+  // 呼び出し側の xref ストリーム経路は .xrefStm() を呼ばないため到達不能
+  const result = trailerDictBuilder()
+    .root(validRoot)
+    .size(validSize)
+    .xrefStm({ type: "integer", value: 1024 })
+    .build();
+
+  assert(result.ok);
+  expect(result.value.xrefStm).toBe(ByteOffset.of(1024));
+});
+
+test("/ID のみを追加設定した場合に 2 要素の Uint8Array 組が id に載る", () => {
+  // 正常系: 文書 ID を持つ PDF
+  const result = trailerDictBuilder()
+    .root(validRoot)
+    .size(validSize)
+    .id({
+      type: "array",
+      elements: [
+        { type: "string", value: new Uint8Array([0xab]), encoding: "hex" },
+        { type: "string", value: new Uint8Array([0xcd]), encoding: "hex" },
+      ],
+    })
+    .build();
+
+  assert(result.ok);
+  expect(result.value.id?.[0]).toEqual(new Uint8Array([0xab]));
+  expect(result.value.id?.[1]).toEqual(new Uint8Array([0xcd]));
+});
+
+test("/Info のみを追加設定した場合に info が間接参照として載る", () => {
+  // 正常系: 文書情報辞書への間接参照を持つ PDF
+  const result = trailerDictBuilder()
+    .root(validRoot)
+    .size(validSize)
+    .info({ type: "indirect-ref", objectNumber: 2, generationNumber: 3 })
+    .build();
+
+  assert(result.ok);
+  expect(result.value.info).toEqual({
+    objectNumber: ObjectNumber.of(2),
+    generationNumber: GenerationNumber.of(3),
+  });
+});
+
+test("/Encrypt が indirect-ref の場合に encrypt が間接参照として載る", () => {
+  // 正常系: 暗号化辞書を間接参照で持つ標準的な暗号化 PDF
+  const result = trailerDictBuilder()
+    .root(validRoot)
+    .size(validSize)
+    .encrypt({ type: "indirect-ref", objectNumber: 5, generationNumber: 0 })
+    .build();
+
+  assert(result.ok);
+  expect(result.value.encrypt).toEqual({
+    objectNumber: ObjectNumber.of(5),
+    generationNumber: GenerationNumber.of(0),
+  });
+});
+
+test("/Encrypt が dictionary の場合に辞書をそのまま encrypt に格納する", () => {
+  // 正常系: dictionary バリアント。
+  // parseTrailer 経由の既存テスト（parser.parsing.test.ts の
+  // 「/Encryptが直接辞書として与えられた場合にPdfDictionaryとして抽出される」）が
+  // 間接カバー済みだが、Builder 直接呼び出しでも同じ挙動になることを固定する
+  const encryptDict: PdfValue = {
+    type: "dictionary",
+    entries: new Map<string, PdfValue>([
+      ["Filter", { type: "name", value: "Standard" }],
+      ["V", { type: "integer", value: 2 }],
+    ]),
+  };
+  const result = trailerDictBuilder()
+    .root(validRoot)
+    .size(validSize)
+    .encrypt(encryptDict)
+    .build();
+
+  assert(result.ok);
+  // 参照同一性まで固定する。toEqual だけだと「同値の別オブジェクトへコピーする」
+  // 実装変更を検出できず、パススルーであることを保証できない
+  expect(result.value.encrypt).toBe(encryptDict);
+});

--- a/packages/core/src/xref/trailer/dict-builder/__tests__/dict-builder.boundary.test.ts
+++ b/packages/core/src/xref/trailer/dict-builder/__tests__/dict-builder.boundary.test.ts
@@ -1,0 +1,350 @@
+// 担当範囲: 数値の境界値（0 / 65535 / 65536 / MAX_SAFE_INTEGER / +1）。
+// 許容側と拒否側を必ずペアで書き、どこで切り替わるかを固定する。
+// 必須フィールドの型不一致は validation、オプションフィールドの型不一致は error を参照。
+
+import { assert, expect, test } from "vitest";
+import { ByteOffset } from "../../../../pdf/types/byte-offset/index";
+import { GenerationNumber } from "../../../../pdf/types/generation-number/index";
+import type { PdfValue } from "../../../../pdf/types/index";
+import { ObjectNumber } from "../../../../pdf/types/object-number/index";
+import { trailerDictBuilder } from "../index";
+
+const validRoot: PdfValue = {
+  type: "indirect-ref",
+  objectNumber: 1,
+  generationNumber: 0,
+};
+const validSize: PdfValue = { type: "integer", value: 10 };
+
+const MAX_GENERATION_NUMBER = 65535;
+
+test("/Root の objectNumber が 0 の場合は Ok を返す", () => {
+  // 境界値: 最小の有効なオブジェクト番号（許容側）
+  const result = trailerDictBuilder()
+    .root({ type: "indirect-ref", objectNumber: 0, generationNumber: 0 })
+    .size(validSize)
+    .build();
+
+  assert(result.ok);
+  expect(result.value.root.objectNumber).toBe(ObjectNumber.of(0));
+});
+
+test("/Root の objectNumber が MAX_SAFE_INTEGER の場合は Ok を返す", () => {
+  // 境界値: safe integer 上限ちょうど（許容側）
+  const result = trailerDictBuilder()
+    .root({
+      type: "indirect-ref",
+      objectNumber: Number.MAX_SAFE_INTEGER,
+      generationNumber: 0,
+    })
+    .size(validSize)
+    .build();
+
+  assert(result.ok);
+  expect(result.value.root.objectNumber).toBe(
+    ObjectNumber.of(Number.MAX_SAFE_INTEGER),
+  );
+});
+
+test("/Root の objectNumber が MAX_SAFE_INTEGER + 1 の場合は ROOT_NOT_FOUND を返す", () => {
+  // 境界値: safe integer 超過（拒否側）
+  const result = trailerDictBuilder()
+    .root({
+      type: "indirect-ref",
+      objectNumber: Number.MAX_SAFE_INTEGER + 1,
+      generationNumber: 0,
+    })
+    .size(validSize)
+    .build();
+
+  assert(!result.ok);
+  expect(result.error.code).toBe("ROOT_NOT_FOUND");
+});
+
+test("/Root の generationNumber が 0 の場合は Ok を返す", () => {
+  // 境界値: generation の下限（許容側）
+  const result = trailerDictBuilder()
+    .root({ type: "indirect-ref", objectNumber: 1, generationNumber: 0 })
+    .size(validSize)
+    .build();
+
+  assert(result.ok);
+  expect(result.value.root.generationNumber).toBe(GenerationNumber.of(0));
+});
+
+test("/Root の generationNumber が 65535 の場合は Ok を返す", () => {
+  // 境界値: GenerationNumber.create の上限そのもの（許容側）
+  const result = trailerDictBuilder()
+    .root({
+      type: "indirect-ref",
+      objectNumber: 1,
+      generationNumber: MAX_GENERATION_NUMBER,
+    })
+    .size(validSize)
+    .build();
+
+  assert(result.ok);
+  expect(result.value.root.generationNumber).toBe(
+    GenerationNumber.of(MAX_GENERATION_NUMBER),
+  );
+});
+
+test("/Root の generationNumber が 65536 の場合は ROOT_NOT_FOUND を返す", () => {
+  // 境界値: GenerationNumber.create の範囲外（拒否側）。
+  // isSafeIntegerAtLeastZero ガードは通り、create だけが落とす唯一の帯域
+  const result = trailerDictBuilder()
+    .root({
+      type: "indirect-ref",
+      objectNumber: 1,
+      generationNumber: MAX_GENERATION_NUMBER + 1,
+    })
+    .size(validSize)
+    .build();
+
+  assert(!result.ok);
+  expect(result.error.code).toBe("ROOT_NOT_FOUND");
+});
+
+test("/Size が 0 の場合は Ok を返す", () => {
+  // 境界値: 空の xref を示す最小値（許容側）
+  const result = trailerDictBuilder()
+    .root(validRoot)
+    .size({ type: "integer", value: 0 })
+    .build();
+
+  assert(result.ok);
+  expect(result.value.size).toBe(0);
+});
+
+test("/Size が MAX_SAFE_INTEGER の場合は Ok を返す", () => {
+  // 境界値: safe integer 上限ちょうど（許容側）
+  const result = trailerDictBuilder()
+    .root(validRoot)
+    .size({ type: "integer", value: Number.MAX_SAFE_INTEGER })
+    .build();
+
+  assert(result.ok);
+  expect(result.value.size).toBe(Number.MAX_SAFE_INTEGER);
+});
+
+test("/Size が MAX_SAFE_INTEGER + 1 の場合は SIZE_NOT_FOUND を返す", () => {
+  // 境界値: safe integer 超過（拒否側）
+  const result = trailerDictBuilder()
+    .root(validRoot)
+    .size({ type: "integer", value: Number.MAX_SAFE_INTEGER + 1 })
+    .build();
+
+  assert(!result.ok);
+  expect(result.error.code).toBe("SIZE_NOT_FOUND");
+});
+
+test("/Prev が 0 の場合は Ok を返す", () => {
+  // 境界値: ファイル先頭を指す前世代 xref オフセット（許容側）
+  const result = trailerDictBuilder()
+    .root(validRoot)
+    .size(validSize)
+    .prev({ type: "integer", value: 0 })
+    .build();
+
+  assert(result.ok);
+  expect(result.value.prev).toBe(ByteOffset.of(0));
+});
+
+test("/Prev が MAX_SAFE_INTEGER の場合は Ok を返す", () => {
+  // 境界値: 巨大オフセット（許容側）
+  const result = trailerDictBuilder()
+    .root(validRoot)
+    .size(validSize)
+    .prev({ type: "integer", value: Number.MAX_SAFE_INTEGER })
+    .build();
+
+  assert(result.ok);
+  expect(result.value.prev).toBe(ByteOffset.of(Number.MAX_SAFE_INTEGER));
+});
+
+test("/Prev が MAX_SAFE_INTEGER + 1 の場合は TRAILER_DICT_INVALID を返す", () => {
+  // 境界値: safe integer 超過（拒否側）
+  const result = trailerDictBuilder()
+    .root(validRoot)
+    .size(validSize)
+    .prev({ type: "integer", value: Number.MAX_SAFE_INTEGER + 1 })
+    .build();
+
+  assert(!result.ok);
+  expect(result.error.code).toBe("TRAILER_DICT_INVALID");
+});
+
+test("/XRefStm が 0 の場合は Ok を返す", () => {
+  // 境界値: ハイブリッド参照で先頭を指す（許容側）
+  const result = trailerDictBuilder()
+    .root(validRoot)
+    .size(validSize)
+    .xrefStm({ type: "integer", value: 0 })
+    .build();
+
+  assert(result.ok);
+  expect(result.value.xrefStm).toBe(ByteOffset.of(0));
+});
+
+test("/XRefStm が MAX_SAFE_INTEGER の場合は Ok を返す", () => {
+  // 境界値: safe integer 上限ちょうど（許容側）
+  const result = trailerDictBuilder()
+    .root(validRoot)
+    .size(validSize)
+    .xrefStm({ type: "integer", value: Number.MAX_SAFE_INTEGER })
+    .build();
+
+  assert(result.ok);
+  expect(result.value.xrefStm).toBe(ByteOffset.of(Number.MAX_SAFE_INTEGER));
+});
+
+test("/XRefStm が MAX_SAFE_INTEGER + 1 の場合は TRAILER_DICT_INVALID を返す", () => {
+  // 境界値: safe integer 超過（拒否側）
+  const result = trailerDictBuilder()
+    .root(validRoot)
+    .size(validSize)
+    .xrefStm({ type: "integer", value: Number.MAX_SAFE_INTEGER + 1 })
+    .build();
+
+  assert(!result.ok);
+  expect(result.error.code).toBe("TRAILER_DICT_INVALID");
+});
+
+test("/Info の objectNumber が MAX_SAFE_INTEGER の場合は Ok を返す", () => {
+  // 境界値: safe integer 上限ちょうど（許容側）
+  const result = trailerDictBuilder()
+    .root(validRoot)
+    .size(validSize)
+    .info({
+      type: "indirect-ref",
+      objectNumber: Number.MAX_SAFE_INTEGER,
+      generationNumber: 0,
+    })
+    .build();
+
+  assert(result.ok);
+  expect(result.value.info?.objectNumber).toBe(
+    ObjectNumber.of(Number.MAX_SAFE_INTEGER),
+  );
+});
+
+test("/Info の objectNumber が MAX_SAFE_INTEGER + 1 の場合は TRAILER_DICT_INVALID を返す", () => {
+  // 境界値: safe integer 超過（拒否側）
+  const result = trailerDictBuilder()
+    .root(validRoot)
+    .size(validSize)
+    .info({
+      type: "indirect-ref",
+      objectNumber: Number.MAX_SAFE_INTEGER + 1,
+      generationNumber: 0,
+    })
+    .build();
+
+  assert(!result.ok);
+  expect(result.error.code).toBe("TRAILER_DICT_INVALID");
+});
+
+test("/Info の generationNumber が 65535 の場合は Ok を返す", () => {
+  // 境界値: generation 上限ちょうど（許容側）
+  const result = trailerDictBuilder()
+    .root(validRoot)
+    .size(validSize)
+    .info({
+      type: "indirect-ref",
+      objectNumber: 2,
+      generationNumber: MAX_GENERATION_NUMBER,
+    })
+    .build();
+
+  assert(result.ok);
+  expect(result.value.info?.generationNumber).toBe(
+    GenerationNumber.of(MAX_GENERATION_NUMBER),
+  );
+});
+
+test("/Info の generationNumber が 65536 の場合は TRAILER_DICT_INVALID を返す", () => {
+  // 境界値: generation 上限超過（拒否側）。
+  // isSafeIntegerAtLeastZero ガードは通り、create だけが落とす唯一の帯域
+  const result = trailerDictBuilder()
+    .root(validRoot)
+    .size(validSize)
+    .info({
+      type: "indirect-ref",
+      objectNumber: 2,
+      generationNumber: MAX_GENERATION_NUMBER + 1,
+    })
+    .build();
+
+  assert(!result.ok);
+  expect(result.error.code).toBe("TRAILER_DICT_INVALID");
+});
+
+test("/Encrypt の objectNumber が 0 の場合は Ok を返す", () => {
+  // 境界値: 最小の有効なオブジェクト番号（許容側）。拒否側は error を参照
+  const result = trailerDictBuilder()
+    .root(validRoot)
+    .size(validSize)
+    .encrypt({ type: "indirect-ref", objectNumber: 0, generationNumber: 0 })
+    .build();
+
+  assert(result.ok);
+  expect(result.value.encrypt).toEqual({
+    objectNumber: ObjectNumber.of(0),
+    generationNumber: GenerationNumber.of(0),
+  });
+});
+
+test("/Encrypt の objectNumber が MAX_SAFE_INTEGER の場合は Ok を返す", () => {
+  // 境界値: safe integer 上限ちょうど（許容側）
+  const result = trailerDictBuilder()
+    .root(validRoot)
+    .size(validSize)
+    .encrypt({
+      type: "indirect-ref",
+      objectNumber: Number.MAX_SAFE_INTEGER,
+      generationNumber: 0,
+    })
+    .build();
+
+  assert(result.ok);
+  expect(result.value.encrypt).toEqual({
+    objectNumber: ObjectNumber.of(Number.MAX_SAFE_INTEGER),
+    generationNumber: GenerationNumber.of(0),
+  });
+});
+
+test("/Encrypt の generationNumber が 65535 の場合は Ok を返す", () => {
+  // 境界値: 暗号化辞書参照の generation 上限ちょうど（許容側）
+  const result = trailerDictBuilder()
+    .root(validRoot)
+    .size(validSize)
+    .encrypt({
+      type: "indirect-ref",
+      objectNumber: 3,
+      generationNumber: MAX_GENERATION_NUMBER,
+    })
+    .build();
+
+  assert(result.ok);
+  expect(result.value.encrypt).toEqual({
+    objectNumber: ObjectNumber.of(3),
+    generationNumber: GenerationNumber.of(MAX_GENERATION_NUMBER),
+  });
+});
+
+test("/Encrypt の generationNumber が 65536 の場合は TRAILER_DICT_INVALID を返す", () => {
+  // 境界値: generation 上限超過（拒否側）。
+  // isSafeIntegerAtLeastZero ガードは通り、create だけが落とす唯一の帯域
+  const result = trailerDictBuilder()
+    .root(validRoot)
+    .size(validSize)
+    .encrypt({
+      type: "indirect-ref",
+      objectNumber: 3,
+      generationNumber: MAX_GENERATION_NUMBER + 1,
+    })
+    .build();
+
+  assert(!result.ok);
+  expect(result.error.code).toBe("TRAILER_DICT_INVALID");
+});

--- a/packages/core/src/xref/trailer/dict-builder/__tests__/dict-builder.edge.test.ts
+++ b/packages/core/src/xref/trailer/dict-builder/__tests__/dict-builder.edge.test.ts
@@ -1,0 +1,140 @@
+// 担当範囲: null オブジェクト（{ type: "null" }）の扱いにおける
+// 必須フィールドとオプションフィールドの非対称、および offset 伝播とセッタの再代入挙動。
+// 型不一致そのものの主担当は必須フィールドが validation、オプションフィールドが error。
+
+import { assert, expect, test } from "vitest";
+import { ByteOffset } from "../../../../pdf/types/byte-offset/index";
+import type { PdfValue } from "../../../../pdf/types/index";
+import { trailerDictBuilder } from "../index";
+
+const validRoot: PdfValue = {
+  type: "indirect-ref",
+  objectNumber: 1,
+  generationNumber: 0,
+};
+const validSize: PdfValue = { type: "integer", value: 10 };
+const nullValue: PdfValue = { type: "null" };
+
+// オプション 5 フィールドの null は isPresent() が「不在」として扱う（ISO 32000-1 §7.3.9）。
+// parseTrailer 経由の既存 test.each（parser.parsing.test.ts の
+// 「/$keyがnullの場合は…」）が間接カバー済みだが、
+// パーサのトークン解析に依存せず Builder 単体でも挙動を固定するために残す。
+
+test("/Prev に null オブジェクトを渡すとキー不在として扱われ prev が未設定になる", () => {
+  const result = trailerDictBuilder()
+    .root(validRoot)
+    .size(validSize)
+    .prev(nullValue)
+    .build();
+
+  assert(result.ok);
+  expect(result.value.prev).toBeUndefined();
+});
+
+test("/Info に null オブジェクトを渡すとキー不在として扱われ info が未設定になる", () => {
+  const result = trailerDictBuilder()
+    .root(validRoot)
+    .size(validSize)
+    .info(nullValue)
+    .build();
+
+  assert(result.ok);
+  expect(result.value.info).toBeUndefined();
+});
+
+test("/ID に null オブジェクトを渡すとキー不在として扱われ id が未設定になる", () => {
+  const result = trailerDictBuilder()
+    .root(validRoot)
+    .size(validSize)
+    .id(nullValue)
+    .build();
+
+  assert(result.ok);
+  expect(result.value.id).toBeUndefined();
+});
+
+test("/Encrypt に null オブジェクトを渡すとキー不在として扱われ暗号化なしと解釈される", () => {
+  const result = trailerDictBuilder()
+    .root(validRoot)
+    .size(validSize)
+    .encrypt(nullValue)
+    .build();
+
+  assert(result.ok);
+  expect(result.value.encrypt).toBeUndefined();
+});
+
+test("/XRefStm に null オブジェクトを渡すとキー不在として扱われ xrefStm が未設定になる", () => {
+  const result = trailerDictBuilder()
+    .root(validRoot)
+    .size(validSize)
+    .xrefStm(nullValue)
+    .build();
+
+  assert(result.ok);
+  expect(result.value.xrefStm).toBeUndefined();
+});
+
+test("/Root に null オブジェクトを渡すと不在ではなく型不一致として offset 付きで失敗する", () => {
+  // 必須フィールドは isPresent() を通らないためオプションと非対称になる。
+  // 未設定時（offset なし）ではなく「非 indirect-ref」分岐（offset あり）に落ちる
+  const result = trailerDictBuilder()
+    .root(nullValue, ByteOffset.of(11))
+    .size(validSize)
+    .build();
+
+  assert(!result.ok);
+  expect(result.error.code).toBe("ROOT_NOT_FOUND");
+  expect(result.error.offset).toBe(ByteOffset.of(11));
+});
+
+test("/Size に null オブジェクトを渡すと不在ではなく型不一致として offset 付きで失敗する", () => {
+  // /Root と同じ非対称。!_size は null オブジェクトを truthy として通す
+  const result = trailerDictBuilder()
+    .root(validRoot)
+    .size(nullValue, ByteOffset.of(22))
+    .build();
+
+  assert(!result.ok);
+  expect(result.error.code).toBe("SIZE_NOT_FOUND");
+  expect(result.error.offset).toBe(ByteOffset.of(22));
+});
+
+test("セッタに offset を渡さずに検証を失敗させると error.offset が undefined になる", () => {
+  // 呼び出し側（buildXRefStreamTrailerDict）が offset を渡さない実運用ケース
+  const result = trailerDictBuilder()
+    .root(validRoot)
+    .size(validSize)
+    .prev({ type: "integer", value: -1 })
+    .build();
+
+  assert(!result.ok);
+  expect(result.error.code).toBe("TRAILER_DICT_INVALID");
+  expect(result.error.offset).toBeUndefined();
+});
+
+test("同じセッタを 2 回呼ぶと後に渡した値で検証される", () => {
+  // Builder はクロージャ変数への再代入で値を保持するため後勝ちになる。
+  // 1 回目の不正値が残っていれば失敗するはずのケース
+  const result = trailerDictBuilder()
+    .root(validRoot)
+    .size({ type: "integer", value: -1 })
+    .size(validSize)
+    .build();
+
+  assert(result.ok);
+  expect(result.value.size).toBe(10);
+});
+
+test("同じセッタを 2 回呼ぶと offset も後に渡した値で上書きされる", () => {
+  // 値だけでなく offset も対で再代入される
+  const result = trailerDictBuilder()
+    .root(validRoot)
+    .size(validSize)
+    .prev({ type: "integer", value: -1 }, ByteOffset.of(33))
+    .prev({ type: "integer", value: -1 }, ByteOffset.of(44))
+    .build();
+
+  assert(!result.ok);
+  expect(result.error.offset).toBe(ByteOffset.of(44));
+});

--- a/packages/core/src/xref/trailer/dict-builder/__tests__/dict-builder.error.test.ts
+++ b/packages/core/src/xref/trailer/dict-builder/__tests__/dict-builder.error.test.ts
@@ -1,0 +1,426 @@
+// 担当範囲: オプションフィールド /Prev・/XRefStm・/Info・/ID・/Encrypt の異常系。
+// いずれも TRAILER_DICT_INVALID（呼び出し側が文脈別コードに書き換える前の生コード）を返す。
+// 必須フィールドの異常系は validation、境界値は boundary を参照。
+
+import { assert, expect, test } from "vitest";
+import { ByteOffset } from "../../../../pdf/types/byte-offset/index";
+import type { PdfValue } from "../../../../pdf/types/index";
+import { trailerDictBuilder } from "../index";
+
+const validRoot: PdfValue = {
+  type: "indirect-ref",
+  objectNumber: 1,
+  generationNumber: 0,
+};
+const validSize: PdfValue = { type: "integer", value: 10 };
+
+// フィールドごとに別の offset を渡し、どのフィールドの offset が伝播したかを識別する
+const PREV_OFFSET = ByteOffset.of(55);
+const XREF_STM_OFFSET = ByteOffset.of(66);
+const INFO_OFFSET = ByteOffset.of(77);
+const ID_OFFSET = ByteOffset.of(88);
+const ENCRYPT_OFFSET = ByteOffset.of(99);
+
+test("/Prev が real 型で値が非負 safe integer（10）の場合に TRAILER_DICT_INVALID と offset を返す", () => {
+  // 異常系: `/Prev 10.0`。短絡評価の第 1 項 `_prev.type !== "integer"` を単独で踏む
+  const result = trailerDictBuilder()
+    .root(validRoot)
+    .size(validSize)
+    .prev({ type: "real", value: 10 }, PREV_OFFSET)
+    .build();
+
+  assert(!result.ok);
+  expect(result.error.code).toBe("TRAILER_DICT_INVALID");
+  expect(result.error.offset).toBe(PREV_OFFSET);
+});
+
+test("/Prev が real 型で値も非整数（1.5）の場合に TRAILER_DICT_INVALID と offset を返す", () => {
+  // 異常系: `/Prev 1.5` の不正 PDF
+  const result = trailerDictBuilder()
+    .root(validRoot)
+    .size(validSize)
+    .prev({ type: "real", value: 1.5 }, PREV_OFFSET)
+    .build();
+
+  assert(!result.ok);
+  expect(result.error.code).toBe("TRAILER_DICT_INVALID");
+  expect(result.error.offset).toBe(PREV_OFFSET);
+});
+
+test("/Prev が integer で -1 の場合に TRAILER_DICT_INVALID と offset を返す", () => {
+  // 異常系: `/Prev -1`。短絡評価の第 2 項（isSafeIntegerAtLeastZero）側
+  const result = trailerDictBuilder()
+    .root(validRoot)
+    .size(validSize)
+    .prev({ type: "integer", value: -1 }, PREV_OFFSET)
+    .build();
+
+  assert(!result.ok);
+  expect(result.error.code).toBe("TRAILER_DICT_INVALID");
+  expect(result.error.offset).toBe(PREV_OFFSET);
+});
+
+test("/Prev が integer だが NaN の場合に TRAILER_DICT_INVALID と offset を返す", () => {
+  // NaN は test.each の label 表示が壊れるため単独で検証
+  const result = trailerDictBuilder()
+    .root(validRoot)
+    .size(validSize)
+    .prev({ type: "integer", value: NaN }, PREV_OFFSET)
+    .build();
+
+  assert(!result.ok);
+  expect(result.error.code).toBe("TRAILER_DICT_INVALID");
+  expect(result.error.offset).toBe(PREV_OFFSET);
+});
+
+test("/XRefStm が real 型で値が非負 safe integer（10）の場合に TRAILER_DICT_INVALID と offset を返す", () => {
+  // 異常系: ハイブリッド参照 PDF の `/XRefStm 10.0`。
+  // 短絡評価の第 1 項を単独で踏む。xref ストリーム経路からは到達不能な分岐
+  const result = trailerDictBuilder()
+    .root(validRoot)
+    .size(validSize)
+    .xrefStm({ type: "real", value: 10 }, XREF_STM_OFFSET)
+    .build();
+
+  assert(!result.ok);
+  expect(result.error.code).toBe("TRAILER_DICT_INVALID");
+  expect(result.error.offset).toBe(XREF_STM_OFFSET);
+});
+
+test("/XRefStm が real 型で値も非整数（1.5）の場合に TRAILER_DICT_INVALID と offset を返す", () => {
+  // 異常系: `/XRefStm 1.5`
+  const result = trailerDictBuilder()
+    .root(validRoot)
+    .size(validSize)
+    .xrefStm({ type: "real", value: 1.5 }, XREF_STM_OFFSET)
+    .build();
+
+  assert(!result.ok);
+  expect(result.error.code).toBe("TRAILER_DICT_INVALID");
+  expect(result.error.offset).toBe(XREF_STM_OFFSET);
+});
+
+test("/XRefStm が integer で -1 の場合に TRAILER_DICT_INVALID と offset を返す", () => {
+  // 異常系: `/XRefStm -1`。短絡評価の第 2 項側
+  const result = trailerDictBuilder()
+    .root(validRoot)
+    .size(validSize)
+    .xrefStm({ type: "integer", value: -1 }, XREF_STM_OFFSET)
+    .build();
+
+  assert(!result.ok);
+  expect(result.error.code).toBe("TRAILER_DICT_INVALID");
+  expect(result.error.offset).toBe(XREF_STM_OFFSET);
+});
+
+test("/Info が indirect-ref 以外（dictionary）の場合に TRAILER_DICT_INVALID と offset を返す", () => {
+  // 異常系: `/Info << … >>` のように直接辞書が書かれた PDF
+  const result = trailerDictBuilder()
+    .root(validRoot)
+    .size(validSize)
+    .info(
+      { type: "dictionary", entries: new Map<string, PdfValue>() },
+      INFO_OFFSET,
+    )
+    .build();
+
+  assert(!result.ok);
+  expect(result.error.code).toBe("TRAILER_DICT_INVALID");
+  expect(result.error.offset).toBe(INFO_OFFSET);
+});
+
+test("/Info の objectNumber が -1 の場合に TRAILER_DICT_INVALID と offset を返す", () => {
+  // 異常系: `/Info -1 0 R`。既存の間接テストは MAX_SAFE 超のみで負値は未到達
+  const result = trailerDictBuilder()
+    .root(validRoot)
+    .size(validSize)
+    .info(
+      { type: "indirect-ref", objectNumber: -1, generationNumber: 0 },
+      INFO_OFFSET,
+    )
+    .build();
+
+  assert(!result.ok);
+  expect(result.error.code).toBe("TRAILER_DICT_INVALID");
+  expect(result.error.offset).toBe(INFO_OFFSET);
+});
+
+test("/Info の objectNumber が NaN の場合に TRAILER_DICT_INVALID と offset を返す", () => {
+  // NaN は test.each の label 表示が壊れるため単独で検証
+  const result = trailerDictBuilder()
+    .root(validRoot)
+    .size(validSize)
+    .info(
+      { type: "indirect-ref", objectNumber: NaN, generationNumber: 0 },
+      INFO_OFFSET,
+    )
+    .build();
+
+  assert(!result.ok);
+  expect(result.error.code).toBe("TRAILER_DICT_INVALID");
+  expect(result.error.offset).toBe(INFO_OFFSET);
+});
+
+test.each([
+  -1,
+  1.5,
+  Infinity,
+  -Infinity,
+  Number.MAX_SAFE_INTEGER + 1,
+])("/Info の generationNumber が %s の場合に TRAILER_DICT_INVALID と offset を返す", (invalid) => {
+  // 異常系: 既存の間接テストが踏んでいない不正 generation 値。
+  // どの不正値でも TRAILER_DICT_INVALID を返すという契約の固定が目的
+  const result = trailerDictBuilder()
+    .root(validRoot)
+    .size(validSize)
+    .info(
+      { type: "indirect-ref", objectNumber: 2, generationNumber: invalid },
+      INFO_OFFSET,
+    )
+    .build();
+
+  assert(!result.ok);
+  expect(result.error.code).toBe("TRAILER_DICT_INVALID");
+  expect(result.error.offset).toBe(INFO_OFFSET);
+});
+
+test("/Info の generationNumber が NaN の場合に TRAILER_DICT_INVALID と offset を返す", () => {
+  // NaN は test.each の label 表示が壊れるため単独で検証
+  const result = trailerDictBuilder()
+    .root(validRoot)
+    .size(validSize)
+    .info(
+      { type: "indirect-ref", objectNumber: 2, generationNumber: NaN },
+      INFO_OFFSET,
+    )
+    .build();
+
+  assert(!result.ok);
+  expect(result.error.code).toBe("TRAILER_DICT_INVALID");
+  expect(result.error.offset).toBe(INFO_OFFSET);
+});
+
+test("/ID が array 以外（string）の場合に TRAILER_DICT_INVALID と offset を返す", () => {
+  // 異常系: `/ID (abc)` の不正 PDF。要素数チェックより手前の分岐
+  const result = trailerDictBuilder()
+    .root(validRoot)
+    .size(validSize)
+    .id(
+      { type: "string", value: new Uint8Array([0x01]), encoding: "literal" },
+      ID_OFFSET,
+    )
+    .build();
+
+  assert(!result.ok);
+  expect(result.error.code).toBe("TRAILER_DICT_INVALID");
+  expect(result.error.offset).toBe(ID_OFFSET);
+});
+
+test("/ID の要素数が 1 の場合に TRAILER_DICT_INVALID と offset を返す", () => {
+  // 異常系: 片方の ID しか書かれていない PDF
+  const result = trailerDictBuilder()
+    .root(validRoot)
+    .size(validSize)
+    .id(
+      {
+        type: "array",
+        elements: [
+          { type: "string", value: new Uint8Array([0x01]), encoding: "hex" },
+        ],
+      },
+      ID_OFFSET,
+    )
+    .build();
+
+  assert(!result.ok);
+  expect(result.error.code).toBe("TRAILER_DICT_INVALID");
+  expect(result.error.offset).toBe(ID_OFFSET);
+});
+
+test("/ID の要素数が 3 の場合に TRAILER_DICT_INVALID と offset を返す", () => {
+  // 異常系: 要素数超過
+  const result = trailerDictBuilder()
+    .root(validRoot)
+    .size(validSize)
+    .id(
+      {
+        type: "array",
+        elements: [
+          { type: "string", value: new Uint8Array([0x01]), encoding: "hex" },
+          { type: "string", value: new Uint8Array([0x02]), encoding: "hex" },
+          { type: "string", value: new Uint8Array([0x03]), encoding: "hex" },
+        ],
+      },
+      ID_OFFSET,
+    )
+    .build();
+
+  assert(!result.ok);
+  expect(result.error.code).toBe("TRAILER_DICT_INVALID");
+  expect(result.error.offset).toBe(ID_OFFSET);
+});
+
+test("/ID の第 1 要素が string 以外の場合に TRAILER_DICT_INVALID と offset を返す", () => {
+  // 異常系: `/ID [1 2]` 相当のループ i=0 側の分岐。
+  // parser.error.test.ts が間接カバー済みだが Builder 単体で再固定する
+  const result = trailerDictBuilder()
+    .root(validRoot)
+    .size(validSize)
+    .id(
+      {
+        type: "array",
+        elements: [
+          { type: "integer", value: 1 },
+          { type: "string", value: new Uint8Array([0x02]), encoding: "hex" },
+        ],
+      },
+      ID_OFFSET,
+    )
+    .build();
+
+  assert(!result.ok);
+  expect(result.error.code).toBe("TRAILER_DICT_INVALID");
+  expect(result.error.offset).toBe(ID_OFFSET);
+});
+
+test("/ID の第 2 要素のみが string 以外の場合に TRAILER_DICT_INVALID と offset を返す", () => {
+  // 異常系: ループ i=1 側の実行パス。
+  // 既存の間接テストは両要素とも非 string のため i=1 のイテレーションを通っていない
+  const result = trailerDictBuilder()
+    .root(validRoot)
+    .size(validSize)
+    .id(
+      {
+        type: "array",
+        elements: [
+          { type: "string", value: new Uint8Array([0x01]), encoding: "hex" },
+          { type: "integer", value: 2 },
+        ],
+      },
+      ID_OFFSET,
+    )
+    .build();
+
+  assert(!result.ok);
+  expect(result.error.code).toBe("TRAILER_DICT_INVALID");
+  expect(result.error.offset).toBe(ID_OFFSET);
+});
+
+test("/Encrypt の objectNumber が -1 の場合に TRAILER_DICT_INVALID と offset を返す", () => {
+  // 異常系: `/Encrypt -1 0 R`。
+  // 暗号化 PDF のすり抜け防止に直結する indirect-ref 側の数値検証
+  const result = trailerDictBuilder()
+    .root(validRoot)
+    .size(validSize)
+    .encrypt(
+      { type: "indirect-ref", objectNumber: -1, generationNumber: 0 },
+      ENCRYPT_OFFSET,
+    )
+    .build();
+
+  assert(!result.ok);
+  expect(result.error.code).toBe("TRAILER_DICT_INVALID");
+  expect(result.error.offset).toBe(ENCRYPT_OFFSET);
+});
+
+test("/Encrypt の objectNumber が MAX_SAFE_INTEGER + 1 の場合に TRAILER_DICT_INVALID と offset を返す", () => {
+  // 異常系: 数値破損した参照
+  const result = trailerDictBuilder()
+    .root(validRoot)
+    .size(validSize)
+    .encrypt(
+      {
+        type: "indirect-ref",
+        objectNumber: Number.MAX_SAFE_INTEGER + 1,
+        generationNumber: 0,
+      },
+      ENCRYPT_OFFSET,
+    )
+    .build();
+
+  assert(!result.ok);
+  expect(result.error.code).toBe("TRAILER_DICT_INVALID");
+  expect(result.error.offset).toBe(ENCRYPT_OFFSET);
+});
+
+test("/Encrypt の objectNumber が NaN の場合に TRAILER_DICT_INVALID と offset を返す", () => {
+  // NaN は test.each の label 表示が壊れるため単独で検証
+  const result = trailerDictBuilder()
+    .root(validRoot)
+    .size(validSize)
+    .encrypt(
+      { type: "indirect-ref", objectNumber: NaN, generationNumber: 0 },
+      ENCRYPT_OFFSET,
+    )
+    .build();
+
+  assert(!result.ok);
+  expect(result.error.code).toBe("TRAILER_DICT_INVALID");
+  expect(result.error.offset).toBe(ENCRYPT_OFFSET);
+});
+
+test.each([
+  -1,
+  1.5,
+  Infinity,
+  -Infinity,
+  Number.MAX_SAFE_INTEGER + 1,
+])("/Encrypt の generationNumber が %s の場合に TRAILER_DICT_INVALID と offset を返す", (invalid) => {
+  // 異常系: `/Encrypt 3 -1 R` など。
+  // どの不正値でも TRAILER_DICT_INVALID を返すという契約の固定が目的
+  const result = trailerDictBuilder()
+    .root(validRoot)
+    .size(validSize)
+    .encrypt(
+      { type: "indirect-ref", objectNumber: 3, generationNumber: invalid },
+      ENCRYPT_OFFSET,
+    )
+    .build();
+
+  assert(!result.ok);
+  expect(result.error.code).toBe("TRAILER_DICT_INVALID");
+  expect(result.error.offset).toBe(ENCRYPT_OFFSET);
+});
+
+test("/Encrypt の generationNumber が NaN の場合に TRAILER_DICT_INVALID と offset を返す", () => {
+  // NaN は test.each の label 表示が壊れるため単独で検証
+  const result = trailerDictBuilder()
+    .root(validRoot)
+    .size(validSize)
+    .encrypt(
+      { type: "indirect-ref", objectNumber: 3, generationNumber: NaN },
+      ENCRYPT_OFFSET,
+    )
+    .build();
+
+  assert(!result.ok);
+  expect(result.error.code).toBe("TRAILER_DICT_INVALID");
+  expect(result.error.offset).toBe(ENCRYPT_OFFSET);
+});
+
+test("/Encrypt が name 型の場合に TRAILER_DICT_INVALID と offset を返す", () => {
+  // 異常系: `/Encrypt /Standard` の不正 PDF。
+  // indirect-ref でも dictionary でもない else 分岐
+  const result = trailerDictBuilder()
+    .root(validRoot)
+    .size(validSize)
+    .encrypt({ type: "name", value: "Standard" }, ENCRYPT_OFFSET)
+    .build();
+
+  assert(!result.ok);
+  expect(result.error.code).toBe("TRAILER_DICT_INVALID");
+  expect(result.error.offset).toBe(ENCRYPT_OFFSET);
+});
+
+test("/Encrypt が array 型の場合に TRAILER_DICT_INVALID と offset を返す", () => {
+  // 異常系: 型不一致のバリエーション
+  const result = trailerDictBuilder()
+    .root(validRoot)
+    .size(validSize)
+    .encrypt({ type: "array", elements: [] }, ENCRYPT_OFFSET)
+    .build();
+
+  assert(!result.ok);
+  expect(result.error.code).toBe("TRAILER_DICT_INVALID");
+  expect(result.error.offset).toBe(ENCRYPT_OFFSET);
+});

--- a/packages/core/src/xref/trailer/dict-builder/__tests__/dict-builder.validation.test.ts
+++ b/packages/core/src/xref/trailer/dict-builder/__tests__/dict-builder.validation.test.ts
@@ -1,0 +1,178 @@
+// 担当範囲: 必須フィールド /Root・/Size の異常系（ROOT_NOT_FOUND / SIZE_NOT_FOUND）。
+// オプションフィールドの異常系は error、境界値は boundary を参照。
+
+import { assert, expect, test } from "vitest";
+import { ByteOffset } from "../../../../pdf/types/byte-offset/index";
+import type { PdfValue } from "../../../../pdf/types/index";
+import { trailerDictBuilder } from "../index";
+
+const validRoot: PdfValue = {
+  type: "indirect-ref",
+  objectNumber: 1,
+  generationNumber: 0,
+};
+const validSize: PdfValue = { type: "integer", value: 10 };
+
+const ROOT_OFFSET = ByteOffset.of(42);
+const SIZE_OFFSET = ByteOffset.of(77);
+
+test("/Root 未設定の場合に ROOT_NOT_FOUND を offset なしで返す", () => {
+  // 異常系: !_root 分岐。この err だけ offset フィールドを持たない非対称を固定する
+  const result = trailerDictBuilder().size(validSize).build();
+
+  assert(!result.ok);
+  expect(result.error.code).toBe("ROOT_NOT_FOUND");
+  expect(result.error.offset).toBeUndefined();
+});
+
+test("/Root が indirect-ref 以外（integer）の場合に ROOT_NOT_FOUND と offset を返す", () => {
+  // 異常系: `/Root 5` のように直接値が書かれた不正 PDF
+  const result = trailerDictBuilder()
+    .root({ type: "integer", value: 5 }, ROOT_OFFSET)
+    .size(validSize)
+    .build();
+
+  assert(!result.ok);
+  expect(result.error.code).toBe("ROOT_NOT_FOUND");
+  expect(result.error.offset).toBe(ROOT_OFFSET);
+});
+
+test("/Root の objectNumber が -1 の場合に ROOT_NOT_FOUND と offset を返す", () => {
+  // 異常系: `/Root -1 0 R` 相当の不正参照
+  const result = trailerDictBuilder()
+    .root(
+      { type: "indirect-ref", objectNumber: -1, generationNumber: 0 },
+      ROOT_OFFSET,
+    )
+    .size(validSize)
+    .build();
+
+  assert(!result.ok);
+  expect(result.error.code).toBe("ROOT_NOT_FOUND");
+  expect(result.error.offset).toBe(ROOT_OFFSET);
+});
+
+test("/Root の objectNumber が NaN の場合に ROOT_NOT_FOUND と offset を返す", () => {
+  // NaN は test.each の label 表示が壊れるため単独で検証
+  const result = trailerDictBuilder()
+    .root(
+      { type: "indirect-ref", objectNumber: NaN, generationNumber: 0 },
+      ROOT_OFFSET,
+    )
+    .size(validSize)
+    .build();
+
+  assert(!result.ok);
+  expect(result.error.code).toBe("ROOT_NOT_FOUND");
+  expect(result.error.offset).toBe(ROOT_OFFSET);
+});
+
+test.each([
+  -1,
+  1.5,
+  Infinity,
+  -Infinity,
+  Number.MAX_SAFE_INTEGER + 1,
+])("/Root の generationNumber が %s の場合に ROOT_NOT_FOUND と offset を返す", (invalid) => {
+  // 異常系: 既存の間接テストが踏んでいない不正 generation 値。
+  // どの不正値でも ROOT_NOT_FOUND を返すという契約の固定が目的であり、
+  // isSafeIntegerAtLeastZero ガードと GenerationNumber.create の
+  // どちらで落ちたかは同一 code + offset のため区別しない
+  const result = trailerDictBuilder()
+    .root(
+      { type: "indirect-ref", objectNumber: 1, generationNumber: invalid },
+      ROOT_OFFSET,
+    )
+    .size(validSize)
+    .build();
+
+  assert(!result.ok);
+  expect(result.error.code).toBe("ROOT_NOT_FOUND");
+  expect(result.error.offset).toBe(ROOT_OFFSET);
+});
+
+test("/Root の generationNumber が NaN の場合に ROOT_NOT_FOUND と offset を返す", () => {
+  // NaN は test.each の label 表示が壊れるため単独で検証
+  const result = trailerDictBuilder()
+    .root(
+      { type: "indirect-ref", objectNumber: 1, generationNumber: NaN },
+      ROOT_OFFSET,
+    )
+    .size(validSize)
+    .build();
+
+  assert(!result.ok);
+  expect(result.error.code).toBe("ROOT_NOT_FOUND");
+  expect(result.error.offset).toBe(ROOT_OFFSET);
+});
+
+test("/Size 未設定の場合に SIZE_NOT_FOUND を offset なしで返す", () => {
+  // 異常系: !_size 分岐。この err だけ offset フィールドを持たない非対称を固定する
+  const result = trailerDictBuilder().root(validRoot).build();
+
+  assert(!result.ok);
+  expect(result.error.code).toBe("SIZE_NOT_FOUND");
+  expect(result.error.offset).toBeUndefined();
+});
+
+test("/Size が real 型で値が非負 safe integer（10）の場合に SIZE_NOT_FOUND と offset を返す", () => {
+  // 異常系: `/Size 10.0` 相当。短絡評価の第 1 項 `_size.type !== "integer"` を
+  // 単独で踏める唯一の入力（第 2 項は値 10 を通してしまう）
+  const result = trailerDictBuilder()
+    .root(validRoot)
+    .size({ type: "real", value: 10 }, SIZE_OFFSET)
+    .build();
+
+  assert(!result.ok);
+  expect(result.error.code).toBe("SIZE_NOT_FOUND");
+  expect(result.error.offset).toBe(SIZE_OFFSET);
+});
+
+test("/Size が real 型で値も非整数（1.5）の場合に SIZE_NOT_FOUND と offset を返す", () => {
+  // 異常系: `/Size 1.5`。parser.error.test.ts が間接カバー済みだが
+  // Builder 単体で再固定する。短絡評価の第 1 項・第 2 項の両方に該当する
+  const result = trailerDictBuilder()
+    .root(validRoot)
+    .size({ type: "real", value: 1.5 }, SIZE_OFFSET)
+    .build();
+
+  assert(!result.ok);
+  expect(result.error.code).toBe("SIZE_NOT_FOUND");
+  expect(result.error.offset).toBe(SIZE_OFFSET);
+});
+
+test("/Size が name 型の場合に SIZE_NOT_FOUND と offset を返す", () => {
+  // 異常系: `/Size /Foo` のような型不一致
+  const result = trailerDictBuilder()
+    .root(validRoot)
+    .size({ type: "name", value: "Foo" }, SIZE_OFFSET)
+    .build();
+
+  assert(!result.ok);
+  expect(result.error.code).toBe("SIZE_NOT_FOUND");
+  expect(result.error.offset).toBe(SIZE_OFFSET);
+});
+
+test("/Size が integer で -1 の場合に SIZE_NOT_FOUND と offset を返す", () => {
+  // 異常系: `/Size -1`。短絡評価の第 2 項（isSafeIntegerAtLeastZero）側
+  const result = trailerDictBuilder()
+    .root(validRoot)
+    .size({ type: "integer", value: -1 }, SIZE_OFFSET)
+    .build();
+
+  assert(!result.ok);
+  expect(result.error.code).toBe("SIZE_NOT_FOUND");
+  expect(result.error.offset).toBe(SIZE_OFFSET);
+});
+
+test("/Size が integer だが NaN の場合に SIZE_NOT_FOUND と offset を返す", () => {
+  // 異常系: 型は integer だが値が非 safe integer。短絡評価の第 2 項を独立に踏む
+  const result = trailerDictBuilder()
+    .root(validRoot)
+    .size({ type: "integer", value: NaN }, SIZE_OFFSET)
+    .build();
+
+  assert(!result.ok);
+  expect(result.error.code).toBe("SIZE_NOT_FOUND");
+  expect(result.error.offset).toBe(SIZE_OFFSET);
+});


### PR DESCRIPTION
## 概要

共有 Builder である `trailerDictBuilder`（`packages/core/src/xref/trailer/dict-builder/index.ts`）には専用のユニットテストが無く、`xref/stream/trailer` と `xref/trailer/parser` 経由の**間接検証だけ**に依存していました。その結果、負値や非 safe integer などのバリデーション分岐が一度も実行されない状態でした。

`dict-builder/__tests__/` を新設し、`build()` の全バリデーション分岐を Builder の直接呼び出しで網羅します。**本体コード `dict-builder/index.ts` は 1 行も変更していません**（テスト追加のみ）。

文カバレッジは **87.16% → 100%**（Branch / Funcs / Lines も 100%）になりました。

## 変更内容

### 🎯 変更の種類

- [x] 🚨 テスト追加/修正 (Tests)

### 📝 詳細な変更内容

#### 追加された機能・修正

新規テスト 5 ファイル・計 **89 テスト**。カテゴリ別に分割し、`describe` 不使用のフラット構造・日本語テスト名というリポジトリ規約に従っています。

| ファイル | テスト数 | 担当範囲 |
|---|---|---|
| `dict-builder.basic.test.ts` | 8 | 正常系。最小構成 / 全フィールド / 各オプション単独 / `/Encrypt` の 2 バリアント |
| `dict-builder.validation.test.ts` | 16 | 必須 `/Root`・`/Size` の異常系（`ROOT_NOT_FOUND` / `SIZE_NOT_FOUND`） |
| `dict-builder.error.test.ts` | 32 | オプション `/Prev`・`/XRefStm`・`/Info`・`/ID`・`/Encrypt` の異常系（`TRAILER_DICT_INVALID`） |
| `dict-builder.boundary.test.ts` | 23 | 境界値（0 / 65535 / 65536 / `MAX_SAFE_INTEGER` / +1）を許容側・拒否側のペアで |
| `dict-builder.edge.test.ts` | 10 | null オブジェクトの必須/オプション非対称、offset 伝播、セッタ再代入 |

Issue に記載された**未到達 5 分岐**をすべて解消しています。

- `/Root` の generationNumber が負値 / 非 safe integer
- `/Info` の objectNumber が負値
- `/Info` の generationNumber が負値 / 非 safe integer
- `/Size` が real 型
- `/ID` 配列要素が非 string

加えて、Issue には挙がっていなかった以下の未到達分岐も網羅しました。

- `/ID` が非 array、`/Encrypt` の objectNumber・generationNumber の数値検証
- `/XRefStm` を含む全フィールド設定の正常系（呼び出し側が `.xrefStm()` を呼ばないため到達不能だった）
- `/Root`・`/Size` に null オブジェクトを渡した場合の非対称

#### 変更されたファイル

- なし（既存ファイルへの差分ゼロ）

#### 削除されたファイル・機能

- なし

## 📊 システム図

### 状態マシン / フロー図

`build()` の検証順序と、各分岐が返すエラーコード。**すべての分岐に新規テストが到達します**（オレンジ = 今回のテストで初めて到達した分岐）。

```mermaid
flowchart TD
    Start([build 呼び出し]) --> R1{/Root 未設定?}
    R1 -->|Yes| ERoot1[ROOT_NOT_FOUND<br/>offset なし]
    R1 -->|No| R2{間接参照でない?}
    R2 -->|Yes| ERoot2[ROOT_NOT_FOUND<br/>offset あり]
    R2 -->|No| R3{objectNumber が<br/>非負 safe integer でない?}
    R3 -->|Yes| ERoot2
    R3 -->|No| R4{generationNumber が<br/>非負 safe integer でない?}:::new
    R4 -->|Yes| ERoot2
    R4 -->|No| R5{世代番号が 0-65535 の範囲外?}
    R5 -->|Yes| ERoot2
    R5 -->|No| S1{/Size 未設定?}

    S1 -->|Yes| ESize1[SIZE_NOT_FOUND<br/>offset なし]
    S1 -->|No| S2{integer 型でない<br/>または非負 safe integer でない?}:::new
    S2 -->|Yes| ESize2[SIZE_NOT_FOUND<br/>offset あり]
    S2 -->|No| P1{/Prev あり?}

    P1 -->|Yes| P2{integer 型でない<br/>または非負 safe integer でない?}
    P2 -->|Yes| EOpt[TRAILER_DICT_INVALID<br/>offset あり]
    P2 -->|No| I1
    P1 -->|No| I1{/Info あり?}

    I1 -->|Yes| I2{間接参照でない<br/>または番号が不正?}:::new
    I2 -->|Yes| EOpt
    I2 -->|No| D1
    I1 -->|No| D1{/ID あり?}

    D1 -->|Yes| D2{array でない<br/>または要素数 != 2?}:::new
    D2 -->|Yes| EOpt
    D2 -->|No| D3{要素が string でない?<br/>ループ 2 周}:::new
    D3 -->|Yes| EOpt
    D3 -->|No| E1
    D1 -->|No| E1{/Encrypt あり?}

    E1 -->|Yes| E2{間接参照?}
    E2 -->|Yes| E3{番号が不正?}:::new
    E3 -->|Yes| EOpt
    E3 -->|No| X1
    E2 -->|No| E4{dictionary?}:::new
    E4 -->|Yes| E5[辞書をそのまま格納<br/>パススルー]:::new
    E5 --> X1
    E4 -->|No| EOpt
    E1 -->|No| X1{/XRefStm あり?}

    X1 -->|Yes| X2{integer 型でない<br/>または非負 safe integer でない?}:::new
    X2 -->|Yes| EOpt
    X2 -->|No| OK([Ok TrailerDict])
    X1 -->|No| OK

    classDef new fill:#ffe4b5,stroke:#d97706,stroke-width:2px
```

### データフロー

null オブジェクトの扱いが**必須フィールドとオプションフィールドで非対称**である点が本 PR の中核です。

```
PdfValue（各セッタ経由）
    │
    ├─→ /Root・/Size（必須）
    │       │
    │       └─→ 素の truthy 判定（!_root / !_size）
    │               │
    │               └─→ { type: "null" } はオブジェクト = truthy
    │                       ↓
    │                   「未設定」を素通りし「型不一致」分岐へ  [NEW: テストで固定]
    │                       ↓
    │                   同じエラーコード + offset あり
    │                   （未設定時は offset なし = 唯一の識別点）
    │
    └─→ /Prev・/Info・/ID・/Encrypt・/XRefStm（オプション）
            │
            └─→ isPresent()（undefined でなく null オブジェクトでもない）
                    │
                    └─→ { type: "null" } は「キー不在」扱い  [NEW: Builder 単体で固定]
                            ↓
                        検証をスキップし result に現れない
                        （ISO 32000-1 §7.3.9）
```

## 📋 関連 Issue

- Closes #497

## 🧪 テスト

### テスト実行方法

```bash
# 新規テストのみ
pnpm test:run packages/core/src/xref/trailer/dict-builder

# trailer 周辺（既存の間接テストのリグレッション確認込み）
pnpm test:run packages/core/src/xref/trailer packages/core/src/xref/stream/trailer

# 全体 + カバレッジ
pnpm test:run --coverage
```

### テスト項目

- [x] 単体テスト (Unit tests)
- [x] 手動テスト (Manual testing) — 意図的破壊（mutation）検証

### テスト結果

| 項目 | 結果 |
|---|---|
| `pnpm test:run`（全体） | **3452 passed**（283 files） |
| `pnpm test:run packages/core/src/xref/trailer/dict-builder` | 89 passed |
| trailer 周辺（既存間接テスト） | 163 passed（リグレッションなし） |
| `pnpm typecheck` | 通過 |
| `pnpm lint`（biome + oxlint） | 通過 |
| `dict-builder/index.ts` のカバレッジ | 87.16% → **100%**（Stmts / Branch / Funcs / Lines） |

#### 意図的破壊（mutation）検証

`message` 文言をアサートしない方針のため、同一エラーコードを返す複数分岐はアサーションだけでは区別できません。そこで各テストを書いたあと**本体の検証を一時的に壊して対応テストが落ちるかを確認し、毎回 `git restore` + `git diff --exit-code` で復元**しています（計 8 回）。

| 壊した箇所 | 落ちたテスト | 判定 |
|---|---|---|
| `return ok(result)` を err に | basic 全 8 件 | 期待どおり |
| `/Encrypt` の dictionary 分岐を除去 | dictionary の 1 件のみ | 期待どおり |
| `/Size` の型チェック項のみ除去 | `{ type: "real", value: 10 }` の 1 件のみ | 期待どおり（後述） |
| `/Info` の objectNumber ガード除去 | 該当 2 件 | 期待どおり |
| `/ID` の要素型チェック除去 | 第 1 要素 / 第 2 要素の 2 件 | 期待どおり |
| `/Encrypt` の objectNumber ガード除去 | 該当 3 件 | 期待どおり |
| 世代番号の範囲チェック除去（Root/Info/Encrypt 各々） | それぞれ 65536 の 1 件のみ | 期待どおり（後述） |
| `isPresent` から null 判定を除去 | オプション 5 フィールドの 5 件 | 期待どおり |
| `/Root` の判定を `isPresent` に変更 | `/Root` null の 1 件のみ | 期待どおり |

**本体コードには最終的に 1 行の差分もありません**（`git diff HEAD` が空であることを確認済み）。

## 🔍 レビューポイント

### 1. `/Size`・`/Prev`・`/XRefStm` に `{ type: "real", value: 10 }` を必ず含めている理由

これらの検証は「integer 型でない **||** 非負 safe integer でない」の短絡評価です。`{ type: "real", value: 1.5 }` は後段の項でも弾かれるため、**型チェック側の項を単独で踏める入力は「型は real だが値は非負 safe integer」＝ value: 10 だけ**です。実際に型チェック項だけを外したところ、value: 10 のテストのみが落ち 1.5 のテストは pass のままでした。この入力が無いと mutation が偽陰性になり、分岐到達を証明できません。

### 2. 世代番号の 2 段検証には mutation を課していない（equivalent mutant）

事前ガード（非負 safe integer か）の**拒否集合は後段の範囲チェック（0〜65535）の拒否集合に完全に含まれ**、両者は同一のエラーコード + offset を返します。したがってどちらを外しても負値・非整数のテストは 1 件も落ちません。分岐同定が可能なのは 65536（ガードを通過し範囲チェックだけが弾く唯一の帯域）だけで、実際に範囲チェックを外したときに落ちたのも 65536 のテストのみでした。

負値・非整数のテストの目的は分岐同定ではなく「**どんな不正な世代番号でも一貫して同じエラーを返す**」という契約の固定です。

### 3. `/ID` の第 2 要素のみが非 string のケース

要素チェックは 2 要素を回すループ内にあり、既存の間接テスト（両要素とも非 string）は 1 周目で必ず早期 return するため**2 周目のイテレーションを一度も実行していません**。ソース上は同一分岐なのでカバレッジ計測では見えない、実行パスとしての未到達です。

### 4. `/Encrypt` の dictionary は `toBe`（参照同一性）で比較

実装は受け取った辞書をそのまま代入するパススルーです。`toEqual` だと「同値の別オブジェクトへコピーする」実装変更を検出できず、パススルーであることを保証できません。

### 5. null 扱いの非対称を「現行仕様」として固定してよいか

`/Root null` と書かれた PDF は「未設定」ではなく「型不一致」分岐に落ちます（offset が付く点だけが違い、エラーコードは同じ）。リファクタリングで意図せず対称化されるとエラー位置を報告できなくなるため固定しましたが、**そもそもこの非対称が望ましいかは別途議論の余地があります**（本 PR では挙動を変えず、現状を明文化するに留めています）。

## ⚠️ 破壊的変更

- [ ] この変更は既存の API に破壊的変更を含みます

なし。テストの追加のみで、プロダクションコードへの変更はありません。

## 📚 追加情報

### 注意事項

- 既存の間接テスト（`xref/stream/trailer/__tests__/` 3 ファイル、`xref/trailer/parser/__tests__/` 2 ファイル、`xref/__tests__/xref-pipeline.integration.test.ts`）は**意図的にそのまま残しています**。呼び出し側での `TRAILER_DICT_INVALID → XREF_STREAM_INVALID` / `→ XREF_TABLE_INVALID` の書き換えを検証する固有の価値があるため、検証内容が一部重複しても整理していません。
- 合否判定に**カバレッジ数値は使っていません**。カバレッジ計測器は短絡評価の各項を独立分岐として数えないため、100% でも「型が違う」ケースと「値が負」ケースの片方しか検証していない状態を見逃しうるからです（参考指標として記載）。

## ✅ チェックリスト

- [x] コードレビューの準備ができている
- [x] テストが正常に実行される
- [x] ドキュメントが更新されている（該当なし）
- [x] コミットメッセージが適切な形式で書かれている
- [x] 関連する Issue が PR 本文に記載されている
- [x] セルフレビューを実施した
- [x] 破壊的変更なし