### PR TITLE
♻️ [Refactor]: #346 Err を返し得ない 2 つの公開 API から Result ラッパーを外す

### DIFF
--- a/packages/core/src/document/date/pdf-date/__tests__/pdf-date.parse.test.ts
+++ b/packages/core/src/document/date/pdf-date/__tests__/pdf-date.parse.test.ts
@@ -1,4 +1,4 @@
-import { expect, test } from "vitest";
+import { assert, expect, test } from "vitest";
 import { none } from "../../../../utils/option";
 import { parsePdfDate } from "../../pdf-date";
 
@@ -19,15 +19,13 @@ test.each([
   ["D:20230615120530-05'30'", { y: 2023, mo: 5, d: 15, h: 17, mi: 35, s: 30 }],
 ] as const)("TZ 付き日時 %s を UTC として解釈する", (raw, e) => {
   const result = parsePdfDate(raw);
-  expect(result.some).toBe(true);
-  if (result.some) {
-    expect(result.value.getUTCFullYear()).toBe(e.y);
-    expect(result.value.getUTCMonth()).toBe(e.mo);
-    expect(result.value.getUTCDate()).toBe(e.d);
-    expect(result.value.getUTCHours()).toBe(e.h);
-    expect(result.value.getUTCMinutes()).toBe(e.mi);
-    expect(result.value.getUTCSeconds()).toBe(e.s);
-  }
+  assert(result.some);
+  expect(result.value.getUTCFullYear()).toBe(e.y);
+  expect(result.value.getUTCMonth()).toBe(e.mo);
+  expect(result.value.getUTCDate()).toBe(e.d);
+  expect(result.value.getUTCHours()).toBe(e.h);
+  expect(result.value.getUTCMinutes()).toBe(e.mi);
+  expect(result.value.getUTCSeconds()).toBe(e.s);
 });
 
 test.each([
@@ -40,13 +38,11 @@ test.each([
   ["D:20240229", { y: 2024, mo: 1, d: 29, h: 0, mi: 0, s: 0 }],
 ] as const)("TZ なし日時 %s をローカル時刻として解釈する", (raw, e) => {
   const result = parsePdfDate(raw);
-  expect(result.some).toBe(true);
-  if (result.some) {
-    expect(result.value.getFullYear()).toBe(e.y);
-    expect(result.value.getMonth()).toBe(e.mo);
-    expect(result.value.getDate()).toBe(e.d);
-    expect(result.value.getHours()).toBe(e.h);
-    expect(result.value.getMinutes()).toBe(e.mi);
-    expect(result.value.getSeconds()).toBe(e.s);
-  }
+  assert(result.some);
+  expect(result.value.getFullYear()).toBe(e.y);
+  expect(result.value.getMonth()).toBe(e.mo);
+  expect(result.value.getDate()).toBe(e.d);
+  expect(result.value.getHours()).toBe(e.h);
+  expect(result.value.getMinutes()).toBe(e.mi);
+  expect(result.value.getSeconds()).toBe(e.s);
 });

--- a/packages/core/src/document/metadata/document-info-parser/__tests__/document-info-parser.behavior.test.ts
+++ b/packages/core/src/document/metadata/document-info-parser/__tests__/document-info-parser.behavior.test.ts
@@ -15,7 +15,6 @@ import {
   makeResolverWithInfo,
   makeTrailerNoInfo,
   makeTrailerWithInfo,
-  unwrapOk,
   utf16BeString,
 } from "./document-info-parser.test.helpers";
 
@@ -28,7 +27,7 @@ const failingResolver = (
 test("/Info が trailer に無い場合は空 metadata と空 warnings を返し resolver を呼ばない", async () => {
   const resolver = vi.fn();
   const result = await DocumentInfoParser.parse(makeTrailerNoInfo(), resolver);
-  const { metadata, warnings } = unwrapOk(result);
+  const { metadata, warnings } = result;
   expect(metadata).toEqual({});
   expect(warnings).toHaveLength(0);
   expect(resolver).not.toHaveBeenCalled();
@@ -41,7 +40,7 @@ test("/Info に ASCII Title のみがある場合 metadata.title が抽出され
     makeTrailerWithInfo(makeRef(2)),
     resolver,
   );
-  const { metadata, warnings } = unwrapOk(result);
+  const { metadata, warnings } = result;
   expect(metadata.title).toBe("Hello");
   expect(warnings).toHaveLength(0);
 });
@@ -59,7 +58,7 @@ test("/Info の Title / Author / Subject / Keywords / Creator / Producer が全�
     makeTrailerWithInfo(makeRef(2)),
     makeResolverWithInfo(dict),
   );
-  const { metadata, warnings } = unwrapOk(result);
+  const { metadata, warnings } = result;
   expect(metadata.title).toBe("MyTitle");
   expect(metadata.author).toBe("Alice");
   expect(metadata.subject).toBe("Subject1");
@@ -75,7 +74,7 @@ test("/Title が UTF-16BE BOM 付き多言語文字列の場合に正しくデ�
     makeTrailerWithInfo(makeRef(2)),
     makeResolverWithInfo(dict),
   );
-  const { metadata } = unwrapOk(result);
+  const { metadata } = result;
   expect(metadata.title).toBe("日本語");
 });
 
@@ -85,7 +84,7 @@ test("/Title が UTF-16BE 補助平面 🚀 を含む場合に正しくデコー
     makeTrailerWithInfo(makeRef(2)),
     makeResolverWithInfo(dict),
   );
-  const { metadata } = unwrapOk(result);
+  const { metadata } = result;
   expect(metadata.title).toBe("🚀 Launch");
 });
 
@@ -107,7 +106,7 @@ test.each(
     makeTrailerWithInfo(makeRef(2)),
     makeResolverWithInfo(dict),
   );
-  const { metadata, warnings } = unwrapOk(result);
+  const { metadata, warnings } = result;
   expect(metadata[prop]).toBeUndefined();
   expect(warnings).toHaveLength(1);
   expect(warnings[0].code).toBe("STRING_DECODE_FAILED");
@@ -123,7 +122,7 @@ test("/CreationDate が D:20230615120530+09'00' の場合 UTC 換算 Date が抽
     makeTrailerWithInfo(makeRef(2)),
     makeResolverWithInfo(dict),
   );
-  const { metadata, warnings } = unwrapOk(result);
+  const { metadata, warnings } = result;
   expect(metadata.creationDate).toBeDefined();
   expect((metadata.creationDate as Date).getUTCHours()).toBe(3);
   expect((metadata.creationDate as Date).getUTCMinutes()).toBe(5);
@@ -137,7 +136,7 @@ test("/ModDate が D:20240101000000Z の場合 UTC Date が抽出される", asy
     makeTrailerWithInfo(makeRef(2)),
     makeResolverWithInfo(dict),
   );
-  const { metadata, warnings } = unwrapOk(result);
+  const { metadata, warnings } = result;
   expect(metadata.modDate).toBeDefined();
   expect((metadata.modDate as Date).getUTCFullYear()).toBe(2024);
   expect(warnings).toHaveLength(0);
@@ -149,7 +148,7 @@ test("/CreationDate が不正フォーマット D:abcd の場合 undefined + DAT
     makeTrailerWithInfo(makeRef(2)),
     makeResolverWithInfo(dict),
   );
-  const { metadata, warnings } = unwrapOk(result);
+  const { metadata, warnings } = result;
   expect(metadata.creationDate).toBeUndefined();
   expect(warnings).toHaveLength(1);
   expect(warnings[0].code).toBe("DATE_PARSE_FAILED");
@@ -170,7 +169,7 @@ test.each(
     makeTrailerWithInfo(makeRef(2)),
     makeResolverWithInfo(dict),
   );
-  const { metadata, warnings } = unwrapOk(result);
+  const { metadata, warnings } = result;
   expect(metadata[prop]).toBeUndefined();
   expect(warnings).toHaveLength(1);
   expect(warnings[0].code).toBe("DATE_PARSE_FAILED");
@@ -192,7 +191,7 @@ test.each(
     makeTrailerWithInfo(makeRef(2)),
     makeResolverWithInfo(dict),
   );
-  const { metadata, warnings } = unwrapOk(result);
+  const { metadata, warnings } = result;
   expect(metadata.trapped).toBe(name);
   expect(warnings).toHaveLength(0);
 });
@@ -204,7 +203,7 @@ test("/Trapped が未知 Name 'Yes' の場合 undefined + TRAPPED_INVALID", asyn
     makeTrailerWithInfo(makeRef(2)),
     makeResolverWithInfo(dict),
   );
-  const { metadata, warnings } = unwrapOk(result);
+  const { metadata, warnings } = result;
   expect(metadata.trapped).toBeUndefined();
   expect(warnings).toHaveLength(1);
   expect(warnings[0].code).toBe("TRAPPED_INVALID");
@@ -220,7 +219,7 @@ test("resolver が err を返した場合 INFO_RESOLVE_FAILED + 空 metadata", a
     makeTrailerWithInfo(infoRef),
     resolver,
   );
-  const { metadata, warnings } = unwrapOk(result);
+  const { metadata, warnings } = result;
   expect(metadata).toEqual({});
   expect(warnings).toHaveLength(1);
   expect(warnings[0].code).toBe("INFO_RESOLVE_FAILED");
@@ -238,7 +237,7 @@ test("/Info が dictionary 以外 (stream) に解決された場合 INFO_NOT_DIC
     makeTrailerWithInfo(makeRef(2)),
     makeResolverWithInfo(stream),
   );
-  const { metadata, warnings } = unwrapOk(result);
+  const { metadata, warnings } = result;
   expect(metadata).toEqual({});
   expect(warnings).toHaveLength(1);
   expect(warnings[0].code).toBe("INFO_NOT_DICTIONARY");
@@ -262,7 +261,7 @@ test("/Info に全フィールド（9 件）が揃った場合の統合抽出", 
     makeTrailerWithInfo(makeRef(2)),
     makeResolverWithInfo(dict),
   );
-  const { metadata, warnings } = unwrapOk(result);
+  const { metadata, warnings } = result;
   expect(metadata.title).toBe("MyDoc");
   expect(metadata.author).toBe("Alice");
   expect(metadata.subject).toBe("Sample");

--- a/packages/core/src/document/metadata/document-info-parser/__tests__/document-info-parser.test.helpers.ts
+++ b/packages/core/src/document/metadata/document-info-parser/__tests__/document-info-parser.test.helpers.ts
@@ -1,4 +1,3 @@
-import { expect } from "vitest";
 import type { PdfError } from "../../../../pdf/errors/error/index";
 import { GenerationNumber } from "../../../../pdf/types/generation-number/index";
 import { ObjectNumber } from "../../../../pdf/types/object-number/index";
@@ -17,17 +16,6 @@ const BOM_BYTE_1 = 0xff;
 const BYTES_PER_CHAR_CODE = 2;
 const HIGH_BYTE_SHIFT = 8;
 const BYTE_MASK = 0xff;
-
-/**
- * Result が Ok であることを `expect` で保証し、値を返す（テスト専用ヘルパ）。
- *
- * @param result - 検査対象
- * @returns 成功値
- */
-export const unwrapOk = <T>(result: Result<T, unknown>): T => {
-  expect(result.ok).toBe(true);
-  return (result as { ok: true; value: T }).value;
-};
 
 /**
  * ブランド付き `IndirectRef` を手軽に作るヘルパ。

--- a/packages/core/src/document/metadata/document-info-parser/index.ts
+++ b/packages/core/src/document/metadata/document-info-parser/index.ts
@@ -1,4 +1,3 @@
-import type { PdfError } from "../../../pdf/errors/error/index";
 import type { PdfWarning } from "../../../pdf/errors/warning/index";
 import type {
   PdfDictionary,
@@ -6,8 +5,6 @@ import type {
   TrailerDict,
 } from "../../../pdf/types/pdf-types/index";
 import { stripUndefined } from "../../../utils/object";
-import type { Result } from "../../../utils/result/index";
-import { ok } from "../../../utils/result/index";
 import type { ResolveRef } from "../../catalog/catalog-parser";
 import { parsePdfDate } from "../../date/pdf-date";
 import { decodePdfString } from "../../encoding/decode-pdf-string";
@@ -145,14 +142,13 @@ const extractMetadata = (
  * トレーラ辞書の `/Info` 間接参照を解決し、{@link DocumentMetadata} を抽出する
  * companion object。ISO 32000-2:2020 § 14.3.3 (Document Information Dictionary) 準拠。
  *
+ * すべての失敗は warning に降格されるため、この companion object は失敗しない。
+ *
  * 分岐:
- *  - `/Info` 不在 → 空 metadata + 空 warnings の Ok
+ *  - `/Info` 不在 → 空 metadata + 空 warnings
  *  - resolver 失敗 → `INFO_RESOLVE_FAILED` 警告 + 空 metadata
  *  - 解決値が dictionary 以外 → `INFO_NOT_DICTIONARY` 警告 + 空 metadata
  *  - 辞書あり → 9 フィールドを抽出して返す
- *
- * 現状 `Result.err` 経路は使用していない（resolver は契約上 Promise を reject せず
- * `err` を `Result.ok` に正規化して戻す）。
  */
 export const DocumentInfoParser = {
   /**
@@ -160,15 +156,15 @@ export const DocumentInfoParser = {
    *
    * @param trailerDict - trailer parser 出力（`info` は IndirectRef または undefined）
    * @param resolveRef - 間接参照を解決する関数
-   * @returns 抽出結果と警告を含む `Ok`
+   * @returns 抽出したメタデータと、抽出中に蓄積された警告
    */
   async parse(
     trailerDict: TrailerDict,
     resolveRef: ResolveRef,
-  ): Promise<Result<ParsedDocumentInfo, PdfError>> {
+  ): Promise<ParsedDocumentInfo> {
     const warnings: PdfWarning[] = [];
     if (trailerDict.info === undefined) {
-      return ok({ metadata: EMPTY_METADATA, warnings });
+      return { metadata: EMPTY_METADATA, warnings };
     }
     const resolved = await resolveRef(trailerDict.info);
     if (!resolved.ok) {
@@ -176,16 +172,16 @@ export const DocumentInfoParser = {
         code: "INFO_RESOLVE_FAILED",
         message: `Failed to resolve /Info ${trailerDict.info.objectNumber} ${trailerDict.info.generationNumber}: cause=${resolved.error.code}, message=${resolved.error.message}`,
       });
-      return ok({ metadata: EMPTY_METADATA, warnings });
+      return { metadata: EMPTY_METADATA, warnings };
     }
     if (resolved.value.type !== "dictionary") {
       warnings.push({
         code: "INFO_NOT_DICTIONARY",
         message: `Trailer /Info did not resolve to a dictionary (got: ${resolved.value.type})`,
       });
-      return ok({ metadata: EMPTY_METADATA, warnings });
+      return { metadata: EMPTY_METADATA, warnings };
     }
     const metadata = extractMetadata(resolved.value, warnings);
-    return ok({ metadata, warnings });
+    return { metadata, warnings };
   },
 } as const;

--- a/packages/core/src/document/metadata/document-metadata/__tests__/document-metadata.error.test.ts
+++ b/packages/core/src/document/metadata/document-metadata/__tests__/document-metadata.error.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test } from "vitest";
+import { expect, test } from "vitest";
 import type { PdfWarning } from "../../../../pdf/errors/warning/index";
 import { GenerationNumber } from "../../../../pdf/types/generation-number/index";
 import { ObjectNumber } from "../../../../pdf/types/object-number/index";
@@ -7,129 +7,125 @@ import { parseTrappedName, summarizePdfValue } from "../../document-metadata";
 
 const makeName = (value: string): PdfValue => ({ type: "name", value });
 
-describe("summarizePdfValue", () => {
-  test.each([
-    [{ type: "null" } as PdfValue, "null"],
-    [{ type: "boolean", value: true } as PdfValue, "true"],
-    [{ type: "boolean", value: false } as PdfValue, "false"],
-    [{ type: "integer", value: 42 } as PdfValue, "42"],
-    [{ type: "real", value: 3.14 } as PdfValue, "3.14"],
-    [
-      {
-        type: "string",
-        value: new Uint8Array([0x41]),
-        encoding: "literal",
-      } as PdfValue,
-      "<bytes len=1 enc=literal>",
-    ],
-    [{ type: "name", value: "Helvetica" } as PdfValue, "'Helvetica'"],
-    [{ type: "array", elements: [] } as PdfValue, "<array length=0>"],
-    [{ type: "dictionary", entries: new Map() } as PdfValue, "<dict size=0>"],
-    [
-      {
-        type: "indirect-ref",
-        objectNumber: ObjectNumber.of(1),
-        generationNumber: GenerationNumber.of(0),
-      } as PdfValue,
-      "<ref 1 0>",
-    ],
-  ])("summarizePdfValue(%o) -> %s", (value, expected) => {
-    expect(summarizePdfValue(value)).toBe(expected);
-  });
+test.each([
+  [{ type: "null" } as PdfValue, "null"],
+  [{ type: "boolean", value: true } as PdfValue, "true"],
+  [{ type: "boolean", value: false } as PdfValue, "false"],
+  [{ type: "integer", value: 42 } as PdfValue, "42"],
+  [{ type: "real", value: 3.14 } as PdfValue, "3.14"],
+  [
+    {
+      type: "string",
+      value: new Uint8Array([0x41]),
+      encoding: "literal",
+    } as PdfValue,
+    "<bytes len=1 enc=literal>",
+  ],
+  [{ type: "name", value: "Helvetica" } as PdfValue, "'Helvetica'"],
+  [{ type: "array", elements: [] } as PdfValue, "<array length=0>"],
+  [{ type: "dictionary", entries: new Map() } as PdfValue, "<dict size=0>"],
+  [
+    {
+      type: "indirect-ref",
+      objectNumber: ObjectNumber.of(1),
+      generationNumber: GenerationNumber.of(0),
+    } as PdfValue,
+    "<ref 1 0>",
+  ],
+])("summarizePdfValue(%o) -> %s", (value, expected) => {
+  expect(summarizePdfValue(value)).toBe(expected);
 });
 
-describe("parseTrappedName", () => {
-  test("/Trapped Name 'Yes' は undefined + TRAPPED_INVALID", () => {
-    const warnings: PdfWarning[] = [];
-    const result = parseTrappedName(makeName("Yes"), warnings);
-    expect(result).toBeUndefined();
-    expect(warnings).toHaveLength(1);
-    expect(warnings[0].code).toBe("TRAPPED_INVALID");
-  });
+test("parseTrappedName: /Trapped Name 'Yes' は undefined + TRAPPED_INVALID", () => {
+  const warnings: PdfWarning[] = [];
+  const result = parseTrappedName(makeName("Yes"), warnings);
+  expect(result).toBeUndefined();
+  expect(warnings).toHaveLength(1);
+  expect(warnings[0].code).toBe("TRAPPED_INVALID");
+});
 
-  test.each([
-    ["true"],
-    ["false"],
-    ["unknown"],
-  ])("/Trapped Name '%s' (小文字) は undefined + TRAPPED_INVALID（大文字小文字を区別する）", (lowercase) => {
-    const warnings: PdfWarning[] = [];
-    const result = parseTrappedName(makeName(lowercase), warnings);
-    expect(result).toBeUndefined();
-    expect(warnings).toHaveLength(1);
-    expect(warnings[0].code).toBe("TRAPPED_INVALID");
-  });
+test.each([
+  ["true"],
+  ["false"],
+  ["unknown"],
+])("parseTrappedName: /Trapped Name '%s' (小文字) は undefined + TRAPPED_INVALID（大文字小文字を区別する）", (lowercase) => {
+  const warnings: PdfWarning[] = [];
+  const result = parseTrappedName(makeName(lowercase), warnings);
+  expect(result).toBeUndefined();
+  expect(warnings).toHaveLength(1);
+  expect(warnings[0].code).toBe("TRAPPED_INVALID");
+});
 
-  test("/Trapped Name '' (空文字) は undefined + TRAPPED_INVALID", () => {
-    const warnings: PdfWarning[] = [];
-    const result = parseTrappedName(makeName(""), warnings);
-    expect(result).toBeUndefined();
-    expect(warnings).toHaveLength(1);
-    expect(warnings[0].code).toBe("TRAPPED_INVALID");
-  });
+test("parseTrappedName: /Trapped Name '' (空文字) は undefined + TRAPPED_INVALID", () => {
+  const warnings: PdfWarning[] = [];
+  const result = parseTrappedName(makeName(""), warnings);
+  expect(result).toBeUndefined();
+  expect(warnings).toHaveLength(1);
+  expect(warnings[0].code).toBe("TRAPPED_INVALID");
+});
 
-  test("/Trapped が PdfString のとき undefined + TRAPPED_INVALID（メッセージに type と値要約を含む）", () => {
-    const warnings: PdfWarning[] = [];
-    const stringValue: PdfValue = {
-      type: "string",
-      value: new Uint8Array([0x54, 0x72, 0x75, 0x65]),
-      encoding: "literal",
-    };
-    const result = parseTrappedName(stringValue, warnings);
-    expect(result).toBeUndefined();
-    expect(warnings).toHaveLength(1);
-    expect(warnings[0].code).toBe("TRAPPED_INVALID");
-    expect(warnings[0].message).toContain("string");
-    expect(warnings[0].message).toContain("len=4");
-    expect(warnings[0].message).toContain("enc=literal");
-  });
+test("parseTrappedName: /Trapped が PdfString のとき undefined + TRAPPED_INVALID（メッセージに type と値要約を含む）", () => {
+  const warnings: PdfWarning[] = [];
+  const stringValue: PdfValue = {
+    type: "string",
+    value: new Uint8Array([0x54, 0x72, 0x75, 0x65]),
+    encoding: "literal",
+  };
+  const result = parseTrappedName(stringValue, warnings);
+  expect(result).toBeUndefined();
+  expect(warnings).toHaveLength(1);
+  expect(warnings[0].code).toBe("TRAPPED_INVALID");
+  expect(warnings[0].message).toContain("string");
+  expect(warnings[0].message).toContain("len=4");
+  expect(warnings[0].message).toContain("enc=literal");
+});
 
-  test("/Trapped が PdfBoolean のとき undefined + TRAPPED_INVALID（メッセージに type と値を含む）", () => {
-    const warnings: PdfWarning[] = [];
-    const boolValue: PdfValue = { type: "boolean", value: true };
-    const result = parseTrappedName(boolValue, warnings);
-    expect(result).toBeUndefined();
-    expect(warnings).toHaveLength(1);
-    expect(warnings[0].code).toBe("TRAPPED_INVALID");
-    expect(warnings[0].message).toContain("boolean");
-    expect(warnings[0].message).toContain("true");
-  });
+test("parseTrappedName: /Trapped が PdfBoolean のとき undefined + TRAPPED_INVALID（メッセージに type と値を含む）", () => {
+  const warnings: PdfWarning[] = [];
+  const boolValue: PdfValue = { type: "boolean", value: true };
+  const result = parseTrappedName(boolValue, warnings);
+  expect(result).toBeUndefined();
+  expect(warnings).toHaveLength(1);
+  expect(warnings[0].code).toBe("TRAPPED_INVALID");
+  expect(warnings[0].message).toContain("boolean");
+  expect(warnings[0].message).toContain("true");
+});
 
-  test("/Trapped が PdfInteger のとき undefined + TRAPPED_INVALID（メッセージに type と値を含む）", () => {
-    const warnings: PdfWarning[] = [];
-    const intValue: PdfValue = { type: "integer", value: 1 };
-    const result = parseTrappedName(intValue, warnings);
-    expect(result).toBeUndefined();
-    expect(warnings).toHaveLength(1);
-    expect(warnings[0].code).toBe("TRAPPED_INVALID");
-    expect(warnings[0].message).toContain("integer");
-    expect(warnings[0].message).toContain("1");
-  });
+test("parseTrappedName: /Trapped が PdfInteger のとき undefined + TRAPPED_INVALID（メッセージに type と値を含む）", () => {
+  const warnings: PdfWarning[] = [];
+  const intValue: PdfValue = { type: "integer", value: 1 };
+  const result = parseTrappedName(intValue, warnings);
+  expect(result).toBeUndefined();
+  expect(warnings).toHaveLength(1);
+  expect(warnings[0].code).toBe("TRAPPED_INVALID");
+  expect(warnings[0].message).toContain("integer");
+  expect(warnings[0].message).toContain("1");
+});
 
-  test.each([
-    ["null", { type: "null" } as PdfValue, "null"],
-    ["real", { type: "real", value: 3.14 } as PdfValue, "3.14"],
-    ["array", { type: "array", elements: [] } as PdfValue, "<array length=0>"],
-    [
-      "dictionary",
-      { type: "dictionary", entries: new Map() } as PdfValue,
-      "<dict size=0>",
-    ],
-    [
-      "indirect-ref",
-      {
-        type: "indirect-ref",
-        objectNumber: ObjectNumber.of(1),
-        generationNumber: GenerationNumber.of(0),
-      } as PdfValue,
-      "<ref 1 0>",
-    ],
-  ])("/Trapped が %s のとき undefined + TRAPPED_INVALID（メッセージに type と値要約を含む）", (type, value, expectedSubstr) => {
-    const warnings: PdfWarning[] = [];
-    const result = parseTrappedName(value, warnings);
-    expect(result).toBeUndefined();
-    expect(warnings).toHaveLength(1);
-    expect(warnings[0].code).toBe("TRAPPED_INVALID");
-    expect(warnings[0].message).toContain(type);
-    expect(warnings[0].message).toContain(expectedSubstr);
-  });
+test.each([
+  ["null", { type: "null" } as PdfValue, "null"],
+  ["real", { type: "real", value: 3.14 } as PdfValue, "3.14"],
+  ["array", { type: "array", elements: [] } as PdfValue, "<array length=0>"],
+  [
+    "dictionary",
+    { type: "dictionary", entries: new Map() } as PdfValue,
+    "<dict size=0>",
+  ],
+  [
+    "indirect-ref",
+    {
+      type: "indirect-ref",
+      objectNumber: ObjectNumber.of(1),
+      generationNumber: GenerationNumber.of(0),
+    } as PdfValue,
+    "<ref 1 0>",
+  ],
+])("parseTrappedName: /Trapped が %s のとき undefined + TRAPPED_INVALID（メッセージに type と値要約を含む）", (type, value, expectedSubstr) => {
+  const warnings: PdfWarning[] = [];
+  const result = parseTrappedName(value, warnings);
+  expect(result).toBeUndefined();
+  expect(warnings).toHaveLength(1);
+  expect(warnings[0].code).toBe("TRAPPED_INVALID");
+  expect(warnings[0].message).toContain(type);
+  expect(warnings[0].message).toContain(expectedSubstr);
 });

--- a/packages/core/src/document/metadata/document-metadata/__tests__/document-metadata.parse.test.ts
+++ b/packages/core/src/document/metadata/document-metadata/__tests__/document-metadata.parse.test.ts
@@ -1,4 +1,4 @@
-import { expect, test } from "vitest";
+import { assert, expect, test } from "vitest";
 import type { PdfWarning } from "../../../../pdf/errors/warning/index";
 import type { PdfValue } from "../../../../pdf/types/pdf-types/index";
 import { none } from "../../../../utils/option";
@@ -13,13 +13,11 @@ test.each([
 ])("/Trapped Name '%s' は PdfTrapped '%s' に解釈される", (literal) => {
   const warnings: PdfWarning[] = [];
   const result = parseTrappedName(makeName(literal), warnings);
-  expect(result.some).toBe(true);
-  if (result.some) {
-    expect(PdfTrapped.create(literal)).toStrictEqual({
-      ok: true,
-      value: result.value,
-    });
-  }
+  assert(result.some);
+  expect(PdfTrapped.create(literal)).toStrictEqual({
+    ok: true,
+    value: result.value,
+  });
   expect(warnings).toHaveLength(0);
 });
 

--- a/packages/core/src/document/pdf-document/index.ts
+++ b/packages/core/src/document/pdf-document/index.ts
@@ -200,18 +200,15 @@ const resolveXRefStructure = async (
   const startXRefResult = scanStartXRef(data);
   if (!startXRefResult.ok) {
     const fb = scanFallback(data);
-    if (!fb.ok) {
-      return fb;
-    }
-    if (!fb.value.trailer.some) {
+    if (!fb.trailer.some) {
       return err({
         code: "ROOT_NOT_FOUND",
         message: "fallback xref scan could not reconstruct trailer",
         offset: ByteOffset.of(0),
       });
     }
-    emitWarnings(fb.value.warnings);
-    return ok({ xref: fb.value.xrefTable, trailer: fb.value.trailer.value });
+    emitWarnings(fb.warnings);
+    return ok({ xref: fb.xrefTable, trailer: fb.trailer.value });
   }
 
   const mergeResult = await mergeXRefChain(startXRefResult.value, (off) =>
@@ -225,14 +222,11 @@ const resolveXRefStructure = async (
   }
 
   const fb = scanFallback(data);
-  if (!fb.ok) {
-    return fb;
-  }
-  if (!fb.value.trailer.some) {
+  if (!fb.trailer.some) {
     return mergeResult;
   }
-  emitWarnings(fb.value.warnings);
-  return ok({ xref: fb.value.xrefTable, trailer: fb.value.trailer.value });
+  emitWarnings(fb.warnings);
+  return ok({ xref: fb.xrefTable, trailer: fb.trailer.value });
 };
 
 /**
@@ -365,20 +359,14 @@ export class PdfDocument {
     }
     emitWarnings(walkResult.value.warnings);
 
-    const infoResult = await DocumentInfoParser.parse(
-      latestTrailer,
-      resolveRef,
-    );
-    if (!infoResult.ok) {
-      return infoResult;
-    }
-    emitWarnings(infoResult.value.warnings);
+    const info = await DocumentInfoParser.parse(latestTrailer, resolveRef);
+    emitWarnings(info.warnings);
 
     return ok(
       new PdfDocument({
         version: catalogResult.value.version,
         pages: walkResult.value.pages,
-        metadata: infoResult.value.metadata,
+        metadata: info.metadata,
         resolver: store,
       }),
     );

--- a/packages/core/src/xref/__tests__/xref-pipeline.integration.test.ts
+++ b/packages/core/src/xref/__tests__/xref-pipeline.integration.test.ts
@@ -331,31 +331,26 @@ test("scanStartXRef -> parseXRefTable失敗 -> scanFallbackでend-to-endにtrail
   expect(tableResult.error.code).toBe("XREF_TABLE_INVALID");
 
   const fallbackResult = scanFallback(data);
-  assert(fallbackResult.ok);
 
-  expect(fallbackResult.value.trailer.some).toBe(true);
-  assert(fallbackResult.value.trailer.some);
-  expect(fallbackResult.value.trailer.value.root).toEqual({
+  expect(fallbackResult.trailer.some).toBe(true);
+  assert(fallbackResult.trailer.some);
+  expect(fallbackResult.trailer.value.root).toEqual({
     objectNumber: ObjectNumber.of(1),
     generationNumber: GenerationNumber.of(0),
   });
-  expect(fallbackResult.value.trailer.value.size).toBe(3);
+  expect(fallbackResult.trailer.value.size).toBe(3);
 
-  expect(
-    fallbackResult.value.xrefTable.entries.get(ObjectNumber.of(1)),
-  ).toEqual({
+  expect(fallbackResult.xrefTable.entries.get(ObjectNumber.of(1))).toEqual({
     type: 1,
     offset: ByteOffset.of(obj1Offset),
     generationNumber: GenerationNumber.of(0),
   });
-  expect(
-    fallbackResult.value.xrefTable.entries.get(ObjectNumber.of(2)),
-  ).toEqual({
+  expect(fallbackResult.xrefTable.entries.get(ObjectNumber.of(2))).toEqual({
     type: 1,
     offset: ByteOffset.of(obj2Offset),
     generationNumber: GenerationNumber.of(0),
   });
 
-  expect(fallbackResult.value.warnings).toHaveLength(1);
-  expect(fallbackResult.value.warnings[0].code).toBe("XREF_REBUILD");
+  expect(fallbackResult.warnings).toHaveLength(1);
+  expect(fallbackResult.warnings[0].code).toBe("XREF_REBUILD");
 });

--- a/packages/core/src/xref/fallback/fallback-scanner/__tests__/fallback-scanner.behavior.test.ts
+++ b/packages/core/src/xref/fallback/fallback-scanner/__tests__/fallback-scanner.behavior.test.ts
@@ -13,8 +13,7 @@ function encode(s: string): Uint8Array {
 test("`1 0 obj` 1 件含むデータから XRefTable を構築する (FB-001)", () => {
   const data = encode("1 0 obj\n<<>>\nendobj\n");
   const result = scanFallback(data);
-  assert(result.ok);
-  const { xrefTable, trailer, warnings } = result.value;
+  const { xrefTable, trailer, warnings } = result;
   expect(xrefTable.entries.size).toBe(1);
   expect(xrefTable.size).toBe(2);
   expect(xrefTable.entries.get(ObjectNumber.of(1))).toEqual({
@@ -30,8 +29,7 @@ test("`1 0 obj` 1 件含むデータから XRefTable を構築する (FB-001)", 
 test("`obj` 皆無のデータでは空 XRefTable と XREF_REBUILD warning 1 件を返す", () => {
   const data = encode("%PDF-1.7\n%%EOF\n");
   const result = scanFallback(data);
-  assert(result.ok);
-  const { xrefTable, warnings } = result.value;
+  const { xrefTable, warnings } = result;
   expect(xrefTable.entries.size).toBe(0);
   expect(xrefTable.size).toBe(0);
   expect(warnings).toHaveLength(1);
@@ -43,36 +41,33 @@ test.each([
   ["1KB 未満", new Uint8Array(512)],
 ])("境界条件 %s でもエラーにならず空 XRefTable を返す", (_label, data) => {
   const result = scanFallback(data);
-  assert(result.ok);
-  expect(result.value.xrefTable.entries.size).toBe(0);
-  expect(result.value.xrefTable.size).toBe(0);
-  expect(result.value.warnings).toHaveLength(1);
-  expect(result.value.warnings[0].code).toBe("XREF_REBUILD");
+  expect(result.xrefTable.entries.size).toBe(0);
+  expect(result.xrefTable.size).toBe(0);
+  expect(result.warnings).toHaveLength(1);
+  expect(result.warnings[0].code).toBe("XREF_REBUILD");
 });
 
 test("同一オブジェクト番号の重複は末尾優先で採用される (FB-003)", () => {
   const body = "1 0 obj\n<<>>\nendobj\n1 0 obj\n<</Late true>>\nendobj\n";
   const data = encode(body);
   const result = scanFallback(data);
-  assert(result.ok);
-  const entry = result.value.xrefTable.entries.get(ObjectNumber.of(1));
+  const entry = result.xrefTable.entries.get(ObjectNumber.of(1));
   const lastOffset = body.lastIndexOf("1 0 obj");
   expect(entry).toEqual({
     type: 1,
     offset: ByteOffset.of(lastOffset),
     generationNumber: GenerationNumber.of(0),
   });
-  expect(result.value.xrefTable.entries.size).toBe(1);
-  expect(result.value.xrefTable.size).toBe(2);
+  expect(result.xrefTable.entries.size).toBe(1);
+  expect(result.xrefTable.size).toBe(2);
 });
 
 test("XRefTable.size は max(objectNumber) + 1 で計算される", () => {
   const body = "1 0 obj\nx\nendobj\n5 0 obj\nx\nendobj\n3 0 obj\nx\nendobj\n";
   const data = encode(body);
   const result = scanFallback(data);
-  assert(result.ok);
-  expect(result.value.xrefTable.size).toBe(6);
-  expect(result.value.xrefTable.entries.size).toBe(3);
+  expect(result.xrefTable.size).toBe(6);
+  expect(result.xrefTable.entries.size).toBe(3);
 });
 
 test("MAX_SAFE_INTEGER のオブジェクト番号は size 超過のため skip され、recovery に size-overflow が記録される", () => {
@@ -80,12 +75,11 @@ test("MAX_SAFE_INTEGER のオブジェクト番号は size 超過のため skip 
   const body = `1 0 obj\n<<>>\nendobj\n${maxSafeInt} 0 obj\n<<>>\nendobj\n`;
   const data = encode(body);
   const result = scanFallback(data);
-  assert(result.ok);
-  expect(Number.isSafeInteger(result.value.xrefTable.size)).toBe(true);
-  expect(result.value.xrefTable.size).toBe(2);
-  expect(result.value.xrefTable.entries.size).toBe(1);
-  expect(result.value.warnings).toHaveLength(1);
-  const warning = result.value.warnings[0];
+  expect(Number.isSafeInteger(result.xrefTable.size)).toBe(true);
+  expect(result.xrefTable.size).toBe(2);
+  expect(result.xrefTable.entries.size).toBe(1);
+  expect(result.warnings).toHaveLength(1);
+  const warning = result.warnings[0];
   expect(warning.code).toBe("XREF_REBUILD");
   expect(warning.recovery).toContain("size-overflow");
 });
@@ -98,9 +92,8 @@ test("skip 候補があっても warnings は XREF_REBUILD 1 件のみで recove
     "2 70000 obj\n<<>>\nendobj\n";
   const data = encode(body);
   const result = scanFallback(data);
-  assert(result.ok);
-  expect(result.value.warnings).toHaveLength(1);
-  const warning = result.value.warnings[0];
+  expect(result.warnings).toHaveLength(1);
+  const warning = result.warnings[0];
   expect(warning.code).toBe("XREF_REBUILD");
   expect(warning.recovery).toBeDefined();
   expect(warning.recovery).toContain("2");
@@ -118,22 +111,20 @@ test.each([
       "1 0 obj\n<<>>\nendobj\n2 70000 obj\n<<>>\nendobj\n",
     ),
   ],
-])("任意の入力 %s で常に ok を返す", (_label, data) => {
-  const result = scanFallback(data);
-  expect(result.ok).toBe(true);
+])("任意の入力 %s で例外を投げない", (_label, data) => {
+  expect(() => scanFallback(data)).not.toThrow();
 });
 
 test("末尾の trailer << /Root 1 0 R /Size 2 >> から TrailerDict が取得される (FB-002)", () => {
   const body = "1 0 obj\n<<>>\nendobj\ntrailer\n<< /Root 1 0 R /Size 2 >>\n";
   const data = encode(body);
   const result = scanFallback(data);
-  assert(result.ok);
-  assert(result.value.trailer.some);
-  expect(result.value.trailer.value.root).toEqual({
+  assert(result.trailer.some);
+  expect(result.trailer.value.root).toEqual({
     objectNumber: ObjectNumber.of(1),
     generationNumber: GenerationNumber.of(0),
   });
-  expect(result.value.trailer.value.size).toBe(2);
+  expect(result.trailer.value.size).toBe(2);
 });
 
 test("コメント内 `% trailer << ... >>` は trailer として採用しない", () => {
@@ -141,8 +132,7 @@ test("コメント内 `% trailer << ... >>` は trailer として採用しない
     "1 0 obj\n<<>>\nendobj\n" + "% trailer << /Root 999 0 R /Size 999 >>\n";
   const data = encode(body);
   const result = scanFallback(data);
-  assert(result.ok);
-  expect(result.value.trailer.some).toBe(false);
+  expect(result.trailer.some).toBe(false);
 });
 
 test("`mytrailer` のような部分一致は trailer として扱わない", () => {
@@ -150,8 +140,7 @@ test("`mytrailer` のような部分一致は trailer として扱わない", ()
     "1 0 obj\n<<>>\nendobj\n" + "mytrailer << /Root 999 0 R /Size 999 >>\n";
   const data = encode(body);
   const result = scanFallback(data);
-  assert(result.ok);
-  expect(result.value.trailer.some).toBe(false);
+  expect(result.trailer.some).toBe(false);
 });
 
 test("scope 外の `trailer xyz` (parseTrailer 失敗) があっても次候補の正規 trailer にフォールバックする", () => {
@@ -161,22 +150,20 @@ test("scope 外の `trailer xyz` (parseTrailer 失敗) があっても次候補�
     "trailer xyz\n";
   const data = encode(body);
   const result = scanFallback(data);
-  assert(result.ok);
-  assert(result.value.trailer.some);
-  expect(result.value.trailer.value.root).toEqual({
+  assert(result.trailer.some);
+  expect(result.trailer.value.root).toEqual({
     objectNumber: ObjectNumber.of(1),
     generationNumber: GenerationNumber.of(0),
   });
-  expect(result.value.trailer.value.size).toBe(2);
+  expect(result.trailer.value.size).toBe(2);
 });
 
 test("trailer 不在 + /Type /Catalog 単一 → 最小 TrailerDict を合成する (FB-004)", () => {
   const body = "1 0 obj\n<< /Type /Catalog >>\nendobj\n";
   const data = encode(body);
   const result = scanFallback(data);
-  assert(result.ok);
-  assert(result.value.trailer.some);
-  expect(result.value.trailer.value).toEqual({
+  assert(result.trailer.some);
+  expect(result.trailer.value).toEqual({
     root: {
       objectNumber: ObjectNumber.of(1),
       generationNumber: GenerationNumber.of(0),
@@ -191,22 +178,20 @@ test("/Type /Catalog が複数あるときは末尾 obj を root に採用する
     "5 0 obj\n<< /Type /Catalog >>\nendobj\n";
   const data = encode(body);
   const result = scanFallback(data);
-  assert(result.ok);
-  assert(result.value.trailer.some);
-  expect(result.value.trailer.value.root).toEqual({
+  assert(result.trailer.some);
+  expect(result.trailer.value.root).toEqual({
     objectNumber: ObjectNumber.of(5),
     generationNumber: GenerationNumber.of(0),
   });
-  expect(result.value.trailer.value.size).toBe(6);
+  expect(result.trailer.value.size).toBe(6);
 });
 
 test("/Type/Catalog（スペース無し派生）も Catalog 推定の対象になる", () => {
   const body = "1 0 obj\n<</Type/Catalog>>\nendobj\n";
   const data = encode(body);
   const result = scanFallback(data);
-  assert(result.ok);
-  assert(result.value.trailer.some);
-  expect(result.value.trailer.value.root.objectNumber).toBe(ObjectNumber.of(1));
+  assert(result.trailer.some);
+  expect(result.trailer.value.root.objectNumber).toBe(ObjectNumber.of(1));
 });
 
 test("ストリームデータ内の `/Type /Catalog` バイト列は別 obj の正規 Catalog より優先しない", () => {
@@ -215,9 +200,8 @@ test("ストリームデータ内の `/Type /Catalog` バイト列は別 obj の
     "5 0 obj\n<< /Length 14 >>\nstream\n/Type /Catalog\nendstream\nendobj\n";
   const data = encode(body);
   const result = scanFallback(data);
-  assert(result.ok);
-  assert(result.value.trailer.some);
-  expect(result.value.trailer.value.root).toEqual({
+  assert(result.trailer.some);
+  expect(result.trailer.value.root).toEqual({
     objectNumber: ObjectNumber.of(1),
     generationNumber: GenerationNumber.of(0),
   });
@@ -227,8 +211,7 @@ test("`endobj` 後の `garbage /Type /Catalog` は obj scope 外のため root �
   const body = "1 0 obj\n<<>>\nendobj\ngarbage /Type /Catalog\n";
   const data = encode(body);
   const result = scanFallback(data);
-  assert(result.ok);
-  expect(result.value.trailer.some).toBe(false);
+  expect(result.trailer.some).toBe(false);
 });
 
 test("ストリーム内に `endobj` と valid-looking trailer が同居しても obj scope は本当の endobj まで保たれる", () => {
@@ -238,13 +221,12 @@ test("ストリーム内に `endobj` と valid-looking trailer が同居して�
     "5 0 obj\n<< /Length 99 >>\nstream\nendobj\ntrailer << /Root 9 0 R /Size 99 >>\nendstream\nendobj\n";
   const data = encode(body);
   const result = scanFallback(data);
-  assert(result.ok);
-  assert(result.value.trailer.some);
-  expect(result.value.trailer.value.root).toEqual({
+  assert(result.trailer.some);
+  expect(result.trailer.value.root).toEqual({
     objectNumber: ObjectNumber.of(1),
     generationNumber: GenerationNumber.of(0),
   });
-  expect(result.value.trailer.value.size).toBe(2);
+  expect(result.trailer.value.size).toBe(2);
 });
 
 test("ストリーム内の valid-looking `trailer << /Root .. /Size .. >>` は obj scope のため採用しない", () => {
@@ -254,23 +236,21 @@ test("ストリーム内の valid-looking `trailer << /Root .. /Size .. >>` は 
     "5 0 obj\n<<>>\nstream\ntrailer << /Root 9 0 R /Size 99 >>\nendstream\nendobj\n";
   const data = encode(body);
   const result = scanFallback(data);
-  assert(result.ok);
-  assert(result.value.trailer.some);
-  expect(result.value.trailer.value.root).toEqual({
+  assert(result.trailer.some);
+  expect(result.trailer.value.root).toEqual({
     objectNumber: ObjectNumber.of(1),
     generationNumber: GenerationNumber.of(0),
   });
-  expect(result.value.trailer.value.size).toBe(2);
+  expect(result.trailer.value.size).toBe(2);
 });
 
 test("trailer も /Type /Catalog も無い場合 trailer は None", () => {
   const body = "1 0 obj\n<<>>\nendobj\n";
   const data = encode(body);
   const result = scanFallback(data);
-  assert(result.ok);
-  expect(result.value.trailer.some).toBe(false);
-  expect(result.value.warnings).toHaveLength(1);
-  expect(result.value.warnings[0].code).toBe("XREF_REBUILD");
+  expect(result.trailer.some).toBe(false);
+  expect(result.warnings).toHaveLength(1);
+  expect(result.warnings[0].code).toBe("XREF_REBUILD");
 });
 
 test.each([
@@ -293,9 +273,8 @@ test.each([
     "comment trailer",
     new TextEncoder().encode("1 0 obj\n<<>>\nendobj\n% trailer << ... >>\n"),
   ],
-])("trailer 系入力 %s でも常に ok を返す", (_label, data) => {
-  const result = scanFallback(data);
-  expect(result.ok).toBe(true);
+])("trailer 系入力 %s でも例外を投げない", (_label, data) => {
+  expect(() => scanFallback(data)).not.toThrow();
 });
 
 test("/Type /XRef obj 内に /Encrypt があるとき合成 trailer に encrypt を付与する", () => {
@@ -304,9 +283,8 @@ test("/Type /XRef obj 内に /Encrypt があるとき合成 trailer に encrypt 
     "1 0 obj\n<< /Type /Catalog >>\nendobj\n";
   const data = encode(body);
   const result = scanFallback(data);
-  assert(result.ok);
-  assert(result.value.trailer.some);
-  expect(result.value.trailer.value.encrypt).toBeDefined();
+  assert(result.trailer.some);
+  expect(result.trailer.value.encrypt).toBeDefined();
 });
 
 test("/Type /XRef obj に /Encrypt が無いとき合成 trailer に encrypt を付与しない", () => {
@@ -315,9 +293,8 @@ test("/Type /XRef obj に /Encrypt が無いとき合成 trailer に encrypt を
     "1 0 obj\n<< /Type /Catalog >>\nendobj\n";
   const data = encode(body);
   const result = scanFallback(data);
-  assert(result.ok);
-  assert(result.value.trailer.some);
-  expect(result.value.trailer.value.encrypt).toBeUndefined();
+  assert(result.trailer.some);
+  expect(result.trailer.value.encrypt).toBeUndefined();
 });
 
 test("/Type/XRef（スペース無し派生）+ /Encrypt も暗号化として検出する", () => {
@@ -326,9 +303,8 @@ test("/Type/XRef（スペース無し派生）+ /Encrypt も暗号化として�
     "1 0 obj\n<< /Type /Catalog >>\nendobj\n";
   const data = encode(body);
   const result = scanFallback(data);
-  assert(result.ok);
-  assert(result.value.trailer.some);
-  expect(result.value.trailer.value.encrypt).toBeDefined();
+  assert(result.trailer.some);
+  expect(result.trailer.value.encrypt).toBeDefined();
 });
 
 test("/Type/XRef（スペース無し派生）に /Encrypt が無ければ encrypt を付与しない", () => {
@@ -337,9 +313,8 @@ test("/Type/XRef（スペース無し派生）に /Encrypt が無ければ encry
     "1 0 obj\n<< /Type /Catalog >>\nendobj\n";
   const data = encode(body);
   const result = scanFallback(data);
-  assert(result.ok);
-  assert(result.value.trailer.some);
-  expect(result.value.trailer.value.encrypt).toBeUndefined();
+  assert(result.trailer.some);
+  expect(result.trailer.value.encrypt).toBeUndefined();
 });
 
 test("ストリームデータ内の `/Encrypt` バイト列は暗号化として検出しない", () => {
@@ -348,9 +323,8 @@ test("ストリームデータ内の `/Encrypt` バイト列は暗号化とし�
     "1 0 obj\n<< /Type /Catalog >>\nendobj\n";
   const data = encode(body);
   const result = scanFallback(data);
-  assert(result.ok);
-  assert(result.value.trailer.some);
-  expect(result.value.trailer.value.encrypt).toBeUndefined();
+  assert(result.trailer.some);
+  expect(result.trailer.value.encrypt).toBeUndefined();
 });
 
 test("ストリームデータ内の `/Type /XRef` バイト列は xref ストリーム obj として扱わない", () => {
@@ -359,9 +333,8 @@ test("ストリームデータ内の `/Type /XRef` バイト列は xref スト�
     "1 0 obj\n<< /Type /Catalog >>\nendobj\n";
   const data = encode(body);
   const result = scanFallback(data);
-  assert(result.ok);
-  assert(result.value.trailer.some);
-  expect(result.value.trailer.value.encrypt).toBeUndefined();
+  assert(result.trailer.some);
+  expect(result.trailer.value.encrypt).toBeUndefined();
 });
 
 test("/Encrypt が /Type /XRef と別 obj にある場合は暗号化として検出しない", () => {
@@ -371,9 +344,8 @@ test("/Encrypt が /Type /XRef と別 obj にある場合は暗号化として�
     "1 0 obj\n<< /Type /Catalog >>\nendobj\n";
   const data = encode(body);
   const result = scanFallback(data);
-  assert(result.ok);
-  assert(result.value.trailer.some);
-  expect(result.value.trailer.value.encrypt).toBeUndefined();
+  assert(result.trailer.some);
+  expect(result.trailer.value.encrypt).toBeUndefined();
 });
 
 test("`endobj` 後の `garbage /Type /XRef /Encrypt` は obj scope 外のため検出しない", () => {
@@ -382,9 +354,8 @@ test("`endobj` 後の `garbage /Type /XRef /Encrypt` は obj scope 外のため�
     "garbage /Type /XRef /Encrypt 4 0 R\n";
   const data = encode(body);
   const result = scanFallback(data);
-  assert(result.ok);
-  assert(result.value.trailer.some);
-  expect(result.value.trailer.value.encrypt).toBeUndefined();
+  assert(result.trailer.some);
+  expect(result.trailer.value.encrypt).toBeUndefined();
 });
 
 test("/Type /XRef obj が複数あり片方だけ /Encrypt を持つ場合も検出する", () => {
@@ -394,16 +365,14 @@ test("/Type /XRef obj が複数あり片方だけ /Encrypt を持つ場合も検
     "1 0 obj\n<< /Type /Catalog >>\nendobj\n";
   const data = encode(body);
   const result = scanFallback(data);
-  assert(result.ok);
-  assert(result.value.trailer.some);
-  expect(result.value.trailer.value.encrypt).toBeDefined();
+  assert(result.trailer.some);
+  expect(result.trailer.value.encrypt).toBeDefined();
 });
 
 test("obj が 1 件も無いデータでは /Type /XRef /Encrypt があっても trailer は None", () => {
   const data = encode("%PDF-1.7\n/Type /XRef /Encrypt 4 0 R\n%%EOF\n");
   const result = scanFallback(data);
-  assert(result.ok);
-  expect(result.value.trailer.some).toBe(false);
+  expect(result.trailer.some).toBe(false);
 });
 
 test("/Encrypt を持たないテキスト trailer 採用時も /Type /XRef obj の /Encrypt を検出する (FB-002)", () => {
@@ -413,9 +382,8 @@ test("/Encrypt を持たないテキスト trailer 採用時も /Type /XRef obj 
     "5 0 obj\n<< /Type /XRef /Size 6 /Encrypt 4 0 R >>\nendobj\n";
   const data = encode(body);
   const result = scanFallback(data);
-  assert(result.ok);
-  assert(result.value.trailer.some);
-  expect(result.value.trailer.value.encrypt).toBeDefined();
+  assert(result.trailer.some);
+  expect(result.trailer.value.encrypt).toBeDefined();
 });
 
 test("テキスト trailer 自身の /Encrypt はマーカーで上書きされず間接参照のまま保たれる (FB-002)", () => {
@@ -425,9 +393,8 @@ test("テキスト trailer 自身の /Encrypt はマーカーで上書きされ�
     "5 0 obj\n<< /Type /XRef /Size 6 /Encrypt 4 0 R >>\nendobj\n";
   const data = encode(body);
   const result = scanFallback(data);
-  assert(result.ok);
-  assert(result.value.trailer.some);
-  expect(result.value.trailer.value.encrypt).toEqual({
+  assert(result.trailer.some);
+  expect(result.trailer.value.encrypt).toEqual({
     objectNumber: ObjectNumber.of(4),
     generationNumber: GenerationNumber.of(0),
   });
@@ -439,7 +406,6 @@ test("テキスト trailer 採用時に /Type /XRef obj が無ければ encrypt 
     "trailer\n<< /Root 1 0 R /Size 6 >>\n";
   const data = encode(body);
   const result = scanFallback(data);
-  assert(result.ok);
-  assert(result.value.trailer.some);
-  expect(result.value.trailer.value.encrypt).toBeUndefined();
+  assert(result.trailer.some);
+  expect(result.trailer.value.encrypt).toBeUndefined();
 });

--- a/packages/core/src/xref/fallback/fallback-scanner/index.ts
+++ b/packages/core/src/xref/fallback/fallback-scanner/index.ts
@@ -1,5 +1,5 @@
 import { isPdfTokenBoundary, matchesBytesAt } from "../../../lexer/bytes/index";
-import type { PdfError, PdfWarning } from "../../../pdf/errors/index";
+import type { PdfWarning } from "../../../pdf/errors/index";
 import { ByteOffset } from "../../../pdf/types/byte-offset/index";
 import type {
   ObjectNumber,
@@ -9,8 +9,6 @@ import type {
 } from "../../../pdf/types/index";
 import type { Option } from "../../../utils/option/index";
 import { none, some } from "../../../utils/option/index";
-import type { Result } from "../../../utils/result/index";
-import { ok } from "../../../utils/result/index";
 import { parseTrailer } from "../../trailer/index";
 import {
   type ObjectHit,
@@ -684,9 +682,7 @@ function withXRefStreamEncrypt(
  * @param data - PDF ファイル全体のバイト配列
  * @returns 復元した XRef テーブル / trailer / `XREF_REBUILD` warning 1 件
  */
-export function scanFallback(
-  data: Uint8Array,
-): Result<FallbackScanResult, PdfError> {
+export function scanFallback(data: Uint8Array): FallbackScanResult {
   const report = scanObjectHeaders(data);
   const { xrefTable, sizeOverflowCount } = rebuildXRefTable(report.hits);
   const warning = formatRebuildWarning(report, sizeOverflowCount);
@@ -694,13 +690,13 @@ export function scanFallback(
   const scopes = buildObjectScopes(data, report.hits, streamRegions);
   const directTrailer = findValidTrailer(data, scopes);
   if (directTrailer.some) {
-    return ok({
+    return {
       xrefTable,
       trailer: some(
         withXRefStreamEncrypt(directTrailer.value, data, scopes, streamRegions),
       ),
       warnings: [warning],
-    });
+    };
   }
   const synthTrailer = inferCatalogRoot(
     data,
@@ -709,13 +705,13 @@ export function scanFallback(
     xrefTable.size,
   );
   if (!synthTrailer.some) {
-    return ok({ xrefTable, trailer: synthTrailer, warnings: [warning] });
+    return { xrefTable, trailer: synthTrailer, warnings: [warning] };
   }
-  return ok({
+  return {
     xrefTable,
     trailer: some(
       withXRefStreamEncrypt(synthTrailer.value, data, scopes, streamRegions),
     ),
     warnings: [warning],
-  });
+  };
 }


### PR DESCRIPTION
## 概要

`err(...)` を一度も返さない 2 つの公開 API（`DocumentInfoParser.parse` / `scanFallback`）の戻り値から `Result` ラッパーを外し、呼び出し側 `PdfDocument` に強制されていた到達不能な `if (!x.ok)` 分岐 3 箇所を削除します。**振る舞いは一切変えていません。**

```
DocumentInfoParser.parse : Promise<Result<ParsedDocumentInfo, PdfError>> → Promise<ParsedDocumentInfo>
scanFallback             : Result<FallbackScanResult, PdfError>          → FallbackScanResult
```

## 変更内容

### 🎯 変更の種類

- [x] ♻️ リファクタリング (Refactoring)
- [x] 🚨 テスト追加/修正 (Tests)

### 📝 詳細な変更内容

#### 変更されたファイル

| ファイル | 変更 |
|---|---|
| `document/metadata/document-info-parser/index.ts` | 戻り値型・`ok()` 剥がし 4 箇所・JSDoc・不要 import 削除 |
| `xref/fallback/fallback-scanner/index.ts` | 戻り値型・`ok()` 剥がし 3 箇所・不要 import 削除 |
| `document/pdf-document/index.ts` | 到達不能な `.ok` 分岐 3 箇所を削除、`infoResult` → `info` に改名 |
| `document-info-parser.behavior.test.ts` | `unwrapOk(result)` → `result` 14 箇所 |
| `document-info-parser.test.helpers.ts` | 未使用になった `unwrapOk` 定義を削除 |
| `fallback-scanner.behavior.test.ts` | `assert(result.ok)` 32 箇所削除、`test.each` 2 件を差し替え |
| `xref-pipeline.integration.test.ts` | `assert(fallbackResult.ok)` 削除 |
| `document-metadata.error.test.ts` | `describe` を外してフラット構造に（本 Issue とは別件・下記参照） |

#### 削除されたもの

- `PdfDocument` の到達不能分岐 3 箇所
- テストヘルパー `unwrapOk`（利用者が全て消えたため）

## 🧭 意思決定と経緯

### 背景

CLAUDE.md は `Result<T, E>` を「値を生成するか、**エラー情報付きで失敗する**操作」に使うと定めています。しかし対象 2 API は `Result` を返しながら実装上の全 return が `ok(...)` でした。`DocumentInfoParser.parse` の JSDoc には「現状 `Result.err` 経路は使用していない」と自ら明記されている状態です。

型が「失敗し得る」と嘘をつくため、呼び出し側にデッドコードが生まれ、利用者が `.d.ts` を読んだときに不要な防御コードを書く動機を与えていました。

### なぜこの方針か

**破壊的変更として一度に切り替えました。**

- `@pdfmod/core` は `version: 0.0.1` で、SemVer 上も破壊的変更が許容される段階
- 影響範囲を実測で確認済み — プロダクションの呼び出し元は `pdf-document/index.ts` の 3 箇所のみ、`packages/react` からの参照なし、README / docs にコード例なし
- `PdfDocument.load` が外部に返す `Result<PdfDocument, PdfDocumentLoadError>` の型・エラーコードは不変なので、利用者から見た `load()` の契約は無傷

### 検討した代替案

- **案: `@deprecated` を付けた旧 API を残し、bare 型を返す新 API を並置する**
  - 却下理由: 移行コストを払う外部利用者が現時点で存在しない（v0.0.1・react からの参照なし）。API 面が 2 倍になり「どちらを使うべきか」の判断を利用者に押し付けるだけで、負債の解消が先送りになる
- **案: 公開シグネチャは `Result` のまま維持し、内部関数だけ bare 型に切り出す**
  - 却下理由: Issue #346 の主眼は「呼び出し側に不要な分岐を強制している」点。公開シグネチャを維持すると `PdfDocument` 側のデッドコード 3 箇所が残り、問題がまったく解決しない
- **案: `Result` を返さない代わりに例外を投げる設計に寄せる**
  - 却下理由: 両関数は本当に失敗しない。失敗を表現する必要がないのだから例外機構も要らない。`scanFallback` の「復元不能」は既に `Option` で表現済みで、CLAUDE.md の「値の有無は `Option`」方針とも合致する

### 影響とトレードオフ

- **犠牲にしたもの**: 公開 API の後方互換性。`.ok` / `.value` を書いている外部コードはコンパイルエラーになります（現時点で該当なしを確認済み）
- **`Option` は撤廃していません**。`scanFallback` の「復元できなかった」は従来どおり `FallbackScanResult.trailer` の `none` で表現します。`Result` と `Option` の二重表現のうち、実体のない `Result` だけを外した形です
- コミット分割: `pdf-document/index.ts` が両 API の呼び出し元を兼ねているため、API 単位で割るとコンパイルの通らない中間コミットになります。#346 本体は 1 コミットにまとめました

### 今回見送ったこと

- **同種 API のリポジトリ全体の洗い出し** — 「`Result` を返すが `err` を一度も返さない関数」は他にもある可能性がありますが、本 PR は Issue 記載の 2 箇所に限定しました
- **型レベルの回帰テスト**（`expectTypeOf` で戻り値が `Result` でないことを固定する）— 現状の型チェックで十分と判断

## 📊 システム図

`scanFallback` 呼び出し側の変化。二重の失敗表現が一段減ります。

```mermaid
flowchart TD
    subgraph after["after"]
        A2[PdfDocument.resolveXRefStructure] --> B2["scanFallback(data)"]
        B2 --> C2[FallbackScanResult]
        C2 --> D2{"trailer.some ?"}
        D2 -->|yes| E2[ok - xref/trailer]
        D2 -->|no| F2[err ROOT_NOT_FOUND]
    end

    subgraph before["before"]
        A1[PdfDocument.resolveXRefStructure] --> B1["scanFallback(data)"]
        B1 --> C1["Result&lt;FallbackScanResult, PdfError&gt;"]
        C1 --> X1{"!fb.ok ?"}
        X1 -->|"到達不能 (デッドコード)"| Y1[return fb]
        X1 -->|ok| D1{"fb.value.trailer.some ?"}
        D1 -->|yes| E1[ok - xref/trailer]
        D1 -->|no| F1[err ROOT_NOT_FOUND]
    end

    style X1 fill:#ffdddd,stroke:#cc0000
    style Y1 fill:#ffdddd,stroke:#cc0000
```

## 🔗 関連Issue

Closes #346

## 🚨 テスト

既存テストを新シグネチャに追従させるのみで、テストケースの追加・削除・アサーション内容の変更はしていません（下記 1 件を除く）。

| コマンド | 結果 |
|---|---|
| `pnpm typecheck` | エラー 0 |
| `pnpm test:run` | **3597 tests / 289 files 全パス** |
| `pnpm lint` | 0 errors / 0 warnings |

### 検証内容が消滅した test.each 2 件の扱い

`fallback-scanner.behavior.test.ts` にあった「任意の入力で常に ok を返す」`test.each` 2 件は、`Result` 撤廃で検証対象そのものが消滅します。入力バリエーション 8 ケース（空 / 512 バイトのランダム / trailer 系 4 種ほか）のカバレッジを失わないよう、`expect(() => scanFallback(data)).not.toThrow()` に差し替えました。

構造不変式（`warnings` が 1 件、`xrefTable` が存在する）の検証に差し替える案も検討しましたが、実質的に新規テストの追加になりリファクタリング PR のスコープを超えるため見送っています。

## 🔍 レビューポイント

- **`resolveXRefStructure` の `return mergeResult;`（`pdf-document/index.ts`）** — `if (!fb.ok) return fb;` を消しても型が成立するのは、直前の `if (mergeResult.ok) { return ok(...) }` で `mergeResult` が `Err<PdfError>` に narrowing 済みだからです
- **残った `.ok` 分岐がすべて本物の `Result` に対するものか** — `resolved.ok`（`resolveRef` の失敗を warning に降格する処理）、`startXRefResult.ok` / `mergeResult.ok` / `catalogResult.ok` / `walkResult.ok` は本物の失敗経路なので残しています
- **`document-metadata.error.test.ts` の `describe` 除去は本 Issue と無関係です** — pre-push のテストルール検査（フラット構造必須）が main 由来の既存違反で push をブロックしていたため、別コミット（`9b43816`）で対応しました。テストケース数（23 件）・入力・アサーションは不変です

## ⚠️ 破壊的変更

- [x] この変更は既存の API に破壊的変更を含みます

### 破壊的変更の詳細

`@pdfmod/core` の 2 つの公開 API の戻り値型が変わります。

```ts
// before
const r = await DocumentInfoParser.parse(trailer, resolveRef);
if (!r.ok) return r;
use(r.value.metadata);

// after
const info = await DocumentInfoParser.parse(trailer, resolveRef);
use(info.metadata);
```

```ts
// before
const fb = scanFallback(data);
if (!fb.ok) return fb;
use(fb.value.xrefTable);

// after
const fb = scanFallback(data);
use(fb.xrefTable);
```

移行方法は `.ok` チェックを削除し `.value.` を外すだけです。公開型 `ParsedDocumentInfo` / `FallbackScanResult` の名前と構造は変えていません。

## ✅ チェックリスト

- [x] コードレビューの準備ができている
- [x] テストが正常に実行される
- [x] ドキュメントが更新されている（README / docs に該当記述なしを確認）
- [x] コミットメッセージが適切な形式で書かれている
- [x] PR 本文に `Closes #346` を記載した
- [x] セルフレビューを実施した
- [x] 意思決定と経緯を記載した
- [x] 破壊的変更を明記した