### PR TITLE
🚨 [Tests]: #484 Q ハンドラに多段 Q の中間状態・入力 stack 非破壊性・非デフォルト復帰・unbalanced 後の復帰を追加

### DIFF
--- a/packages/core/src/content-stream/operators/graphics-state/q-restore/__tests__/q-restore.basic.test.ts
+++ b/packages/core/src/content-stream/operators/graphics-state/q-restore/__tests__/q-restore.basic.test.ts
@@ -101,3 +101,55 @@ test("非空 operandStack で Q を実行しても operand が消費されない
   assert(top.some);
   expect(top.value).toEqual(operand2);
 });
+
+test("Q 実行後も入力 context の graphicsStateStack は変更されない", () => {
+  const ctx = buildContext();
+  const seededState = GraphicsState.update(
+    GraphicsStateStack.current(ctx.graphicsStateStack),
+    { lineWidth: 7.5 },
+  );
+  const inputStack = GraphicsStateStack.save(
+    GraphicsStateStack.replaceCurrent(ctx.graphicsStateStack, seededState),
+  );
+
+  const result = qRestoreHandler({
+    ...ctx,
+    graphicsStateStack: inputStack,
+  });
+
+  assert(result.ok);
+  expect(inputStack.saved).toHaveLength(1);
+  expect(inputStack.saved[0]).toEqual(seededState);
+  expect(GraphicsStateStack.current(inputStack)).toEqual(seededState);
+  expect(result.value.graphicsStateStack).not.toBe(inputStack);
+});
+
+test("非デフォルト state を保存した後の Q は既定値ではなく保存値へ復帰する", () => {
+  const ctx = buildContext();
+  const defaultState = GraphicsStateStack.current(ctx.graphicsStateStack);
+  const savedState = GraphicsState.update(defaultState, {
+    lineWidth: 4.5,
+    miterLimit: 2.5,
+  });
+  const savedStack = GraphicsStateStack.save(
+    GraphicsStateStack.replaceCurrent(ctx.graphicsStateStack, savedState),
+  );
+  const modified = GraphicsStateStack.replaceCurrent(
+    savedStack,
+    GraphicsState.update(savedState, { lineWidth: 1, miterLimit: 10 }),
+  );
+
+  const result = qRestoreHandler({
+    ...ctx,
+    graphicsStateStack: modified,
+  });
+
+  assert(result.ok);
+  const restoredCurrent = GraphicsStateStack.current(
+    result.value.graphicsStateStack,
+  );
+  expect(restoredCurrent).toEqual(savedState);
+  expect(restoredCurrent).not.toEqual(defaultState);
+  expect(restoredCurrent.lineWidth).toBe(4.5);
+  expect(restoredCurrent.miterLimit).toBe(2.5);
+});

--- a/packages/core/src/content-stream/operators/graphics-state/q-restore/__tests__/q-restore.nested.test.ts
+++ b/packages/core/src/content-stream/operators/graphics-state/q-restore/__tests__/q-restore.nested.test.ts
@@ -1,0 +1,109 @@
+// 本ファイルは深度 3 の saved を積んだ stack に Q を 3 回通し、
+// 中間 current と残存 saved の内容を検証する。
+// q-restore.basic.test.ts は深度 1 の save / restore を、
+// q-restore.unbalanced.test.ts は saved 空起点の no-op を担当済み。
+// graphics-state-operators.integration.test.ts は 3 段ネストを registry 経由で
+// 通すが最終 current のみを検証し、graphics-state/stack の stack.basic.test.ts は
+// 中間状態を見るが深度 2 まで。本ファイルの差分は handler 層で中間状態を見る
+// 唯一のテストであること、および深度 3 への三角測量の 2 点。
+import { assert, expect, test } from "vitest";
+import {
+  GraphicsState,
+  GraphicsStateStack,
+} from "../../../../graphics-state/index";
+import { MarkedContentStack } from "../../../../marked-content/stack";
+import { OperandStack } from "../../../../operand-stack/index";
+import type { OperatorHandlerContext } from "../../../../operator-registry/index";
+import { qRestoreHandler } from "../../q-restore";
+
+const buildContext = (): OperatorHandlerContext => {
+  const operandStack = OperandStack.create();
+  const graphicsStateStack = GraphicsStateStack.create();
+  return {
+    operandStack,
+    graphicsStateStack,
+    markedContentStack: MarkedContentStack.create(),
+  };
+};
+
+const buildNestedStack = (
+  base: GraphicsStateStack,
+  states: readonly GraphicsState[],
+): GraphicsStateStack => {
+  let stack = base;
+  for (const state of states) {
+    stack = GraphicsStateStack.save(
+      GraphicsStateStack.replaceCurrent(stack, state),
+    );
+  }
+  return stack;
+};
+
+test("深度 3 の saved に Q を 3 回通すと current が保存の逆順に復帰する", () => {
+  const ctx = buildContext();
+  const state1 = GraphicsStateStack.current(ctx.graphicsStateStack);
+  const state2 = GraphicsState.update(state1, { lineWidth: 2 });
+  const state3 = GraphicsState.update(state1, { lineWidth: 4 });
+  const state4 = GraphicsState.update(state1, { lineWidth: 8 });
+  const nested = GraphicsStateStack.replaceCurrent(
+    buildNestedStack(ctx.graphicsStateStack, [state1, state2, state3]),
+    state4,
+  );
+
+  const first = qRestoreHandler({ ...ctx, graphicsStateStack: nested });
+  assert(first.ok);
+  expect(GraphicsStateStack.current(first.value.graphicsStateStack)).toEqual(
+    state3,
+  );
+
+  const second = qRestoreHandler({
+    ...ctx,
+    graphicsStateStack: first.value.graphicsStateStack,
+  });
+  assert(second.ok);
+  expect(GraphicsStateStack.current(second.value.graphicsStateStack)).toEqual(
+    state2,
+  );
+
+  const third = qRestoreHandler({
+    ...ctx,
+    graphicsStateStack: second.value.graphicsStateStack,
+  });
+  assert(third.ok);
+  expect(GraphicsStateStack.current(third.value.graphicsStateStack)).toEqual(
+    state1,
+  );
+});
+
+test("深度 3 の saved に Q を 3 回通すと残存 saved が先頭側から保たれたまま 1 段ずつ減る", () => {
+  const ctx = buildContext();
+  const state1 = GraphicsStateStack.current(ctx.graphicsStateStack);
+  const state2 = GraphicsState.update(state1, { lineWidth: 2 });
+  const state3 = GraphicsState.update(state1, { lineWidth: 4 });
+  const nested = buildNestedStack(ctx.graphicsStateStack, [
+    state1,
+    state2,
+    state3,
+  ]);
+  expect(nested.saved).toHaveLength(3);
+
+  const first = qRestoreHandler({ ...ctx, graphicsStateStack: nested });
+  assert(first.ok);
+  expect(first.value.graphicsStateStack.saved).toEqual([state1, state2]);
+
+  const second = qRestoreHandler({
+    ...ctx,
+    graphicsStateStack: first.value.graphicsStateStack,
+  });
+  assert(second.ok);
+  expect(second.value.graphicsStateStack.saved).toEqual([state1]);
+
+  const third = qRestoreHandler({
+    ...ctx,
+    graphicsStateStack: second.value.graphicsStateStack,
+  });
+  assert(third.ok);
+  expect(third.value.graphicsStateStack.saved).toEqual([]);
+
+  expect(nested.saved).toHaveLength(3);
+});

--- a/packages/core/src/content-stream/operators/graphics-state/q-restore/__tests__/q-restore.unbalanced.test.ts
+++ b/packages/core/src/content-stream/operators/graphics-state/q-restore/__tests__/q-restore.unbalanced.test.ts
@@ -1,6 +1,9 @@
 import { assert, expect, test } from "vitest";
 import type { PdfObject } from "../../../../../pdf/types/pdf-types/index";
-import { GraphicsStateStack } from "../../../../graphics-state/index";
+import {
+  GraphicsState,
+  GraphicsStateStack,
+} from "../../../../graphics-state/index";
 import { MarkedContentStack } from "../../../../marked-content/stack";
 import { OperandStack } from "../../../../operand-stack/index";
 import type { OperatorHandlerContext } from "../../../../operator-registry/index";
@@ -96,4 +99,47 @@ test("連続 Q 実行後も operandStack が消費されない", () => {
   const top = OperandStack.peek(second.value.operandStack);
   assert(top.some);
   expect(top.value).toEqual(operand2);
+});
+
+test("非デフォルト current で saved が空の Q を打っても値が保たれ、その後の q → Q で復帰する", () => {
+  const ctx = buildContext();
+  const seeded = GraphicsState.update(
+    GraphicsStateStack.current(ctx.graphicsStateStack),
+    { lineWidth: 3.75 },
+  );
+
+  const unbalanced = qRestoreHandler({
+    ...ctx,
+    graphicsStateStack: GraphicsStateStack.replaceCurrent(
+      ctx.graphicsStateStack,
+      seeded,
+    ),
+  });
+
+  assert(unbalanced.ok);
+  expect(
+    GraphicsStateStack.current(unbalanced.value.graphicsStateStack),
+  ).toEqual(seeded);
+  expect(unbalanced.value.graphicsStateStack.saved).toHaveLength(0);
+
+  const savedStack = GraphicsStateStack.save(
+    unbalanced.value.graphicsStateStack,
+  );
+  const modified = GraphicsStateStack.replaceCurrent(
+    savedStack,
+    GraphicsState.update(seeded, { lineWidth: 99 }),
+  );
+
+  const restored = qRestoreHandler({
+    ...ctx,
+    graphicsStateStack: modified,
+  });
+
+  assert(restored.ok);
+  const finalCurrent = GraphicsStateStack.current(
+    restored.value.graphicsStateStack,
+  );
+  expect(finalCurrent).toEqual(seeded);
+  expect(finalCurrent.lineWidth).toBe(3.75);
+  expect(restored.value.graphicsStateStack.saved).toHaveLength(0);
 });


### PR DESCRIPTION
## 概要

`Q`（`qRestoreHandler`）ハンドラのテストを 10 本 → 15 本に補強する。PR #563 で `q` 側に入れた 3 観点（多段操作・非デフォルト state・入力 stack 非破壊性）の鏡像を `Q` 側に置き、加えて `Q` 固有の LIFO 順序と unbalanced 後の復帰可能性を固定する。

**production code の差分はゼロ**（変更は `q-restore/__tests__/` 配下 3 ファイルのみ）。

### 本 PR の位置づけ（正直な整理）

新規 5 本のうち **リポジトリ全体の穴を塞ぐのは B6（入力 stack 非破壊性・深度 1）と N2 末尾の入力 stack 再確認 1 行（深度 3）だけ**である。残る N1 / N2 / B7 / U6 の目的は **handler 層に同等の保護を置く層対称性**であり、`stack.basic.test.ts:31`（データ構造層）や `fill.basic.test.ts:265`（描画演算子側）との重複は認識のうえで受容している。この位置づけは下記 Red 検証の実測（R2 で既存が全緑 / R3 で `fill` 系が赤）で裏付けている。

## 変更内容

### 🎯 変更の種類

- [x] 🚨 テスト追加/修正 (Tests)

### 📝 詳細な変更内容

#### 追加されたテスト

| ID | テスト名 | ファイル |
|----|---------|---------|
| B6 | Q 実行後も入力 context の graphicsStateStack は変更されない | `q-restore.basic.test.ts` |
| B7 | 非デフォルト state を保存した後の Q は既定値ではなく保存値へ復帰する | `q-restore.basic.test.ts` |
| N1 | 深度 3 の saved に Q を 3 回通すと current が保存の逆順に復帰する | `q-restore.nested.test.ts`（新規） |
| N2 | 深度 3 の saved に Q を 3 回通すと残存 saved が先頭側から保たれたまま 1 段ずつ減る | `q-restore.nested.test.ts`（新規） |
| U6 | 非デフォルト current で saved が空の Q を打っても値が保たれ、その後の q → Q で復帰する | `q-restore.unbalanced.test.ts` |

#### 変更されたファイル

- `packages/core/src/content-stream/operators/graphics-state/q-restore/__tests__/q-restore.basic.test.ts`（103 → 155 行 / 5 → 7 テスト）
- `packages/core/src/content-stream/operators/graphics-state/q-restore/__tests__/q-restore.nested.test.ts`（**新規** 109 行 / 2 テスト）
- `packages/core/src/content-stream/operators/graphics-state/q-restore/__tests__/q-restore.unbalanced.test.ts`（99 → 145 行 / 5 → 6 テスト）

既存 10 テストと `buildContext` は無改変（`unbalanced` の import 行のみ例外。`GraphicsState.update` の利用に伴うもの）。

#### 削除されたファイル・機能

なし

## 📊 システム図

### 状態マシン / フロー図 — `q` / `Q` による stack 遷移と各テストが固定するポイント

```mermaid
flowchart TD
    Create([GraphicsStateStack.create]) --> S0["current: 既定値<br/>saved: []"]

    S0 -->|"Q（unbalanced・no-op）"| U["current 維持<br/>saved: []<br/>+ warning は handler が破棄"]
    U -.->|"U6 [NEW]: 非デフォルト current が保たれる"| U

    S0 -->|"replaceCurrent → save ×3"| S3["current: 8<br/>saved: [1, 2, 4]"]

    S3 -->|Q| R1["current: 4<br/>saved: [1, 2]"]
    R1 -->|Q| R2["current: 2<br/>saved: [1]"]
    R2 -->|Q| R3["current: 1<br/>saved: []"]

    R1 -.->|"N1/N2 [NEW]: 中間 current と残存 saved の内容"| R1
    R2 -.->|"N1/N2 [NEW]: 中間 current と残存 saved の内容"| R2

    S0 -->|"非デフォルト state を save → current を既定値相当へ"| B["current: 既定値相当<br/>saved: [非デフォルト]"]
    B -->|Q| BR["current: 保存値<br/>saved: []"]
    BR -.->|"B7 [NEW]: 既定値ではなく保存値へ復帰"| BR

    S0 -->|"入力 stack（深度 1）"| IN["inputStack"]
    IN -->|Q| OUT["返り値は別インスタンス"]
    IN -.->|"B6 [NEW]: 入力側の saved が長さ 1・内容も不変"| IN

    classDef new fill:#ffe4b5,stroke:#d97706,stroke-width:2px
    class U,R1,R2,BR,IN new
```

### データフロー

```
OperatorHandlerContext (operandStack / graphicsStateStack / markedContentStack)
    ↓
qRestoreHandler(context)
    ↓
GraphicsStateStack.restore(context.graphicsStateStack)
    ├─ saved が空          → { stack: { current: 維持, saved: [] }, warning: UNBALANCED_RESTORE }
    │                          ↑ U6 [NEW] がこの分岐の「current 維持」を固定
    │                          ※ warning は handler が破棄（受け皿が型に無い）
    │
    └─ saved に要素あり    → { stack: { current: saved[last], saved: saved.slice(0, last) } }
                               ↑ B7 [NEW] が復帰先＝保存値、N1 [NEW] が中間 current、
                                 N2 [NEW] が残存 saved の内容を固定
                               ↑ B6 / N2 末尾 [NEW] が入力側 saved の非破壊性を固定
    ↓
ok({ operandStack: 素通し, graphicsStateStack: restoreResult.stack, markedContentStack: 素通し })
```

## 📋 関連 Issue

- Refs #484

Issue #484 のタスク 2。interpreter 層のタスクが残るため **Issue はクローズしない**。

## 🧪 テスト

### テスト実行方法

```bash
pnpm --filter @pdfmod/core exec vitest run q-restore
pnpm --filter @pdfmod/core test
pnpm lint
pnpm typecheck
pnpm --filter @pdfmod/core build
```

### テスト項目

- [x] 単体テスト (Unit tests)
- [x] 手動テスト (Manual testing) — Red 検証 R1〜R5

### テスト結果

- `vitest run q-restore`: **3 ファイル / 15 テスト全緑**（既存 10 + 新規 5）
- `pnpm --filter @pdfmod/core test`: **280 ファイル / 3456 テスト全緑**
- `pnpm lint`（biome check + oxlint）/ `pnpm typecheck` / `pnpm --filter @pdfmod/core build`: すべて緑

### Red 検証（R1〜R5）の実測結果

production が既に緑のため、RED フェーズの代替として `GraphicsStateStack.restore` を 1 パターンずつ退行させ、**対象ハンドラのみの実行とフルスイートの 2 段**で赤／緑を実測した。各パターン後に `git checkout` で復元し `git diff` が空であることを確認済み。

| 改変 | N1 | N2 | B6 | B7 | U6 | `q-restore` 既存 10 | `stack.basic:31` | `fill.basic:265` | `fill-stroke.basic` | `integration:46` | フルスイート |
|------|----|----|----|----|----|-------------------|-----------------|------------------|--------------------|-----------------|------------|
| R1 FIFO（`saved[0]` + `slice(1)`） | ❌ | ❌ | ✅ | ✅ | ✅ | ✅ 全緑 | ❌ | ✅ | ✅ | ❌ | 4 failed / 3452 passed |
| **R2 破壊的 pop（`stack.saved.pop()`）** | ✅ | ❌ | ❌ | ✅ | ✅ | ✅ 全緑 | ✅ | ✅ | ✅ | ✅ | **2 failed / 3454 passed（既存は 1 本も落ちない）** |
| R3 復帰先を `create()` 固定 | ❌ | ✅ | ✅ | ❌ | ❌ | ✅ 全緑 | ❌ | ❌ | ❌ | ✅ | 6 failed / 3450 passed |
| R4 2 段消費（`slice(0, lastIndex - 1)`） | ❌ | ❌ | ✅ | ✅ | ✅ | ✅ 全緑 | ❌ | ✅ | ✅ | ✅ | 3 failed / 3453 passed |
| **R5 unbalanced 分岐の既定値化** | ✅ | ✅ | ✅ | ✅ | ❌ | **✅ 全緑** | ✅ (※) | ✅ | ✅ | ✅ | 2 failed / 3454 passed |

❌ = 赤 / ✅ = 緑。※ R5 では同ファイルの別テスト `stack.basic.test.ts:53` が赤になる（`:61` が `toBe` で参照同一性を見ているため）。

**5 パターンすべてが事前の予測表と完全に一致し、予測に無い赤は 1 件も出なかった。** 特に重要な 2 点:

- **R2 で既存 3454 本が全緑** — 入力 stack の破壊的 pop を検出できるのは B6 と N2 末尾の 1 行だけ。これが「リポジトリ全体の穴を塞ぐのはこの 2 箇所」という位置づけの実測的裏付け。`saved` の型が `readonly GraphicsState[]` ではなく `GraphicsState[]` なので、この退行は型検査を素通りする
- **R5 で既存 unbalanced 5 本が全緑・U6 のみ赤** — 既存はすべて既定値起点なので unbalanced 分岐の値引き継ぎ退行を検出できない。U6 の新規性の証明

また R3 で `q-restore` 既存 10 本が全緑・`fill` 系が赤になったことは、「復帰先＝保存値」の保護が **handler 層には無かった**（データ構造層と描画演算子側では守られていた）ことを示す。R4 で `integration:46` が緑のままなのは、アサーションが最終 current のみで、1 段目に保存されるのが既定値のため 2 段消費しても最終状態が一致してしまうことによる。

Red 検証中に production の実バグは発見されなかった。

## 🔍 レビューポイント

- **production 差分がゼロであること** — `git diff --stat` で変更が `q-restore/__tests__/` 配下 3 件のみ。`stack/index.ts` / `q-restore/index.ts` に差分なし
- **N1 / N2 の位置づけの正確さ** — 「中間状態の検証が固有価値」ではない。`stack.basic.test.ts:31` が深度 2 の中間 current を既に検証しており、`graphics-state-operators.integration.test.ts:46` が 3 段ネストを registry 経由で通している。N1 / N2 に残る差分は **(a) handler 層で中間状態を見る唯一のテスト、(b) 深度 3 への三角測量** の 2 点のみ
- **N2 が `toHaveLength` ではなく `toEqual` を使う理由** — 長さは正しいが要素が差し替わる退行（`saved.map(() => GraphicsState.create())`）を `toHaveLength` だけでは新規 5 本すべてが素通りする
- **N1 の中間アサーション配置は可読性上の理由** — 検出力の理由ではない。末尾へまとめても R4 は検出できる（逆に R2 に対しては末尾集約のほうが検出力が高いが、R2 は B6 が専任するため per-step のままにした）
- **`buildContext` を 3 ファイルとも個別定義している点** — `content-stream/operators/` 配下は 59 ファイルが個別定義で、`helpers` / `test-utils` ディレクトリは 0 件。リポジトリ全体には `*.test.helpers.ts` 規約が 9 ファイルあるが `document/` `objects/` `xref/` 配下の慣習であり、本ディレクトリでは採用されていない
- **`.saved` の直参照を維持した判断** — 代替案（4 回目の `Q` が no-op になることで深度 0 を外部観測する形）は、検出対象が unbalanced 分岐の挙動に依存して濁るため却下した。根本原因は `GraphicsStateStack` に深度取得の公開 API が無いこと（`MarkedContentStack.depth` と非対称）で、API 追加は production 変更になるため別 Issue とする

## ⚠️ 破壊的変更

- [ ] この変更は既存の API に破壊的変更を含みます

なし（テストのみ・production 差分ゼロ）。

## ✅ チェックリスト

- [x] コードレビューの準備ができている
- [x] テストが正常に実行される
- [x] ドキュメントが更新されている（該当なし）
- [x] コミットメッセージが適切な形式で書かれている
- [x] PR 本文に `Refs #` で Issue が記載されている
- [x] セルフレビューを実施した（codex CLI によるレビューも実施 — 指摘なし）
- [x] 破壊的変更なし

## 🤝 レビュアーへのお願い

- 新規 5 本それぞれについて「落ちたら検出するバグ」が Red 検証の実測表と対応しており、トートロジーテストが含まれていないかを確認してほしい
- 本文中の「リポジトリ全体の穴を塞ぐのは B6 と N2 末尾 1 行だけ」という位置づけが過大にも過小にもなっていないか（既存カバレッジとの重複を隠していないか）を見てほしい