### PR TITLE
[Tests] document-metadata の非文字列フィールド警告メッセージ分岐テスト拡充

### DIFF
--- a/packages/core/src/document/metadata/document-info-parser/__tests__/document-info-parser.behavior.test.ts
+++ b/packages/core/src/document/metadata/document-info-parser/__tests__/document-info-parser.behavior.test.ts
@@ -89,20 +89,32 @@ test("/Title が UTF-16BE 補助平面 🚀 を含む場合に正しくデコー
   expect(metadata.title).toBe("🚀 Launch");
 });
 
-test("/Title が PdfString 以外 (PdfInteger) の場合 undefined + STRING_DECODE_FAILED", async () => {
-  const integerValue: PdfValue = { type: "integer", value: 42 };
-  const dict = makeInfoDict([["Title", integerValue]]);
-  const result = await DocumentInfoParser.parse(
-    makeTrailerWithInfo(makeRef(2)),
-    makeResolverWithInfo(dict),
-  );
-  const { metadata, warnings } = unwrapOk(result);
-  expect(metadata.title).toBeUndefined();
-  expect(warnings).toHaveLength(1);
-  expect(warnings[0].code).toBe("STRING_DECODE_FAILED");
-  expect(warnings[0].message).toContain("Title");
-  expect(warnings[0].message).toContain("integer");
-});
+const STRING_FIELDS = [
+  ["Title", "title"],
+  ["Author", "author"],
+  ["Subject", "subject"],
+  ["Keywords", "keywords"],
+  ["Creator", "creator"],
+  ["Producer", "producer"],
+] as const;
+
+test.each(STRING_FIELDS)(
+  "/%s が PdfString 以外 (PdfInteger) の場合 undefined + STRING_DECODE_FAILED",
+  async (key, prop) => {
+    const integerValue: PdfValue = { type: "integer", value: 42 };
+    const dict = makeInfoDict([[key, integerValue]]);
+    const result = await DocumentInfoParser.parse(
+      makeTrailerWithInfo(makeRef(2)),
+      makeResolverWithInfo(dict),
+    );
+    const { metadata, warnings } = unwrapOk(result);
+    expect(metadata[prop]).toBeUndefined();
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0].code).toBe("STRING_DECODE_FAILED");
+    expect(warnings[0].message).toContain(key);
+    expect(warnings[0].message).toContain("integer");
+  },
+);
 
 test("/CreationDate が D:20230615120530+09'00' の場合 UTC 換算 Date が抽出される", async () => {
   const dict = makeInfoDict([
@@ -145,19 +157,27 @@ test("/CreationDate が不正フォーマット D:abcd の場合 undefined + DAT
   expect(warnings[0].message).toContain("CreationDate");
 });
 
-test("/CreationDate が PdfString 以外 (PdfInteger) の場合 undefined + DATE_PARSE_FAILED", async () => {
-  const integerValue: PdfValue = { type: "integer", value: 0 };
-  const dict = makeInfoDict([["CreationDate", integerValue]]);
-  const result = await DocumentInfoParser.parse(
-    makeTrailerWithInfo(makeRef(2)),
-    makeResolverWithInfo(dict),
-  );
-  const { metadata, warnings } = unwrapOk(result);
-  expect(metadata.creationDate).toBeUndefined();
-  expect(warnings).toHaveLength(1);
-  expect(warnings[0].code).toBe("DATE_PARSE_FAILED");
-  expect(warnings[0].message).toContain("CreationDate");
-});
+const DATE_FIELDS = [
+  ["CreationDate", "creationDate"],
+  ["ModDate", "modDate"],
+] as const;
+
+test.each(DATE_FIELDS)(
+  "/%s が PdfString 以外 (PdfInteger) の場合 undefined + DATE_PARSE_FAILED",
+  async (key, prop) => {
+    const integerValue: PdfValue = { type: "integer", value: 0 };
+    const dict = makeInfoDict([[key, integerValue]]);
+    const result = await DocumentInfoParser.parse(
+      makeTrailerWithInfo(makeRef(2)),
+      makeResolverWithInfo(dict),
+    );
+    const { metadata, warnings } = unwrapOk(result);
+    expect(metadata[prop]).toBeUndefined();
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0].code).toBe("DATE_PARSE_FAILED");
+    expect(warnings[0].message).toContain(key);
+  },
+);
 
 const VALID_TRAPPED: ReadonlyArray<readonly ["True" | "False" | "Unknown"]> = [
   ["True"],

--- a/packages/core/src/document/metadata/document-info-parser/__tests__/document-info-parser.behavior.test.ts
+++ b/packages/core/src/document/metadata/document-info-parser/__tests__/document-info-parser.behavior.test.ts
@@ -98,23 +98,22 @@ const STRING_FIELDS = [
   ["Producer", "producer"],
 ] as const;
 
-test.each(STRING_FIELDS)(
-  "/%s が PdfString 以外 (PdfInteger) の場合 undefined + STRING_DECODE_FAILED",
-  async (key, prop) => {
-    const integerValue: PdfValue = { type: "integer", value: 42 };
-    const dict = makeInfoDict([[key, integerValue]]);
-    const result = await DocumentInfoParser.parse(
-      makeTrailerWithInfo(makeRef(2)),
-      makeResolverWithInfo(dict),
-    );
-    const { metadata, warnings } = unwrapOk(result);
-    expect(metadata[prop]).toBeUndefined();
-    expect(warnings).toHaveLength(1);
-    expect(warnings[0].code).toBe("STRING_DECODE_FAILED");
-    expect(warnings[0].message).toContain(key);
-    expect(warnings[0].message).toContain("integer");
-  },
-);
+test.each(
+  STRING_FIELDS,
+)("/%s が PdfString 以外 (PdfInteger) の場合 undefined + STRING_DECODE_FAILED", async (key, prop) => {
+  const integerValue: PdfValue = { type: "integer", value: 42 };
+  const dict = makeInfoDict([[key, integerValue]]);
+  const result = await DocumentInfoParser.parse(
+    makeTrailerWithInfo(makeRef(2)),
+    makeResolverWithInfo(dict),
+  );
+  const { metadata, warnings } = unwrapOk(result);
+  expect(metadata[prop]).toBeUndefined();
+  expect(warnings).toHaveLength(1);
+  expect(warnings[0].code).toBe("STRING_DECODE_FAILED");
+  expect(warnings[0].message).toContain(key);
+  expect(warnings[0].message).toContain("integer");
+});
 
 test("/CreationDate が D:20230615120530+09'00' の場合 UTC 換算 Date が抽出される", async () => {
   const dict = makeInfoDict([
@@ -162,22 +161,21 @@ const DATE_FIELDS = [
   ["ModDate", "modDate"],
 ] as const;
 
-test.each(DATE_FIELDS)(
-  "/%s が PdfString 以外 (PdfInteger) の場合 undefined + DATE_PARSE_FAILED",
-  async (key, prop) => {
-    const integerValue: PdfValue = { type: "integer", value: 0 };
-    const dict = makeInfoDict([[key, integerValue]]);
-    const result = await DocumentInfoParser.parse(
-      makeTrailerWithInfo(makeRef(2)),
-      makeResolverWithInfo(dict),
-    );
-    const { metadata, warnings } = unwrapOk(result);
-    expect(metadata[prop]).toBeUndefined();
-    expect(warnings).toHaveLength(1);
-    expect(warnings[0].code).toBe("DATE_PARSE_FAILED");
-    expect(warnings[0].message).toContain(key);
-  },
-);
+test.each(
+  DATE_FIELDS,
+)("/%s が PdfString 以外 (PdfInteger) の場合 undefined + DATE_PARSE_FAILED", async (key, prop) => {
+  const integerValue: PdfValue = { type: "integer", value: 0 };
+  const dict = makeInfoDict([[key, integerValue]]);
+  const result = await DocumentInfoParser.parse(
+    makeTrailerWithInfo(makeRef(2)),
+    makeResolverWithInfo(dict),
+  );
+  const { metadata, warnings } = unwrapOk(result);
+  expect(metadata[prop]).toBeUndefined();
+  expect(warnings).toHaveLength(1);
+  expect(warnings[0].code).toBe("DATE_PARSE_FAILED");
+  expect(warnings[0].message).toContain(key);
+});
 
 const VALID_TRAPPED: ReadonlyArray<readonly ["True" | "False" | "Unknown"]> = [
   ["True"],

--- a/packages/core/src/document/metadata/document-metadata/__tests__/document-metadata.error.test.ts
+++ b/packages/core/src/document/metadata/document-metadata/__tests__/document-metadata.error.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, test } from "vitest";
 import type { PdfWarning } from "../../../../pdf/errors/warning/index";
+import { GenerationNumber } from "../../../../pdf/types/generation-number/index";
+import { ObjectNumber } from "../../../../pdf/types/object-number/index";
 import type { PdfValue } from "../../../../pdf/types/pdf-types/index";
 import { parseTrappedName, summarizePdfValue } from "../../document-metadata";
 
@@ -13,14 +15,22 @@ describe("summarizePdfValue", () => {
     [{ type: "integer", value: 42 } as PdfValue, "42"],
     [{ type: "real", value: 3.14 } as PdfValue, "3.14"],
     [
-      { type: "string", value: new Uint8Array([0x41]), encoding: "literal" } as PdfValue,
+      {
+        type: "string",
+        value: new Uint8Array([0x41]),
+        encoding: "literal",
+      } as PdfValue,
       "<bytes len=1 enc=literal>",
     ],
     [{ type: "name", value: "Helvetica" } as PdfValue, "'Helvetica'"],
     [{ type: "array", elements: [] } as PdfValue, "<array length=0>"],
     [{ type: "dictionary", entries: new Map() } as PdfValue, "<dict size=0>"],
     [
-      { type: "indirect-ref", objectNumber: 1 as any, generationNumber: 0 as any } as PdfValue,
+      {
+        type: "indirect-ref",
+        objectNumber: ObjectNumber.of(1),
+        generationNumber: GenerationNumber.of(0),
+      } as PdfValue,
       "<ref 1 0>",
     ],
   ])("summarizePdfValue(%o) -> %s", (value, expected) => {
@@ -99,10 +109,18 @@ describe("parseTrappedName", () => {
     ["null", { type: "null" } as PdfValue, "null"],
     ["real", { type: "real", value: 3.14 } as PdfValue, "3.14"],
     ["array", { type: "array", elements: [] } as PdfValue, "<array length=0>"],
-    ["dictionary", { type: "dictionary", entries: new Map() } as PdfValue, "<dict size=0>"],
+    [
+      "dictionary",
+      { type: "dictionary", entries: new Map() } as PdfValue,
+      "<dict size=0>",
+    ],
     [
       "indirect-ref",
-      { type: "indirect-ref", objectNumber: 1 as any, generationNumber: 0 as any } as PdfValue,
+      {
+        type: "indirect-ref",
+        objectNumber: ObjectNumber.of(1),
+        generationNumber: GenerationNumber.of(0),
+      } as PdfValue,
       "<ref 1 0>",
     ],
   ])("/Trapped が %s のとき undefined + TRAPPED_INVALID（メッセージに type と値要約を含む）", (type, value, expectedSubstr) => {

--- a/packages/core/src/document/metadata/document-metadata/__tests__/document-metadata.error.test.ts
+++ b/packages/core/src/document/metadata/document-metadata/__tests__/document-metadata.error.test.ts
@@ -1,72 +1,117 @@
-import { expect, test } from "vitest";
+import { describe, expect, test } from "vitest";
 import type { PdfWarning } from "../../../../pdf/errors/warning/index";
 import type { PdfValue } from "../../../../pdf/types/pdf-types/index";
-import { parseTrappedName } from "../../document-metadata";
+import { parseTrappedName, summarizePdfValue } from "../../document-metadata";
 
 const makeName = (value: string): PdfValue => ({ type: "name", value });
 
-test("/Trapped Name 'Yes' は undefined + TRAPPED_INVALID", () => {
-  const warnings: PdfWarning[] = [];
-  const result = parseTrappedName(makeName("Yes"), warnings);
-  expect(result).toBeUndefined();
-  expect(warnings).toHaveLength(1);
-  expect(warnings[0].code).toBe("TRAPPED_INVALID");
+describe("summarizePdfValue", () => {
+  test.each([
+    [{ type: "null" } as PdfValue, "null"],
+    [{ type: "boolean", value: true } as PdfValue, "true"],
+    [{ type: "boolean", value: false } as PdfValue, "false"],
+    [{ type: "integer", value: 42 } as PdfValue, "42"],
+    [{ type: "real", value: 3.14 } as PdfValue, "3.14"],
+    [
+      { type: "string", value: new Uint8Array([0x41]), encoding: "literal" } as PdfValue,
+      "<bytes len=1 enc=literal>",
+    ],
+    [{ type: "name", value: "Helvetica" } as PdfValue, "'Helvetica'"],
+    [{ type: "array", elements: [] } as PdfValue, "<array length=0>"],
+    [{ type: "dictionary", entries: new Map() } as PdfValue, "<dict size=0>"],
+    [
+      { type: "indirect-ref", objectNumber: 1 as any, generationNumber: 0 as any } as PdfValue,
+      "<ref 1 0>",
+    ],
+  ])("summarizePdfValue(%o) -> %s", (value, expected) => {
+    expect(summarizePdfValue(value)).toBe(expected);
+  });
 });
 
-test.each([
-  ["true"],
-  ["false"],
-  ["unknown"],
-])("/Trapped Name '%s' (小文字) は undefined + TRAPPED_INVALID（大文字小文字を区別する）", (lowercase) => {
-  const warnings: PdfWarning[] = [];
-  const result = parseTrappedName(makeName(lowercase), warnings);
-  expect(result).toBeUndefined();
-  expect(warnings).toHaveLength(1);
-  expect(warnings[0].code).toBe("TRAPPED_INVALID");
-});
+describe("parseTrappedName", () => {
+  test("/Trapped Name 'Yes' は undefined + TRAPPED_INVALID", () => {
+    const warnings: PdfWarning[] = [];
+    const result = parseTrappedName(makeName("Yes"), warnings);
+    expect(result).toBeUndefined();
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0].code).toBe("TRAPPED_INVALID");
+  });
 
-test("/Trapped Name '' (空文字) は undefined + TRAPPED_INVALID", () => {
-  const warnings: PdfWarning[] = [];
-  const result = parseTrappedName(makeName(""), warnings);
-  expect(result).toBeUndefined();
-  expect(warnings).toHaveLength(1);
-  expect(warnings[0].code).toBe("TRAPPED_INVALID");
-});
+  test.each([
+    ["true"],
+    ["false"],
+    ["unknown"],
+  ])("/Trapped Name '%s' (小文字) は undefined + TRAPPED_INVALID（大文字小文字を区別する）", (lowercase) => {
+    const warnings: PdfWarning[] = [];
+    const result = parseTrappedName(makeName(lowercase), warnings);
+    expect(result).toBeUndefined();
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0].code).toBe("TRAPPED_INVALID");
+  });
 
-test("/Trapped が PdfString のとき undefined + TRAPPED_INVALID（メッセージに type と値要約を含む）", () => {
-  const warnings: PdfWarning[] = [];
-  const stringValue: PdfValue = {
-    type: "string",
-    value: new Uint8Array([0x54, 0x72, 0x75, 0x65]),
-    encoding: "literal",
-  };
-  const result = parseTrappedName(stringValue, warnings);
-  expect(result).toBeUndefined();
-  expect(warnings).toHaveLength(1);
-  expect(warnings[0].code).toBe("TRAPPED_INVALID");
-  expect(warnings[0].message).toContain("string");
-  expect(warnings[0].message).toContain("len=4");
-  expect(warnings[0].message).toContain("enc=literal");
-});
+  test("/Trapped Name '' (空文字) は undefined + TRAPPED_INVALID", () => {
+    const warnings: PdfWarning[] = [];
+    const result = parseTrappedName(makeName(""), warnings);
+    expect(result).toBeUndefined();
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0].code).toBe("TRAPPED_INVALID");
+  });
 
-test("/Trapped が PdfBoolean のとき undefined + TRAPPED_INVALID（メッセージに type と値を含む）", () => {
-  const warnings: PdfWarning[] = [];
-  const boolValue: PdfValue = { type: "boolean", value: true };
-  const result = parseTrappedName(boolValue, warnings);
-  expect(result).toBeUndefined();
-  expect(warnings).toHaveLength(1);
-  expect(warnings[0].code).toBe("TRAPPED_INVALID");
-  expect(warnings[0].message).toContain("boolean");
-  expect(warnings[0].message).toContain("true");
-});
+  test("/Trapped が PdfString のとき undefined + TRAPPED_INVALID（メッセージに type と値要約を含む）", () => {
+    const warnings: PdfWarning[] = [];
+    const stringValue: PdfValue = {
+      type: "string",
+      value: new Uint8Array([0x54, 0x72, 0x75, 0x65]),
+      encoding: "literal",
+    };
+    const result = parseTrappedName(stringValue, warnings);
+    expect(result).toBeUndefined();
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0].code).toBe("TRAPPED_INVALID");
+    expect(warnings[0].message).toContain("string");
+    expect(warnings[0].message).toContain("len=4");
+    expect(warnings[0].message).toContain("enc=literal");
+  });
 
-test("/Trapped が PdfInteger のとき undefined + TRAPPED_INVALID（メッセージに type と値を含む）", () => {
-  const warnings: PdfWarning[] = [];
-  const intValue: PdfValue = { type: "integer", value: 1 };
-  const result = parseTrappedName(intValue, warnings);
-  expect(result).toBeUndefined();
-  expect(warnings).toHaveLength(1);
-  expect(warnings[0].code).toBe("TRAPPED_INVALID");
-  expect(warnings[0].message).toContain("integer");
-  expect(warnings[0].message).toContain("1");
+  test("/Trapped が PdfBoolean のとき undefined + TRAPPED_INVALID（メッセージに type と値を含む）", () => {
+    const warnings: PdfWarning[] = [];
+    const boolValue: PdfValue = { type: "boolean", value: true };
+    const result = parseTrappedName(boolValue, warnings);
+    expect(result).toBeUndefined();
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0].code).toBe("TRAPPED_INVALID");
+    expect(warnings[0].message).toContain("boolean");
+    expect(warnings[0].message).toContain("true");
+  });
+
+  test("/Trapped が PdfInteger のとき undefined + TRAPPED_INVALID（メッセージに type と値を含む）", () => {
+    const warnings: PdfWarning[] = [];
+    const intValue: PdfValue = { type: "integer", value: 1 };
+    const result = parseTrappedName(intValue, warnings);
+    expect(result).toBeUndefined();
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0].code).toBe("TRAPPED_INVALID");
+    expect(warnings[0].message).toContain("integer");
+    expect(warnings[0].message).toContain("1");
+  });
+
+  test.each([
+    ["null", { type: "null" } as PdfValue, "null"],
+    ["real", { type: "real", value: 3.14 } as PdfValue, "3.14"],
+    ["array", { type: "array", elements: [] } as PdfValue, "<array length=0>"],
+    ["dictionary", { type: "dictionary", entries: new Map() } as PdfValue, "<dict size=0>"],
+    [
+      "indirect-ref",
+      { type: "indirect-ref", objectNumber: 1 as any, generationNumber: 0 as any } as PdfValue,
+      "<ref 1 0>",
+    ],
+  ])("/Trapped が %s のとき undefined + TRAPPED_INVALID（メッセージに type と値要約を含む）", (type, value, expectedSubstr) => {
+    const warnings: PdfWarning[] = [];
+    const result = parseTrappedName(value, warnings);
+    expect(result).toBeUndefined();
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0].code).toBe("TRAPPED_INVALID");
+    expect(warnings[0].message).toContain(type);
+    expect(warnings[0].message).toContain(expectedSubstr);
+  });
 });

--- a/packages/core/src/document/metadata/document-metadata/index.ts
+++ b/packages/core/src/document/metadata/document-metadata/index.ts
@@ -40,7 +40,7 @@ export { PdfTrapped };
  * @param value - 要約対象の PdfValue
  * @returns 値の種別ごとの簡潔な文字列表現
  */
-const summarizePdfValue = (value: PdfValue): string => {
+export const summarizePdfValue = (value: PdfValue): string => {
   switch (value.type) {
     case "null":
       return "null";


### PR DESCRIPTION
## 概要
Issue #503 に基づき、`packages/core/src/document/metadata/document-metadata/index.ts` の `summarizePdfValue` の未到達型分岐および `/Info` 辞書メタデータパーサーにおける非文字列型受領時警告テストを拡充しました。

## 変更内容
1. **`summarizePdfValue` の `export` 追加と単体テスト**
   - `summarizePdfValue` を `export` して `null`, `boolean`, `integer`, `real`, `string`, `name`, `array`, `dictionary`, `indirect-ref` の全 9 分岐に対する単体テストを `document-metadata.error.test.ts` に追加。
   - `parseTrappedName` 経由での非 Name 型受領時（`null`, `real`, `array`, `dictionary`, `indirect-ref`）の `TRAPPED_INVALID` 警告テストを拡充。

2. **`/Info` 辞書非文字列フィールドの警告テスト拡充**
   - `document-info-parser.behavior.test.ts` において、`Title`, `Author`, `Subject`, `Keywords`, `Creator`, `Producer` の非 `string` 受領時 `STRING_DECODE_FAILED` 警告テストを `test.each` で追加。
   - `CreationDate`, `ModDate` の非 `string` 受領時 `DATE_PARSE_FAILED` 警告テストを `test.each` で追加。

Closes #503