### PR TITLE
test(xref): add error handling and boundary test cases for trailer parser (#498)

### DIFF
--- a/packages/core/src/xref/trailer/parser/__tests__/parser.error.test.ts
+++ b/packages/core/src/xref/trailer/parser/__tests__/parser.error.test.ts
@@ -396,9 +396,7 @@ test("/ID要素パース中にデータ末尾(EOF)に達した場合にXREF_TABL
 });
 
 test("トップレベルの辞書キーがNameでない場合にXREF_TABLE_INVALIDエラーが返る", () => {
-  const { data, offset } = trailerAt(
-    "trailer << 123 /Root 1 0 R /Size 10 >>",
-  );
+  const { data, offset } = trailerAt("trailer << 123 /Root 1 0 R /Size 10 >>");
   const result = parseTrailer(data, offset);
   assert(!result.ok);
   expect(result.error.code).toBe("XREF_TABLE_INVALID");
@@ -406,9 +404,7 @@ test("トップレベルの辞書キーがNameでない場合にXREF_TABLE_INVAL
 });
 
 test("トップレベルの辞書値の前にDictEnd(>>)が現れた場合にXREF_TABLE_INVALIDエラーが返る", () => {
-  const { data, offset } = trailerAt(
-    "trailer << /Root 1 0 R /Size >>",
-  );
+  const { data, offset } = trailerAt("trailer << /Root 1 0 R /Size >>");
   const result = parseTrailer(data, offset);
   assert(!result.ok);
   expect(result.error.code).toBe("XREF_TABLE_INVALID");
@@ -416,9 +412,7 @@ test("トップレベルの辞書値の前にDictEnd(>>)が現れた場合にXRE
 });
 
 test("トップレベルの辞書値の前にEOFに達した場合にXREF_TABLE_INVALIDエラーが返る", () => {
-  const { data, offset } = trailerAt(
-    "trailer << /Root 1 0 R /Size",
-  );
+  const { data, offset } = trailerAt("trailer << /Root 1 0 R /Size");
   const result = parseTrailer(data, offset);
   assert(!result.ok);
   expect(result.error.code).toBe("XREF_TABLE_INVALID");
@@ -432,7 +426,9 @@ test("スキップ対象辞書内で予期せぬトークン(])が現れた場�
   const result = parseTrailer(data, offset);
   assert(!result.ok);
   expect(result.error.code).toBe("XREF_TABLE_INVALID");
-  expect(result.error.message).toContain("unexpected ] while skipping dictionary value");
+  expect(result.error.message).toContain(
+    "unexpected ] while skipping dictionary value",
+  );
 });
 
 test("スキップ対象辞書内で非Nameキーが現れた場合でもスキップされ正常に処理される", () => {
@@ -460,7 +456,9 @@ test("ネストした辞書内でキー読み取り直前にEOFに達した場�
   const result = parseTrailer(data, offset);
   assert(!result.ok);
   expect(result.error.code).toBe("XREF_TABLE_INVALID");
-  expect(result.error.message).toContain("unexpected end of data while parsing dictionary value");
+  expect(result.error.message).toContain(
+    "unexpected end of data while parsing dictionary value",
+  );
 });
 
 test("スキップ対象の単体数値のプッシュバック処理が正常に動作する", () => {
@@ -478,5 +476,7 @@ test("スキップ対象で整数が2個連続しRでない場合に2個目の�
   const result = parseTrailer(data, offset);
   assert(!result.ok);
   expect(result.error.code).toBe("XREF_TABLE_INVALID");
-  expect(result.error.message).toContain("expected name key in trailer dictionary");
+  expect(result.error.message).toContain(
+    "expected name key in trailer dictionary",
+  );
 });

--- a/packages/core/src/xref/trailer/parser/__tests__/parser.error.test.ts
+++ b/packages/core/src/xref/trailer/parser/__tests__/parser.error.test.ts
@@ -264,3 +264,219 @@ test("/Encrypt の世代番号が65535超の場合にXREF_TABLE_INVALIDエラー
   assert(!result.ok);
   expect(result.error.code).toBe("XREF_TABLE_INVALID");
 });
+
+test("/Sizeにboolean値(true)が指定された場合にSIZE_NOT_FOUNDエラーが返る", () => {
+  const { data, offset } = trailerAt("trailer << /Size true /Root 1 0 R >>");
+  const result = parseTrailer(data, offset);
+  assert(!result.ok);
+  expect(result.error.code).toBe("SIZE_NOT_FOUND");
+  expect(result.error.message).toContain("/Size");
+});
+
+test("/Sizeにboolean値(false)が指定された場合にSIZE_NOT_FOUNDエラーが返る", () => {
+  const { data, offset } = trailerAt("trailer << /Size false /Root 1 0 R >>");
+  const result = parseTrailer(data, offset);
+  assert(!result.ok);
+  expect(result.error.code).toBe("SIZE_NOT_FOUND");
+  expect(result.error.message).toContain("/Size");
+});
+
+test("/Sizeにnullが指定された場合にSIZE_NOT_FOUNDエラーが返る", () => {
+  const { data, offset } = trailerAt("trailer << /Size null /Root 1 0 R >>");
+  const result = parseTrailer(data, offset);
+  assert(!result.ok);
+  expect(result.error.code).toBe("SIZE_NOT_FOUND");
+  expect(result.error.message).toContain("/Size");
+});
+
+test("/Sizeに辞書値<< >>が指定された場合にSIZE_NOT_FOUNDエラーが返る", () => {
+  const { data, offset } = trailerAt("trailer << /Size << >> /Root 1 0 R >>");
+  const result = parseTrailer(data, offset);
+  assert(!result.ok);
+  expect(result.error.code).toBe("SIZE_NOT_FOUND");
+  expect(result.error.message).toContain("/Size");
+});
+
+test("リテラル文字列に0-255範囲外のコードユニット(\\400)が含まれる場合にXREF_TABLE_INVALIDエラーが返る", () => {
+  const { data, offset } = trailerAt(
+    "trailer << /Size 10 /Root 1 0 R /ID [(\\400) (b)] >>",
+  );
+  const result = parseTrailer(data, offset);
+  assert(!result.ok);
+  expect(result.error.code).toBe("XREF_TABLE_INVALID");
+  expect(result.error.message).toContain("outside 0-255");
+});
+
+test("値の位置に予期せぬトークン(])が現れた場合にXREF_TABLE_INVALIDエラーが返る", () => {
+  const { data, offset } = trailerAt("trailer << /Size ] /Root 1 0 R >>");
+  const result = parseTrailer(data, offset);
+  assert(!result.ok);
+  expect(result.error.code).toBe("XREF_TABLE_INVALID");
+  expect(result.error.message).toContain(
+    "unexpected token at value position in trailer dictionary",
+  );
+});
+
+test("/Encryptの値が65段ネストの辞書の場合にNESTING_TOO_DEEPエラーが返る", () => {
+  const depth = 65;
+  const open = "<< /K ".repeat(depth);
+  const close = " >>".repeat(depth);
+  const { data, offset } = trailerAt(
+    `trailer << /Root 1 0 R /Size 10 /Encrypt ${open}1${close} >>`,
+  );
+  const result = parseTrailer(data, offset);
+  assert(!result.ok);
+  expect(result.error.code).toBe("NESTING_TOO_DEEP");
+});
+
+test("/Encryptの値が65段ネストの配列の場合にNESTING_TOO_DEEPエラーが返る", () => {
+  const depth = 65;
+  const open = "[".repeat(depth);
+  const close = "]".repeat(depth);
+  const { data, offset } = trailerAt(
+    `trailer << /Root 1 0 R /Size 10 /Encrypt ${open}1${close} >>`,
+  );
+  const result = parseTrailer(data, offset);
+  assert(!result.ok);
+  expect(result.error.code).toBe("NESTING_TOO_DEEP");
+});
+
+test("ネストした辞書内で非Nameキーが現れた場合にXREF_TABLE_INVALIDエラーが返る", () => {
+  const { data, offset } = trailerAt(
+    "trailer << /Root 1 0 R /Size 10 /Encrypt << 123 /Standard >> >>",
+  );
+  const result = parseTrailer(data, offset);
+  assert(!result.ok);
+  expect(result.error.code).toBe("XREF_TABLE_INVALID");
+  expect(result.error.message).toContain(
+    "expected name key in nested dictionary value",
+  );
+});
+
+test("ネストした辞書内で値の直前にEOFに達した場合にXREF_TABLE_INVALIDエラーが返る", () => {
+  const { data, offset } = trailerAt(
+    "trailer << /Root 1 0 R /Size 10 /Encrypt << /Filter",
+  );
+  const result = parseTrailer(data, offset);
+  assert(!result.ok);
+  expect(result.error.code).toBe("XREF_TABLE_INVALID");
+  expect(result.error.message).toContain("unexpected end of data");
+});
+
+test("/IDの値が配列でない場合にXREF_TABLE_INVALIDエラーが返る", () => {
+  const { data, offset } = trailerAt(
+    "trailer << /Root 1 0 R /Size 10 /ID <00> >>",
+  );
+  const result = parseTrailer(data, offset);
+  assert(!result.ok);
+  expect(result.error.code).toBe("XREF_TABLE_INVALID");
+  expect(result.error.message).toContain("/ID entry must be an array");
+});
+
+test("/IDの要素が3個以上の場合にXREF_TABLE_INVALIDエラーが返る", () => {
+  const { data, offset } = trailerAt(
+    "trailer << /Root 1 0 R /Size 10 /ID [<00> <00> <00>] >>",
+  );
+  const result = parseTrailer(data, offset);
+  assert(!result.ok);
+  expect(result.error.code).toBe("XREF_TABLE_INVALID");
+  expect(result.error.message).toContain("2-element array");
+});
+
+test("/ID要素パース中にデータ末尾(EOF)に達した場合にXREF_TABLE_INVALIDエラーが返る", () => {
+  const { data, offset } = trailerAt(
+    "trailer << /Root 1 0 R /Size 10 /ID [<00>",
+  );
+  const result = parseTrailer(data, offset);
+  assert(!result.ok);
+  expect(result.error.code).toBe("XREF_TABLE_INVALID");
+  expect(result.error.message).toContain(
+    "unexpected end of data while parsing /ID array",
+  );
+});
+
+test("トップレベルの辞書キーがNameでない場合にXREF_TABLE_INVALIDエラーが返る", () => {
+  const { data, offset } = trailerAt(
+    "trailer << 123 /Root 1 0 R /Size 10 >>",
+  );
+  const result = parseTrailer(data, offset);
+  assert(!result.ok);
+  expect(result.error.code).toBe("XREF_TABLE_INVALID");
+  expect(result.error.message).toContain("expected name key");
+});
+
+test("トップレベルの辞書値の前にDictEnd(>>)が現れた場合にXREF_TABLE_INVALIDエラーが返る", () => {
+  const { data, offset } = trailerAt(
+    "trailer << /Root 1 0 R /Size >>",
+  );
+  const result = parseTrailer(data, offset);
+  assert(!result.ok);
+  expect(result.error.code).toBe("XREF_TABLE_INVALID");
+  expect(result.error.message).toContain("expected value for key");
+});
+
+test("トップレベルの辞書値の前にEOFに達した場合にXREF_TABLE_INVALIDエラーが返る", () => {
+  const { data, offset } = trailerAt(
+    "trailer << /Root 1 0 R /Size",
+  );
+  const result = parseTrailer(data, offset);
+  assert(!result.ok);
+  expect(result.error.code).toBe("XREF_TABLE_INVALID");
+  expect(result.error.message).toContain("unexpected end of data");
+});
+
+test("スキップ対象辞書内で予期せぬトークン(])が現れた場合にXREF_TABLE_INVALIDエラーが返る", () => {
+  const { data, offset } = trailerAt(
+    "trailer << /Root 1 0 R /Size 10 /Unknown << ] >>",
+  );
+  const result = parseTrailer(data, offset);
+  assert(!result.ok);
+  expect(result.error.code).toBe("XREF_TABLE_INVALID");
+  expect(result.error.message).toContain("unexpected ] while skipping dictionary value");
+});
+
+test("スキップ対象辞書内で非Nameキーが現れた場合でもスキップされ正常に処理される", () => {
+  const { data, offset } = trailerAt(
+    "trailer << /Root 1 0 R /Size 10 /Unknown << 123 /A 1 >> >>",
+  );
+  const result = parseTrailer(data, offset);
+  assert(result.ok);
+});
+
+test("スキップ対象辞書内でキー直後にEOFに達した場合にXREF_TABLE_INVALIDエラーが返る", () => {
+  const { data, offset } = trailerAt(
+    "trailer << /Root 1 0 R /Size 10 /Unknown << /A",
+  );
+  const result = parseTrailer(data, offset);
+  assert(!result.ok);
+  expect(result.error.code).toBe("XREF_TABLE_INVALID");
+  expect(result.error.message).toContain("unexpected end of data");
+});
+
+test("ネストした辞書内でキー読み取り直前にEOFに達した場合にXREF_TABLE_INVALIDエラーが返る", () => {
+  const { data, offset } = trailerAt(
+    "trailer << /Root 1 0 R /Size 10 /Encrypt <<",
+  );
+  const result = parseTrailer(data, offset);
+  assert(!result.ok);
+  expect(result.error.code).toBe("XREF_TABLE_INVALID");
+  expect(result.error.message).toContain("unexpected end of data while parsing dictionary value");
+});
+
+test("スキップ対象の単体数値のプッシュバック処理が正常に動作する", () => {
+  const { data, offset } = trailerAt(
+    "trailer << /Unknown 1 /Root 1 0 R /Size 10 >>",
+  );
+  const result = parseTrailer(data, offset);
+  assert(result.ok);
+});
+
+test("スキップ対象で整数が2個連続しRでない場合に2個目の整数がプッシュバックされトップレベルキー不正で失敗する", () => {
+  const { data, offset } = trailerAt(
+    "trailer << /Unknown 1 2 /Root 1 0 R /Size 10 >>",
+  );
+  const result = parseTrailer(data, offset);
+  assert(!result.ok);
+  expect(result.error.code).toBe("XREF_TABLE_INVALID");
+  expect(result.error.message).toContain("expected name key in trailer dictionary");
+});


### PR DESCRIPTION
## 概要
`packages/core/src/xref/trailer/parser/index.ts` の文カバレッジ向上（未カバーだったエラー分岐・希少値型処理）を目的に、ユニットテストを追加・拡充しました。

## 主な追加テストケース
- `boolean` (`true`/`false`), `null`, `<< >>` 値に対する `SIZE_NOT_FOUND` ドメインバリデーション拒否テスト
- 0-255 範囲外コードユニット (`\400`) に対する `XREF_TABLE_INVALID` ("outside 0-255") エラーテスト
- 値位置での予期せぬトークン (例: `]`) に対する `XREF_TABLE_INVALID` テスト
- 65段ネスト上限超過 (`NESTING_TOO_DEEP`) テスト（辞書・配列）
- `readDictValueEntries` / `readIdArray` / `parseDictTokens` / `skipValue` の境界値およびプッシュバック動作の正常性・エラー分岐テスト

## 関連 Issue
Closes #498