### PR TITLE
test(flatedecode): add maxDecompressedSize validation and stream writer error tests (#500)

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -11,7 +11,8 @@
       "packages/*/tsconfig*.json",
       "vitest*.ts",
       ".storybook/**",
-      "!.claude/worktrees"
+      "!.claude/worktrees",
+      "!.gemini"
     ]
   },
   "formatter": {

--- a/packages/core/src/xref/stream/flatedecode/__tests__/flatedecode.validation.test.ts
+++ b/packages/core/src/xref/stream/flatedecode/__tests__/flatedecode.validation.test.ts
@@ -76,13 +76,19 @@ interface MockDecompressionStreamInstance {
   readable: { getReader: () => MockDecompressionStreamInstance["mockReader"] };
 }
 
-type MockDecompressionStreamClass = new () => MockDecompressionStreamInstance;
+type MockDecompressionStreamClass =
+  (new () => MockDecompressionStreamInstance) & {
+    lastMockReader: MockDecompressionStreamInstance["mockReader"] | null;
+  };
 
 function createMockDecompressionStream(options: {
   writeError?: Error;
   closeError?: Error;
 }): MockDecompressionStreamClass {
-  return class MockDecompressionStream
+  let lastMockReader: MockDecompressionStreamInstance["mockReader"] | null =
+    null;
+
+  const MockClass = class MockDecompressionStream
     implements MockDecompressionStreamInstance
   {
     mockWriter = {
@@ -102,7 +108,16 @@ function createMockDecompressionStream(options: {
 
     writable = { getWriter: () => this.mockWriter };
     readable = { getReader: () => this.mockReader };
+
+    constructor() {
+      lastMockReader = this.mockReader;
+    }
   };
+
+  return Object.defineProperty(MockClass, "lastMockReader", {
+    get: () => lastMockReader,
+    configurable: true,
+  }) as MockDecompressionStreamClass;
 }
 
 test("writer.write() がエラーを起こした場合に FLATEDECODE_FAILED エラーを返し reader.cancel が呼ばれる", async () => {
@@ -118,6 +133,7 @@ test("writer.write() がエラーを起こした場合に FLATEDECODE_FAILED エ
   expect(result.error.message).toBe(
     "FlateDecode decompression failed during write",
   );
+  expect(MockDS.lastMockReader?.cancel).toHaveBeenCalled();
 });
 
 test("writer.close() がエラーを起こした場合に FLATEDECODE_FAILED エラーを返し reader.cancel が呼ばれる", async () => {
@@ -133,4 +149,5 @@ test("writer.close() がエラーを起こした場合に FLATEDECODE_FAILED エ
   expect(result.error.message).toBe(
     "FlateDecode decompression failed during write",
   );
+  expect(MockDS.lastMockReader?.cancel).toHaveBeenCalled();
 });

--- a/packages/core/src/xref/stream/flatedecode/__tests__/flatedecode.validation.test.ts
+++ b/packages/core/src/xref/stream/flatedecode/__tests__/flatedecode.validation.test.ts
@@ -32,7 +32,8 @@ test("展開サイズがmaxDecompressedSizeを超過した場合にFLATEDECODE_F
 
 // --- Issue #500: maxDecompressedSize 不正引数バリデーションテスト ---
 const dummyData = new Uint8Array([
-  120, 156, 243, 72, 205, 201, 201, 215, 81, 8, 112, 113, 83, 4, 0, 21, 171, 3, 60,
+  120, 156, 243, 72, 205, 201, 201, 215, 81, 8, 112, 113, 83, 4, 0, 21, 171, 3,
+  60,
 ]);
 
 test.each([
@@ -46,18 +47,15 @@ test.each([
     "MAX_SAFE_INTEGER超過 (Number.MAX_SAFE_INTEGER + 1)",
     Number.MAX_SAFE_INTEGER + 1,
   ],
-])(
-  "maxDecompressedSize に不正な値 (%s) を渡した場合にFLATEDECODE_FAILEDエラーを返す",
-  async (_, invalidSize) => {
-    const result = await decompressFlate(dummyData, invalidSize);
-    expect(result.ok).toBe(false);
-    assert(!result.ok);
-    expect(result.error.code).toBe("FLATEDECODE_FAILED");
-    expect(result.error.message).toBe(
-      "Invalid maxDecompressedSize: must be a finite, positive safe integer",
-    );
-  },
-);
+])("maxDecompressedSize に不正な値 (%s) を渡した場合にFLATEDECODE_FAILEDエラーを返す", async (_, invalidSize) => {
+  const result = await decompressFlate(dummyData, invalidSize);
+  expect(result.ok).toBe(false);
+  assert(!result.ok);
+  expect(result.error.code).toBe("FLATEDECODE_FAILED");
+  expect(result.error.message).toBe(
+    "Invalid maxDecompressedSize: must be a finite, positive safe integer",
+  );
+});
 
 // --- Issue #500: Stream Writer エラーハンドリングテスト ---
 afterEach(() => {

--- a/packages/core/src/xref/stream/flatedecode/__tests__/flatedecode.validation.test.ts
+++ b/packages/core/src/xref/stream/flatedecode/__tests__/flatedecode.validation.test.ts
@@ -62,11 +62,29 @@ afterEach(() => {
   vi.unstubAllGlobals();
 });
 
+interface MockDecompressionStreamInstance {
+  mockWriter: {
+    write: ReturnType<typeof vi.fn>;
+    close: ReturnType<typeof vi.fn>;
+    abort: ReturnType<typeof vi.fn>;
+  };
+  mockReader: {
+    read: ReturnType<typeof vi.fn>;
+    cancel: ReturnType<typeof vi.fn>;
+  };
+  writable: { getWriter: () => MockDecompressionStreamInstance["mockWriter"] };
+  readable: { getReader: () => MockDecompressionStreamInstance["mockReader"] };
+}
+
+type MockDecompressionStreamClass = new () => MockDecompressionStreamInstance;
+
 function createMockDecompressionStream(options: {
   writeError?: Error;
   closeError?: Error;
-}) {
-  return class MockDecompressionStream {
+}): MockDecompressionStreamClass {
+  return class MockDecompressionStream
+    implements MockDecompressionStreamInstance
+  {
     mockWriter = {
       write: options.writeError
         ? vi.fn().mockRejectedValue(options.writeError)

--- a/packages/core/src/xref/stream/flatedecode/__tests__/flatedecode.validation.test.ts
+++ b/packages/core/src/xref/stream/flatedecode/__tests__/flatedecode.validation.test.ts
@@ -1,4 +1,4 @@
-import { assert, expect, test } from "vitest";
+import { afterEach, assert, expect, test, vi } from "vitest";
 import { decompressFlate } from "../index";
 
 test("不正な圧縮データに対してFLATEDECODE_FAILEDエラーを返す", async () => {
@@ -28,4 +28,93 @@ test("展開サイズがmaxDecompressedSizeを超過した場合にFLATEDECODE_F
   assert(!result.ok);
   expect(result.error.code).toBe("FLATEDECODE_FAILED");
   expect(result.error.message).toContain("exceeds limit");
+});
+
+// --- Issue #500: maxDecompressedSize 不正引数バリデーションテスト ---
+const dummyData = new Uint8Array([
+  120, 156, 243, 72, 205, 201, 201, 215, 81, 8, 112, 113, 83, 4, 0, 21, 171, 3, 60,
+]);
+
+test.each([
+  ["NaN", NaN],
+  ["Infinity", Infinity],
+  ["-Infinity", -Infinity],
+  ["0", 0],
+  ["負の数 (-1)", -1],
+  ["非整数 (1.5)", 1.5],
+  [
+    "MAX_SAFE_INTEGER超過 (Number.MAX_SAFE_INTEGER + 1)",
+    Number.MAX_SAFE_INTEGER + 1,
+  ],
+])(
+  "maxDecompressedSize に不正な値 (%s) を渡した場合にFLATEDECODE_FAILEDエラーを返す",
+  async (_, invalidSize) => {
+    const result = await decompressFlate(dummyData, invalidSize);
+    expect(result.ok).toBe(false);
+    assert(!result.ok);
+    expect(result.error.code).toBe("FLATEDECODE_FAILED");
+    expect(result.error.message).toBe(
+      "Invalid maxDecompressedSize: must be a finite, positive safe integer",
+    );
+  },
+);
+
+// --- Issue #500: Stream Writer エラーハンドリングテスト ---
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+function createMockDecompressionStream(options: {
+  writeError?: Error;
+  closeError?: Error;
+}) {
+  return class MockDecompressionStream {
+    mockWriter = {
+      write: options.writeError
+        ? vi.fn().mockRejectedValue(options.writeError)
+        : vi.fn().mockResolvedValue(undefined),
+      close: options.closeError
+        ? vi.fn().mockRejectedValue(options.closeError)
+        : vi.fn().mockResolvedValue(undefined),
+      abort: vi.fn().mockResolvedValue(undefined),
+    };
+
+    mockReader = {
+      read: vi.fn().mockResolvedValue({ done: true, value: undefined }),
+      cancel: vi.fn().mockResolvedValue(undefined),
+    };
+
+    writable = { getWriter: () => this.mockWriter };
+    readable = { getReader: () => this.mockReader };
+  };
+}
+
+test("writer.write() がエラーを起こした場合に FLATEDECODE_FAILED エラーを返し reader.cancel が呼ばれる", async () => {
+  const MockDS = createMockDecompressionStream({
+    writeError: new Error("Simulated write error"),
+  });
+  vi.stubGlobal("DecompressionStream", MockDS);
+
+  const result = await decompressFlate(dummyData);
+  expect(result.ok).toBe(false);
+  assert(!result.ok);
+  expect(result.error.code).toBe("FLATEDECODE_FAILED");
+  expect(result.error.message).toBe(
+    "FlateDecode decompression failed during write",
+  );
+});
+
+test("writer.close() がエラーを起こした場合に FLATEDECODE_FAILED エラーを返し reader.cancel が呼ばれる", async () => {
+  const MockDS = createMockDecompressionStream({
+    closeError: new Error("Simulated close error"),
+  });
+  vi.stubGlobal("DecompressionStream", MockDS);
+
+  const result = await decompressFlate(dummyData);
+  expect(result.ok).toBe(false);
+  assert(!result.ok);
+  expect(result.error.code).toBe("FLATEDECODE_FAILED");
+  expect(result.error.message).toBe(
+    "FlateDecode decompression failed during write",
+  );
 });

--- a/packages/core/src/xref/stream/parser/__tests__/parser.validation.test.ts
+++ b/packages/core/src/xref/stream/parser/__tests__/parser.validation.test.ts
@@ -1,4 +1,7 @@
 import { assert, expect, test } from "vitest";
+import { ByteOffset } from "../../../../pdf/types/byte-offset/index";
+import { GenerationNumber } from "../../../../pdf/types/generation-number/index";
+import { ObjectNumber } from "../../../../pdf/types/object-number/index";
 import { decodeXRefStreamEntries } from "../index";
 
 test("/W配列の要素数が3でない場合にエラー", () => {
@@ -252,3 +255,74 @@ test("entryWidth=0 かつ totalEntries>0 の場合にエラー（CPU DoS防止�
     "entry width is 0 but total entries is non-zero",
   );
 });
+
+test("Type 1 エントリで field3 (世代番号) が 65535 を超える場合 (65536) にエラー", () => {
+  // W=[1, 2, 3], total width = 6
+  // type=1, offset=10, gen=65536 (0x010000)
+  const data = new Uint8Array([0x01, 0x00, 0x0a, 0x01, 0x00, 0x00]);
+  const result = decodeXRefStreamEntries({ data, w: [1, 2, 3], size: 1 });
+
+  assert(!result.ok);
+  expect(result.error.code).toBe("XREF_STREAM_INVALID");
+  expect(result.error.message).toContain("Invalid GenerationNumber: 65536");
+});
+
+test("Type 1 エントリで field3 (世代番号) が 境界値 65535 の場合は正常にパースされる", () => {
+  // W=[1, 2, 3], type=1, offset=10, gen=65535 (0x00FFFF)
+  const data = new Uint8Array([0x01, 0x00, 0x0a, 0x00, 0xff, 0xff]);
+  const result = decodeXRefStreamEntries({ data, w: [1, 2, 3], size: 1 });
+
+  assert(result.ok);
+  const entry = result.value.entries.get(ObjectNumber.of(0));
+  assert(entry && entry.type === 1);
+  expect(entry.generationNumber).toBe(GenerationNumber.of(65535));
+});
+
+test("Type 0 エントリで field3 (世代番号) が 65535 を超える場合 (65536) にエラー", () => {
+  // W=[1, 2, 3], total width = 6
+  // type=0, nextFreeObject=5, gen=65536 (0x010000)
+  const data = new Uint8Array([0x00, 0x00, 0x05, 0x01, 0x00, 0x00]);
+  const result = decodeXRefStreamEntries({ data, w: [1, 2, 3], size: 1 });
+
+  assert(!result.ok);
+  expect(result.error.code).toBe("XREF_STREAM_INVALID");
+  expect(result.error.message).toContain("Invalid GenerationNumber: 65536");
+});
+
+test("baseOffset 指定時に field3 (世代番号) エラーの offset が絶対オフセットになる", () => {
+  // W=[1, 2, 3], total width = 6
+  // type=1 (1 byte), offset=10 (2 bytes), gen=65536 (3 bytes)
+  // field3 starts at offset 3 of the entry
+  const data = new Uint8Array([0x01, 0x00, 0x0a, 0x01, 0x00, 0x00]);
+  const result = decodeXRefStreamEntries({
+    data,
+    w: [1, 2, 3],
+    size: 1,
+    baseOffset: ByteOffset.of(1000),
+  });
+
+  assert(!result.ok);
+  expect(result.error.code).toBe("XREF_STREAM_INVALID");
+  expect(result.error.offset).toBe(ByteOffset.of(1003));
+});
+
+test("2番目のエントリで field3 エラー発生時に baseOffset + entryOffset + field3Offset の絶対オフセットが計算される", () => {
+  // W=[1, 2, 3], total width = 6
+  // entry 0: type=1, offset=10, gen=0 (正常)
+  // entry 1: type=1, offset=10, gen=65536 (エラー: field3 offset = 6 + 3 = 9)
+  const data = new Uint8Array([
+    0x01, 0x00, 0x0a, 0x00, 0x00, 0x00, // entry 0
+    0x01, 0x00, 0x0a, 0x01, 0x00, 0x00, // entry 1
+  ]);
+  const result = decodeXRefStreamEntries({
+    data,
+    w: [1, 2, 3],
+    size: 2,
+    baseOffset: ByteOffset.of(1000),
+  });
+
+  assert(!result.ok);
+  expect(result.error.code).toBe("XREF_STREAM_INVALID");
+  expect(result.error.offset).toBe(ByteOffset.of(1009));
+});
+

--- a/packages/core/src/xref/stream/parser/__tests__/parser.validation.test.ts
+++ b/packages/core/src/xref/stream/parser/__tests__/parser.validation.test.ts
@@ -311,8 +311,18 @@ test("2番目のエントリで field3 エラー発生時に baseOffset + entryO
   // entry 0: type=1, offset=10, gen=0 (正常)
   // entry 1: type=1, offset=10, gen=65536 (エラー: field3 offset = 6 + 3 = 9)
   const data = new Uint8Array([
-    0x01, 0x00, 0x0a, 0x00, 0x00, 0x00, // entry 0
-    0x01, 0x00, 0x0a, 0x01, 0x00, 0x00, // entry 1
+    0x01,
+    0x00,
+    0x0a,
+    0x00,
+    0x00,
+    0x00, // entry 0
+    0x01,
+    0x00,
+    0x0a,
+    0x01,
+    0x00,
+    0x00, // entry 1
   ]);
   const result = decodeXRefStreamEntries({
     data,
@@ -325,4 +335,3 @@ test("2番目のエントリで field3 エラー発生時に baseOffset + entryO
   expect(result.error.code).toBe("XREF_STREAM_INVALID");
   expect(result.error.offset).toBe(ByteOffset.of(1009));
 });
-


### PR DESCRIPTION
## 概要

Issue #500 および Issue #499 に対応し、以下のユニットテストを追加しました。

### 1. FlateDecode バリデーション & ストリームエラーテスト (Issue #500)
- **`maxDecompressedSize` 不正引数バリデーションテスト (`VAL-01` 〜 `VAL-07`)**:
  - `NaN`, `Infinity`, `-Infinity`, `0`, `-1`, `1.5`, `Number.MAX_SAFE_INTEGER + 1` の全7ケースを `test.each` で追加。
  - `Result.ok === false` かつエラーコード `"FLATEDECODE_FAILED"`、メッセージ `"Invalid maxDecompressedSize: must be a finite, positive safe integer"` が返されることを確認。
- **Stream Writer エラー経路テスト (`WRITER-01`, `WRITER-02`)**:
  - `vi.stubGlobal("DecompressionStream", MockDS)` を使用し、`writer.write()` および `writer.close()` の Promise rejection をシミュレート。
  - `MockDS.lastMockReader?.cancel` を通じて、エラー発生時に `reader.cancel()` が確実に呼び出されることを検証。
  - `afterEach(() => { vi.unstubAllGlobals(); })` によりグローバル環境の完全クリーンアップを実施。

### 2. XRef Stream Parser 追加テスト (Issue #499)
- Type 1 エントリにおける世代番号（field3 > 65535）上限オーバーフローのバリデーションテスト。
- `decodeXRefStreamEntries` の境界値および offset 計算の追加検証。

### 動作確認

- `pnpm --filter @pdfmod/core test src/xref/stream/flatedecode/__tests__/flatedecode.validation.test.ts` (12/12 パス)
- `pnpm --filter @pdfmod/core test` (全281テストファイル 3,505件のユニットテストがパス)

Refs #500, Refs #499