### PR TITLE
✨ [New Feature]: #485 破線パターンを表す DashPattern 型 + companion を追加

### DIFF
--- a/packages/core/src/content-stream/graphics-state/dash-pattern/__tests__/dash-pattern.basic.test.ts
+++ b/packages/core/src/content-stream/graphics-state/dash-pattern/__tests__/dash-pattern.basic.test.ts
@@ -1,0 +1,35 @@
+import { expect, test } from "vitest";
+import { DashPattern } from "../../dash-pattern";
+
+test("DashPattern.solid() は array が空配列で phase が 0", () => {
+  expect(DashPattern.solid()).toEqual({ array: [], phase: 0 });
+});
+
+test("DashPattern.create([], 0) は空配列と phase を保持する", () => {
+  expect(DashPattern.create([], 0)).toEqual({ array: [], phase: 0 });
+});
+
+test("DashPattern.create は複数要素の array と phase を保持する", () => {
+  expect(DashPattern.create([2, 1, 4, 3], 5)).toEqual({
+    array: [2, 1, 4, 3],
+    phase: 5,
+  });
+});
+
+test("DashPattern.create の array は引数と別配列参照", () => {
+  const source = [2, 1];
+  expect(DashPattern.create(source, 0).array).not.toBe(source);
+});
+
+test("引数の配列を後から変更しても DashPattern.array は変化しない", () => {
+  const source = [2, 1];
+  const pattern = DashPattern.create(source, 0);
+  source.push(4, 3);
+  expect(pattern.array).toEqual([2, 1]);
+});
+
+test("solid() は共有配列を返さない (array を変更しても次の solid() は空配列)", () => {
+  const leaked = DashPattern.solid().array as number[];
+  leaked.push(2, 1);
+  expect(DashPattern.solid()).toEqual({ array: [], phase: 0 });
+});

--- a/packages/core/src/content-stream/graphics-state/dash-pattern/index.ts
+++ b/packages/core/src/content-stream/graphics-state/dash-pattern/index.ts
@@ -25,7 +25,7 @@ export type DashPattern = Brand<DashPatternFields, typeof DashPatternBrand>;
 export const DashPattern = {
   /**
    * 破線なし (solid line) を表す `DashPattern` を返す。
-   * graphics state の初期値 `[[] 0]` に対応する。
+   * graphics state の初期値 (`[] 0 d` 相当) に対応する。
    *
    * 参照同一性 (singleton かどうか) は API 契約にしない。
    * 呼び出し側は `toEqual` で構造比較すること (`toBe` / `not.toBe` を assert しない)。

--- a/packages/core/src/content-stream/graphics-state/dash-pattern/index.ts
+++ b/packages/core/src/content-stream/graphics-state/dash-pattern/index.ts
@@ -17,7 +17,8 @@ type DashPatternFields = {
  * (`Object.freeze` はしないため実行時に強制されるわけではない)。
  *
  * 値の検証 (負値 / `NaN` / `Infinity` / 奇数長 / 全要素 0 など) はここでは行わない。
- * operand の型検証も、値の妥当性検証も operator handler 層 (`d` handler) の責務。
+ * operand の型検証は operator handler 層 (`d` handler) が担う。
+ * 値の妥当性検証をどの層で行うかは未確定であり、上位層の方針に従う。
  */
 export type DashPattern = Brand<DashPatternFields, typeof DashPatternBrand>;
 

--- a/packages/core/src/content-stream/graphics-state/dash-pattern/index.ts
+++ b/packages/core/src/content-stream/graphics-state/dash-pattern/index.ts
@@ -1,0 +1,59 @@
+import type { Brand } from "../../../utils/brand/index";
+
+declare const DashPatternBrand: unique symbol;
+
+type DashPatternFields = {
+  readonly array: ReadonlyArray<number>;
+  readonly phase: number;
+};
+
+/**
+ * PDF content stream の dash pattern setting operator (`d`) が設定する
+ * 破線パターン (ISO 32000-1:2008 §8.4.3.6)。
+ *
+ * `array` は dash の on / off 長を交互に並べた列で、空配列は solid line を表す。
+ * `phase` はパターン内の開始オフセット。
+ * フィールドは型上 readonly であり、直接 mutate してはならない
+ * (`Object.freeze` はしないため実行時に強制されるわけではない)。
+ *
+ * 値の検証 (負値 / `NaN` / `Infinity` / 奇数長 / 全要素 0 など) はここでは行わない。
+ * operand の型検証も、値の妥当性検証も operator handler 層 (`d` handler) の責務。
+ */
+export type DashPattern = Brand<DashPatternFields, typeof DashPatternBrand>;
+
+export const DashPattern = {
+  /**
+   * 破線なし (solid line) を表す `DashPattern` を返す。
+   * graphics state の初期値 `[[] 0]` に対応する。
+   *
+   * 参照同一性 (singleton かどうか) は API 契約にしない。
+   * 呼び出し側は `toEqual` で構造比較すること (`toBe` / `not.toBe` を assert しない)。
+   *
+   * ただし **共有された mutable 配列は返さない**ことは契約とする。
+   * 実行時 freeze をしないため、共有配列を返すと呼び出し側の mutate が
+   * 以降のすべての呼び出し元へ波及してしまう。
+   *
+   * @returns `array` が空配列、`phase` が 0 の `DashPattern`
+   */
+  solid(): DashPattern {
+    return { array: [], phase: 0 } as unknown as DashPattern;
+  },
+  /**
+   * `array` と `phase` を保持する `DashPattern` を生成する。
+   *
+   * `array` は `[...array]` でコピーして保持する。
+   * これにより呼び出し側が元配列を後から変更しても、
+   * 生成済み `DashPattern` の `array` は影響を受けない
+   * (保証するのは「入力配列の後続 mutate からの隔離」であり、
+   * 返却後の `array` が実行時に freeze されるわけではない)。
+   *
+   * 値の検証は行わず、渡された値をそのまま保持する。
+   *
+   * @param array - dash の on / off 長を交互に並べた列。空配列は solid line を表す
+   * @param phase - パターン内の開始オフセット
+   * @returns `array` のコピーと `phase` を保持する `DashPattern`
+   */
+  create(array: ReadonlyArray<number>, phase: number): DashPattern {
+    return { array: [...array], phase } as unknown as DashPattern;
+  },
+} as const;


### PR DESCRIPTION
## 概要

PDF content stream の `d` operator（ISO 32000-1:2008 §8.4.3.6, dash pattern setting）が扱う破線パターンを表す値オブジェクトが `packages/core` に存在しなかったため、Brand 型 `DashPattern` と同名 companion object を先行して追加しました。

後続タスク（`GraphicsState` への `dashPattern` フィールド追加 / `dHandler` 実装 / operator 登録）の土台となる新規 2 ファイルの追加のみで、**既存ファイルの変更は 0 件**です。そのため本 PR 時点で `DashPattern` はどこからも import されない未接続モジュールになりますが、これは計画上意図した状態です。

## 変更内容

### 🎯 変更の種類

- [x] ✨ 新機能 (New feature)
- [x] 🚨 テスト追加/修正 (Tests)

### 📝 詳細な変更内容

#### 追加された機能・修正

- Brand 型 `DashPattern`（`readonly array: ReadonlyArray<number>` / `readonly phase: number`）
- `DashPattern.solid()` — 破線なし（solid line）を表す `{ array: [], phase: 0 }` をリテラルで直接返す（`create()` へ委譲しない）
- `DashPattern.create(array, phase)` — `array` を `[...array]` で防御的コピーして保持し、`phase` は素通しで保持する
- 単体テスト 6 件（デフォルト値 / 代表値保持 / 防御的コピー / プリセット汚染耐性）

#### 変更されたファイル

- `packages/core/src/content-stream/graphics-state/dash-pattern/index.ts` [NEW]
- `packages/core/src/content-stream/graphics-state/dash-pattern/__tests__/dash-pattern.basic.test.ts` [NEW]

既存ファイルの差分は 0 件です（`graphics-state/index.ts` バレル、`GraphicsState`、`graphics-state-operators` はいずれも未変更）。

#### 削除されたファイル・機能

- なし

## 📊 システム図

### 状態マシン / フロー図

```mermaid
flowchart TD
    UC1["UC-1: GraphicsState.create()<br/>引数なし（デフォルト要求）"] --> Solid["DashPattern.solid()<br/>リテラルを直接返す"]:::new
    UC2["UC-2: dHandler（後続タスク）<br/>array + phase を渡す"] --> Create["DashPattern.create(array, phase)<br/>検証なし・array は防御的コピー"]:::new

    Solid --> Brand["Brand 付与<br/>（実行時プロパティは array / phase のみ）"]:::new
    Create --> Brand

    Brand --> RO["READONLY（型上のみ）<br/>書き換え API なし / freeze はしない"]:::new

    RO --> Read["array / phase を読み取る"]
    RO --> GS["GraphicsState への格納<br/>（タスク2: スコープ外）"]:::out

    Mut["呼び出し元が元配列を後から mutate"] -.->|"別配列なので影響なし"| RO

    classDef new fill:#ffe4b5,stroke:#d97706,stroke-width:2px
    classDef out fill:#eeeeee,stroke:#999999,stroke-dasharray: 4 3
```

### データフロー

```
【UC-2: d operator からの生成（将来の全体像）】

PDF content stream  "[2 1] 0 d"
    ↓
Tokenizer → OperandStack                        ... 既存
    ↓ pop
dHandler (operand 型検証・PdfArray → number[])  ... タスク3 / 本PRのスコープ外
    ↓ array: ReadonlyArray<number>, phase: number
┌───────────────────────────────────────────┐
│ DashPattern.create(array, phase)          │  [NEW] ← 本PRの実装範囲
│   ├─ [...array]  防御的コピー（O(n)）      │
│   ├─ phase        素通し（検証なし）        │
│   └─ Brand 付与                            │
└───────────────────┬───────────────────────┘
                    ↓
              DashPattern 値
                    ↓
        GraphicsState.update(...)               ... タスク2 / 本PRのスコープ外


【依存方向（本PRの追加分）】

dash-pattern/index.ts
    └── import type { Brand } from "../../../utils/brand/index"   ← これのみ

（dash-pattern を import する他モジュールは存在しない = 逆依存ゼロ）
```

## 📋 関連 Issue

- Refs #485（タスク1 のみ / 親 Epic #483）

Issue #485 のうち本 PR で扱うのはタスク1（型 + companion の追加）だけで、タスク2〜6 は未着手のため Close しません。

## 🧪 テスト

### テスト実行方法

```bash
pnpm --filter @pdfmod/core test
pnpm lint
pnpm typecheck
pnpm --filter @pdfmod/core build
pnpm test:run --coverage
```

### テスト項目

- [x] 単体テスト (Unit tests)
- [x] 手動テスト (Manual testing)

統合テストは `dHandler` が未実装で統合先が存在しないため、Issue #485 のタスク6 に委ねています。

### テスト結果

| 検証 | 結果 |
|:-|:-|
| `pnpm --filter @pdfmod/core test` | ✅ 282 files / 3517 tests passed |
| `pnpm lint`（biome + oxlint） | ✅ 0 warnings / 0 errors |
| `pnpm typecheck` | ✅ core / react とも成功 |
| `pnpm --filter @pdfmod/core build` | ✅ 成功（`dist/.../dash-pattern/index.d.ts` の生成を確認） |
| `dash-pattern/index.ts` カバレッジ | ✅ 100%（Stmts / Branch / Funcs / Lines） |

Codex CLI によるコードレビューも実施し、指摘 0 件（「問題なし」）でした。

## 🔍 レビューポイント

- **`as unknown as DashPattern` の二段キャスト**: プロジェクトのコーディング規約は二段アサーションを禁止していますが、Brand 型で構造的型付けを封じるための必要悪として、`CurrentPath` / `Matrix` など graphics-state 配下の既存モジュールと同じ手法を踏襲しています。
- **値オブジェクト層で入力検証をしない設計**: 負値・`NaN`・`Infinity`・奇数長・空配列をすべて素通しで保持し、`Result` / `Option` を返しません。`Color` / `lineWidthHandler` の既存 JSDoc に明記された層責務に一致させています。
- **テスト粒度を意図的に絞っている点**: `phase` の値網羅、`NaN` / `Infinity` / 奇数長、`solid()` の singleton 性、型エラー入力は、トートロジー / 言語保証のテストになるため書いていません。
- **未接続モジュールであること**: バレルへの re-export も意図的に行っていません（バレル非掲載は `path-segment` の前例に倣った判断です）。

## ⚠️ 破壊的変更

- [ ] この変更は既存の API に破壊的変更を含みます

新規ファイル 2 件の追加のみで、既存の公開 API に影響はありません。

## 📚 追加情報

### 参考資料

- ISO 32000-1:2008 §8.4.3.6（dash pattern setting）

### 注意事項

- **値の妥当性検証の責務が本 PR では宙に浮いています**。ISO 32000-1:2008 §8.4.3.6 では dash array の負値・全要素 0 はエラー扱いですが、`DashPattern` はこれらを素通しします。**型**検証（`PdfArray` か / 要素が numeric か）は Issue #485 のタスク3 `dHandler` の受け入れ基準に明記されている一方、**値**の妥当性検証（負値 / 全要素 0 / 奇数長）はどのタスクの DoD にも紐づいていません。タスク3 の計画時に「値の妥当性をどこで弾くか（`dHandler` で弾く / レンダリング層まで持ち越す）」を決める必要があります。
- `solid()` の参照同一性は API 契約にしていません（`CurrentPath.empty()` / `Matrix.identity()` に倣い singleton 化していません）。ただし「共有された mutable 配列は返さない」ことは契約とし、テストで退行を検知しています。

## ✅ チェックリスト

- [x] コードレビューの準備ができている
- [x] テストが正常に実行される
- [x] ドキュメントが更新されている（必要に応じて）
- [x] コミットメッセージが適切な形式で書かれている
- [x] PR 本文に `Refs #485` で Issue が記載されている
- [x] セルフレビューを実施した
- [x] 破壊的変更がある場合は明記されている（該当なし）

## 🤝 レビュアーへのお願い

- 値オブジェクト層で入力検証を行わないという責務分担が、既存の `Color` / `lineWidthHandler` の方針と整合しているかご確認ください。
- 「注意事項」に記載した**値の妥当性検証の置き場所**（後続タスクへの申し送り）について、方針のご意見をいただけると助かります。

🤖 Generated with [Claude Code](https://claude.com/claude-code)