### PR TITLE
🚨 [Tests]: #484 q ハンドラに多段 save・非デフォルト state・入力 stack 非破壊性の未検証パターンを追加

### DIFF
--- a/packages/core/src/content-stream/operators/graphics-state/q/__tests__/q.basic.test.ts
+++ b/packages/core/src/content-stream/operators/graphics-state/q/__tests__/q.basic.test.ts
@@ -1,6 +1,9 @@
 import { assert, expect, test } from "vitest";
 import type { PdfObject } from "../../../../../pdf/types/pdf-types/index";
-import { GraphicsStateStack } from "../../../../graphics-state/index";
+import {
+  GraphicsState,
+  GraphicsStateStack,
+} from "../../../../graphics-state/index";
 import { MarkedContentStack } from "../../../../marked-content/stack";
 import { OperandStack } from "../../../../operand-stack/index";
 import type { OperatorHandlerContext } from "../../../../operator-registry/index";
@@ -74,4 +77,84 @@ test("非空 operandStack で q を実行しても operand が消費されない
   const top = OperandStack.peek(result.value.operandStack);
   assert(top.some);
   expect(top.value).toEqual(operand2);
+});
+
+test("current を変更しながら q を3回実行すると saved に適用時点の state が順序通り積み上がる", () => {
+  const ctx = buildContext();
+  const state1 = GraphicsStateStack.current(ctx.graphicsStateStack);
+
+  const first = qHandler(ctx);
+
+  assert(first.ok);
+  const state2 = GraphicsState.update(
+    GraphicsStateStack.current(first.value.graphicsStateStack),
+    { lineWidth: 2 },
+  );
+  const second = qHandler({
+    operandStack: first.value.operandStack,
+    graphicsStateStack: GraphicsStateStack.replaceCurrent(
+      first.value.graphicsStateStack,
+      state2,
+    ),
+    markedContentStack: first.value.markedContentStack,
+  });
+
+  assert(second.ok);
+  const state3 = GraphicsState.update(
+    GraphicsStateStack.current(second.value.graphicsStateStack),
+    { lineWidth: 3 },
+  );
+  const third = qHandler({
+    operandStack: second.value.operandStack,
+    graphicsStateStack: GraphicsStateStack.replaceCurrent(
+      second.value.graphicsStateStack,
+      state3,
+    ),
+    markedContentStack: second.value.markedContentStack,
+  });
+
+  assert(third.ok);
+  const saved = third.value.graphicsStateStack.saved;
+  expect(saved).toHaveLength(3);
+  expect(saved[0]).toEqual(state1);
+  expect(saved[1]).toEqual(state2);
+  expect(saved[2]).toEqual(state3);
+  expect(GraphicsStateStack.current(third.value.graphicsStateStack)).toEqual(
+    state3,
+  );
+});
+
+test("非デフォルト state を持つ context で q を実行すると変更後の値が saved に入る", () => {
+  const ctx = buildContext();
+  const defaultState = GraphicsStateStack.current(ctx.graphicsStateStack);
+  const modifiedState = GraphicsState.update(defaultState, {
+    lineWidth: 4.5,
+    miterLimit: 2.5,
+  });
+
+  const result = qHandler({
+    operandStack: ctx.operandStack,
+    graphicsStateStack: GraphicsStateStack.replaceCurrent(
+      ctx.graphicsStateStack,
+      modifiedState,
+    ),
+    markedContentStack: ctx.markedContentStack,
+  });
+
+  assert(result.ok);
+  const saved = result.value.graphicsStateStack.saved;
+  expect(saved).toHaveLength(1);
+  expect(saved[0]).toEqual(modifiedState);
+  expect(saved[0]).not.toEqual(defaultState);
+});
+
+test("q 実行後も入力 context の graphicsStateStack は変更されない", () => {
+  const ctx = buildContext();
+  const inputStack = ctx.graphicsStateStack;
+
+  const result = qHandler(ctx);
+
+  assert(result.ok);
+  expect(inputStack.saved).toHaveLength(0);
+  expect(result.value.graphicsStateStack).not.toBe(inputStack);
 });


### PR DESCRIPTION
## 概要

`q`（save graphics state, ISO 32000-1:2008 §8.4.4）のハンドラは PR #555 で production 実装済みですが、`q.basic.test.ts` は **「`q` を 1 回だけ適用した、デフォルト graphics state」** のケースしか検証していませんでした。

そのため以下の退行が handler 層のどのテストでも検出できない状態でした。本 PR はこの 3 つの穴を塞ぐテストを追加します。**production code の差分はゼロ**です。

| 退行 | 従来の検出可否 |
|:-|:-|
| `saved` の順序逆転 / 既存 `saved` の切り捨て | ❌ 未検証（1 段しか積まないため） |
| `GraphicsState.create()` を push する（現在の state を保存しない） | ❌ 未検証（デフォルト state しか使わないため） |
| `save` の破壊的実装への退行（入力 stack を直接変更） | ❌ **リポジトリ全体で未検証** |

3 つ目は特に無防備で、`save` を `stack.saved.push(stack.current); return stack;` に書き換えても **既存 5 件が全て green のまま通過** します（`stack.basic.test.ts` の非破壊性テストは `replaceCurrent` のみが対象）。

## 変更内容

### 🎯 変更の種類

- [x] 🚨 テスト追加/修正 (Tests)

### 📝 詳細な変更内容

#### 追加されたテスト

- **T1 多段 save**: `current` を変更しながら `q` を 3 回実行すると、`saved` に適用時点の state が **順序通り** 積み上がる（各段の間に `replaceCurrent` で `lineWidth` を 1.0 → 2 → 3 と変更し、順序逆転を検出できるようにしている）。併せて 3 段目適用後も `current` が最後の state のままであること（保存が「移動」になっていないこと）も検証
- **T2 非デフォルト state の save**: `lineWidth: 4.5` / `miterLimit: 2.5` に変更した `current` を持つ context で `q` を実行すると、変更後の値が `saved` に入る。2 フィールド同時に変えることで「1 フィールドだけ拾って残りを既定値で組み立て直す」実装の取りこぼしを検出する
- **T3 入力 stack の非破壊性**: `q` 実行後も入力 context の stack は変更されず（`saved` は空のまま）、返り値が別インスタンスであること

#### 変更されたファイル

- `packages/core/src/content-stream/operators/graphics-state/q/__tests__/q.basic.test.ts`（+84 / -1、5 → 8 テスト）
  - import に `GraphicsState` を追加
  - 既存 5 テストと `buildContext` は **無改変**

#### 削除されたファイル・機能

- なし

## 📊 システム図

### 状態マシン / フロー図

```mermaid
flowchart TD
    Create([GraphicsStateStack.create]) --> S0["current = S0 (lineWidth 1.0)<br/>saved = []"]

    S0 -->|q| D1["current = S0<br/>saved = [S0]"]
    D1 --> Cov{{"既存テスト 1〜5 のカバー範囲<br/>(1 段 / デフォルト state のみ)"}}

    D1 -->|"replaceCurrent → lineWidth 2"| S2["current = S2<br/>saved = [S0]"]
    S2 -->|q| D2["current = S2<br/>saved = [S0, S2]"]
    D2 -->|"replaceCurrent → lineWidth 3"| S3["current = S3<br/>saved = [S0, S2]"]
    S3 -->|q| D3["current = S3<br/>saved = [S0, S2, S3]"]:::new
    D3 --> T1{{"T1 が固定: 長さ 3 かつ順序 [S0, S2, S3]<br/>current は S3 のまま"}}:::new

    S0 -->|"replaceCurrent → lineWidth 4.5 / miterLimit 2.5"| SM["current = SM (非デフォルト)<br/>saved = []"]
    SM -->|q| DM["current = SM<br/>saved = [SM]"]:::new
    DM --> T2{{"T2 が固定: saved[0] === SM<br/>かつ デフォルト state と不一致"}}:::new

    S0 -->|q| T3{{"T3 が固定: 入力 stack の saved は空のまま<br/>返り値は別インスタンス"}}:::new

    classDef new fill:#ffe4b5,stroke:#d97706,stroke-width:2px
```

### データフロー

```
テスト側 (q.basic.test.ts)
    │
    │  buildContext()   ※既存ファクトリを再利用。新規ヘルパーは追加しない
    ▼
OperatorHandlerContext (in)
    ├─ operandStack        ── (同一参照が素通り) ───────┐
    ├─ graphicsStateStack   ※T1 / T2 はここだけを       │
    │                         replaceCurrent した値に    │
    │                         差し替えてから渡す  [NEW]   │
    └─ markedContentStack  ── (同一参照が素通り) ───────┤
    │                                                    │
    ▼                                                    │
qHandler(context)                                        │
    │                                                    │
    ├─▶ GraphicsStateStack.save(stack)                   │
    │       { current: 同一参照,                          │
    │         saved:   [...stack.saved, stack.current] }  │
    │       ※入力 stack は mutate しない  ← T3 が固定 [NEW]│
    │                                                    │
    └─▶ ok({ operandStack, graphicsStateStack, ... })    │
             │                                           │
             ▼                                           │
   assert(result.ok) → result.value  ←───────────────────┘
             │
             ▼
   result.value.graphicsStateStack.saved
             │
             ├─ T1: toHaveLength(3) + 各段の toEqual + current の toEqual   [NEW]
             ├─ T2: toEqual(modifiedState) + not.toEqual(defaultState)      [NEW]
             └─ T3: 入力 stack の saved が空 + not.toBe(inputStack)         [NEW]
```

## 📋 関連 Issue

- Refs #484

（Issue #484 の実装本体は PR #555 で完了済みです。本 PR はその残作業であるテスト補強のみを扱うため、クローズはしません。）

## 🧪 テスト

### テスト実行方法

```bash
# 対象ファイルのみ
pnpm --filter @pdfmod/core exec vitest run q.basic

# パッケージ全体
pnpm --filter @pdfmod/core exec vitest run

# lint / 型チェック
pnpm lint
pnpm typecheck
```

### テスト項目

- [x] 単体テスト (Unit tests)
- [x] 手動テスト (Manual testing) — 後述の擬似 Red / 本物の Red 検証

### テスト結果

| 項目 | 結果 |
|:-|:-|
| `q.basic.test.ts` | ✅ 8 passed |
| `@pdfmod/core` 全体 | ✅ 279 files / 3435 tests passed |
| `pnpm lint`（biome + oxlint） | ✅ 0 warnings / 0 errors |
| `pnpm typecheck` | ✅ core / react とも Done |

#### テストが実際に退行を検出することの確認

production 実装が既に存在するため通常の Red が作れません。そこで以下を実測しています。

**擬似 Red（アサーションを崩して落ちることの確認）**

- T1: `expect(saved[1]).toEqual(state2)` → `state1` に変更 → ❌ 失敗（順序検証が効いている）
- T1: `toHaveLength(3)` → `toHaveLength(2)` に変更 → ❌ 失敗
- T2: `expect(saved[0]).toEqual(modifiedState)` → `toEqual(defaultState)` に変更 → ❌ 失敗

**本物の Red（T3 が塞いだ穴の証明）**

`packages/core/src/content-stream/graphics-state/stack/index.ts` の `save` を一時的に破壊的実装（`stack.saved.push(stack.current); return stack;`）へ書き換えて実行した結果:

```
   ✓ q 実行後に saved に current がプッシュされる
   ✓ q 実行後の current は実行前と同じ state
   ✓ q 実行後も operandStack は同一参照のまま
   ✓ q 実行後も markedContentStack は同一参照のまま
   ✓ 非空 operandStack で q を実行しても operand が消費されない
   ✓ current を変更しながら q を3回実行すると saved に適用時点の state が順序通り積み上がる
   ✓ 非デフォルト state を持つ context で q を実行すると変更後の値が saved に入る
   × q 実行後も入力 context の graphicsStateStack は変更されない
      Tests  1 failed | 7 passed (8)
```

**T3 だけが失敗し、既存 5 件・T1・T2 は green のまま通過**することを確認しました。T1 が素通りするのは、各段の間に挟む `replaceCurrent` が `saved: [...stack.saved]` とコピーを作るため、破壊的に育った配列でも最終的な中身と順序が正しくなってしまうためです。

確認後 `git checkout` で復元し、`git diff` が空であること（production 差分ゼロ）を確認済みです。

## 🔍 レビューポイント

- **T3 の配置**: 検出したい退行の実体は `qHandler` 固有ではなく `GraphicsStateStack.save` の immutability 退行であり、責務としては本来データ構造層（`stack.basic.test.ts`）が自然です。本 PR は変更ファイル 1 件のスコープ制約から handler 経由で最小限固定する位置づけにしています。データ構造層への同種テスト追加は別途検討の余地があります
- **`saved` への直接アクセス**: `GraphicsStateStack` の JSDoc は `saved` を規約上 private としていますが、既存 5 テストが同一モジュール群として直接参照しているため、新たな公開 API を追加せず既存書式に揃えました
- **ファイル行数**: 160 行となり testing スキルの「100〜150 行を超えたら分割」指針をわずかに超えます。分割すると `buildContext` がコピーになるため、1 ファイル維持としています
- **T1 の冗長さ**: 各段で `lineWidth` を変える分だけコードは長くなりますが、全段同一 state だと順序逆転を検出できないため意図的にこの形にしています
- **`not.toEqual(defaultState)`（T2）**: 検出主体は `toEqual(modifiedState)` 側で論理的には冗長ですが、「デフォルト state を push する退行を検出する」意図の明示として残しています

## ⚠️ 破壊的変更

- [ ] この変更は既存の API に破壊的変更を含みます

なし。テスト追加のみで production code の差分はゼロです。

## ✅ チェックリスト

- [x] コードレビューの準備ができている
- [x] テストが正常に実行される
- [x] ドキュメントが更新されている（該当なし）
- [x] コミットメッセージが適切な形式で書かれている
- [x] PR 本文に `Refs #484` を記載
- [x] セルフレビューを実施した（AI レビュー（codex）も実施し「問題なし」）
- [x] 破壊的変更なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)