### PR TITLE
✨ [New Feature]: #485 GraphicsState に DashPattern を統合しバレルから re-export

### DIFF
--- a/packages/core/src/content-stream/graphics-state/graphics-state/__tests__/graphics-state.basic.test.ts
+++ b/packages/core/src/content-stream/graphics-state/graphics-state/__tests__/graphics-state.basic.test.ts
@@ -3,6 +3,7 @@ import {
   Color,
   ColorSpace,
   CurrentPath,
+  DashPattern,
   GraphicsState,
   LineCap,
   LineJoin,
@@ -20,6 +21,7 @@ test("createはPDF仕様準拠のデフォルト値を返す", () => {
     lineCap: LineCap.create(0),
     lineJoin: LineJoin.create(0),
     miterLimit: 10.0,
+    dashPattern: DashPattern.solid(),
     currentPath: CurrentPath.empty(),
     strokeColor: Color.defaultBlack(),
     fillColor: Color.defaultBlack(),
@@ -43,6 +45,7 @@ test("updateは未指定フィールドを保持する", () => {
   expect(updated.lineCap).toBe(state.lineCap);
   expect(updated.lineJoin).toBe(state.lineJoin);
   expect(updated.miterLimit).toBe(state.miterLimit);
+  expect(updated.dashPattern).toBe(state.dashPattern);
   expect(updated.currentPath).toBe(state.currentPath);
 });
 
@@ -63,6 +66,7 @@ test.each([
   ["lineCap", { lineCap: LineCap.create(1) }],
   ["lineJoin", { lineJoin: LineJoin.create(2) }],
   ["miterLimit", { miterLimit: 5.0 }],
+  ["dashPattern", { dashPattern: DashPattern.create([2, 1], 0) }],
   ["ctm", { ctm: Matrix.create(2, 0, 0, 2, 0, 0) }],
   [
     "currentPath",
@@ -115,6 +119,7 @@ test("updateはundefinedの明示指定で既存フィールドを壊さない",
     CurrentPath.empty(),
     PathSegment.moveTo(1, 2),
   );
+  const dashPattern = DashPattern.create([2, 1], 0);
   const strokeColor = Color.rgb(1, 0, 0);
   const fillColor = Color.cmyk(0, 1, 1, 0);
   const strokeColorSpace = ColorSpace.deviceRGB();
@@ -124,6 +129,7 @@ test("updateはundefinedの明示指定で既存フィールドを壊さない",
   const state = GraphicsState.update(GraphicsState.create(), {
     lineWidth: 2.0,
     miterLimit: 5.0,
+    dashPattern,
     currentPath: path,
     strokeColor,
     fillColor,
@@ -135,6 +141,7 @@ test("updateはundefinedの明示指定で既存フィールドを壊さない",
   const updated = GraphicsState.update(state, {
     lineWidth: undefined,
     miterLimit: undefined,
+    dashPattern: undefined,
     currentPath: undefined,
     strokeColor: undefined,
     fillColor: undefined,
@@ -145,6 +152,7 @@ test("updateはundefinedの明示指定で既存フィールドを壊さない",
   });
   expect(updated.lineWidth).toBe(2.0);
   expect(updated.miterLimit).toBe(5.0);
+  expect(updated.dashPattern).toEqual(dashPattern);
   expect(updated.currentPath).toBe(path);
   expect(updated.strokeColor).toBe(strokeColor);
   expect(updated.fillColor).toBe(fillColor);

--- a/packages/core/src/content-stream/graphics-state/graphics-state/index.ts
+++ b/packages/core/src/content-stream/graphics-state/graphics-state/index.ts
@@ -46,7 +46,7 @@ export const GraphicsState = {
    *   lineCap          = 0 (Butt)
    *   lineJoin         = 0 (Miter)
    *   miterLimit       = 10.0
-   *   dashPattern      = solid()
+   *   dashPattern      = DashPattern.solid()
    *   currentPath      = empty()
    *   strokeColor      = defaultBlack (DeviceGray gray=0)
    *   fillColor        = defaultBlack (DeviceGray gray=0)

--- a/packages/core/src/content-stream/graphics-state/graphics-state/index.ts
+++ b/packages/core/src/content-stream/graphics-state/graphics-state/index.ts
@@ -2,6 +2,7 @@ import type { Brand } from "../../../utils/brand/index";
 import { Color } from "../color";
 import { ColorSpace } from "../color-space";
 import { CurrentPath } from "../current-path";
+import { DashPattern } from "../dash-pattern";
 import { LineCap } from "../line-cap";
 import { LineJoin } from "../line-join";
 import { Matrix } from "../matrix";
@@ -16,6 +17,7 @@ type GraphicsStateFields = {
   readonly lineCap: LineCap;
   readonly lineJoin: LineJoin;
   readonly miterLimit: number;
+  readonly dashPattern: DashPattern;
   readonly currentPath: CurrentPath;
   readonly strokeColor: Color;
   readonly fillColor: Color;
@@ -44,6 +46,7 @@ export const GraphicsState = {
    *   lineCap          = 0 (Butt)
    *   lineJoin         = 0 (Miter)
    *   miterLimit       = 10.0
+   *   dashPattern      = solid()
    *   currentPath      = empty()
    *   strokeColor      = defaultBlack (DeviceGray gray=0)
    *   fillColor        = defaultBlack (DeviceGray gray=0)
@@ -61,6 +64,7 @@ export const GraphicsState = {
       lineCap: LineCap.create(0),
       lineJoin: LineJoin.create(0),
       miterLimit: 10.0,
+      dashPattern: DashPattern.solid(),
       currentPath: CurrentPath.empty(),
       strokeColor: Color.defaultBlack(),
       fillColor: Color.defaultBlack(),
@@ -91,6 +95,10 @@ export const GraphicsState = {
         partial.miterLimit !== undefined
           ? partial.miterLimit
           : state.miterLimit,
+      dashPattern:
+        partial.dashPattern !== undefined
+          ? partial.dashPattern
+          : state.dashPattern,
       currentPath:
         partial.currentPath !== undefined
           ? partial.currentPath

--- a/packages/core/src/content-stream/graphics-state/index.ts
+++ b/packages/core/src/content-stream/graphics-state/index.ts
@@ -7,6 +7,7 @@
 export { Color } from "./color";
 export { ColorSpace } from "./color-space";
 export { CurrentPath } from "./current-path";
+export { DashPattern } from "./dash-pattern";
 export { GraphicsState } from "./graphics-state";
 export { LineCap } from "./line-cap";
 export { LineJoin } from "./line-join";


### PR DESCRIPTION
## 概要

ISO 32000-1:2008 §8.4.3.6 準拠の破線パターン (`DashPattern`) を `GraphicsState` に統合し、状態の初期化・非破壊更新および外部バレルからのアクセスを可能にしました。

## 変更内容

### 🎯 変更の種類

- [x] ✨ 新機能 (New feature)
- [x] 🚨 テスト追加/修正 (Tests)

### 📝 詳細な変更内容

#### 追加された機能・修正
- `GraphicsStateFields` に `readonly dashPattern: DashPattern` を追加
- `GraphicsState.create()` の初期値として `dashPattern: DashPattern.solid()` (`[] 0 d` 相当) を設定
- `GraphicsState.update()` に `dashPattern` のマージ・未指定時および `undefined` 明示指定時の保持ロジックを追加
- `packages/core/src/content-stream/graphics-state/index.ts` から `DashPattern` 型およびコンパニオンオブジェクトを re-export

#### 変更されたファイル
- `packages/core/src/content-stream/graphics-state/graphics-state/index.ts`
- `packages/core/src/content-stream/graphics-state/index.ts`
- `packages/core/src/content-stream/graphics-state/graphics-state/__tests__/graphics-state.basic.test.ts`

## 📊 システム図

### データフロー

```mermaid
flowchart TD
    Init[GraphicsState.create] -->|dashPattern: DashPattern.solid| State[GraphicsState Instance]
    Operator[d handler] -->|DashPattern.create| Update[GraphicsState.update]
    State --> Update
    Update -->|dashPattern: partial.dashPattern| NextState[New GraphicsState Instance]
    NextState --> Stack[GraphicsStateStack]
```

## 📋 関連 Issue

- Refs #485

## 🧪 テスト

### テスト実行方法

```bash
npx vitest run packages/core/src/content-stream/graphics-state/graphics-state/__tests__/graphics-state.basic.test.ts
pnpm --filter @pdfmod/core test
```

### テスト項目

- [x] 単体テスト (Unit tests)

### テスト結果

- `graphics-state.basic.test.ts` 22件のテスト全パス
- `@pdfmod/core` 全282ファイル / 3,539件のテスト全パス
- Biome check / Oxlint 0エラー0警告

## 🔍 レビューポイント

- プロジェクトの単体テスト規約（`describe` 不使用、`test.each` / `test` フラット構造）への準拠
- `GraphicsState.update()` での非破壊性および `undefined` 明示指定時の不変保持

## ✅ チェックリスト

- [x] コードレビューの準備ができている
- [x] テストが正常に実行される
- [x] コミットメッセージが適切な形式で書かれている (`✨ [New Feature]`, `🧪 [Tests]`)
- [x] PR 本文に Issue 参照 (`Refs #485`) が記載されている
- [x] セルフレビューを実施した