### PR TITLE
🚨 [Tests]: #484 interpreter 層に q/Q の中間状態検証を追加し dispatch テストの mock 重複定義を除去

### DIFF
--- a/packages/core/src/content-stream/interpreter/__tests__/interpreter.dispatch.test.ts
+++ b/packages/core/src/content-stream/interpreter/__tests__/interpreter.dispatch.test.ts
@@ -11,6 +11,10 @@ import {
   type OperatorHandler,
   OperatorRegistry,
 } from "../../operator-registry/index";
+import {
+  qHandler,
+  qRestoreHandler,
+} from "../../operators/graphics-state/graphics-state-operators/index";
 import { ContentStreamInterpreter } from "../index";
 
 const encode = (value: string): Uint8Array => new TextEncoder().encode(value);
@@ -423,16 +427,8 @@ test("handlerのErrは同じerrorを返して後続operatorを実行しない", 
   expect(laterCalled).toBe(false);
 });
 
-test("qとQはregistry handler経由でgraphics state stackを更新する", () => {
-  const qRegistry = registerOperator(
-    OperatorRegistry.create(),
-    "q",
-    (context) =>
-      ok({
-        ...context,
-        graphicsStateStack: GraphicsStateStack.save(context.graphicsStateStack),
-      }),
-  );
+test("production の q/Q handler が registry 経由で graphics state stack を更新する", () => {
+  const qRegistry = registerOperator(OperatorRegistry.create(), "q", qHandler);
   const changeRegistry = registerOperator(qRegistry, "change", (context) =>
     ok({
       ...context,
@@ -448,13 +444,7 @@ test("qとQはregistry handler経由でgraphics state stackを更新する", () 
       ),
     }),
   );
-  const registry = registerOperator(changeRegistry, "Q", (context) =>
-    ok({
-      ...context,
-      graphicsStateStack: GraphicsStateStack.restore(context.graphicsStateStack)
-        .stack,
-    }),
-  );
+  const registry = registerOperator(changeRegistry, "Q", qRestoreHandler);
 
   const result = ContentStreamInterpreter.execute({
     data: encode("q change Q"),

--- a/packages/core/src/content-stream/interpreter/__tests__/interpreter.graphics-state-stack.test.ts
+++ b/packages/core/src/content-stream/interpreter/__tests__/interpreter.graphics-state-stack.test.ts
@@ -2,18 +2,26 @@
 // 「中間状態」と「unbalanced Q で warnings が積まれないこと」を担当する。
 //
 // 既存の担当範囲（重複を作らないための境界）:
-//   - graphics-state-operators.integration.test.ts:46 が 3 段ネスト
-//     `q 2 w q 3 w q 4 w Q Q Q` の interpreter 経由の初期復帰を検証済み
+//   - graphics-state-operators.integration.test.ts の
+//     「3 段ネスト `q 2 w q 3 w q 4 w Q Q Q` で初期状態に復帰する」が
+//     interpreter 経由の初期復帰を検証済み
 //     （Issue #484 の「ネスト 3 段以上の動作確認」はこのテストで充足されている）。
-//     同 :62 が unbalanced Q の ok・current 不変、同 :30 が cm + w の一括巻き戻しを担当。
+//     同ファイルの「unbalanced Q を interpreter 経由で実行しても ok で継続する」が
+//     unbalanced Q の ok・current 不変を、
+//     「`q 1 0 0 1 100 200 cm 2 w Q` を実行すると save/restore で初期
+//     GraphicsState に戻る」が cm + w の一括巻き戻しを担当。
 //   - q-restore.nested.test.ts / q.basic.test.ts が handler 直呼びで
 //     中間 current と saved の中身を検証済み。
-//   - q.basic.test.ts:48,66 / q-restore.basic.test.ts:59,85 /
-//     q-restore.unbalanced.test.ts:83 が operand stack の同一参照・非消費を
-//     handler 層で検証済み（本ファイルでは独立ケースを立てず、ケース 1 の
-//     アサーションとして interpreter 層でも一度だけ確認する）。
-//   - q-restore.unbalanced.test.ts:104 が非デフォルト state での unbalanced Q と
-//     その後の復帰を検証済み（本ファイルでは扱わない）。
+//   - q.basic.test.ts / q-restore.basic.test.ts の
+//     「（q または Q）実行後も operandStack は同一参照のまま」および
+//     「非空 operandStack で（q または Q）を実行しても operand が消費されない」、
+//     q-restore.unbalanced.test.ts の「連続 Q 実行後も operandStack が消費されない」が
+//     operand stack の同一参照・非消費を handler 層で検証済み
+//     （本ファイルでは独立ケースを立てず、ケース 1 のアサーションとして
+//     interpreter 層でも一度だけ確認する）。
+//   - q-restore.unbalanced.test.ts の「非デフォルト current で saved が空の Q を
+//     打っても値が保たれ、その後の q → Q で復帰する」が非デフォルト state での
+//     unbalanced Q とその後の復帰を検証済み（本ファイルでは扱わない）。
 //
 // 本ファイルの差分は次の 3 点:
 //   1. ストリームのプレフィックスを段階的に伸ばして毎回 fresh context で一括実行し、

--- a/packages/core/src/content-stream/interpreter/__tests__/interpreter.graphics-state-stack.test.ts
+++ b/packages/core/src/content-stream/interpreter/__tests__/interpreter.graphics-state-stack.test.ts
@@ -1,0 +1,212 @@
+// 本ファイルは content stream を interpreter に流したときの graphics state stack の
+// 「中間状態」と「unbalanced Q で warnings が積まれないこと」を担当する。
+//
+// 既存の担当範囲（重複を作らないための境界）:
+//   - graphics-state-operators.integration.test.ts:46 が 3 段ネスト
+//     `q 2 w q 3 w q 4 w Q Q Q` の interpreter 経由の初期復帰を検証済み
+//     （Issue #484 の「ネスト 3 段以上の動作確認」はこのテストで充足されている）。
+//     同 :62 が unbalanced Q の ok・current 不変、同 :30 が cm + w の一括巻き戻しを担当。
+//   - q-restore.nested.test.ts / q.basic.test.ts が handler 直呼びで
+//     中間 current と saved の中身を検証済み。
+//   - q.basic.test.ts:48,66 / q-restore.basic.test.ts:59,85 /
+//     q-restore.unbalanced.test.ts:83 が operand stack の同一参照・非消費を
+//     handler 層で検証済み（本ファイルでは独立ケースを立てず、ケース 1 の
+//     アサーションとして interpreter 層でも一度だけ確認する）。
+//   - q-restore.unbalanced.test.ts:104 が非デフォルト state での unbalanced Q と
+//     その後の復帰を検証済み（本ファイルでは扱わない）。
+//
+// 本ファイルの差分は次の 3 点:
+//   1. ストリームのプレフィックスを段階的に伸ばして毎回 fresh context で一括実行し、
+//      各段の中間 current / saved を interpreter（tokenizer + dispatch）経由で観測すること
+//   2. unbalanced Q で warnings が空である現行挙動を pin down すること
+//      （qRestoreHandler が UNBALANCED_RESTORE を破棄する事実は既存未検証）
+//   3. lineWidth / lineCap / ctm の 3 フィールド同時変更が Q で一括して戻ること
+//      （既存 integration は 2 フィールドまで）
+//
+// 観測手法について: 中間状態は「累積プレフィックス方式」で観測する。すなわち
+// execute("q 2 w") / execute("q 2 w q 3 w") / ... と毎回 fresh context で
+// 伸ばしたストリームを一括実行する。execute の結果 context を次の execute の
+// initialContext に渡すチェーン方式は採らない（観測点が fragment 境界に限られ、
+// interpreter が単一の連続ストリームを実行する途中の状態を見たことにならないため）。
+
+import { assert, expect, test } from "vitest";
+import type { PdfObject } from "../../../pdf/types/pdf-types/index";
+import {
+  GraphicsState,
+  GraphicsStateStack,
+  LineCap,
+  Matrix,
+} from "../../graphics-state/index";
+import { MarkedContentStack } from "../../marked-content/stack/index";
+import { OperandStack } from "../../operand-stack/index";
+import type { OperatorHandlerContext } from "../../operator-registry/index";
+import { OperatorRegistry } from "../../operator-registry/index";
+import { registerGraphicsStateOperators } from "../../operators/graphics-state/graphics-state-operators/index";
+import type { ContentStreamInterpreterResult } from "../index";
+import { ContentStreamInterpreter } from "../index";
+
+const encode = (s: string): Uint8Array => new TextEncoder().encode(s);
+
+/** production の登録ヘルパ経由で q / Q / w / J / cm を持つ registry を組み立てる。 */
+const createRegistry = (): OperatorRegistry => {
+  const registered = registerGraphicsStateOperators(OperatorRegistry.create());
+  assert(registered.ok);
+  return registered.value;
+};
+
+/**
+ * content stream を実行し `{ context, warnings }` を返すヘルパ（失敗時は assert で即座に検出）。
+ * initialContext は operand を積んだ状態から開始したい場合にのみ渡す。
+ *
+ * @param stream - 実行する content stream 文字列
+ * @param initialContext - 任意の初期 context（省略時は interpreter 側で新規生成される）
+ * @returns 実行完了時点の context と warnings
+ */
+const execute = (
+  stream: string,
+  initialContext?: OperatorHandlerContext,
+): ContentStreamInterpreterResult => {
+  const result = ContentStreamInterpreter.execute({
+    data: encode(stream),
+    registry: createRegistry(),
+    initialContext,
+  });
+  assert(result.ok);
+  return result.value;
+};
+
+/**
+ * 初期 context を組み立てる。q/Q 系 handler テストの buildContext と同一形。
+ *
+ * @returns 空の operand stack / 既定の graphics state stack を持つ context
+ */
+const buildContext = (): OperatorHandlerContext => ({
+  operandStack: OperandStack.create(),
+  graphicsStateStack: GraphicsStateStack.create(),
+  markedContentStack: MarkedContentStack.create(),
+});
+
+const defaultState = GraphicsState.create();
+const lineWidth2State = GraphicsState.update(defaultState, { lineWidth: 2 });
+const lineWidth3State = GraphicsState.update(lineWidth2State, { lineWidth: 3 });
+const lineWidth4State = GraphicsState.update(lineWidth3State, { lineWidth: 4 });
+const lineWidth5State = GraphicsState.update(lineWidth4State, { lineWidth: 5 });
+
+// q を積むたびに saved が 1 段ずつ伸び、current が直前の w の値を保つことを
+// interpreter 経由で観測する。warnings 空の確認は registerGraphicsStateOperators の
+// 登録漏れによる UNKNOWN_OPERATOR 回帰を直接検知するために同居させている。
+// 末尾の operand 注入は UC-4（q / Q が operand stack を破壊しない）の interpreter 層確認。
+test("q と w のプレフィックスを伸ばして実行すると各段の current と saved が 1 段ずつ積み上がる", () => {
+  const step1 = execute("q 2 w");
+  expect(GraphicsStateStack.current(step1.context.graphicsStateStack)).toEqual(
+    lineWidth2State,
+  );
+  expect(step1.context.graphicsStateStack.saved).toEqual([defaultState]);
+  expect(step1.warnings).toEqual([]);
+
+  const step2 = execute("q 2 w q 3 w");
+  expect(GraphicsStateStack.current(step2.context.graphicsStateStack)).toEqual(
+    lineWidth3State,
+  );
+  expect(step2.context.graphicsStateStack.saved).toEqual([
+    defaultState,
+    lineWidth2State,
+  ]);
+
+  const step3 = execute("q 2 w q 3 w q 4 w");
+  expect(GraphicsStateStack.current(step3.context.graphicsStateStack)).toEqual(
+    lineWidth4State,
+  );
+  expect(step3.context.graphicsStateStack.saved).toEqual([
+    defaultState,
+    lineWidth2State,
+    lineWidth3State,
+  ]);
+
+  // UC-4: operand を積んだ context で q / Q 双方の経路を通しても operand stack は
+  // 同一参照のまま depth も中身も変化しない
+  const seeded = buildContext();
+  const operand1: PdfObject = { type: "integer", value: 10 };
+  const operand2: PdfObject = { type: "integer", value: 20 };
+  OperandStack.push(seeded.operandStack, operand1);
+  OperandStack.push(seeded.operandStack, operand2);
+
+  const withOperands = execute("q 2 w q 3 w q 4 w Q Q Q", seeded);
+  expect(withOperands.context.operandStack).toBe(seeded.operandStack);
+  expect(OperandStack.depth(withOperands.context.operandStack)).toBe(2);
+  const top = OperandStack.peek(withOperands.context.operandStack);
+  assert(top.some);
+  expect(top.value).toEqual(operand2);
+});
+
+// Q を 1 つずつ足したストリームを一括実行し、current と saved が 1 段ずつ
+// 巻き戻る（一気に深度 0 へ落ちない）ことを interpreter 経由で観測する。
+// 深度 3 の初期状態は q ... w を含むストリーム側で作り、テスト内で
+// GraphicsStateStack の save API を直接呼んで組み立てることはしない。
+test("Q のプレフィックスを伸ばして実行すると各段の current と saved が 1 段ずつ巻き戻る", () => {
+  const step1 = execute("q 2 w q 3 w q 4 w Q");
+  expect(GraphicsStateStack.current(step1.context.graphicsStateStack)).toEqual(
+    lineWidth3State,
+  );
+  expect(step1.context.graphicsStateStack.saved).toEqual([
+    defaultState,
+    lineWidth2State,
+  ]);
+
+  const step2 = execute("q 2 w q 3 w q 4 w Q Q");
+  expect(GraphicsStateStack.current(step2.context.graphicsStateStack)).toEqual(
+    lineWidth2State,
+  );
+  expect(step2.context.graphicsStateStack.saved).toEqual([defaultState]);
+
+  const step3 = execute("q 2 w q 3 w q 4 w Q Q Q");
+  expect(GraphicsStateStack.current(step3.context.graphicsStateStack)).toEqual(
+    defaultState,
+  );
+  expect(step3.context.graphicsStateStack.saved).toEqual([]);
+});
+
+// 深度 4 への三角測量。既存テストの最大深度は 3 のため、深度 3 固定の実装に
+// 依存していないことを確認する。前半 3 段はケース 1 が担当済みなので、
+// 深度 4 到達時点の current と saved のみを見る。
+test("深度 4 まで q を積んでも同じ規則で current と saved が積み上がる", () => {
+  const result = execute("q 2 w q 3 w q 4 w q 5 w");
+
+  expect(GraphicsStateStack.current(result.context.graphicsStateStack)).toEqual(
+    lineWidth5State,
+  );
+  expect(result.context.graphicsStateStack.saved).toEqual([
+    defaultState,
+    lineWidth2State,
+    lineWidth3State,
+    lineWidth4State,
+  ]);
+});
+
+// qRestoreHandler が GraphicsStateStack の restore API が返す UNBALANCED_RESTORE
+// warning を破棄するため、saved が空の Q を通しても warnings には何も積まれない。
+// これは現行挙動の pin down であり、将来 warning を interpreter へ伝播させる
+// 設計変更を行えば意図的に red になる。
+test("saved が空の状態で Q を実行しても warnings は空のまま", () => {
+  const result = execute("Q");
+
+  expect(result.warnings).toEqual([]);
+});
+
+// lineWidth / lineCap / ctm の 3 フィールドを同時に変更してから Q を打つと、
+// 3 つとも一括で保存時点の state へ戻る（既存 integration は cm + w の 2 フィールドまで）。
+// Q 前の期待値はリテラルで固定し、production の計算結果を流用しない。
+test("lineWidth・lineCap・ctm の 3 フィールドを変更しても Q で一括して初期状態へ戻る", () => {
+  const beforeRestore = execute("q 5 w 2 J 2 0 0 2 10 20 cm");
+  const current = GraphicsStateStack.current(
+    beforeRestore.context.graphicsStateStack,
+  );
+  expect(current.lineWidth).toBe(5);
+  expect(current.lineCap).toEqual(LineCap.create(2));
+  expect(current.ctm).toEqual(Matrix.create(2, 0, 0, 2, 10, 20));
+
+  const afterRestore = execute("q 5 w 2 J 2 0 0 2 10 20 cm Q");
+  expect(
+    GraphicsStateStack.current(afterRestore.context.graphicsStateStack),
+  ).toEqual(GraphicsState.create());
+});


### PR DESCRIPTION
## 概要

Issue #484 の残タスク（interpreter test での `q ... Q` ネスト動作確認、受け入れ基準「mock 重複定義なし」）を充足する。

interpreter 層に新規テストファイルを追加し、既存テストが観測していない **中間状態**・**unbalanced `Q` で warning が積まれないこと**・**3 フィールドの一括巻き戻し** を検証する。併せて `interpreter.dispatch.test.ts` にインライン定義されていた q/Q の mock handler を production 実装へ置換した。

**production コードの差分は 0 件**（変更はテスト 2 ファイルのみ）。

## 変更内容

### 🎯 変更の種類

- [x] 🚨 テスト追加/修正 (Tests)
- [x] ♻️ リファクタリング (Refactoring)

### 📝 詳細な変更内容

#### 追加された機能・修正

- `interpreter.graphics-state-stack.test.ts` を新規追加（5 ケース）
  1. **save 方向の中間状態** — `q 2 w` → `q 2 w q 3 w` → `q 2 w q 3 w q 4 w` と伸ばして毎回 fresh context で一括実行し、`current` と `saved` が 1 段ずつ積み上がることを **中身まで** `toEqual` で検証。`warnings` が空であること（`registerGraphicsStateOperators` の登録漏れによる `UNKNOWN_OPERATOR` 回帰検知）と、operand を 2 つ積んだ context で `Q` 側の経路も通したときの operand stack 非破壊性を同居させる
  2. **restore 方向の中間状態** — `Q` を 1 つずつ足し、一気に深度 0 へ落ちず 1 段ずつ巻き戻ることを検証
  3. **深度 4 への三角測量** — 既存の最大深度は 3。深度 3 固定の実装に依存していないことを確認
  4. **unbalanced `Q` の warnings 空** — `qRestoreHandler` が `UNBALANCED_RESTORE` warning を破棄する現行挙動の pin down（既存のどのテストも押さえていない）
  5. **3 フィールド一括巻き戻し** — `lineWidth` / `lineCap` / `ctm` を同時変更してから `Q` で戻ることを、リテラル固定の期待値で検証（既存 integration は 2 フィールドまで）
- `interpreter.dispatch.test.ts` の q/Q インライン mock を production の `qHandler` / `qRestoreHandler` へ置換

#### 変更されたファイル

- `packages/core/src/content-stream/interpreter/__tests__/interpreter.graphics-state-stack.test.ts`（新規）
- `packages/core/src/content-stream/interpreter/__tests__/interpreter.dispatch.test.ts`（修正）

#### 削除されたファイル・機能

- `interpreter.dispatch.test.ts` 内の q/Q インライン handler 定義（production と同一ロジックの重複実装）

## 📊 システム図

### 状態マシン / フロー図

```mermaid
flowchart TD
    D0["D0: saved=[] / current=default"]
    D1["D1: saved=[S0] / current=S1"]
    D2["D2: saved=[S0,S1] / current=S2"]
    D3["D3: saved=[S0,S1,S2] / current=S3"]
    D4["D4: saved=[S0..S3] / current=S4"]:::new
    NOOP["unbalanced Q: current 不変・warnings 空"]:::new

    D0 -->|q| D1
    D1 -->|q| D2
    D2 -->|q| D3
    D3 -->|q| D4
    D1 -->|Q| D0
    D2 -->|Q| D1
    D3 -->|Q| D2
    D0 -->|Q| NOOP
    NOOP -->|以降の q ... Q は正常動作| D0

    classDef new fill:#ffe4b5,stroke:#d97706,stroke-width:2px
```

`[NEW]` 部分（深度 4 と unbalanced 時の warnings 空）が本 PR で新たに観測対象になった箇所。中間ノード（D1 / D2 / D3）の `current` と `saved` を interpreter 経由で検証するのも本 PR が初めて。

### データフロー

```
"q 2 w" / "q 2 w q 3 w" / "q 2 w q 3 w q 4 w"（累積プレフィックス）  [NEW]
    ↓ TextEncoder().encode()
ContentStreamInterpreter.execute({ data, registry, initialContext? })
    ↓
├─ createInitialContext  … initialContext 未指定 → 各 stack を毎回新規生成
│                          （中間状態の観測はこの fresh 経路のみを使う）  [NEW]
├─ ContentStreamTokenizer … bytes → Token 列
├─ number token → OperandStack.push
├─ operator token → OperatorRegistry.lookup
│     ├─ "q" → qHandler          … saved に current を退避
│     ├─ "Q" → qRestoreHandler   … saved 末尾を current へ復帰
│     │                            warning は破棄され interpreter に届かない  [NEW: 検証点]
│     └─ "w"/"J"/"cm" → operand を消費し current のみ差し替え（saved は不変）
    ↓
{ context, warnings }
    ↓ テストのアサーション
    ├─ GraphicsStateStack.current(context.graphicsStateStack)
    ├─ context.graphicsStateStack.saved  … 中身を toEqual で比較（length のみの検証はしない）
    ├─ warnings                          … toEqual([])
    └─ context.operandStack              … toBe（同一参照）/ depth / peek
```

## 📋 関連 Issue

- Refs #484
- 親 Epic: #483

## 🧪 テスト

### テスト実行方法

```bash
pnpm --filter @pdfmod/core exec vitest run src/content-stream/interpreter/__tests__/interpreter.graphics-state-stack.test.ts
pnpm --filter @pdfmod/core exec vitest run src/content-stream/interpreter/__tests__/interpreter.dispatch.test.ts
pnpm --filter @pdfmod/core test
pnpm lint
pnpm typecheck
pnpm test:run --coverage
pnpm build
```

### テスト項目

- [x] 単体テスト (Unit tests)
- [x] 統合テスト (Integration tests)

### テスト結果

| 項目 | 結果 |
|:-|:-|
| 新規ファイル単体 | 5 件パス |
| `interpreter.dispatch.test.ts` | 22 件パス（置換後もリグレッションなし） |
| `pnpm --filter @pdfmod/core test` | 281 ファイル / 3461 件パス |
| `pnpm lint`（biome + oxlint） | エラー 0 件・警告 0 件 |
| `pnpm typecheck` | エラー 0 件 |
| `pnpm build` | 成功 |
| カバレッジ | `content-stream/interpreter` 97.63% / `operators/graphics-state` 100%（テスト追加のみのため低下なし） |

production 実装が既に存在するため TDD の Red は「意図どおり green になること」＋「期待値を 1 つ壊すと red になること」の 2 段確認で代替した（実施済み・期待値は復元済み）。

## 🔍 レビューポイント

- **中間状態の観測手法** — 前段の実行結果 context を次の `execute` の `initialContext` に渡すチェーン方式ではなく、毎回 fresh context で伸ばしたストリームを一括実行する「累積プレフィックス方式」を採用している。理由はファイル冒頭コメントに記載
- **ケース 4 は現行挙動の pin down** — `UNBALANCED_RESTORE` warning が握り潰される既知の負債は本 PR では修正しない。将来 warning を interpreter へ伝播させる設計変更を入れると、このテストが意図的に red になる（＝仕様変更の検知点）
- **既存テストとの重複回避** — 「ネスト 3 段以上の最終復帰」「unbalanced `Q` が ok であること」「非デフォルト state での unbalanced」は既存テストが担当済みのため、新規側では再実装していない。ファイル冒頭に担当範囲の境界をコメントで明記
- **ケース 5 の期待値** — `Matrix.create(2, 0, 0, 2, 10, 20)` などをリテラルで固定し、production の計算結果を流用した同語反復アサーションにしていない

## ⚠️ 破壊的変更

- [ ] この変更は既存の API に破壊的変更を含みます

production コード差分 0 件のため、破壊的変更なし。

## ✅ チェックリスト

- [x] コードレビューの準備ができている
- [x] テストが正常に実行される
- [x] ドキュメントが更新されている（必要に応じて）
- [x] コミットメッセージが適切な形式で書かれている
- [ ] 関連する Issue が PR の「Development」に Linked されている
- [x] PR 本文に `Refs #` で Issue が記載されている
- [x] セルフレビューを実施した（Codex CLI レビュー結果: 問題なし）
- [x] 破壊的変更がある場合は明記されている