### PR TITLE
test(lexer): add octal escape boundary test cases for \377 and \400 (#504)

### DIFF
--- a/packages/core/src/lexer/tokenizer/__tests__/tokenizer.basic.test.ts
+++ b/packages/core/src/lexer/tokenizer/__tests__/tokenizer.basic.test.ts
@@ -197,6 +197,22 @@ test("1桁オクタルエスケープ \\5 を処理する", () => {
   });
 });
 
+test("オクタルエスケープの上端境界 \\377 (0xFF) を処理する", () => {
+  const tokens = tokenize("(\\377)");
+  expect(tokens[0]).toMatchObject({
+    type: TokenType.LiteralString,
+    value: "\u00ff",
+  });
+});
+
+test("現行挙動: オクタルエスケープ境界外 \\400 (0x100 / 256) を 0x100 としてトークン化する (0xFF超は上位で検証)", () => {
+  const tokens = tokenize("(\\400)");
+  expect(tokens[0]).toMatchObject({
+    type: TokenType.LiteralString,
+    value: "\u0100",
+  });
+});
+
 test("16進文字列内の空白を無視する", () => {
   const tokens = tokenize("<4 8 65 6C>");
   expect(tokens[0]).toMatchObject({


### PR DESCRIPTION
## 概要
Issue #504 に基づき、`lexer/tokenizer` のリテラル文字列における 8進エスケープ成功上端境界 `\377` (0xFF = 255 -> `"\u00ff"`) および 3桁境界外 `\400` (0x100 = 256 -> `"\u0100"`) の単体テストを `packages/core/src/lexer/tokenizer/__tests__/tokenizer.basic.test.ts` に追加・整備し、現行 Tokenizer 層でのレイヤー分離挙動をテストで固定しました。

## 変更内容
- `tokenizer.basic.test.ts` に以下の2つの単体テストを追加:
  - `オクタルエスケープの上端境界 \377 (0xFF) を処理する`
  - `現行挙動: オクタルエスケープ境界外 \400 (0x100 / 256) を 0x100 としてトークン化する (0xFF超は上位で検証)`

## テスト結果
- `pnpm --filter @pdfmod/core test src/lexer/tokenizer/__tests__/tokenizer.basic.test.ts` (40/40 tests pass)
- `pnpm --filter @pdfmod/core test src/lexer/tokenizer/` (63/63 tests pass)

Closes #504