### PR TITLE
♻️ [Refactoring]: #341 T | undefined 返却関数を Option<T> へ統一

### DIFF
--- a/packages/core/src/document/date/pdf-date/__tests__/pdf-date.error.test.ts
+++ b/packages/core/src/document/date/pdf-date/__tests__/pdf-date.error.test.ts
@@ -1,4 +1,5 @@
 import { expect, test } from "vitest";
+import { none } from "../../../../utils/option";
 import { parsePdfDate } from "../../pdf-date";
 
 test.each([
@@ -29,6 +30,7 @@ test.each([
   ["D:20260431"],
   ["D:20260230000000Z"],
   ["D:20260431000000Z"],
-])("不正な PDF 日時 %s は undefined を返す", (raw) => {
-  expect(parsePdfDate(raw)).toBeUndefined();
+])("不正な PDF 日時 %s は none を返す", (raw) => {
+  expect(parsePdfDate(raw)).toEqual(none);
 });
+

--- a/packages/core/src/document/date/pdf-date/__tests__/pdf-date.error.test.ts
+++ b/packages/core/src/document/date/pdf-date/__tests__/pdf-date.error.test.ts
@@ -33,4 +33,3 @@ test.each([
 ])("不正な PDF 日時 %s は none を返す", (raw) => {
   expect(parsePdfDate(raw)).toEqual(none);
 });
-

--- a/packages/core/src/document/date/pdf-date/__tests__/pdf-date.parse.test.ts
+++ b/packages/core/src/document/date/pdf-date/__tests__/pdf-date.parse.test.ts
@@ -1,8 +1,9 @@
 import { expect, test } from "vitest";
+import { none } from "../../../../utils/option";
 import { parsePdfDate } from "../../pdf-date";
 
-test("D: プレフィックスを欠いた文字列は undefined を返す", () => {
-  expect(parsePdfDate("20230101")).toBeUndefined();
+test("D: プレフィックスを欠いた文字列は none を返す", () => {
+  expect(parsePdfDate("20230101")).toEqual(none);
 });
 
 test.each([
@@ -18,13 +19,15 @@ test.each([
   ["D:20230615120530-05'30'", { y: 2023, mo: 5, d: 15, h: 17, mi: 35, s: 30 }],
 ] as const)("TZ 付き日時 %s を UTC として解釈する", (raw, e) => {
   const result = parsePdfDate(raw);
-  expect(result).toBeDefined();
-  expect(result?.getUTCFullYear()).toBe(e.y);
-  expect(result?.getUTCMonth()).toBe(e.mo);
-  expect(result?.getUTCDate()).toBe(e.d);
-  expect(result?.getUTCHours()).toBe(e.h);
-  expect(result?.getUTCMinutes()).toBe(e.mi);
-  expect(result?.getUTCSeconds()).toBe(e.s);
+  expect(result.some).toBe(true);
+  if (result.some) {
+    expect(result.value.getUTCFullYear()).toBe(e.y);
+    expect(result.value.getUTCMonth()).toBe(e.mo);
+    expect(result.value.getUTCDate()).toBe(e.d);
+    expect(result.value.getUTCHours()).toBe(e.h);
+    expect(result.value.getUTCMinutes()).toBe(e.mi);
+    expect(result.value.getUTCSeconds()).toBe(e.s);
+  }
 });
 
 test.each([
@@ -37,11 +40,14 @@ test.each([
   ["D:20240229", { y: 2024, mo: 1, d: 29, h: 0, mi: 0, s: 0 }],
 ] as const)("TZ なし日時 %s をローカル時刻として解釈する", (raw, e) => {
   const result = parsePdfDate(raw);
-  expect(result).toBeDefined();
-  expect(result?.getFullYear()).toBe(e.y);
-  expect(result?.getMonth()).toBe(e.mo);
-  expect(result?.getDate()).toBe(e.d);
-  expect(result?.getHours()).toBe(e.h);
-  expect(result?.getMinutes()).toBe(e.mi);
-  expect(result?.getSeconds()).toBe(e.s);
+  expect(result.some).toBe(true);
+  if (result.some) {
+    expect(result.value.getFullYear()).toBe(e.y);
+    expect(result.value.getMonth()).toBe(e.mo);
+    expect(result.value.getDate()).toBe(e.d);
+    expect(result.value.getHours()).toBe(e.h);
+    expect(result.value.getMinutes()).toBe(e.mi);
+    expect(result.value.getSeconds()).toBe(e.s);
+  }
 });
+

--- a/packages/core/src/document/date/pdf-date/__tests__/pdf-date.parse.test.ts
+++ b/packages/core/src/document/date/pdf-date/__tests__/pdf-date.parse.test.ts
@@ -50,4 +50,3 @@ test.each([
     expect(result.value.getSeconds()).toBe(e.s);
   }
 });
-

--- a/packages/core/src/document/date/pdf-date/index.ts
+++ b/packages/core/src/document/date/pdf-date/index.ts
@@ -1,3 +1,6 @@
+import type { Option } from "../../../utils/option";
+import { none, some } from "../../../utils/option";
+
 /**
  * `D:YYYY[MM[DD[HH[mm[SS]]]]][TZ]` 形式の PDF 日時文字列の各成分を保持する。
  *
@@ -238,19 +241,19 @@ const tzOffsetMs = (sign: "+" | "-", tzHour: number, tzMin: number): number => {
  *      - `Z` は UTC 時刻として構築
  *      - `±HH'mm'` は UTC へオフセット補正
  *
- * 警告 push は本関数では行わず、戻り値が `undefined` のとき呼び出し側で
+ * 警告 push は本関数では行わず、戻り値が `none` のとき呼び出し側で
  * `DATE_PARSE_FAILED` 警告を push する設計（pure 関数）。
  *
  * @param raw - PDF 日時文字列
- * @returns 成功時は `Date`、構文・範囲・不在日いずれかで失敗した場合は `undefined`
+ * @returns 成功時は Option.some(Date)、構文・範囲・不在日いずれかで失敗した場合は Option.none
  */
-export const parsePdfDate = (raw: string): Date | undefined => {
+export const parsePdfDate = (raw: string): Option<Date> => {
   if (!raw.startsWith("D:")) {
-    return undefined;
+    return none;
   }
   const parsed = extractDateFields(raw);
   if (parsed === undefined) {
-    return undefined;
+    return none;
   }
   const probeMs = Date.UTC(
     parsed.year,
@@ -261,7 +264,7 @@ export const parsePdfDate = (raw: string): Date | undefined => {
     parsed.sec,
   );
   if (!matchesProbe(parsed, new Date(probeMs))) {
-    return undefined;
+    return none;
   }
   if (parsed.tzSign === undefined) {
     const local = new Date(
@@ -273,14 +276,14 @@ export const parsePdfDate = (raw: string): Date | undefined => {
       parsed.sec,
     );
     if (!matchesLocal(parsed, local)) {
-      return undefined;
+      return none;
     }
-    return local;
+    return some(local);
   }
   if (parsed.tzSign === "Z") {
-    return new Date(probeMs);
+    return some(new Date(probeMs));
   }
-  return new Date(
-    probeMs + tzOffsetMs(parsed.tzSign, parsed.tzHour, parsed.tzMin),
+  return some(
+    new Date(probeMs + tzOffsetMs(parsed.tzSign, parsed.tzHour, parsed.tzMin)),
   );
 };

--- a/packages/core/src/document/encoding/decode-pdf-string/__tests__/decode-pdf-string.decode.test.ts
+++ b/packages/core/src/document/encoding/decode-pdf-string/__tests__/decode-pdf-string.decode.test.ts
@@ -98,4 +98,3 @@ test("BOM なし + PDFDocEncoding 未割当バイトは U+FFFD 置換 + 警告 1
   expect(warnings).toHaveLength(1);
   expect(warnings[0].code).toBe("STRING_DECODE_FAILED");
 });
-

--- a/packages/core/src/document/encoding/decode-pdf-string/__tests__/decode-pdf-string.decode.test.ts
+++ b/packages/core/src/document/encoding/decode-pdf-string/__tests__/decode-pdf-string.decode.test.ts
@@ -1,6 +1,7 @@
 import { expect, test } from "vitest";
 import type { PdfWarning } from "../../../../pdf/errors/warning/index";
 import type { PdfString } from "../../../../pdf/types/pdf-types/index";
+import { none, some } from "../../../../utils/option";
 import { decodePdfString } from "../../decode-pdf-string";
 import { REPLACEMENT_CHAR } from "../../pdf-doc-encoding";
 
@@ -17,7 +18,7 @@ test("空バイト列は空文字列を返し警告を出さない", () => {
     "Title",
     warnings,
   );
-  expect(result).toBe("");
+  expect(result).toEqual(some(""));
   expect(warnings).toHaveLength(0);
 });
 
@@ -28,7 +29,7 @@ test("BOM 単独 (0xFE 0xFF のみ) は空文字列を返し警告を出さな�
     "Title",
     warnings,
   );
-  expect(result).toBe("");
+  expect(result).toEqual(some(""));
   expect(warnings).toHaveLength(0);
 });
 
@@ -37,7 +38,7 @@ test("BOM + UTF-16BE バイト列が日本語文字列にデコードされる",
   // "日本" = U+65E5 U+672C → BE bytes: 65 E5 67 2C
   const bytes = new Uint8Array([0xfe, 0xff, 0x65, 0xe5, 0x67, 0x2c]);
   const result = decodePdfString(pdfString(bytes), "Title", warnings);
-  expect(result).toBe("日本");
+  expect(result).toEqual(some("日本"));
   expect(warnings).toHaveLength(0);
 });
 
@@ -46,36 +47,36 @@ test("BOM + UTF-16BE のサロゲートペア（🚀 = U+1F680）が正しくデ
   // 🚀 = U+1F680 → UTF-16: D83D DE80 → BE bytes: D8 3D DE 80
   const bytes = new Uint8Array([0xfe, 0xff, 0xd8, 0x3d, 0xde, 0x80]);
   const result = decodePdfString(pdfString(bytes), "Title", warnings);
-  expect(result).toBe("🚀");
+  expect(result).toEqual(some("🚀"));
   expect(warnings).toHaveLength(0);
 });
 
-test("BOM + 奇数長バイト列は undefined + STRING_DECODE_FAILED", () => {
+test("BOM + 奇数長バイト列は none + STRING_DECODE_FAILED", () => {
   const warnings: PdfWarning[] = [];
   // 0xFE 0xFF + [0x00, 0x41, 0x00] (3 バイト = 奇数)
   const bytes = new Uint8Array([0xfe, 0xff, 0x00, 0x41, 0x00]);
   const result = decodePdfString(pdfString(bytes), "Title", warnings);
-  expect(result).toBeUndefined();
+  expect(result).toEqual(none);
   expect(warnings).toHaveLength(1);
   expect(warnings[0].code).toBe("STRING_DECODE_FAILED");
   expect(warnings[0].message).toContain("Title");
 });
 
-test("BOM + 単独 high surrogate (D8 3D + 通常文字) は undefined + STRING_DECODE_FAILED", () => {
+test("BOM + 単独 high surrogate (D8 3D + 通常文字) は none + STRING_DECODE_FAILED", () => {
   const warnings: PdfWarning[] = [];
   // 0xFE 0xFF + 0xD8 0x3D 0x00 0x41 (high surrogate の後に通常の A が続く = 不正)
   const bytes = new Uint8Array([0xfe, 0xff, 0xd8, 0x3d, 0x00, 0x41]);
   const result = decodePdfString(pdfString(bytes), "Title", warnings);
-  expect(result).toBeUndefined();
+  expect(result).toEqual(none);
   expect(warnings).toHaveLength(1);
   expect(warnings[0].code).toBe("STRING_DECODE_FAILED");
 });
 
-test("BOM + 単独 low surrogate (DE 80 単独) は undefined + STRING_DECODE_FAILED", () => {
+test("BOM + 単独 low surrogate (DE 80 単独) は none + STRING_DECODE_FAILED", () => {
   const warnings: PdfWarning[] = [];
   const bytes = new Uint8Array([0xfe, 0xff, 0xde, 0x80]);
   const result = decodePdfString(pdfString(bytes), "Title", warnings);
-  expect(result).toBeUndefined();
+  expect(result).toEqual(none);
   expect(warnings).toHaveLength(1);
   expect(warnings[0].code).toBe("STRING_DECODE_FAILED");
 });
@@ -85,7 +86,7 @@ test("BOM なしバイト列 (ASCII) は decodePdfDocEncoding に委譲される
   // ASCII "Hello"
   const bytes = new Uint8Array([0x48, 0x65, 0x6c, 0x6c, 0x6f]);
   const result = decodePdfString(pdfString(bytes), "Title", warnings);
-  expect(result).toBe("Hello");
+  expect(result).toEqual(some("Hello"));
   expect(warnings).toHaveLength(0);
 });
 
@@ -93,7 +94,8 @@ test("BOM なし + PDFDocEncoding 未割当バイトは U+FFFD 置換 + 警告 1
   const warnings: PdfWarning[] = [];
   const bytes = new Uint8Array([0x9f, 0x41]); // 0x9F 未割当 + "A"
   const result = decodePdfString(pdfString(bytes), "Title", warnings);
-  expect(result).toBe(`${REPLACEMENT_CHAR}A`);
+  expect(result).toEqual(some(`${REPLACEMENT_CHAR}A`));
   expect(warnings).toHaveLength(1);
   expect(warnings[0].code).toBe("STRING_DECODE_FAILED");
 });
+

--- a/packages/core/src/document/encoding/decode-pdf-string/index.ts
+++ b/packages/core/src/document/encoding/decode-pdf-string/index.ts
@@ -66,4 +66,3 @@ export const decodePdfString = (
     return none;
   }
 };
-

--- a/packages/core/src/document/encoding/decode-pdf-string/index.ts
+++ b/packages/core/src/document/encoding/decode-pdf-string/index.ts
@@ -1,5 +1,7 @@
 import type { PdfWarning } from "../../../pdf/errors/warning/index";
 import type { PdfString } from "../../../pdf/types/pdf-types/index";
+import type { Option } from "../../../utils/option";
+import { none, some } from "../../../utils/option";
 import { decodePdfDocEncoding } from "../pdf-doc-encoding";
 
 /** UTF-16BE BOM (Byte Order Mark) の 1 バイト目。 */
@@ -26,8 +28,8 @@ const isUtf16BeBom = (bytes: Uint8Array): boolean => {
  * PdfString の bytes を JavaScript 文字列に復号する。
  *
  * 分岐:
- *  - 空バイト列 → `""`（警告なし、正常扱い）
- *  - BOM 単独 (0xFE 0xFF のみ) → `""`（警告なし、正常扱い）
+ *  - 空バイト列 → `some("")`（警告なし、正常扱い）
+ *  - BOM 単独 (0xFE 0xFF のみ) → `some("")`（警告なし、正常扱い）
  *  - 先頭 0xFE 0xFF + payload → UTF-16BE 厳密復号 (`fatal:true`)。
  *    `TextDecoder` のコンストラクタ呼び出しも try 内に置くことで、未対応環境
  *    （`utf-16be` ラベル拒否等）でも例外を `STRING_DECODE_FAILED` 警告に正規化する。
@@ -36,31 +38,32 @@ const isUtf16BeBom = (bytes: Uint8Array): boolean => {
  * @param pdfString - 入力 PdfString
  * @param fieldName - 警告メッセージに含めるフィールド名（例: `"Title"`）
  * @param warnings - 警告蓄積先（mutable）
- * @returns 復号成功時は文字列。UTF-16BE が fatal に失敗した場合のみ undefined
+ * @returns 復号成功時は Option.some(string)。UTF-16BE が fatal に失敗した場合のみ Option.none
  */
 export const decodePdfString = (
   pdfString: PdfString,
   fieldName: string,
   warnings: PdfWarning[],
-): string | undefined => {
+): Option<string> => {
   const bytes = pdfString.value;
   if (bytes.length === 0) {
-    return "";
+    return some("");
   }
   if (!isUtf16BeBom(bytes)) {
-    return decodePdfDocEncoding(bytes, fieldName, warnings);
+    return some(decodePdfDocEncoding(bytes, fieldName, warnings));
   }
   if (bytes.length === BOM_LENGTH) {
-    return "";
+    return some("");
   }
   try {
     const decoder = new TextDecoder("utf-16be", { fatal: true });
-    return decoder.decode(bytes.subarray(BOM_LENGTH));
+    return some(decoder.decode(bytes.subarray(BOM_LENGTH)));
   } catch {
     warnings.push({
       code: "STRING_DECODE_FAILED",
       message: `UTF-16BE decode failed for /${fieldName}`,
     });
-    return undefined;
+    return none;
   }
 };
+

--- a/packages/core/src/document/metadata/document-info-parser/index.ts
+++ b/packages/core/src/document/metadata/document-info-parser/index.ts
@@ -138,7 +138,10 @@ const extractMetadata = (
     keywords: unwrapOr(readStringField(e, "Keywords", warnings), undefined),
     creator: unwrapOr(readStringField(e, "Creator", warnings), undefined),
     producer: unwrapOr(readStringField(e, "Producer", warnings), undefined),
-    creationDate: unwrapOr(readDateField(e, "CreationDate", warnings), undefined),
+    creationDate: unwrapOr(
+      readDateField(e, "CreationDate", warnings),
+      undefined,
+    ),
     modDate: unwrapOr(readDateField(e, "ModDate", warnings), undefined),
     trapped: unwrapOr(parseTrappedName(e.get("Trapped"), warnings), undefined),
   });

--- a/packages/core/src/document/metadata/document-info-parser/index.ts
+++ b/packages/core/src/document/metadata/document-info-parser/index.ts
@@ -6,6 +6,8 @@ import type {
   TrailerDict,
 } from "../../../pdf/types/pdf-types/index";
 import { stripUndefined } from "../../../utils/object";
+import type { Option } from "../../../utils/option";
+import { none, unwrapOr } from "../../../utils/option";
 import type { Result } from "../../../utils/result/index";
 import { ok } from "../../../utils/result/index";
 import type { ResolveRef } from "../../catalog/catalog-parser";
@@ -31,9 +33,6 @@ export interface ParsedDocumentInfo {
  * 返しても呼び出し側のミューテーションが他の結果に波及しないことを保証する。
  */
 const EMPTY_METADATA: DocumentMetadata = Object.freeze({});
-
-import type { Option } from "../../../utils/option";
-import { none, unwrapOr } from "../../../utils/option";
 
 /**
  * テキストフィールド共通リーダ。値の型チェックと {@link decodePdfString} 呼び出しを束ねる。

--- a/packages/core/src/document/metadata/document-info-parser/index.ts
+++ b/packages/core/src/document/metadata/document-info-parser/index.ts
@@ -32,34 +32,37 @@ export interface ParsedDocumentInfo {
  */
 const EMPTY_METADATA: DocumentMetadata = Object.freeze({});
 
+import type { Option } from "../../../utils/option";
+import { none, unwrapOr } from "../../../utils/option";
+
 /**
  * テキストフィールド共通リーダ。値の型チェックと {@link decodePdfString} 呼び出しを束ねる。
  *
  * 分岐:
- *  - 値が `undefined` → `undefined`（警告なし、未指定扱い）
- *  - 値が PdfString 以外 → `undefined` + `STRING_DECODE_FAILED` 警告
- *  - 値が PdfString → `decodePdfString` に委譲
+ *  - 値が `undefined` → `none`（警告なし、未指定扱い）
+ *  - 値が PdfString 以外 → `none` + `STRING_DECODE_FAILED` 警告
+ *  - 値が PdfString → `decodePdfString` に委譲 (Option<string>)
  *
  * @param entries - /Info 辞書のエントリ
  * @param key - 取得するキー（例: `"Title"`）
  * @param warnings - 警告蓄積先（mutable）
- * @returns 復号成功時は文字列、それ以外は `undefined`
+ * @returns 復号成功時は Option.some(string)、それ以外は Option.none
  */
 const readStringField = (
   entries: Map<string, PdfValue>,
   key: string,
   warnings: PdfWarning[],
-): string | undefined => {
+): Option<string> => {
   const value = entries.get(key);
   if (value === undefined) {
-    return undefined;
+    return none;
   }
   if (value.type !== "string") {
     warnings.push({
       code: "STRING_DECODE_FAILED",
       message: `/${key} expected PdfString but got ${value.type}`,
     });
-    return undefined;
+    return none;
   }
   return decodePdfString(value, key, warnings);
 };
@@ -67,57 +70,57 @@ const readStringField = (
 /**
  * 日時フィールド共通リーダ。値の型チェック → 文字列復号 → {@link parsePdfDate} を束ねる。
  *
- * `parsePdfDate` は警告 push を行わない pure 関数なので、`undefined` を検出した時点で
+ * `parsePdfDate` は警告 push を行わない pure 関数なので、`none` を検出した時点で
  * 本リーダ（caller）が `DATE_PARSE_FAILED` 警告を push する（review-002 反映）。
  *
  * 分岐:
- *  - 値が `undefined` → `undefined`（警告なし、未指定扱い）
- *  - 値が PdfString 以外 → `undefined` + `DATE_PARSE_FAILED` 警告
- *  - 文字列復号失敗 → `undefined`（警告は decodePdfString 側で push 済み）
- *  - 日時パース失敗 → `undefined` + `DATE_PARSE_FAILED` 警告
+ *  - 値が `undefined` → `none`（警告なし、未指定扱い）
+ *  - 値が PdfString 以外 → `none` + `DATE_PARSE_FAILED` 警告
+ *  - 文字列復号失敗 → `none`（警告は decodePdfString 側で push 済み）
+ *  - 日時パース失敗 → `none` + `DATE_PARSE_FAILED` 警告
  *
  * @param entries - /Info 辞書のエントリ
  * @param key - 取得するキー（例: `"CreationDate"`）
  * @param warnings - 警告蓄積先（mutable）
- * @returns パース成功時は `Date`、それ以外は `undefined`
+ * @returns パース成功時は Option.some(Date)、それ以外は Option.none
  */
 const readDateField = (
   entries: Map<string, PdfValue>,
   key: string,
   warnings: PdfWarning[],
-): Date | undefined => {
+): Option<Date> => {
   const value = entries.get(key);
   if (value === undefined) {
-    return undefined;
+    return none;
   }
   if (value.type !== "string") {
     warnings.push({
       code: "DATE_PARSE_FAILED",
       message: `/${key} expected PdfString but got ${value.type}`,
     });
-    return undefined;
+    return none;
   }
-  const raw = decodePdfString(value, key, warnings);
-  if (raw === undefined) {
-    return undefined;
+  const rawOpt = decodePdfString(value, key, warnings);
+  if (!rawOpt.some) {
+    return none;
   }
-  const parsed = parsePdfDate(raw);
-  if (parsed === undefined) {
+  const parsedOpt = parsePdfDate(rawOpt.value);
+  if (!parsedOpt.some) {
     warnings.push({
       code: "DATE_PARSE_FAILED",
-      message: `/${key} failed to parse PDF date ${JSON.stringify(raw)}; expected pattern D:YYYYMMDDHHmmSSOHH'mm'`,
+      message: `/${key} failed to parse PDF date ${JSON.stringify(rawOpt.value)}; expected pattern D:YYYYMMDDHHmmSSOHH'mm'`,
     });
-    return undefined;
+    return none;
   }
-  return parsed;
+  return parsedOpt;
 };
 
 /**
  * `/Info` 辞書から 9 フィールドを抽出して {@link DocumentMetadata} に詰め直す。
  *
  * テキスト 6 フィールド・日時 2 フィールド・Trapped を、それぞれ
- * `readStringField` / `readDateField` / `parseTrappedName` に委譲する。
- * 値が `undefined` のフィールドはオブジェクトに含めない（PR #98 review 反映）。
+ * `readStringField` / `readDateField` / `parseTrappedName` に委譲し、
+ * `unwrapOr(opt, undefined)` で展開後、`stripUndefined` でプロパティ非存在化する。
  *
  * @param dict - 解決済みの `/Info` 辞書
  * @param warnings - 警告蓄積先（mutable）
@@ -129,15 +132,15 @@ const extractMetadata = (
 ): DocumentMetadata => {
   const e = dict.entries;
   return stripUndefined<DocumentMetadata>({
-    title: readStringField(e, "Title", warnings),
-    author: readStringField(e, "Author", warnings),
-    subject: readStringField(e, "Subject", warnings),
-    keywords: readStringField(e, "Keywords", warnings),
-    creator: readStringField(e, "Creator", warnings),
-    producer: readStringField(e, "Producer", warnings),
-    creationDate: readDateField(e, "CreationDate", warnings),
-    modDate: readDateField(e, "ModDate", warnings),
-    trapped: parseTrappedName(e.get("Trapped"), warnings),
+    title: unwrapOr(readStringField(e, "Title", warnings), undefined),
+    author: unwrapOr(readStringField(e, "Author", warnings), undefined),
+    subject: unwrapOr(readStringField(e, "Subject", warnings), undefined),
+    keywords: unwrapOr(readStringField(e, "Keywords", warnings), undefined),
+    creator: unwrapOr(readStringField(e, "Creator", warnings), undefined),
+    producer: unwrapOr(readStringField(e, "Producer", warnings), undefined),
+    creationDate: unwrapOr(readDateField(e, "CreationDate", warnings), undefined),
+    modDate: unwrapOr(readDateField(e, "ModDate", warnings), undefined),
+    trapped: unwrapOr(parseTrappedName(e.get("Trapped"), warnings), undefined),
   });
 };
 

--- a/packages/core/src/document/metadata/document-metadata/__tests__/document-metadata.error.test.ts
+++ b/packages/core/src/document/metadata/document-metadata/__tests__/document-metadata.error.test.ts
@@ -130,4 +130,3 @@ test.each([
   expect(warnings[0].message).toContain(type);
   expect(warnings[0].message).toContain(expectedSubstr);
 });
-

--- a/packages/core/src/document/metadata/document-metadata/__tests__/document-metadata.error.test.ts
+++ b/packages/core/src/document/metadata/document-metadata/__tests__/document-metadata.error.test.ts
@@ -3,6 +3,7 @@ import type { PdfWarning } from "../../../../pdf/errors/warning/index";
 import { GenerationNumber } from "../../../../pdf/types/generation-number/index";
 import { ObjectNumber } from "../../../../pdf/types/object-number/index";
 import type { PdfValue } from "../../../../pdf/types/pdf-types/index";
+import { none } from "../../../../utils/option";
 import { parseTrappedName, summarizePdfValue } from "../../document-metadata";
 
 const makeName = (value: string): PdfValue => ({ type: "name", value });
@@ -36,10 +37,10 @@ test.each([
   expect(summarizePdfValue(value)).toBe(expected);
 });
 
-test("/Trapped Name 'Yes' は undefined + TRAPPED_INVALID", () => {
+test("/Trapped Name 'Yes' は none + TRAPPED_INVALID", () => {
   const warnings: PdfWarning[] = [];
   const result = parseTrappedName(makeName("Yes"), warnings);
-  expect(result).toBeUndefined();
+  expect(result).toEqual(none);
   expect(warnings).toHaveLength(1);
   expect(warnings[0].code).toBe("TRAPPED_INVALID");
 });
@@ -48,23 +49,23 @@ test.each([
   ["true"],
   ["false"],
   ["unknown"],
-])("/Trapped Name '%s' (小文字) は undefined + TRAPPED_INVALID（大文字小文字を区別する）", (lowercase) => {
+])("/Trapped Name '%s' (小文字) は none + TRAPPED_INVALID（大文字小文字を区別する）", (lowercase) => {
   const warnings: PdfWarning[] = [];
   const result = parseTrappedName(makeName(lowercase), warnings);
-  expect(result).toBeUndefined();
+  expect(result).toEqual(none);
   expect(warnings).toHaveLength(1);
   expect(warnings[0].code).toBe("TRAPPED_INVALID");
 });
 
-test("/Trapped Name '' (空文字) は undefined + TRAPPED_INVALID", () => {
+test("/Trapped Name '' (空文字) は none + TRAPPED_INVALID", () => {
   const warnings: PdfWarning[] = [];
   const result = parseTrappedName(makeName(""), warnings);
-  expect(result).toBeUndefined();
+  expect(result).toEqual(none);
   expect(warnings).toHaveLength(1);
   expect(warnings[0].code).toBe("TRAPPED_INVALID");
 });
 
-test("/Trapped が PdfString のとき undefined + TRAPPED_INVALID（メッセージに type と値要約を含む）", () => {
+test("/Trapped が PdfString のとき none + TRAPPED_INVALID（メッセージに type と値要約を含む）", () => {
   const warnings: PdfWarning[] = [];
   const stringValue: PdfValue = {
     type: "string",
@@ -72,7 +73,7 @@ test("/Trapped が PdfString のとき undefined + TRAPPED_INVALID（メッセ�
     encoding: "literal",
   };
   const result = parseTrappedName(stringValue, warnings);
-  expect(result).toBeUndefined();
+  expect(result).toEqual(none);
   expect(warnings).toHaveLength(1);
   expect(warnings[0].code).toBe("TRAPPED_INVALID");
   expect(warnings[0].message).toContain("string");
@@ -80,22 +81,22 @@ test("/Trapped が PdfString のとき undefined + TRAPPED_INVALID（メッセ�
   expect(warnings[0].message).toContain("enc=literal");
 });
 
-test("/Trapped が PdfBoolean のとき undefined + TRAPPED_INVALID（メッセージに type と値を含む）", () => {
+test("/Trapped が PdfBoolean のとき none + TRAPPED_INVALID（メッセージに type と値を含む）", () => {
   const warnings: PdfWarning[] = [];
   const boolValue: PdfValue = { type: "boolean", value: true };
   const result = parseTrappedName(boolValue, warnings);
-  expect(result).toBeUndefined();
+  expect(result).toEqual(none);
   expect(warnings).toHaveLength(1);
   expect(warnings[0].code).toBe("TRAPPED_INVALID");
   expect(warnings[0].message).toContain("boolean");
   expect(warnings[0].message).toContain("true");
 });
 
-test("/Trapped が PdfInteger のとき undefined + TRAPPED_INVALID（メッセージに type と値を含む）", () => {
+test("/Trapped が PdfInteger のとき none + TRAPPED_INVALID（メッセージに type と値を含む）", () => {
   const warnings: PdfWarning[] = [];
   const intValue: PdfValue = { type: "integer", value: 1 };
   const result = parseTrappedName(intValue, warnings);
-  expect(result).toBeUndefined();
+  expect(result).toEqual(none);
   expect(warnings).toHaveLength(1);
   expect(warnings[0].code).toBe("TRAPPED_INVALID");
   expect(warnings[0].message).toContain("integer");
@@ -120,12 +121,13 @@ test.each([
     } as PdfValue,
     "<ref 1 0>",
   ],
-])("/Trapped が %s のとき undefined + TRAPPED_INVALID（メッセージに type と値要約を含む）", (type, value, expectedSubstr) => {
+])("/Trapped が %s のとき none + TRAPPED_INVALID（メッセージに type と値要約を含む）", (type, value, expectedSubstr) => {
   const warnings: PdfWarning[] = [];
   const result = parseTrappedName(value, warnings);
-  expect(result).toBeUndefined();
+  expect(result).toEqual(none);
   expect(warnings).toHaveLength(1);
   expect(warnings[0].code).toBe("TRAPPED_INVALID");
   expect(warnings[0].message).toContain(type);
   expect(warnings[0].message).toContain(expectedSubstr);
 });
+

--- a/packages/core/src/document/metadata/document-metadata/__tests__/document-metadata.parse.test.ts
+++ b/packages/core/src/document/metadata/document-metadata/__tests__/document-metadata.parse.test.ts
@@ -1,6 +1,7 @@
 import { expect, test } from "vitest";
 import type { PdfWarning } from "../../../../pdf/errors/warning/index";
 import type { PdfValue } from "../../../../pdf/types/pdf-types/index";
+import { none } from "../../../../utils/option";
 import { PdfTrapped, parseTrappedName } from "../../document-metadata";
 
 const makeName = (value: string): PdfValue => ({ type: "name", value });
@@ -12,16 +13,20 @@ test.each([
 ])("/Trapped Name '%s' は PdfTrapped '%s' に解釈される", (literal) => {
   const warnings: PdfWarning[] = [];
   const result = parseTrappedName(makeName(literal), warnings);
-  expect(PdfTrapped.create(literal)).toStrictEqual({
-    ok: true,
-    value: result,
-  });
+  expect(result.some).toBe(true);
+  if (result.some) {
+    expect(PdfTrapped.create(literal)).toStrictEqual({
+      ok: true,
+      value: result.value,
+    });
+  }
   expect(warnings).toHaveLength(0);
 });
 
-test("/Trapped 値が未指定（undefined）の場合は undefined（警告なし）", () => {
+test("/Trapped 値が未指定（undefined）の場合は none（警告なし）", () => {
   const warnings: PdfWarning[] = [];
   const result = parseTrappedName(undefined, warnings);
-  expect(result).toBeUndefined();
+  expect(result).toEqual(none);
   expect(warnings).toHaveLength(0);
 });
+

--- a/packages/core/src/document/metadata/document-metadata/__tests__/document-metadata.parse.test.ts
+++ b/packages/core/src/document/metadata/document-metadata/__tests__/document-metadata.parse.test.ts
@@ -29,4 +29,3 @@ test("/Trapped 値が未指定（undefined）の場合は none（警告なし）
   expect(result).toEqual(none);
   expect(warnings).toHaveLength(0);
 });
-

--- a/packages/core/src/document/metadata/document-metadata/index.ts
+++ b/packages/core/src/document/metadata/document-metadata/index.ts
@@ -127,4 +127,3 @@ export const parseTrappedName = (
   }
   return some(result.value);
 };
-

--- a/packages/core/src/document/metadata/document-metadata/index.ts
+++ b/packages/core/src/document/metadata/document-metadata/index.ts
@@ -1,6 +1,8 @@
 import type { PdfWarning } from "../../../pdf/errors/warning/index";
 import type { PdfValue } from "../../../pdf/types/pdf-types/index";
 import type { Brand } from "../../../utils/brand/index";
+import type { Option } from "../../../utils/option";
+import { none, some } from "../../../utils/option";
 import type { Result } from "../../../utils/result/index";
 import { err, ok } from "../../../utils/result/index";
 
@@ -93,27 +95,27 @@ export interface DocumentMetadata {
 /**
  * /Trapped の Name 値を {@link PdfTrapped} リテラルに解釈する。
  *
- * - value が undefined → undefined（警告なし）
- * - value が PdfName で値が "True" / "False" / "Unknown" → 該当 literal
- * - 上記以外 → undefined + TRAPPED_INVALID 警告
+ * - value が undefined → Option.none（警告なし）
+ * - value が PdfName で値が "True" / "False" / "Unknown" → 該当 Option.some(literal)
+ * - 上記以外 → Option.none + TRAPPED_INVALID 警告
  *
  * @param value - /Trapped の値（解決済みの PdfValue または undefined）
  * @param warnings - 警告蓄積先（mutable）
- * @returns PdfTrapped または undefined
+ * @returns Option<PdfTrapped>
  */
 export const parseTrappedName = (
   value: PdfValue | undefined,
   warnings: PdfWarning[],
-): PdfTrapped | undefined => {
+): Option<PdfTrapped> => {
   if (value === undefined) {
-    return undefined;
+    return none;
   }
   if (value.type !== "name") {
     warnings.push({
       code: "TRAPPED_INVALID",
       message: `/Trapped expected Name but got ${value.type} (${summarizePdfValue(value)})`,
     });
-    return undefined;
+    return none;
   }
   const result = PdfTrapped.create(value.value);
   if (!result.ok) {
@@ -121,7 +123,8 @@ export const parseTrappedName = (
       code: "TRAPPED_INVALID",
       message: `/Trapped value '${value.value}' is not in {True, False, Unknown}`,
     });
-    return undefined;
+    return none;
   }
-  return result.value;
+  return some(result.value);
 };
+

--- a/packages/core/src/document/page-tree/dict-reader/__tests__/dict-reader.read.test.ts
+++ b/packages/core/src/document/page-tree/dict-reader/__tests__/dict-reader.read.test.ts
@@ -2,12 +2,20 @@ import { expect, test } from "vitest";
 import { GenerationNumber } from "../../../../pdf/types/generation-number/index";
 import { ObjectNumber } from "../../../../pdf/types/object-number/index";
 import type { PdfValue } from "../../../../pdf/types/pdf-types/index";
-import { DictReader } from "../../dict-reader";
+import { none, some } from "../../../../utils/option";
+import { DictReader, getNumberValue } from "../../dict-reader";
 import { indirectRefValue } from "../../page-tree-walker/__tests__/page-tree-walker.test.helpers";
 
 const integerArray = (values: number[]): PdfValue => ({
   type: "array",
   elements: values.map((v) => ({ type: "integer", value: v })),
+});
+
+test("getNumberValue は integer / real で some(number) を返し、非数値・undefined で none を返す", () => {
+  expect(getNumberValue({ type: "integer", value: 42 })).toEqual(some(42));
+  expect(getNumberValue({ type: "real", value: 3.14 })).toEqual(some(3.14));
+  expect(getNumberValue({ type: "name", value: "Foo" })).toEqual(none);
+  expect(getNumberValue(undefined)).toEqual(none);
 });
 
 test("DictReader.box はキーが存在しないとき None を返す", () => {

--- a/packages/core/src/document/page-tree/dict-reader/index.ts
+++ b/packages/core/src/document/page-tree/dict-reader/index.ts
@@ -8,19 +8,19 @@ const BOX_ELEMENT_COUNT = 4;
 const DEFAULT_USER_UNIT = 1.0;
 
 /**
- * PdfValue が integer / real なら数値を返す。その他の型・undefined は undefined。
+ * PdfValue が integer / real なら数値を Option.some(number) で返す。その他の型・undefined は Option.none。
  *
  * @param value - 判定対象
- * @returns 数値、または undefined
+ * @returns Option.some(number)、または Option.none
  */
-const getNumberValue = (value: PdfValue | undefined): number | undefined => {
+export const getNumberValue = (value: PdfValue | undefined): Option<number> => {
   if (value === undefined) {
-    return undefined;
+    return none;
   }
   if (value.type === "integer" || value.type === "real") {
-    return value.value;
+    return some(value.value);
   }
-  return undefined;
+  return none;
 };
 
 /**
@@ -47,11 +47,11 @@ export const DictReader = {
     }
     const nums: number[] = [];
     for (const el of value.elements) {
-      const n = getNumberValue(el);
-      if (n === undefined) {
+      const nOpt = getNumberValue(el);
+      if (!nOpt.some) {
         return none;
       }
-      nums.push(n);
+      nums.push(nOpt.value);
     }
     const [llx, lly, urx, ury] = nums;
     return some([llx, lly, urx, ury] as PdfRectangle);
@@ -65,11 +65,7 @@ export const DictReader = {
    */
   rotate(entries: Map<string, PdfValue>): Option<number> {
     const value = entries.get("Rotate");
-    const n = getNumberValue(value);
-    if (n === undefined) {
-      return none;
-    }
-    return some(n);
+    return getNumberValue(value);
   },
 
   /**
@@ -81,14 +77,14 @@ export const DictReader = {
    */
   userUnit(entries: Map<string, PdfValue>): number {
     const value = entries.get("UserUnit");
-    const n = getNumberValue(value);
-    if (n === undefined) {
+    const nOpt = getNumberValue(value);
+    if (!nOpt.some) {
       return DEFAULT_USER_UNIT;
     }
-    if (!NumberEx.isPositiveFinite(n)) {
+    if (!NumberEx.isPositiveFinite(nOpt.value)) {
       return DEFAULT_USER_UNIT;
     }
-    return n;
+    return nOpt.value;
   },
 
   /**

--- a/packages/core/src/document/page-tree/page-tree-walker/index.ts
+++ b/packages/core/src/document/page-tree/page-tree-walker/index.ts
@@ -109,47 +109,47 @@ const getKidsRefs = (entries: Map<string, PdfValue>): KidsRefsResult => {
  * `/Count` を非負整数として取り出す。
  *
  * @param entries - 辞書エントリ
- * @returns 非負整数、または undefined
+ * @returns 非負整数、または Option.none
  */
-const readCount = (entries: Map<string, PdfValue>): number | undefined => {
+const readCount = (entries: Map<string, PdfValue>): Option<number> => {
   const value = entries.get("Count");
   if (value === undefined || value.type !== "integer") {
-    return undefined;
+    return none;
   }
   if (!NumberEx.isSafeIntegerAtLeastZero(value.value)) {
-    return undefined;
+    return none;
   }
-  return value.value;
+  return some(value.value);
 };
 
 /**
  * `/Resources` を取得する。間接参照なら resolveRef で 1 段解決する。
  * 解決失敗 (Err / non-dict) の場合は `RESOURCES_RESOLVE_FAILED` 警告を積み
- * undefined を返す（属性未設定 + 走査継続）。
+ * Option.none を返す（属性未設定 + 走査継続）。
  *
  * @param entries - 辞書エントリ
  * @param resolveRef - 間接参照解決関数
  * @param warnings - 警告蓄積先
- * @returns 解決済み PdfDictionary、または undefined
+ * @returns 解決済み Option.some(PdfDictionary)、または Option.none
  */
 const resolveResources = async (
   entries: Map<string, PdfValue>,
   resolveRef: ResolveRef,
   warnings: PdfWarning[],
-): Promise<PdfDictionary | undefined> => {
+): Promise<Option<PdfDictionary>> => {
   const value = entries.get("Resources");
   if (value === undefined) {
-    return undefined;
+    return none;
   }
   if (value.type === "dictionary") {
-    return value;
+    return some(value);
   }
   if (value.type !== "indirect-ref") {
     warnings.push({
       code: "RESOURCES_RESOLVE_FAILED",
       message: `Failed to resolve /Resources: unexpected direct type=${value.type}`,
     });
-    return undefined;
+    return none;
   }
   const indirectRef = IndirectRef.from(value);
   if (!indirectRef.some) {
@@ -157,7 +157,7 @@ const resolveResources = async (
       code: "RESOURCES_RESOLVE_FAILED",
       message: `Failed to resolve /Resources indirect-ref ${value.objectNumber} ${value.generationNumber}: invalid indirect reference`,
     });
-    return undefined;
+    return none;
   }
   const resolved = await resolveRef(indirectRef.value);
   if (!resolved.ok) {
@@ -165,21 +165,21 @@ const resolveResources = async (
       code: "RESOURCES_RESOLVE_FAILED",
       message: `Failed to resolve /Resources indirect-ref ${value.objectNumber} ${value.generationNumber}: cause=${resolved.error.code}`,
     });
-    return undefined;
+    return none;
   }
   if (resolved.value.type !== "dictionary") {
     warnings.push({
       code: "RESOURCES_RESOLVE_FAILED",
       message: `Failed to resolve /Resources indirect-ref ${value.objectNumber} ${value.generationNumber}: resolved to non-dictionary`,
     });
-    return undefined;
+    return none;
   }
-  return resolved.value;
+  return some(resolved.value);
 };
 
 /**
  * `/Pages` または `/Page` ノードから継承可能 4 属性を読み取る。
- * `/Resources` のみ indirect-ref を 1 段解決する（Resources 解決失敗は警告積み + undefined）。
+ * `/Resources` のみ indirect-ref を 1 段解決する（Resources 解決失敗は警告積み + none）。
  * `/Rotate` はキー存在かつ数値のときだけ生値を詰める（非数値は Resolver 側で判定）。
  *
  * @param entries - 辞書エントリ
@@ -205,9 +205,9 @@ const readInheritableAttrs = async (
   if (rotate.some) {
     attrs.rotate = rotate.value;
   }
-  const resources = await resolveResources(entries, resolveRef, warnings);
-  if (resources !== undefined) {
-    attrs.resources = resources;
+  const resourcesOpt = await resolveResources(entries, resolveRef, warnings);
+  if (resourcesOpt.some) {
+    attrs.resources = resourcesOpt.value;
   }
   return attrs;
 };
@@ -351,11 +351,11 @@ const walkInternal = async (
     actualCount += state.pages.length - before;
   }
 
-  const declared = readCount(dict.entries);
-  if (declared !== undefined && declared !== actualCount) {
+  const declaredOpt = readCount(dict.entries);
+  if (declaredOpt.some && declaredOpt.value !== actualCount) {
     state.warnings.push({
       code: "COUNT_MISMATCH",
-      message: `Pages node ${key}: /Count ${declared} but ${actualCount} pages found`,
+      message: `Pages node ${key}: /Count ${declaredOpt.value} but ${actualCount} pages found`,
     });
   }
 

--- a/packages/core/src/objects/lru-cache/index.ts
+++ b/packages/core/src/objects/lru-cache/index.ts
@@ -72,6 +72,9 @@ export class LRUCache<K, V> {
    * キーに対応する値を取得する。
    * アクセスされたエントリは最新として更新される。
    *
+   * 【例外規定】JavaScript 標準の Map コンテナインターフェース（Map.prototype.get）に準拠するため、
+   * `Option<V>` ではなく `V | undefined` を返却する規約を採用している。
+   *
    * @param key - 検索するキー
    * @returns 値が存在する場合はその値、存在しない場合は `undefined`
    *

--- a/packages/core/src/xref/table/parser/index.ts
+++ b/packages/core/src/xref/table/parser/index.ts
@@ -60,6 +60,9 @@ function failXRefTable(
 /**
  * 固定桁数の10進数をパースする。
  *
+ * 【例外規定】ホットループ（xref テーブル行のパース）内でアロケーションを回避するため、
+ * `Option<number>` ではなく `number | undefined` を返却する規約を採用している。
+ *
  * @param data - PDFバイト配列
  * @param pos - パース開始位置
  * @param digitCount - 読み取る桁数
@@ -86,6 +89,9 @@ function parseDecimalDigits(
 
 /**
  * EOL パターンを検出し消費バイト数を返す。
+ *
+ * 【例外規定】ホットループ（xref テーブル行のパース）内でアロケーションを回避するため、
+ * `Option<number>` ではなく `number | undefined` を返却する規約を採用している。
  *
  * @param data - PDFバイト配列
  * @param pos - EOL 検出開始位置

--- a/packages/core/src/xref/trailer/parser/index.ts
+++ b/packages/core/src/xref/trailer/parser/index.ts
@@ -55,15 +55,18 @@ function failTrailer(
 
 // --- 内部ヘルパー ---
 
+import type { Option } from "../../../utils/option";
+import { none, some } from "../../../utils/option";
+
 /**
  * hex 文字列を Uint8Array に変換する。奇数長の場合は末尾に 0 をパディングする。
  *
  * @param hex - 16進文字列
- * @returns 変換されたバイト配列、または不正文字を含む場合は `undefined`
+ * @returns 変換されたバイト配列、または不正文字を含む場合は Option.none
  */
-function hexStringToBytes(hex: string): Uint8Array | undefined {
+function hexStringToBytes(hex: string): Option<Uint8Array> {
   if (!/^[0-9A-Fa-f]*$/.test(hex)) {
-    return undefined;
+    return none;
   }
 
   const padded = hex.length % 2 === 1 ? `${hex}0` : hex;
@@ -72,26 +75,26 @@ function hexStringToBytes(hex: string): Uint8Array | undefined {
     bytes[i / 2] = parseInt(padded.substring(i, i + 2), 16);
   }
 
-  return bytes;
+  return some(bytes);
 }
 
 /**
  * リテラル文字列の各文字をバイト値として Uint8Array に変換する。
  *
  * @param str - リテラル文字列
- * @returns 変換されたバイト配列、または範囲外の code unit を含む場合は `undefined`
+ * @returns 変換されたバイト配列、または範囲外の code unit を含む場合は Option.none
  */
-function literalStringToBytes(str: string): Uint8Array | undefined {
+function literalStringToBytes(str: string): Option<Uint8Array> {
   const bytes = new Uint8Array(str.length);
   for (let i = 0; i < str.length; i++) {
     const codeUnit = str.charCodeAt(i);
     if (codeUnit > MAX_BYTE_VALUE) {
-      return undefined;
+      return none;
     }
     bytes[i] = codeUnit;
   }
 
-  return bytes;
+  return some(bytes);
 }
 
 /**
@@ -332,8 +335,8 @@ function readValue(
         offset,
       });
     case TokenType.HexString: {
-      const hexBytes = hexStringToBytes(firstToken.value);
-      if (!hexBytes) {
+      const hexBytesOpt = hexStringToBytes(firstToken.value);
+      if (!hexBytesOpt.some) {
         return err({
           code: "XREF_TABLE_INVALID",
           message: "invalid hex string: contains non-hex characters",
@@ -343,15 +346,15 @@ function readValue(
       return ok({
         value: {
           type: "string",
-          value: hexBytes,
+          value: hexBytesOpt.value,
           encoding: "hex" as const,
         },
         offset,
       });
     }
     case TokenType.LiteralString: {
-      const litBytes = literalStringToBytes(firstToken.value);
-      if (!litBytes) {
+      const litBytesOpt = literalStringToBytes(firstToken.value);
+      if (!litBytesOpt.some) {
         return err({
           code: "XREF_TABLE_INVALID",
           message:
@@ -362,7 +365,7 @@ function readValue(
       return ok({
         value: {
           type: "string",
-          value: litBytes,
+          value: litBytesOpt.value,
           encoding: "literal" as const,
         },
         offset,

--- a/packages/core/src/xref/trailer/parser/index.ts
+++ b/packages/core/src/xref/trailer/parser/index.ts
@@ -11,6 +11,8 @@ import {
 } from "../../../pdf/types/byte-offset/index";
 import type { PdfValue, Token, TrailerDict } from "../../../pdf/types/index";
 import { TokenType } from "../../../pdf/types/index";
+import type { Option } from "../../../utils/option";
+import { none, some } from "../../../utils/option";
 import type { Result } from "../../../utils/result/index";
 import { err, ok } from "../../../utils/result/index";
 import { trailerDictBuilder } from "../dict-builder/index";
@@ -54,9 +56,6 @@ function failTrailer(
 }
 
 // --- 内部ヘルパー ---
-
-import type { Option } from "../../../utils/option";
-import { none, some } from "../../../utils/option";
 
 /**
  * hex 文字列を Uint8Array に変換する。奇数長の場合は末尾に 0 をパディングする。


### PR DESCRIPTION
## 概要

Issue #341 に基づき、`@pdfmod/core` 内で `T | undefined` を返していた公開・準公開ヘルパー関数群を `Option<T>` 返却型へと統一リファクタリングしました。

## 変更内容

- **`Option<T>` 返却化 (10 関数)**:
  - `decodePdfString`: `Option<string>`
  - `parsePdfDate`: `Option<Date>`
  - `parseTrappedName`: `Option<PdfTrapped>`
  - `readStringField`: `Option<string>`
  - `readDateField`: `Option<Date>`
  - `hexStringToBytes`: `Option<Uint8Array>`
  - `literalStringToBytes`: `Option<Uint8Array>`
  - `getNumberValue`: `Option<number>`
  - `readCount`: `Option<number>`
  - `resolveResources`: `Promise<Option<PdfDictionary>>`
- **呼び出し側対応**: `DocumentInfoParser.extractMetadata` での `unwrapOr` 展開、`DictReader`、`TrailerParser`、`PageTreeWalker` 内での `Option` 判定への統一
- **例外規定コメント記載 (3 関数)**:
  - `parseDecimalDigits`, `detectEol`: xref テーブル解析ホットループにおけるアロケーション回避のため `undefined` 返却を維持し JSDoc に明記
  - `LRUCache.prototype.get`: JS 標準 Map インターフェース準拠のため `undefined` 返却を維持し JSDoc に明記
- **テスト**: 既存テストおよび追加ユニットテストを `Option<T>` (`some` / `none`) 検証に全面対応

## 検証

- `@pdfmod/core` ユニットテスト全件パス確認済み
- `pnpm --filter @pdfmod/core build` ビルド & 型チェック成功確認済み

Closes #341