### PR TITLE
✨ [New Feature]: #485 d (dash pattern) operator handler を実装

### DIFF
--- a/packages/core/src/content-stream/operators/graphics-state/d/__tests__/d.basic.test.ts
+++ b/packages/core/src/content-stream/operators/graphics-state/d/__tests__/d.basic.test.ts
@@ -1,0 +1,117 @@
+import { assert, expect, test } from "vitest";
+import type { PdfObject } from "../../../../../pdf/types/pdf-types/index";
+import {
+  DashPattern,
+  GraphicsStateStack,
+} from "../../../../graphics-state/index";
+import { MarkedContentStack } from "../../../../marked-content/stack";
+import { OperandStack } from "../../../../operand-stack/index";
+import type { OperatorHandlerContext } from "../../../../operator-registry/index";
+import { dHandler } from "../index";
+
+const buildContext = (operands: PdfObject[]): OperatorHandlerContext => {
+  const operandStack = OperandStack.create();
+  for (const operand of operands) {
+    OperandStack.push(operandStack, operand);
+  }
+  return {
+    operandStack,
+    graphicsStateStack: GraphicsStateStack.create(),
+    markedContentStack: MarkedContentStack.create(),
+  };
+};
+
+test("`[3 2] 11 d` 相当の operand で dashPattern が更新される", () => {
+  const ctx = buildContext([
+    {
+      type: "array",
+      elements: [
+        { type: "integer", value: 3 },
+        { type: "integer", value: 2 },
+      ],
+    },
+    { type: "integer", value: 11 },
+  ]);
+
+  const result = dHandler(ctx);
+
+  assert(result.ok);
+  const current = GraphicsStateStack.current(result.value.graphicsStateStack);
+  expect(current.dashPattern).toEqual(DashPattern.create([3, 2], 11));
+});
+
+test("`[1.5 2] 0.5 d` 相当の real 混在 operand で dashPattern が更新される", () => {
+  const ctx = buildContext([
+    {
+      type: "array",
+      elements: [
+        { type: "real", value: 1.5 },
+        { type: "integer", value: 2 },
+      ],
+    },
+    { type: "real", value: 0.5 },
+  ]);
+
+  const result = dHandler(ctx);
+
+  assert(result.ok);
+  const current = GraphicsStateStack.current(result.value.graphicsStateStack);
+  expect(current.dashPattern).toEqual(DashPattern.create([1.5, 2], 0.5));
+});
+
+test("`[3] 11 d` 相当の単一要素配列でも dashPattern が更新される", () => {
+  const ctx = buildContext([
+    { type: "array", elements: [{ type: "integer", value: 3 }] },
+    { type: "integer", value: 11 },
+  ]);
+
+  const result = dHandler(ctx);
+
+  assert(result.ok);
+  const current = GraphicsStateStack.current(result.value.graphicsStateStack);
+  expect(current.dashPattern).toEqual(DashPattern.create([3], 11));
+});
+
+test("成功時に operand 2 個が消費され operand stack が空になる", () => {
+  const ctx = buildContext([
+    { type: "array", elements: [{ type: "integer", value: 3 }] },
+    { type: "integer", value: 11 },
+  ]);
+
+  const result = dHandler(ctx);
+
+  assert(result.ok);
+  expect(OperandStack.depth(result.value.operandStack)).toBe(0);
+});
+
+test("成功時に operandStack / markedContentStack は同一参照、graphicsStateStack は新参照を返す", () => {
+  const ctx = buildContext([
+    { type: "array", elements: [{ type: "integer", value: 3 }] },
+    { type: "integer", value: 11 },
+  ]);
+
+  const result = dHandler(ctx);
+
+  assert(result.ok);
+  expect(result.value.operandStack).toBe(ctx.operandStack);
+  expect(result.value.markedContentStack).toBe(ctx.markedContentStack);
+  expect(result.value.graphicsStateStack).not.toBe(ctx.graphicsStateStack);
+});
+
+test("dashPattern 更新後も lineWidth/lineCap/lineJoin/miterLimit/ctm は不変", () => {
+  const ctx = buildContext([
+    { type: "array", elements: [{ type: "integer", value: 3 }] },
+    { type: "integer", value: 11 },
+  ]);
+  const before = GraphicsStateStack.current(ctx.graphicsStateStack);
+
+  const result = dHandler(ctx);
+
+  assert(result.ok);
+  const after = GraphicsStateStack.current(result.value.graphicsStateStack);
+  expect(after.lineWidth).toBe(before.lineWidth);
+  expect(after.lineCap).toBe(before.lineCap);
+  expect(after.lineJoin).toBe(before.lineJoin);
+  expect(after.miterLimit).toBe(before.miterLimit);
+  expect(after.ctm).toEqual(before.ctm);
+});

--- a/packages/core/src/content-stream/operators/graphics-state/d/__tests__/d.error.test.ts
+++ b/packages/core/src/content-stream/operators/graphics-state/d/__tests__/d.error.test.ts
@@ -1,0 +1,172 @@
+import { assert, expect, test } from "vitest";
+import type { PdfObject } from "../../../../../pdf/types/pdf-types/index";
+import { GraphicsStateStack } from "../../../../graphics-state/index";
+import { MarkedContentStack } from "../../../../marked-content/stack";
+import { OperandStack } from "../../../../operand-stack/index";
+import type { OperatorHandlerContext } from "../../../../operator-registry/index";
+import { dHandler } from "../index";
+
+const buildContext = (operands: PdfObject[]): OperatorHandlerContext => {
+  const operandStack = OperandStack.create();
+  for (const operand of operands) {
+    OperandStack.push(operandStack, operand);
+  }
+  return {
+    operandStack,
+    graphicsStateStack: GraphicsStateStack.create(),
+    markedContentStack: MarkedContentStack.create(),
+  };
+};
+
+test("operand stack が空のとき OPERATOR_OPERAND_MISSING (got 0) を返す", () => {
+  const ctx = buildContext([]);
+
+  const result = dHandler(ctx);
+
+  assert(!result.ok);
+  assert(result.error.code === "OPERATOR_OPERAND_MISSING");
+  expect(result.error.message).toBe(
+    "Operator 'd' requires 2 operand(s), got 0",
+  );
+  expect(result.error.operatorName).toBe("d");
+  expect(result.error.required).toBe(2);
+  expect(result.error.actual).toBe(0);
+});
+
+test("phase が name 型のとき OPERATOR_OPERAND_TYPE_MISMATCH (expected number) を返す", () => {
+  const ctx = buildContext([
+    { type: "array", elements: [{ type: "integer", value: 3 }] },
+    { type: "name", value: "Foo" },
+  ]);
+
+  const result = dHandler(ctx);
+
+  assert(!result.ok);
+  assert(result.error.code === "OPERATOR_OPERAND_TYPE_MISMATCH");
+  expect(result.error.message).toBe(
+    "Operator 'd' expected number operand, got name",
+  );
+  expect(result.error.operatorName).toBe("d");
+  expect(result.error.expected).toBe("number");
+  expect(result.error.actual).toBe("name");
+});
+
+test("operand 1 個のみでそれが配列のとき phase の型 mismatch (got array) になる", () => {
+  const ctx = buildContext([
+    {
+      type: "array",
+      elements: [
+        { type: "integer", value: 3 },
+        { type: "integer", value: 2 },
+      ],
+    },
+  ]);
+
+  const result = dHandler(ctx);
+
+  assert(!result.ok);
+  assert(result.error.code === "OPERATOR_OPERAND_TYPE_MISMATCH");
+  expect(result.error.message).toBe(
+    "Operator 'd' expected number operand, got array",
+  );
+  expect(result.error.operatorName).toBe("d");
+  expect(result.error.expected).toBe("number");
+  expect(result.error.actual).toBe("array");
+});
+
+test("dashArray 位置が integer のとき OPERATOR_OPERAND_TYPE_MISMATCH (expected array) を返す", () => {
+  const ctx = buildContext([
+    { type: "integer", value: 3 },
+    { type: "integer", value: 11 },
+  ]);
+
+  const result = dHandler(ctx);
+
+  assert(!result.ok);
+  assert(result.error.code === "OPERATOR_OPERAND_TYPE_MISMATCH");
+  expect(result.error.message).toBe(
+    "Operator 'd' expected array operand, got integer",
+  );
+  expect(result.error.operatorName).toBe("d");
+  expect(result.error.expected).toBe("array");
+  expect(result.error.actual).toBe("integer");
+});
+
+test("operand が phase 相当の 1 個のみのとき OPERATOR_OPERAND_MISSING (got 1) を返す", () => {
+  const ctx = buildContext([{ type: "integer", value: 11 }]);
+
+  const result = dHandler(ctx);
+
+  assert(!result.ok);
+  assert(result.error.code === "OPERATOR_OPERAND_MISSING");
+  expect(result.error.message).toBe(
+    "Operator 'd' requires 2 operand(s), got 1",
+  );
+  expect(result.error.operatorName).toBe("d");
+  expect(result.error.required).toBe(2);
+  expect(result.error.actual).toBe(1);
+});
+
+test("配列要素の先頭 (index 0) が name のとき index 付き OPERATOR_OPERAND_TYPE_MISMATCH を返す", () => {
+  const ctx = buildContext([
+    { type: "array", elements: [{ type: "name", value: "Foo" }] },
+    { type: "integer", value: 11 },
+  ]);
+
+  const result = dHandler(ctx);
+
+  assert(!result.ok);
+  assert(result.error.code === "OPERATOR_OPERAND_TYPE_MISMATCH");
+  expect(result.error.message).toBe(
+    "Operator 'd' expected number array element, got name at index 0",
+  );
+  expect(result.error.operatorName).toBe("d");
+  expect(result.error.expected).toBe("number");
+  expect(result.error.actual).toBe("name");
+});
+
+test("配列要素の途中 (index 1) が string のとき index 付き OPERATOR_OPERAND_TYPE_MISMATCH を返す", () => {
+  const ctx = buildContext([
+    {
+      type: "array",
+      elements: [
+        { type: "integer", value: 3 },
+        { type: "string", value: new Uint8Array([0x78]), encoding: "literal" },
+        { type: "integer", value: 2 },
+      ],
+    },
+    { type: "integer", value: 11 },
+  ]);
+
+  const result = dHandler(ctx);
+
+  assert(!result.ok);
+  assert(result.error.code === "OPERATOR_OPERAND_TYPE_MISMATCH");
+  expect(result.error.message).toBe(
+    "Operator 'd' expected number array element, got string at index 1",
+  );
+  expect(result.error.operatorName).toBe("d");
+  expect(result.error.expected).toBe("number");
+  expect(result.error.actual).toBe("string");
+});
+
+test("dashArray 不足 (MISSING got 1) エラー後も phase は積み戻されず operand stack は空のまま", () => {
+  const ctx = buildContext([{ type: "integer", value: 11 }]);
+
+  const result = dHandler(ctx);
+
+  assert(!result.ok);
+  expect(OperandStack.depth(ctx.operandStack)).toBe(0);
+});
+
+test("配列要素 mismatch エラー後も phase / dashArray は消費されたまま operand stack は空のまま", () => {
+  const ctx = buildContext([
+    { type: "array", elements: [{ type: "name", value: "Foo" }] },
+    { type: "integer", value: 11 },
+  ]);
+
+  const result = dHandler(ctx);
+
+  assert(!result.ok);
+  expect(OperandStack.depth(ctx.operandStack)).toBe(0);
+});

--- a/packages/core/src/content-stream/operators/graphics-state/d/__tests__/d.solid.test.ts
+++ b/packages/core/src/content-stream/operators/graphics-state/d/__tests__/d.solid.test.ts
@@ -1,0 +1,48 @@
+import { assert, expect, test } from "vitest";
+import type { PdfObject } from "../../../../../pdf/types/pdf-types/index";
+import {
+  DashPattern,
+  GraphicsStateStack,
+} from "../../../../graphics-state/index";
+import { MarkedContentStack } from "../../../../marked-content/stack";
+import { OperandStack } from "../../../../operand-stack/index";
+import type { OperatorHandlerContext } from "../../../../operator-registry/index";
+import { dHandler } from "../index";
+
+const buildContext = (operands: PdfObject[]): OperatorHandlerContext => {
+  const operandStack = OperandStack.create();
+  for (const operand of operands) {
+    OperandStack.push(operandStack, operand);
+  }
+  return {
+    operandStack,
+    graphicsStateStack: GraphicsStateStack.create(),
+    markedContentStack: MarkedContentStack.create(),
+  };
+};
+
+test("`[] 0 d` 相当の operand で dashPattern が solid に戻る", () => {
+  const ctx = buildContext([
+    { type: "array", elements: [] },
+    { type: "integer", value: 0 },
+  ]);
+
+  const result = dHandler(ctx);
+
+  assert(result.ok);
+  const current = GraphicsStateStack.current(result.value.graphicsStateStack);
+  expect(current.dashPattern).toEqual(DashPattern.solid());
+});
+
+test("`[] 5 d` 相当の空配列 + 非ゼロ phase では phase がそのまま保持される", () => {
+  const ctx = buildContext([
+    { type: "array", elements: [] },
+    { type: "integer", value: 5 },
+  ]);
+
+  const result = dHandler(ctx);
+
+  assert(result.ok);
+  const current = GraphicsStateStack.current(result.value.graphicsStateStack);
+  expect(current.dashPattern).toEqual(DashPattern.create([], 5));
+});

--- a/packages/core/src/content-stream/operators/graphics-state/d/index.ts
+++ b/packages/core/src/content-stream/operators/graphics-state/d/index.ts
@@ -1,0 +1,119 @@
+import type { PdfError } from "../../../../pdf/errors/index";
+import { err, ok } from "../../../../utils/result/index";
+import {
+  DashPattern,
+  GraphicsState,
+  GraphicsStateStack,
+} from "../../../graphics-state/index";
+import { OperandStack } from "../../../operand-stack/index";
+import type {
+  OperatorHandler,
+  OperatorHandlerContext,
+} from "../../../operator-registry/index";
+import { NumericPdfObject } from "../numeric-pdf-object/index";
+
+/** PDF 表記を保持した operator 名（"d"）。 */
+const OPERATOR_NAME = "d";
+
+/** `d` operator が要求する operand 数（dashArray dashPhase）。 */
+const OPERAND_COUNT = 2;
+
+/**
+ * PDF §8.4.3.6 `d` operator (line dash pattern) のハンドラ。
+ * operand stack から LIFO 順で dashPhase（数値）→ dashArray（配列）を pop し、
+ * current GraphicsState の `dashPattern` を更新する。
+ *
+ * 検査順序:
+ *   (1) phase pop（none なら `OPERATOR_OPERAND_MISSING`, got 0）
+ *   (2) phase numeric 検査（`OPERATOR_OPERAND_TYPE_MISMATCH`, expected "number"）
+ *   (3) dashArray pop（none なら `OPERATOR_OPERAND_MISSING`, got 1）
+ *   (4) top-level 型検査（type !== "array" なら expected "array"）
+ *   (5) 要素走査（numeric 以外なら expected "number"、message に index を含める）
+ *
+ * - 空配列 `[] 0 d` は solid line（`DashPattern.solid()` と構造的同値）になる
+ * - 値域検証（負値 / 全ゼロ / NaN / Infinity）は本 handler のスコープ外
+ *   （別 issue で validator 化。w / M handler と同方針）
+ * - エラー時に operand stack の部分消費は復元しない（既存ハンドラ規約）
+ *
+ * @param context - 実行コンテキスト (operand stack / graphics state stack)
+ * @returns 成功なら更新後コンテキスト、失敗なら PdfError
+ */
+export const dHandler: OperatorHandler = (context: OperatorHandlerContext) => {
+  const poppedPhase = OperandStack.pop(context.operandStack);
+  if (!poppedPhase.some) {
+    const error: PdfError = {
+      code: "OPERATOR_OPERAND_MISSING",
+      message: `Operator '${OPERATOR_NAME}' requires ${OPERAND_COUNT} operand(s), got 0`,
+      operatorName: OPERATOR_NAME,
+      required: OPERAND_COUNT,
+      actual: 0,
+    };
+    return err(error);
+  }
+
+  const phase = poppedPhase.value;
+  if (!NumericPdfObject.is(phase)) {
+    const error: PdfError = {
+      code: "OPERATOR_OPERAND_TYPE_MISMATCH",
+      message: `Operator '${OPERATOR_NAME}' expected number operand, got ${phase.type}`,
+      operatorName: OPERATOR_NAME,
+      expected: "number",
+      actual: phase.type,
+    };
+    return err(error);
+  }
+
+  const poppedArray = OperandStack.pop(context.operandStack);
+  if (!poppedArray.some) {
+    const error: PdfError = {
+      code: "OPERATOR_OPERAND_MISSING",
+      message: `Operator '${OPERATOR_NAME}' requires ${OPERAND_COUNT} operand(s), got 1`,
+      operatorName: OPERATOR_NAME,
+      required: OPERAND_COUNT,
+      actual: 1,
+    };
+    return err(error);
+  }
+
+  const dashArray = poppedArray.value;
+  if (dashArray.type !== "array") {
+    const error: PdfError = {
+      code: "OPERATOR_OPERAND_TYPE_MISMATCH",
+      message: `Operator '${OPERATOR_NAME}' expected array operand, got ${dashArray.type}`,
+      operatorName: OPERATOR_NAME,
+      expected: "array",
+      actual: dashArray.type,
+    };
+    return err(error);
+  }
+
+  const numbers: number[] = [];
+  for (let i = 0; i < dashArray.elements.length; i++) {
+    const element = dashArray.elements[i];
+    if (!NumericPdfObject.is(element)) {
+      const error: PdfError = {
+        code: "OPERATOR_OPERAND_TYPE_MISMATCH",
+        message: `Operator '${OPERATOR_NAME}' expected number array element, got ${element.type} at index ${i}`,
+        operatorName: OPERATOR_NAME,
+        expected: "number",
+        actual: element.type,
+      };
+      return err(error);
+    }
+    numbers.push(element.value);
+  }
+
+  const dashPattern = DashPattern.create(numbers, phase.value);
+  const current = GraphicsStateStack.current(context.graphicsStateStack);
+  const next = GraphicsState.update(current, { dashPattern });
+  const graphicsStateStack = GraphicsStateStack.replaceCurrent(
+    context.graphicsStateStack,
+    next,
+  );
+
+  return ok({
+    operandStack: context.operandStack,
+    graphicsStateStack,
+    markedContentStack: context.markedContentStack,
+  });
+};

--- a/packages/core/src/content-stream/operators/graphics-state/graphics-state-operators/__tests__/graphics-state-operators.basic.test.ts
+++ b/packages/core/src/content-stream/operators/graphics-state/graphics-state-operators/__tests__/graphics-state-operators.basic.test.ts
@@ -8,6 +8,7 @@ test.each([
   ["J"],
   ["j"],
   ["M"],
+  ["d"],
   ["q"],
   ["Q"],
 ])("registerGraphicsStateOperators は %s を登録する", (name) => {

--- a/packages/core/src/content-stream/operators/graphics-state/graphics-state-operators/__tests__/graphics-state-operators.integration.test.ts
+++ b/packages/core/src/content-stream/operators/graphics-state/graphics-state-operators/__tests__/graphics-state-operators.integration.test.ts
@@ -1,5 +1,6 @@
 import { assert, expect, test } from "vitest";
 import {
+  DashPattern,
   GraphicsState,
   GraphicsStateStack,
   Matrix,
@@ -57,6 +58,22 @@ test("3 段ネスト `q 2 w q 3 w q 4 w Q Q Q` で初期状態に復帰する", 
     result.value.context.graphicsStateStack,
   );
   expect(current).toEqual(GraphicsState.create());
+});
+
+test("barrel 経由で `[3 2] 11 d` を実行すると dashPattern が更新される", () => {
+  const registered = registerGraphicsStateOperators(OperatorRegistry.create());
+  assert(registered.ok);
+
+  const result = ContentStreamInterpreter.execute({
+    data: encode("[3 2] 11 d"),
+    registry: registered.value,
+  });
+
+  assert(result.ok);
+  const current = GraphicsStateStack.current(
+    result.value.context.graphicsStateStack,
+  );
+  expect(current.dashPattern).toEqual(DashPattern.create([3, 2], 11));
 });
 
 test("unbalanced Q を interpreter 経由で実行しても ok で継続する", () => {

--- a/packages/core/src/content-stream/operators/graphics-state/graphics-state-operators/index.ts
+++ b/packages/core/src/content-stream/operators/graphics-state/graphics-state-operators/index.ts
@@ -4,6 +4,7 @@ import { flatMap, ok } from "../../../../utils/result/index";
 import type { OperatorHandler } from "../../../operator-registry/index";
 import { OperatorRegistry } from "../../../operator-registry/index";
 import { cmHandler } from "../cm";
+import { dHandler } from "../d";
 import { lineCapHandler } from "../line-cap-handler";
 import { lineJoinHandler } from "../line-join-handler";
 import { lineWidthHandler } from "../line-width-handler";
@@ -12,6 +13,7 @@ import { qHandler } from "../q";
 import { qRestoreHandler } from "../q-restore";
 
 export { cmHandler } from "../cm";
+export { dHandler } from "../d";
 export { lineCapHandler } from "../line-cap-handler";
 export { lineJoinHandler } from "../line-join-handler";
 export { lineWidthHandler } from "../line-width-handler";
@@ -27,12 +29,13 @@ const GRAPHICS_STATE_OPERATORS: ReadonlyArray<
   ["J", lineCapHandler],
   ["j", lineJoinHandler],
   ["M", miterLimitHandler],
+  ["d", dHandler],
   ["q", qHandler],
   ["Q", qRestoreHandler],
 ];
 
 /**
- * Graphics State operator (cm / w / J / j / M / q / Q) を OperatorRegistry に
+ * Graphics State operator (cm / w / J / j / M / d / q / Q) を OperatorRegistry に
  * 一括登録するヘルパ。
  *
  * fail-fast: いずれかの register が Err を返した時点で reduce 内 flatMap が

--- a/packages/core/src/document/metadata/document-metadata/__tests__/document-metadata.error.test.ts
+++ b/packages/core/src/document/metadata/document-metadata/__tests__/document-metadata.error.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test } from "vitest";
+import { expect, test } from "vitest";
 import type { PdfWarning } from "../../../../pdf/errors/warning/index";
 import { GenerationNumber } from "../../../../pdf/types/generation-number/index";
 import { ObjectNumber } from "../../../../pdf/types/object-number/index";
@@ -7,129 +7,125 @@ import { parseTrappedName, summarizePdfValue } from "../../document-metadata";
 
 const makeName = (value: string): PdfValue => ({ type: "name", value });
 
-describe("summarizePdfValue", () => {
-  test.each([
-    [{ type: "null" } as PdfValue, "null"],
-    [{ type: "boolean", value: true } as PdfValue, "true"],
-    [{ type: "boolean", value: false } as PdfValue, "false"],
-    [{ type: "integer", value: 42 } as PdfValue, "42"],
-    [{ type: "real", value: 3.14 } as PdfValue, "3.14"],
-    [
-      {
-        type: "string",
-        value: new Uint8Array([0x41]),
-        encoding: "literal",
-      } as PdfValue,
-      "<bytes len=1 enc=literal>",
-    ],
-    [{ type: "name", value: "Helvetica" } as PdfValue, "'Helvetica'"],
-    [{ type: "array", elements: [] } as PdfValue, "<array length=0>"],
-    [{ type: "dictionary", entries: new Map() } as PdfValue, "<dict size=0>"],
-    [
-      {
-        type: "indirect-ref",
-        objectNumber: ObjectNumber.of(1),
-        generationNumber: GenerationNumber.of(0),
-      } as PdfValue,
-      "<ref 1 0>",
-    ],
-  ])("summarizePdfValue(%o) -> %s", (value, expected) => {
-    expect(summarizePdfValue(value)).toBe(expected);
-  });
+test.each([
+  [{ type: "null" } as PdfValue, "null"],
+  [{ type: "boolean", value: true } as PdfValue, "true"],
+  [{ type: "boolean", value: false } as PdfValue, "false"],
+  [{ type: "integer", value: 42 } as PdfValue, "42"],
+  [{ type: "real", value: 3.14 } as PdfValue, "3.14"],
+  [
+    {
+      type: "string",
+      value: new Uint8Array([0x41]),
+      encoding: "literal",
+    } as PdfValue,
+    "<bytes len=1 enc=literal>",
+  ],
+  [{ type: "name", value: "Helvetica" } as PdfValue, "'Helvetica'"],
+  [{ type: "array", elements: [] } as PdfValue, "<array length=0>"],
+  [{ type: "dictionary", entries: new Map() } as PdfValue, "<dict size=0>"],
+  [
+    {
+      type: "indirect-ref",
+      objectNumber: ObjectNumber.of(1),
+      generationNumber: GenerationNumber.of(0),
+    } as PdfValue,
+    "<ref 1 0>",
+  ],
+])("summarizePdfValue(%o) -> %s", (value, expected) => {
+  expect(summarizePdfValue(value)).toBe(expected);
 });
 
-describe("parseTrappedName", () => {
-  test("/Trapped Name 'Yes' は undefined + TRAPPED_INVALID", () => {
-    const warnings: PdfWarning[] = [];
-    const result = parseTrappedName(makeName("Yes"), warnings);
-    expect(result).toBeUndefined();
-    expect(warnings).toHaveLength(1);
-    expect(warnings[0].code).toBe("TRAPPED_INVALID");
-  });
+test("/Trapped Name 'Yes' は undefined + TRAPPED_INVALID", () => {
+  const warnings: PdfWarning[] = [];
+  const result = parseTrappedName(makeName("Yes"), warnings);
+  expect(result).toBeUndefined();
+  expect(warnings).toHaveLength(1);
+  expect(warnings[0].code).toBe("TRAPPED_INVALID");
+});
 
-  test.each([
-    ["true"],
-    ["false"],
-    ["unknown"],
-  ])("/Trapped Name '%s' (小文字) は undefined + TRAPPED_INVALID（大文字小文字を区別する）", (lowercase) => {
-    const warnings: PdfWarning[] = [];
-    const result = parseTrappedName(makeName(lowercase), warnings);
-    expect(result).toBeUndefined();
-    expect(warnings).toHaveLength(1);
-    expect(warnings[0].code).toBe("TRAPPED_INVALID");
-  });
+test.each([
+  ["true"],
+  ["false"],
+  ["unknown"],
+])("/Trapped Name '%s' (小文字) は undefined + TRAPPED_INVALID（大文字小文字を区別する）", (lowercase) => {
+  const warnings: PdfWarning[] = [];
+  const result = parseTrappedName(makeName(lowercase), warnings);
+  expect(result).toBeUndefined();
+  expect(warnings).toHaveLength(1);
+  expect(warnings[0].code).toBe("TRAPPED_INVALID");
+});
 
-  test("/Trapped Name '' (空文字) は undefined + TRAPPED_INVALID", () => {
-    const warnings: PdfWarning[] = [];
-    const result = parseTrappedName(makeName(""), warnings);
-    expect(result).toBeUndefined();
-    expect(warnings).toHaveLength(1);
-    expect(warnings[0].code).toBe("TRAPPED_INVALID");
-  });
+test("/Trapped Name '' (空文字) は undefined + TRAPPED_INVALID", () => {
+  const warnings: PdfWarning[] = [];
+  const result = parseTrappedName(makeName(""), warnings);
+  expect(result).toBeUndefined();
+  expect(warnings).toHaveLength(1);
+  expect(warnings[0].code).toBe("TRAPPED_INVALID");
+});
 
-  test("/Trapped が PdfString のとき undefined + TRAPPED_INVALID（メッセージに type と値要約を含む）", () => {
-    const warnings: PdfWarning[] = [];
-    const stringValue: PdfValue = {
-      type: "string",
-      value: new Uint8Array([0x54, 0x72, 0x75, 0x65]),
-      encoding: "literal",
-    };
-    const result = parseTrappedName(stringValue, warnings);
-    expect(result).toBeUndefined();
-    expect(warnings).toHaveLength(1);
-    expect(warnings[0].code).toBe("TRAPPED_INVALID");
-    expect(warnings[0].message).toContain("string");
-    expect(warnings[0].message).toContain("len=4");
-    expect(warnings[0].message).toContain("enc=literal");
-  });
+test("/Trapped が PdfString のとき undefined + TRAPPED_INVALID（メッセージに type と値要約を含む）", () => {
+  const warnings: PdfWarning[] = [];
+  const stringValue: PdfValue = {
+    type: "string",
+    value: new Uint8Array([0x54, 0x72, 0x75, 0x65]),
+    encoding: "literal",
+  };
+  const result = parseTrappedName(stringValue, warnings);
+  expect(result).toBeUndefined();
+  expect(warnings).toHaveLength(1);
+  expect(warnings[0].code).toBe("TRAPPED_INVALID");
+  expect(warnings[0].message).toContain("string");
+  expect(warnings[0].message).toContain("len=4");
+  expect(warnings[0].message).toContain("enc=literal");
+});
 
-  test("/Trapped が PdfBoolean のとき undefined + TRAPPED_INVALID（メッセージに type と値を含む）", () => {
-    const warnings: PdfWarning[] = [];
-    const boolValue: PdfValue = { type: "boolean", value: true };
-    const result = parseTrappedName(boolValue, warnings);
-    expect(result).toBeUndefined();
-    expect(warnings).toHaveLength(1);
-    expect(warnings[0].code).toBe("TRAPPED_INVALID");
-    expect(warnings[0].message).toContain("boolean");
-    expect(warnings[0].message).toContain("true");
-  });
+test("/Trapped が PdfBoolean のとき undefined + TRAPPED_INVALID（メッセージに type と値を含む）", () => {
+  const warnings: PdfWarning[] = [];
+  const boolValue: PdfValue = { type: "boolean", value: true };
+  const result = parseTrappedName(boolValue, warnings);
+  expect(result).toBeUndefined();
+  expect(warnings).toHaveLength(1);
+  expect(warnings[0].code).toBe("TRAPPED_INVALID");
+  expect(warnings[0].message).toContain("boolean");
+  expect(warnings[0].message).toContain("true");
+});
 
-  test("/Trapped が PdfInteger のとき undefined + TRAPPED_INVALID（メッセージに type と値を含む）", () => {
-    const warnings: PdfWarning[] = [];
-    const intValue: PdfValue = { type: "integer", value: 1 };
-    const result = parseTrappedName(intValue, warnings);
-    expect(result).toBeUndefined();
-    expect(warnings).toHaveLength(1);
-    expect(warnings[0].code).toBe("TRAPPED_INVALID");
-    expect(warnings[0].message).toContain("integer");
-    expect(warnings[0].message).toContain("1");
-  });
+test("/Trapped が PdfInteger のとき undefined + TRAPPED_INVALID（メッセージに type と値を含む）", () => {
+  const warnings: PdfWarning[] = [];
+  const intValue: PdfValue = { type: "integer", value: 1 };
+  const result = parseTrappedName(intValue, warnings);
+  expect(result).toBeUndefined();
+  expect(warnings).toHaveLength(1);
+  expect(warnings[0].code).toBe("TRAPPED_INVALID");
+  expect(warnings[0].message).toContain("integer");
+  expect(warnings[0].message).toContain("1");
+});
 
-  test.each([
-    ["null", { type: "null" } as PdfValue, "null"],
-    ["real", { type: "real", value: 3.14 } as PdfValue, "3.14"],
-    ["array", { type: "array", elements: [] } as PdfValue, "<array length=0>"],
-    [
-      "dictionary",
-      { type: "dictionary", entries: new Map() } as PdfValue,
-      "<dict size=0>",
-    ],
-    [
-      "indirect-ref",
-      {
-        type: "indirect-ref",
-        objectNumber: ObjectNumber.of(1),
-        generationNumber: GenerationNumber.of(0),
-      } as PdfValue,
-      "<ref 1 0>",
-    ],
-  ])("/Trapped が %s のとき undefined + TRAPPED_INVALID（メッセージに type と値要約を含む）", (type, value, expectedSubstr) => {
-    const warnings: PdfWarning[] = [];
-    const result = parseTrappedName(value, warnings);
-    expect(result).toBeUndefined();
-    expect(warnings).toHaveLength(1);
-    expect(warnings[0].code).toBe("TRAPPED_INVALID");
-    expect(warnings[0].message).toContain(type);
-    expect(warnings[0].message).toContain(expectedSubstr);
-  });
+test.each([
+  ["null", { type: "null" } as PdfValue, "null"],
+  ["real", { type: "real", value: 3.14 } as PdfValue, "3.14"],
+  ["array", { type: "array", elements: [] } as PdfValue, "<array length=0>"],
+  [
+    "dictionary",
+    { type: "dictionary", entries: new Map() } as PdfValue,
+    "<dict size=0>",
+  ],
+  [
+    "indirect-ref",
+    {
+      type: "indirect-ref",
+      objectNumber: ObjectNumber.of(1),
+      generationNumber: GenerationNumber.of(0),
+    } as PdfValue,
+    "<ref 1 0>",
+  ],
+])("/Trapped が %s のとき undefined + TRAPPED_INVALID（メッセージに type と値要約を含む）", (type, value, expectedSubstr) => {
+  const warnings: PdfWarning[] = [];
+  const result = parseTrappedName(value, warnings);
+  expect(result).toBeUndefined();
+  expect(warnings).toHaveLength(1);
+  expect(warnings[0].code).toBe("TRAPPED_INVALID");
+  expect(warnings[0].message).toContain(type);
+  expect(warnings[0].message).toContain(expectedSubstr);
 });


### PR DESCRIPTION
## 概要

PDF コンテンツストリームの `d` operator（ISO 32000-1:2008 §8.4.3.6, line dash pattern）の handler を実装し、operand stack から `dashArray dashPhase` を消費して current `GraphicsState.dashPattern` を更新できるようにする。#466 で `PdfArray` を operand stack に積めるようになったため、本実装は初めて配列 operand を消費する graphics-state handler となる（DashPattern 型 #572 / GraphicsState 拡張 #573 は完了済み）。

## 変更内容

### 🎯 変更の種類

- [x] ✨ 新機能 (New feature)
- [x] 🚨 テスト追加/修正 (Tests)
- [x] ♻️ リファクタリング (Refactoring)

### 📝 詳細な変更内容

#### 追加された機能・修正

- `dHandler`: phase pop → numeric 検査 → dashArray pop → array 検査 → index 付き要素走査 → `DashPattern.create` → `GraphicsState.update` → `replaceCurrent`
- エラー 4 種（MISSING got 0 / got 1、phase 型 mismatch、array 型 mismatch、要素 mismatch + index 付き message）。エラー時の operand stack 部分消費は復元しない（既存ハンドラ規約）
- 値域検証（負値・全ゼロ・NaN/Infinity）はスコープ外（型チェックのみ。w / M handler と同方針、JSDoc に明記）
- `registerGraphicsStateOperators` へ `d` を登録・re-export、JSDoc 列挙を更新
- 既存 `document-metadata.error.test.ts` の describe 使用（テスト規約違反）をフラット構造へ修正（push 前フック検査対応、#485 とは独立の規約修正）

#### 変更されたファイル

- `packages/core/src/content-stream/operators/graphics-state/d/index.ts` [NEW]
- `packages/core/src/content-stream/operators/graphics-state/d/__tests__/d.basic.test.ts` [NEW]
- `packages/core/src/content-stream/operators/graphics-state/d/__tests__/d.solid.test.ts` [NEW]
- `packages/core/src/content-stream/operators/graphics-state/d/__tests__/d.error.test.ts` [NEW]
- `packages/core/src/content-stream/operators/graphics-state/graphics-state-operators/index.ts` [MODIFY]
- `packages/core/src/content-stream/operators/graphics-state/graphics-state-operators/__tests__/graphics-state-operators.basic.test.ts` [MODIFY]
- `packages/core/src/content-stream/operators/graphics-state/graphics-state-operators/__tests__/graphics-state-operators.integration.test.ts` [MODIFY]
- `packages/core/src/document/metadata/document-metadata/__tests__/document-metadata.error.test.ts` [MODIFY]

#### 削除されたファイル・機能

- なし

## 📊 システム図

### 状態マシン / フロー図

```mermaid
flowchart TD
    Start([dHandler 呼び出し]) --> PopPhase[phase を pop]:::new
    PopPhase -->|stack 空| ErrM0[err: MISSING got 0]:::err
    PopPhase --> CheckPhase[phase の numeric 検査]:::new
    CheckPhase -->|integer/real 以外| ErrT1[err: TYPE_MISMATCH expected number]:::err
    CheckPhase --> PopArray[dashArray を pop]:::new
    PopArray -->|stack 空| ErrM1[err: MISSING got 1<br>※部分消費は復元しない]:::err
    PopArray --> CheckArray[array 型検査]:::new
    CheckArray -->|array 以外| ErrT2[err: TYPE_MISMATCH expected array]:::err
    CheckArray --> Scan[要素を index 付きで走査し number 列へ変換]:::new
    Scan -->|numeric 以外の要素| ErrT3[err: TYPE_MISMATCH<br>got type at index i]:::err
    Scan -->|走査完了 空配列は即通過| Update[DashPattern.create → GraphicsState.update → replaceCurrent]:::new
    Update --> Ok([ok: 更新後コンテキスト])

    classDef new fill:#ffe4b5,stroke:#d97706,stroke-width:2px
    classDef err fill:#fecaca,stroke:#b91c1c
```

### データフロー

```
コンテンツストリーム bytes（例: "[3 2] 11 d"）
    ↓
ContentStreamInterpreter.execute（既存: 配列 operand を PdfArray として push）
    ↓
dHandler(context)  [NEW]
    ├─ OperandStack.pop ×2（phase → dashArray、LIFO）
    ├─ NumericPdfObject.is（phase / 各配列要素の型検査）
    ├─ DashPattern.create([3, 2], 11)  ※ 内部で配列コピー
    └─ GraphicsState.update → GraphicsStateStack.replaceCurrent
    ↓
GraphicsStateStack.current(...).dashPattern === { array: [3, 2], phase: 11 }
```

## 📋 関連 Issue

- Closes #485

## 🧪 テスト

### テスト実行方法

```bash
pnpm --filter @pdfmod/core test
```

### テスト項目

- [x] 単体テスト (Unit tests)
- [x] 統合テスト (Integration tests)

### テスト結果

- 全 3558 件 green（unit: basic 6 / solid 2 / error 9、登録 test.each、integration `[3 2] 11 d`）
- `pnpm --filter @pdfmod/core build` / `tsc --noEmit` / `pnpm lint`（biome + oxlint）通過

## 🔍 レビューポイント

- エラー優先順位: operand が 1 個だけでそれが配列の場合（`[3 2] d` = phase 欠落）、LIFO の逐次検査により MISSING ではなく phase の型 mismatch（got array）になる仕様（cm 等の既存 handler と同挙動、テストで固定）
- 配列要素 mismatch の message は `at index {i}` 付き（TJ の index なし message は踏襲せず string-decoder の前例に準拠）
- `document-metadata.error.test.ts` の修正は describe 除去のみでテスト内容・アサーションに変更なし

## ⚠️ 破壊的変更

- なし（`d` の追加は加法的変更のみ）

🤖 Generated with [Claude Code](https://claude.com/claude-code)