### PR TITLE
✨ [New Feature]: #486 ri (rendering intent) と i (flatness) operator handler を実装

### DIFF
--- a/packages/core/src/content-stream/graphics-state/graphics-state/__tests__/graphics-state.basic.test.ts
+++ b/packages/core/src/content-stream/graphics-state/graphics-state/__tests__/graphics-state.basic.test.ts
@@ -8,6 +8,7 @@ import {
   LineCap,
   LineJoin,
   Matrix,
+  RenderingIntent,
   TextObject,
   TextState,
 } from "../../index";
@@ -29,6 +30,8 @@ test("createはPDF仕様準拠のデフォルト値を返す", () => {
     fillColorSpace: ColorSpace.deviceGray(),
     textState: TextState.create(),
     textObject: TextObject.inactive(),
+    renderingIntent: RenderingIntent.create("RelativeColorimetric"),
+    flatness: 1.0,
   });
 });
 
@@ -47,6 +50,8 @@ test("updateは未指定フィールドを保持する", () => {
   expect(updated.miterLimit).toBe(state.miterLimit);
   expect(updated.dashPattern).toBe(state.dashPattern);
   expect(updated.currentPath).toBe(state.currentPath);
+  expect(updated.renderingIntent).toBe(state.renderingIntent);
+  expect(updated.flatness).toBe(state.flatness);
 });
 
 test("updateは元のstateを変更しない", () => {
@@ -86,6 +91,11 @@ test.each([
     { textState: TextState.update(TextState.create(), { charSpace: 2 }) },
   ],
   ["textObject", { textObject: TextObject.begin() }],
+  [
+    "renderingIntent",
+    { renderingIntent: RenderingIntent.create("AbsoluteColorimetric") },
+  ],
+  ["flatness", { flatness: 0.5 }],
   ["empty", {}],
 ] as const)("update(state, %s) は該当フィールドだけ書き換える", (_label, partial) => {
   const state = GraphicsState.create();
@@ -126,6 +136,8 @@ test("updateはundefinedの明示指定で既存フィールドを壊さない",
   const fillColorSpace = ColorSpace.deviceCMYK();
   const textState = TextState.update(TextState.create(), { charSpace: 2 });
   const textObject = TextObject.begin();
+  const renderingIntent = RenderingIntent.create("Perceptual");
+  const flatness = 0.8;
   const state = GraphicsState.update(GraphicsState.create(), {
     lineWidth: 2.0,
     miterLimit: 5.0,
@@ -137,6 +149,8 @@ test("updateはundefinedの明示指定で既存フィールドを壊さない",
     fillColorSpace,
     textState,
     textObject,
+    renderingIntent,
+    flatness,
   });
   const updated = GraphicsState.update(state, {
     lineWidth: undefined,
@@ -149,6 +163,8 @@ test("updateはundefinedの明示指定で既存フィールドを壊さない",
     fillColorSpace: undefined,
     textState: undefined,
     textObject: undefined,
+    renderingIntent: undefined,
+    flatness: undefined,
   });
   expect(updated.lineWidth).toBe(2.0);
   expect(updated.miterLimit).toBe(5.0);
@@ -160,4 +176,6 @@ test("updateはundefinedの明示指定で既存フィールドを壊さない",
   expect(updated.fillColorSpace).toBe(fillColorSpace);
   expect(updated.textState).toBe(textState);
   expect(updated.textObject).toBe(textObject);
+  expect(updated.renderingIntent).toBe(renderingIntent);
+  expect(updated.flatness).toBe(0.8);
 });

--- a/packages/core/src/content-stream/graphics-state/graphics-state/index.ts
+++ b/packages/core/src/content-stream/graphics-state/graphics-state/index.ts
@@ -6,6 +6,7 @@ import { DashPattern } from "../dash-pattern";
 import { LineCap } from "../line-cap";
 import { LineJoin } from "../line-join";
 import { Matrix } from "../matrix";
+import { RenderingIntent } from "../rendering-intent";
 import { TextObject } from "../text-object";
 import { TextState } from "../text-state";
 
@@ -25,6 +26,8 @@ type GraphicsStateFields = {
   readonly fillColorSpace: ColorSpace;
   readonly textState: TextState;
   readonly textObject: TextObject;
+  readonly renderingIntent: RenderingIntent;
+  readonly flatness: number;
 };
 
 /**
@@ -54,6 +57,8 @@ export const GraphicsState = {
    *   fillColorSpace   = DeviceGray
    *   textState        = TextState.create()
    *   textObject       = TextObject.inactive()
+   *   renderingIntent  = RelativeColorimetric
+   *   flatness         = 1.0
    *
    * @returns デフォルト値で初期化された GraphicsState
    */
@@ -72,6 +77,8 @@ export const GraphicsState = {
       fillColorSpace: ColorSpace.deviceGray(),
       textState: TextState.create(),
       textObject: TextObject.inactive(),
+      renderingIntent: RenderingIntent.create("RelativeColorimetric"),
+      flatness: 1.0,
     } as unknown as GraphicsState;
   },
 
@@ -123,6 +130,12 @@ export const GraphicsState = {
         partial.textObject !== undefined
           ? partial.textObject
           : state.textObject,
+      renderingIntent:
+        partial.renderingIntent !== undefined
+          ? partial.renderingIntent
+          : state.renderingIntent,
+      flatness:
+        partial.flatness !== undefined ? partial.flatness : state.flatness,
     } as unknown as GraphicsState;
   },
 } as const;

--- a/packages/core/src/content-stream/graphics-state/index.ts
+++ b/packages/core/src/content-stream/graphics-state/index.ts
@@ -12,6 +12,7 @@ export { GraphicsState } from "./graphics-state";
 export { LineCap } from "./line-cap";
 export { LineJoin } from "./line-join";
 export { Matrix } from "./matrix";
+export { RenderingIntent } from "./rendering-intent";
 export { GraphicsStateStack } from "./stack";
 export { TextObject } from "./text-object";
 export { TextRenderingMode } from "./text-rendering-mode";

--- a/packages/core/src/content-stream/graphics-state/rendering-intent/__tests__/rendering-intent.basic.test.ts
+++ b/packages/core/src/content-stream/graphics-state/rendering-intent/__tests__/rendering-intent.basic.test.ts
@@ -1,0 +1,12 @@
+import { expect, test } from "vitest";
+import { RenderingIntent } from "../index";
+
+test("create は渡された文字列を持つ RenderingIntent を生成する", () => {
+  const intent = RenderingIntent.create("RelativeColorimetric");
+  expect(intent).toBe("RelativeColorimetric");
+});
+
+test("create は任意の文字列を RenderingIntent として受け入れる", () => {
+  const custom = RenderingIntent.create("CustomIntent");
+  expect(custom).toBe("CustomIntent");
+});

--- a/packages/core/src/content-stream/graphics-state/rendering-intent/index.ts
+++ b/packages/core/src/content-stream/graphics-state/rendering-intent/index.ts
@@ -1,0 +1,22 @@
+import type { Brand } from "../../../utils/brand/index";
+
+declare const RenderingIntentBrand: unique symbol;
+
+/**
+ * ISO 32000-1:2008 §8.6.5.8 Rendering Intents.
+ * 標準的な値: "AbsoluteColorimetric", "RelativeColorimetric", "Saturation", "Perceptual"。
+ * 標準外の name にも対応するため string の Brand 型として表現する。
+ */
+export type RenderingIntent = Brand<string, typeof RenderingIntentBrand>;
+
+export const RenderingIntent = {
+  /**
+   * 文字列から RenderingIntent を生成する。
+   *
+   * @param name - rendering intent 名 (例: "RelativeColorimetric")
+   * @returns Brand 付き RenderingIntent
+   */
+  create(name: string): RenderingIntent {
+    return name as RenderingIntent;
+  },
+} as const;

--- a/packages/core/src/content-stream/operators/graphics-state/graphics-state-operators/__tests__/graphics-state-operators.basic.test.ts
+++ b/packages/core/src/content-stream/operators/graphics-state/graphics-state-operators/__tests__/graphics-state-operators.basic.test.ts
@@ -9,6 +9,8 @@ test.each([
   ["j"],
   ["M"],
   ["d"],
+  ["ri"],
+  ["i"],
   ["q"],
   ["Q"],
 ])("registerGraphicsStateOperators は %s を登録する", (name) => {

--- a/packages/core/src/content-stream/operators/graphics-state/graphics-state-operators/__tests__/graphics-state-operators.integration.test.ts
+++ b/packages/core/src/content-stream/operators/graphics-state/graphics-state-operators/__tests__/graphics-state-operators.integration.test.ts
@@ -91,3 +91,20 @@ test("unbalanced Q を interpreter 経由で実行しても ok で継続する",
   );
   expect(current).toEqual(GraphicsState.create());
 });
+
+test("barrel 経由で `/AbsoluteColorimetric ri 0.5 i` を実行すると renderingIntent と flatness が更新される", () => {
+  const registered = registerGraphicsStateOperators(OperatorRegistry.create());
+  assert(registered.ok);
+
+  const result = ContentStreamInterpreter.execute({
+    data: encode("/AbsoluteColorimetric ri 0.5 i"),
+    registry: registered.value,
+  });
+
+  assert(result.ok);
+  const current = GraphicsStateStack.current(
+    result.value.context.graphicsStateStack,
+  );
+  expect(current.renderingIntent).toBe("AbsoluteColorimetric");
+  expect(current.flatness).toBe(0.5);
+});

--- a/packages/core/src/content-stream/operators/graphics-state/graphics-state-operators/index.ts
+++ b/packages/core/src/content-stream/operators/graphics-state/graphics-state-operators/index.ts
@@ -5,21 +5,25 @@ import type { OperatorHandler } from "../../../operator-registry/index";
 import { OperatorRegistry } from "../../../operator-registry/index";
 import { cmHandler } from "../cm";
 import { dHandler } from "../d";
+import { flatnessHandler } from "../i";
 import { lineCapHandler } from "../line-cap-handler";
 import { lineJoinHandler } from "../line-join-handler";
 import { lineWidthHandler } from "../line-width-handler";
 import { miterLimitHandler } from "../miter-limit-handler";
 import { qHandler } from "../q";
 import { qRestoreHandler } from "../q-restore";
+import { riHandler } from "../ri";
 
 export { cmHandler } from "../cm";
 export { dHandler } from "../d";
+export { flatnessHandler } from "../i";
 export { lineCapHandler } from "../line-cap-handler";
 export { lineJoinHandler } from "../line-join-handler";
 export { lineWidthHandler } from "../line-width-handler";
 export { miterLimitHandler } from "../miter-limit-handler";
 export { qHandler } from "../q";
 export { qRestoreHandler } from "../q-restore";
+export { riHandler } from "../ri";
 
 const GRAPHICS_STATE_OPERATORS: ReadonlyArray<
   readonly [string, OperatorHandler]
@@ -30,12 +34,14 @@ const GRAPHICS_STATE_OPERATORS: ReadonlyArray<
   ["j", lineJoinHandler],
   ["M", miterLimitHandler],
   ["d", dHandler],
+  ["ri", riHandler],
+  ["i", flatnessHandler],
   ["q", qHandler],
   ["Q", qRestoreHandler],
 ];
 
 /**
- * Graphics State operator (cm / w / J / j / M / d / q / Q) を OperatorRegistry に
+ * Graphics State operator (cm / w / J / j / M / d / ri / i / q / Q) を OperatorRegistry に
  * 一括登録するヘルパ。
  *
  * fail-fast: いずれかの register が Err を返した時点で reduce 内 flatMap が

--- a/packages/core/src/content-stream/operators/graphics-state/i/__tests__/i.basic.test.ts
+++ b/packages/core/src/content-stream/operators/graphics-state/i/__tests__/i.basic.test.ts
@@ -1,0 +1,101 @@
+import { assert, expect, test } from "vitest";
+import type { PdfObject } from "../../../../../pdf/types/pdf-types/index";
+import { GraphicsStateStack } from "../../../../graphics-state/index";
+import { MarkedContentStack } from "../../../../marked-content/stack";
+import { OperandStack } from "../../../../operand-stack/index";
+import type { OperatorHandlerContext } from "../../../../operator-registry/index";
+import { flatnessHandler } from "../index";
+
+const buildContext = (operands: PdfObject[]): OperatorHandlerContext => {
+  const operandStack = OperandStack.create();
+  for (const operand of operands) {
+    OperandStack.push(operandStack, operand);
+  }
+  const graphicsStateStack = GraphicsStateStack.create();
+  return {
+    operandStack,
+    graphicsStateStack,
+    markedContentStack: MarkedContentStack.create(),
+  };
+};
+
+test("integer operand 5 で current flatness が 5 に更新される", () => {
+  const ctx = buildContext([{ type: "integer", value: 5 }]);
+
+  const result = flatnessHandler(ctx);
+
+  assert(result.ok);
+  const current = GraphicsStateStack.current(result.value.graphicsStateStack);
+  expect(current.flatness).toBe(5);
+});
+
+test("real operand 0.5 で current flatness が 0.5 に更新される", () => {
+  const ctx = buildContext([{ type: "real", value: 0.5 }]);
+
+  const result = flatnessHandler(ctx);
+
+  assert(result.ok);
+  const current = GraphicsStateStack.current(result.value.graphicsStateStack);
+  expect(current.flatness).toBe(0.5);
+});
+
+test.each([
+  {
+    label: "0",
+    operand: { type: "integer", value: 0 } as PdfObject,
+    expected: 0,
+  },
+  {
+    label: "100",
+    operand: { type: "integer", value: 100 } as PdfObject,
+    expected: 100,
+  },
+  {
+    label: "out of range (101)",
+    operand: { type: "real", value: 101.5 } as PdfObject,
+    expected: 101.5,
+  },
+  {
+    label: "negative (-1.0)",
+    operand: { type: "real", value: -1.0 } as PdfObject,
+    expected: -1.0,
+  },
+])("境界値 $label の operand も handler では検証せずそのまま GraphicsState に格納する", ({
+  operand,
+  expected,
+}) => {
+  const ctx = buildContext([operand]);
+
+  const result = flatnessHandler(ctx);
+
+  assert(result.ok);
+  const current = GraphicsStateStack.current(result.value.graphicsStateStack);
+  expect(current.flatness).toBe(expected);
+});
+
+test("operand stack に複数要素がある場合、成功時は末尾 1 つだけ pop し残りはそのまま", () => {
+  const head: PdfObject = { type: "integer", value: 99 };
+  const tail: PdfObject = { type: "real", value: 2.0 };
+  const ctx = buildContext([head, tail]);
+
+  const result = flatnessHandler(ctx);
+
+  assert(result.ok);
+  expect(OperandStack.depth(result.value.operandStack)).toBe(1);
+  const top = OperandStack.peek(result.value.operandStack);
+  assert(top.some);
+  expect(top.value).toEqual(head);
+});
+
+test("flatness 更新後も他の GraphicsState フィールドは不変", () => {
+  const ctx = buildContext([{ type: "real", value: 4.0 }]);
+  const before = GraphicsStateStack.current(ctx.graphicsStateStack);
+
+  const result = flatnessHandler(ctx);
+
+  assert(result.ok);
+  const after = GraphicsStateStack.current(result.value.graphicsStateStack);
+  expect(after.lineWidth).toBe(before.lineWidth);
+  expect(after.renderingIntent).toBe(before.renderingIntent);
+  expect(after.ctm).toEqual(before.ctm);
+});

--- a/packages/core/src/content-stream/operators/graphics-state/i/__tests__/i.error.test.ts
+++ b/packages/core/src/content-stream/operators/graphics-state/i/__tests__/i.error.test.ts
@@ -1,0 +1,76 @@
+import { assert, expect, test } from "vitest";
+import type { PdfObject } from "../../../../../pdf/types/pdf-types/index";
+import { GraphicsStateStack } from "../../../../graphics-state/index";
+import { MarkedContentStack } from "../../../../marked-content/stack";
+import { OperandStack } from "../../../../operand-stack/index";
+import type { OperatorHandlerContext } from "../../../../operator-registry/index";
+import { flatnessHandler } from "../index";
+
+const buildContext = (operands: PdfObject[]): OperatorHandlerContext => {
+  const operandStack = OperandStack.create();
+  for (const operand of operands) {
+    OperandStack.push(operandStack, operand);
+  }
+  const graphicsStateStack = GraphicsStateStack.create();
+  return {
+    operandStack,
+    graphicsStateStack,
+    markedContentStack: MarkedContentStack.create(),
+  };
+};
+
+test("空 operand stack では OPERATOR_OPERAND_MISSING を返す", () => {
+  const ctx = buildContext([]);
+
+  const result = flatnessHandler(ctx);
+
+  assert(!result.ok);
+  assert(result.error.code === "OPERATOR_OPERAND_MISSING");
+  expect(result.error.operatorName).toBe("i");
+  expect(result.error.required).toBe(1);
+  expect(result.error.actual).toBe(0);
+  expect(result.error.message).toBe(
+    "Operator 'i' requires 1 operand(s), got 0",
+  );
+});
+
+test.each([
+  {
+    type: "name" as const,
+    operand: { type: "name", value: "RelativeColorimetric" } as PdfObject,
+  },
+  {
+    type: "boolean" as const,
+    operand: { type: "boolean", value: false } as PdfObject,
+  },
+])("末尾が $type のとき OPERATOR_OPERAND_TYPE_MISMATCH を返す", ({
+  type,
+  operand,
+}) => {
+  const ctx = buildContext([operand]);
+
+  const result = flatnessHandler(ctx);
+
+  assert(!result.ok);
+  assert(result.error.code === "OPERATOR_OPERAND_TYPE_MISMATCH");
+  expect(result.error.operatorName).toBe("i");
+  expect(result.error.expected).toBe("number");
+  expect(result.error.actual).toBe(type);
+  expect(result.error.message).toBe(
+    `Operator 'i' expected number operand, got ${type}`,
+  );
+});
+
+test("末尾が name のとき (TYPE_MISMATCH)、末尾 1 つだけ pop し残り operand は保持される", () => {
+  const head: PdfObject = { type: "real", value: 1.0 };
+  const tail: PdfObject = { type: "name", value: "Foo" };
+  const ctx = buildContext([head, tail]);
+
+  const result = flatnessHandler(ctx);
+
+  assert(!result.ok);
+  expect(OperandStack.depth(ctx.operandStack)).toBe(1);
+  const top = OperandStack.peek(ctx.operandStack);
+  assert(top.some);
+  expect(top.value).toEqual(head);
+});

--- a/packages/core/src/content-stream/operators/graphics-state/i/index.ts
+++ b/packages/core/src/content-stream/operators/graphics-state/i/index.ts
@@ -1,0 +1,65 @@
+import type { PdfError } from "../../../../pdf/errors/index";
+import { err, ok } from "../../../../utils/result/index";
+import {
+  GraphicsState,
+  GraphicsStateStack,
+} from "../../../graphics-state/index";
+import { OperandStack } from "../../../operand-stack/index";
+import type {
+  OperatorHandler,
+  OperatorHandlerContext,
+} from "../../../operator-registry/index";
+
+const OPERATOR_NAME = "i";
+
+/**
+ * PDF §10.6.2 `i` operator (flatness tolerance) のハンドラ。
+ * operand stack 末尾の数値で current GraphicsState の `flatness` を更新する。
+ *
+ * - operand stack が空なら `OPERATOR_OPERAND_MISSING` を返す
+ * - 末尾が integer / real 以外なら `OPERATOR_OPERAND_TYPE_MISMATCH` を返す
+ * - 範囲外の数値 (負値 / 100 超過等) は handler では弾かない
+ *
+ * @param context - 実行コンテキスト (operand stack / graphics state stack)
+ * @returns 成功なら更新後コンテキスト、失敗なら PdfError
+ */
+export const flatnessHandler: OperatorHandler = (
+  context: OperatorHandlerContext,
+) => {
+  const popped = OperandStack.pop(context.operandStack);
+  if (!popped.some) {
+    const error: PdfError = {
+      code: "OPERATOR_OPERAND_MISSING",
+      message: `Operator '${OPERATOR_NAME}' requires 1 operand(s), got 0`,
+      operatorName: OPERATOR_NAME,
+      required: 1,
+      actual: 0,
+    };
+    return err(error);
+  }
+
+  const operand = popped.value;
+  if (operand.type !== "integer" && operand.type !== "real") {
+    const error: PdfError = {
+      code: "OPERATOR_OPERAND_TYPE_MISMATCH",
+      message: `Operator '${OPERATOR_NAME}' expected number operand, got ${operand.type}`,
+      operatorName: OPERATOR_NAME,
+      expected: "number",
+      actual: operand.type,
+    };
+    return err(error);
+  }
+
+  const current = GraphicsStateStack.current(context.graphicsStateStack);
+  const next = GraphicsState.update(current, { flatness: operand.value });
+  const graphicsStateStack = GraphicsStateStack.replaceCurrent(
+    context.graphicsStateStack,
+    next,
+  );
+
+  return ok({
+    operandStack: context.operandStack,
+    graphicsStateStack,
+    markedContentStack: context.markedContentStack,
+  });
+};

--- a/packages/core/src/content-stream/operators/graphics-state/ri/__tests__/ri.basic.test.ts
+++ b/packages/core/src/content-stream/operators/graphics-state/ri/__tests__/ri.basic.test.ts
@@ -1,0 +1,64 @@
+import { assert, expect, test } from "vitest";
+import type { PdfObject } from "../../../../../pdf/types/pdf-types/index";
+import { GraphicsStateStack } from "../../../../graphics-state/index";
+import { MarkedContentStack } from "../../../../marked-content/stack";
+import { OperandStack } from "../../../../operand-stack/index";
+import type { OperatorHandlerContext } from "../../../../operator-registry/index";
+import { riHandler } from "../index";
+
+const buildContext = (operands: PdfObject[]): OperatorHandlerContext => {
+  const operandStack = OperandStack.create();
+  for (const operand of operands) {
+    OperandStack.push(operandStack, operand);
+  }
+  const graphicsStateStack = GraphicsStateStack.create();
+  return {
+    operandStack,
+    graphicsStateStack,
+    markedContentStack: MarkedContentStack.create(),
+  };
+};
+
+test.each([
+  "AbsoluteColorimetric",
+  "RelativeColorimetric",
+  "Saturation",
+  "Perceptual",
+  "CustomRenderingIntent",
+])("name operand %s で current renderingIntent が更新される", (name) => {
+  const ctx = buildContext([{ type: "name", value: name }]);
+
+  const result = riHandler(ctx);
+
+  assert(result.ok);
+  const current = GraphicsStateStack.current(result.value.graphicsStateStack);
+  expect(current.renderingIntent).toBe(name);
+});
+
+test("operand stack に複数要素がある場合、成功時は末尾 1 つだけ pop し残りはそのまま", () => {
+  const head: PdfObject = { type: "integer", value: 99 };
+  const tail: PdfObject = { type: "name", value: "AbsoluteColorimetric" };
+  const ctx = buildContext([head, tail]);
+
+  const result = riHandler(ctx);
+
+  assert(result.ok);
+  expect(OperandStack.depth(result.value.operandStack)).toBe(1);
+  const top = OperandStack.peek(result.value.operandStack);
+  assert(top.some);
+  expect(top.value).toEqual(head);
+});
+
+test("renderingIntent 更新後も他の GraphicsState フィールドは不変", () => {
+  const ctx = buildContext([{ type: "name", value: "Perceptual" }]);
+  const before = GraphicsStateStack.current(ctx.graphicsStateStack);
+
+  const result = riHandler(ctx);
+
+  assert(result.ok);
+  const after = GraphicsStateStack.current(result.value.graphicsStateStack);
+  expect(after.lineWidth).toBe(before.lineWidth);
+  expect(after.lineCap).toBe(before.lineCap);
+  expect(after.flatness).toBe(before.flatness);
+  expect(after.ctm).toEqual(before.ctm);
+});

--- a/packages/core/src/content-stream/operators/graphics-state/ri/__tests__/ri.error.test.ts
+++ b/packages/core/src/content-stream/operators/graphics-state/ri/__tests__/ri.error.test.ts
@@ -1,0 +1,80 @@
+import { assert, expect, test } from "vitest";
+import type { PdfObject } from "../../../../../pdf/types/pdf-types/index";
+import { GraphicsStateStack } from "../../../../graphics-state/index";
+import { MarkedContentStack } from "../../../../marked-content/stack";
+import { OperandStack } from "../../../../operand-stack/index";
+import type { OperatorHandlerContext } from "../../../../operator-registry/index";
+import { riHandler } from "../index";
+
+const buildContext = (operands: PdfObject[]): OperatorHandlerContext => {
+  const operandStack = OperandStack.create();
+  for (const operand of operands) {
+    OperandStack.push(operandStack, operand);
+  }
+  const graphicsStateStack = GraphicsStateStack.create();
+  return {
+    operandStack,
+    graphicsStateStack,
+    markedContentStack: MarkedContentStack.create(),
+  };
+};
+
+test("空 operand stack では OPERATOR_OPERAND_MISSING を返す", () => {
+  const ctx = buildContext([]);
+
+  const result = riHandler(ctx);
+
+  assert(!result.ok);
+  assert(result.error.code === "OPERATOR_OPERAND_MISSING");
+  expect(result.error.operatorName).toBe("ri");
+  expect(result.error.required).toBe(1);
+  expect(result.error.actual).toBe(0);
+  expect(result.error.message).toBe(
+    "Operator 'ri' requires 1 operand(s), got 0",
+  );
+});
+
+test.each([
+  {
+    type: "integer" as const,
+    operand: { type: "integer", value: 10 } as PdfObject,
+  },
+  {
+    type: "real" as const,
+    operand: { type: "real", value: 0.5 } as PdfObject,
+  },
+  {
+    type: "boolean" as const,
+    operand: { type: "boolean", value: true } as PdfObject,
+  },
+])("末尾が $type のとき OPERATOR_OPERAND_TYPE_MISMATCH を返す", ({
+  type,
+  operand,
+}) => {
+  const ctx = buildContext([operand]);
+
+  const result = riHandler(ctx);
+
+  assert(!result.ok);
+  assert(result.error.code === "OPERATOR_OPERAND_TYPE_MISMATCH");
+  expect(result.error.operatorName).toBe("ri");
+  expect(result.error.expected).toBe("name");
+  expect(result.error.actual).toBe(type);
+  expect(result.error.message).toBe(
+    `Operator 'ri' expected name operand, got ${type}`,
+  );
+});
+
+test("末尾が number のとき (TYPE_MISMATCH)、末尾 1 つだけ pop し残り operand は保持される", () => {
+  const head: PdfObject = { type: "name", value: "RelativeColorimetric" };
+  const tail: PdfObject = { type: "integer", value: 123 };
+  const ctx = buildContext([head, tail]);
+
+  const result = riHandler(ctx);
+
+  assert(!result.ok);
+  expect(OperandStack.depth(ctx.operandStack)).toBe(1);
+  const top = OperandStack.peek(ctx.operandStack);
+  assert(top.some);
+  expect(top.value).toEqual(head);
+});

--- a/packages/core/src/content-stream/operators/graphics-state/ri/index.ts
+++ b/packages/core/src/content-stream/operators/graphics-state/ri/index.ts
@@ -1,4 +1,5 @@
 import type { PdfError } from "../../../../pdf/errors/index";
+import { PdfName } from "../../../../pdf/types/pdf-types/index";
 import { err, ok } from "../../../../utils/result/index";
 import {
   GraphicsState,
@@ -38,7 +39,7 @@ export const riHandler: OperatorHandler = (context: OperatorHandlerContext) => {
   }
 
   const operand = popped.value;
-  if (operand.type !== "name") {
+  if (!PdfName.is(operand)) {
     const error: PdfError = {
       code: "OPERATOR_OPERAND_TYPE_MISMATCH",
       message: `Operator '${OPERATOR_NAME}' expected name operand, got ${operand.type}`,

--- a/packages/core/src/content-stream/operators/graphics-state/ri/index.ts
+++ b/packages/core/src/content-stream/operators/graphics-state/ri/index.ts
@@ -24,9 +24,7 @@ const OPERATOR_NAME = "ri";
  * @param context - 実行コンテキスト (operand stack / graphics state stack)
  * @returns 成功なら更新後コンテキスト、失敗なら PdfError
  */
-export const riHandler: OperatorHandler = (
-  context: OperatorHandlerContext,
-) => {
+export const riHandler: OperatorHandler = (context: OperatorHandlerContext) => {
   const popped = OperandStack.pop(context.operandStack);
   if (!popped.some) {
     const error: PdfError = {

--- a/packages/core/src/content-stream/operators/graphics-state/ri/index.ts
+++ b/packages/core/src/content-stream/operators/graphics-state/ri/index.ts
@@ -1,0 +1,68 @@
+import type { PdfError } from "../../../../pdf/errors/index";
+import { err, ok } from "../../../../utils/result/index";
+import {
+  GraphicsState,
+  GraphicsStateStack,
+  RenderingIntent,
+} from "../../../graphics-state/index";
+import { OperandStack } from "../../../operand-stack/index";
+import type {
+  OperatorHandler,
+  OperatorHandlerContext,
+} from "../../../operator-registry/index";
+
+const OPERATOR_NAME = "ri";
+
+/**
+ * PDF §8.6.5.8 `ri` operator (rendering intent) のハンドラ。
+ * operand stack 末尾の Name で current GraphicsState の `renderingIntent` を更新する。
+ *
+ * - operand stack が空なら `OPERATOR_OPERAND_MISSING` を返す
+ * - 末尾が name 以外なら `OPERATOR_OPERAND_TYPE_MISMATCH` を返す
+ * - 未知の name もそのまま `renderingIntent` に格納する
+ *
+ * @param context - 実行コンテキスト (operand stack / graphics state stack)
+ * @returns 成功なら更新後コンテキスト、失敗なら PdfError
+ */
+export const riHandler: OperatorHandler = (
+  context: OperatorHandlerContext,
+) => {
+  const popped = OperandStack.pop(context.operandStack);
+  if (!popped.some) {
+    const error: PdfError = {
+      code: "OPERATOR_OPERAND_MISSING",
+      message: `Operator '${OPERATOR_NAME}' requires 1 operand(s), got 0`,
+      operatorName: OPERATOR_NAME,
+      required: 1,
+      actual: 0,
+    };
+    return err(error);
+  }
+
+  const operand = popped.value;
+  if (operand.type !== "name") {
+    const error: PdfError = {
+      code: "OPERATOR_OPERAND_TYPE_MISMATCH",
+      message: `Operator '${OPERATOR_NAME}' expected name operand, got ${operand.type}`,
+      operatorName: OPERATOR_NAME,
+      expected: "name",
+      actual: operand.type,
+    };
+    return err(error);
+  }
+
+  const current = GraphicsStateStack.current(context.graphicsStateStack);
+  const next = GraphicsState.update(current, {
+    renderingIntent: RenderingIntent.create(operand.value),
+  });
+  const graphicsStateStack = GraphicsStateStack.replaceCurrent(
+    context.graphicsStateStack,
+    next,
+  );
+
+  return ok({
+    operandStack: context.operandStack,
+    graphicsStateStack,
+    markedContentStack: context.markedContentStack,
+  });
+};


### PR DESCRIPTION
## 概要

Issue #486 に基づき、 (Rendering Intent) オペレータハンドラおよび  (Flatness Tolerance) オペレータハンドラを実装しました。

## 変更内容

- ** Brand 型の実装**:  の Brand 型  および  を実装。
- ** の拡張**:  (デフォルト: ) と  (デフォルト: ) フィールドを追加。
- ** オペレータハンドラ ()**:  から  オペランドを pop して  を更新。
- ** オペレータハンドラ ()**:  から  オペランドを pop して  を更新。
- **オペレータ一括登録**:  に  と  を追加し、インタープリタ連動テストを記述。

## テスト

- 各コンポーネントおよびハンドラの単体テスト (, , ,  等) を追加
-  を介した統合テストを追加

Closes #486