### PR TITLE
✨ [New Feature]: #488 v/y curve operators を追加

### DIFF
--- a/packages/core/src/content-stream/graphics-state/current-path/__tests__/current-path.last-point.test.ts
+++ b/packages/core/src/content-stream/graphics-state/current-path/__tests__/current-path.last-point.test.ts
@@ -1,0 +1,168 @@
+import { assert, expect, test } from "vitest";
+import {
+  CurrentPath,
+  type CurrentPath as CurrentPathType,
+} from "../../current-path";
+import { PathSegment } from "../../path-segment";
+
+const appendSegments = (
+  segments: ReadonlyArray<PathSegment>,
+): CurrentPathType => {
+  let path = CurrentPath.empty();
+  for (const segment of segments) {
+    path = CurrentPath.append(path, segment);
+  }
+  return path;
+};
+
+test("空 path の lastPoint は none を返す", () => {
+  expect(CurrentPath.lastPoint(CurrentPath.empty())).toEqual({ some: false });
+});
+
+test("末尾 moveTo の座標を current point として返す", () => {
+  const path = appendSegments([PathSegment.moveTo(100, 200)]);
+
+  const result = CurrentPath.lastPoint(path);
+
+  assert(result.some);
+  expect(result.value).toEqual({ x: 100, y: 200 });
+});
+
+test("末尾 lineTo の終点を current point として返す", () => {
+  const path = appendSegments([
+    PathSegment.moveTo(100, 200),
+    PathSegment.lineTo(300, 400),
+  ]);
+
+  const result = CurrentPath.lastPoint(path);
+
+  assert(result.some);
+  expect(result.value).toEqual({ x: 300, y: 400 });
+});
+
+test("末尾 curveTo の終点を current point として返す", () => {
+  const path = appendSegments([
+    PathSegment.moveTo(100, 200),
+    PathSegment.curveTo(300, 400, 500, 600, 700, 800),
+  ]);
+
+  const result = CurrentPath.lastPoint(path);
+
+  assert(result.some);
+  expect(result.value).toEqual({ x: 700, y: 800 });
+});
+
+test("末尾 rect の左下座標を current point として返す", () => {
+  const path = appendSegments([PathSegment.rect(10, 20, 100, 50)]);
+
+  const result = CurrentPath.lastPoint(path);
+
+  assert(result.some);
+  expect(result.value).toEqual({ x: 10, y: 20 });
+});
+
+test("末尾 close は直近の moveTo の座標を current point として返す", () => {
+  const path = appendSegments([
+    PathSegment.moveTo(100, 100),
+    PathSegment.lineTo(200, 200),
+    PathSegment.close(),
+  ]);
+
+  const result = CurrentPath.lastPoint(path);
+
+  assert(result.some);
+  expect(result.value).toEqual({ x: 100, y: 100 });
+});
+
+test("末尾 close は rect の座標を subpath 開始点として返す", () => {
+  const path = appendSegments([
+    PathSegment.rect(10, 10, 100, 50),
+    PathSegment.close(),
+  ]);
+
+  const result = CurrentPath.lastPoint(path);
+
+  assert(result.some);
+  expect(result.value).toEqual({ x: 10, y: 10 });
+});
+
+test("複数 subpath の末尾 close は最後の subpath 開始点を返す", () => {
+  const path = appendSegments([
+    PathSegment.moveTo(10, 10),
+    PathSegment.lineTo(20, 20),
+    PathSegment.close(),
+    PathSegment.moveTo(50, 50),
+    PathSegment.lineTo(60, 60),
+    PathSegment.close(),
+  ]);
+
+  const result = CurrentPath.lastPoint(path);
+
+  assert(result.some);
+  expect(result.value).toEqual({ x: 50, y: 50 });
+});
+
+test("連続する close は同じ subpath 開始点を返す", () => {
+  const path = appendSegments([
+    PathSegment.moveTo(100, 100),
+    PathSegment.lineTo(200, 200),
+    PathSegment.close(),
+    PathSegment.close(),
+  ]);
+
+  const result = CurrentPath.lastPoint(path);
+
+  assert(result.some);
+  expect(result.value).toEqual({ x: 100, y: 100 });
+});
+
+test("close の後方走査は直近の rect を subpath 起点として扱う", () => {
+  const path = appendSegments([
+    PathSegment.moveTo(10, 10),
+    PathSegment.lineTo(20, 20),
+    PathSegment.close(),
+    PathSegment.rect(30, 30, 40, 40),
+    PathSegment.close(),
+  ]);
+
+  const result = CurrentPath.lastPoint(path);
+
+  assert(result.some);
+  expect(result.value).toEqual({ x: 30, y: 30 });
+});
+
+test("開始 segment のない close は none を返す", () => {
+  const path = appendSegments([PathSegment.close()]);
+
+  expect(CurrentPath.lastPoint(path)).toEqual({ some: false });
+});
+
+test("座標の NaN と Infinity は検証せずそのまま返す", () => {
+  const path = appendSegments([
+    PathSegment.moveTo(Number.NaN, Number.POSITIVE_INFINITY),
+  ]);
+
+  const result = CurrentPath.lastPoint(path);
+
+  assert(result.some);
+  expect(result.value.x).toBeNaN();
+  expect(result.value.y).toBe(Number.POSITIVE_INFINITY);
+});
+
+test("lastPoint 呼び出し後も segments の参照と内容は不変", () => {
+  const path = appendSegments([
+    PathSegment.moveTo(10, 20),
+    PathSegment.lineTo(30, 40),
+    PathSegment.close(),
+  ]);
+  const beforeSegments = path.segments;
+
+  CurrentPath.lastPoint(path);
+
+  expect(path.segments).toBe(beforeSegments);
+  expect(path.segments).toEqual([
+    PathSegment.moveTo(10, 20),
+    PathSegment.lineTo(30, 40),
+    PathSegment.close(),
+  ]);
+});

--- a/packages/core/src/content-stream/graphics-state/current-path/index.ts
+++ b/packages/core/src/content-stream/graphics-state/current-path/index.ts
@@ -1,6 +1,7 @@
 import { NumberEx } from "../../../ext/number/index";
 import type { Brand } from "../../../utils/brand/index";
-import type { MoveToSegment, PathSegment } from "../path-segment";
+import { none, type Option, some } from "../../../utils/option/index";
+import { type MoveToSegment, PathSegment } from "../path-segment";
 
 declare const CurrentPathBrand: unique symbol;
 
@@ -14,6 +15,27 @@ type CurrentPathFields = {
  * append は元 path を変更せず、新しい `CurrentPath` を返す。
  */
 export type CurrentPath = Brand<CurrentPathFields, typeof CurrentPathBrand>;
+
+/**
+ * `close` segment の直前まで後方走査し、その subpath を開始した
+ * `moveTo` / `rect` の座標を返す。
+ *
+ * @param segments - 走査対象の segment 列
+ * @param closeIndex - 起点となる `close` segment の index
+ * @returns subpath 開始点。開始 segment が見つからなければ `none`
+ */
+const subpathStartPoint = (
+  segments: ReadonlyArray<PathSegment>,
+  closeIndex: number,
+): Option<{ x: number; y: number }> => {
+  for (let i = closeIndex - 1; i >= 0; i--) {
+    const segment = segments[i];
+    if (PathSegment.isMoveTo(segment) || PathSegment.isRect(segment)) {
+      return some({ x: segment.x, y: segment.y });
+    }
+  }
+  return none;
+};
 
 export const CurrentPath = {
   /**
@@ -46,6 +68,36 @@ export const CurrentPath = {
    */
   isEmpty(path: CurrentPath): boolean {
     return path.segments.length === 0;
+  },
+  /**
+   * current point (末尾 segment の終点) を返す。
+   *
+   * `close` の場合は直近の subpath 開始 segment (`moveTo` / `rect`) まで遡る。
+   *
+   * @param path - 対象の `CurrentPath`
+   * @returns current point。未確立なら `none`
+   */
+  lastPoint(path: CurrentPath): Option<{ x: number; y: number }> {
+    const segments = path.segments;
+    const lastIndex = segments.length - 1;
+    if (!NumberEx.isSafeIntegerAtLeastZero(lastIndex)) {
+      return none;
+    }
+    const last = segments[lastIndex];
+    switch (last.kind) {
+      case "moveTo":
+      case "lineTo":
+      case "rect":
+        return some({ x: last.x, y: last.y });
+      case "curveTo":
+        return some({ x: last.x3, y: last.y3 });
+      case "close":
+        return subpathStartPoint(segments, lastIndex);
+      default: {
+        const unreachable: never = last;
+        return unreachable;
+      }
+    }
   },
   /**
    * `m` operator (ISO 32000-1:2008 §8.5.2) で新しい subpath を開始する。

--- a/packages/core/src/content-stream/operators/path/c/index.ts
+++ b/packages/core/src/content-stream/operators/path/c/index.ts
@@ -28,7 +28,7 @@ const OPERAND_COUNT = 6;
  * - operand 不足 (< 6) のとき `OPERATOR_OPERAND_MISSING` を返す
  *   `actual` には pop に成功した個数 (0..5) を入れる
  * - operand に integer / real 以外が混在したとき `OPERATOR_OPERAND_TYPE_MISMATCH` を返す
- * - current point が未確立 (先行する `m` / `re` がない / `currentPath` が空) の場合
+ * - current point が未確立 (`CurrentPath.lastPoint` が `none`) の場合
  *   `OPERATOR_PATH_NO_CURRENT_POINT` を返す (§8.5.2: `c` は current point から伸ばす)
  * - 値域 (`NaN` / `Infinity` / 負値 / 0) は本 handler では検証せずそのまま格納する
  * - エラー時に operand stack の部分消費は復元しない (既存 cm / m / l handler 規約)
@@ -71,7 +71,8 @@ export const cHandler: OperatorHandler = (context: OperatorHandlerContext) => {
     .map((operand) => operand.value);
 
   const current = GraphicsStateStack.current(context.graphicsStateStack);
-  if (CurrentPath.isEmpty(current.currentPath)) {
+  const currentPoint = CurrentPath.lastPoint(current.currentPath);
+  if (!currentPoint.some) {
     const error: PdfError = {
       code: "OPERATOR_PATH_NO_CURRENT_POINT",
       message: `Operator '${OPERATOR_NAME}' requires a current point established by a prior 'm' or 're'`,

--- a/packages/core/src/content-stream/operators/path/path-operators/__tests__/path-operators.basic.test.ts
+++ b/packages/core/src/content-stream/operators/path/path-operators/__tests__/path-operators.basic.test.ts
@@ -13,12 +13,16 @@ import {
   registerPathOperators,
   reHandler,
   strokeHandler,
+  vHandler,
+  yHandler,
 } from "../../path-operators";
 
 test.each<readonly [string, OperatorHandler]>([
   ["m", mHandler],
   ["l", lHandler],
   ["c", cHandler],
+  ["v", vHandler],
+  ["y", yHandler],
   ["h", hHandler],
   ["re", reHandler],
   ["S", strokeHandler],

--- a/packages/core/src/content-stream/operators/path/path-operators/__tests__/path-operators.integration.test.ts
+++ b/packages/core/src/content-stream/operators/path/path-operators/__tests__/path-operators.integration.test.ts
@@ -1,5 +1,6 @@
 import { assert, expect, test } from "vitest";
 import { CurrentPath } from "../../../../graphics-state/current-path/index";
+import { PathSegment } from "../../../../graphics-state/path-segment";
 import { GraphicsStateStack } from "../../../../graphics-state/stack/index";
 import { ContentStreamInterpreter } from "../../../../interpreter/index";
 import { OperatorRegistry } from "../../../../operator-registry/index";
@@ -56,4 +57,63 @@ test("100 100 m を実行すると currentPath に moveTo segment が積まれ�
     result.value.context.graphicsStateStack,
   );
   expect(CurrentPath.isEmpty(current.currentPath)).toBe(false);
+});
+
+test("補正済みの v/y シーケンスを実行すると path 構築から painting まで完走する", () => {
+  const registered = registerPathOperators(OperatorRegistry.create());
+  assert(registered.ok);
+
+  const result = ContentStreamInterpreter.execute({
+    data: encode("100 100 m 120 120 150 50 v 180 180 200 100 y h f"),
+    registry: registered.value,
+  });
+
+  assert(result.ok);
+  expect(result.value.warnings).toEqual([]);
+  const current = GraphicsStateStack.current(
+    result.value.context.graphicsStateStack,
+  );
+  expect(CurrentPath.isEmpty(current.currentPath)).toBe(true);
+});
+
+test("v/y の segment が期待する制御点へ正規化される", () => {
+  const registered = registerPathOperators(OperatorRegistry.create());
+  assert(registered.ok);
+
+  const result = ContentStreamInterpreter.execute({
+    data: encode("100 100 m 150 50 200 200 v 250 250 300 300 y"),
+    registry: registered.value,
+  });
+
+  assert(result.ok);
+  expect(result.value.warnings).toEqual([]);
+  const current = GraphicsStateStack.current(
+    result.value.context.graphicsStateStack,
+  );
+  expect(current.currentPath.segments).toEqual([
+    PathSegment.moveTo(100, 100),
+    PathSegment.curveTo(100, 100, 150, 50, 200, 200),
+    PathSegment.curveTo(250, 250, 300, 300, 300, 300),
+  ]);
+});
+
+test("re h の後の v は rect の subpath 開始点を第1制御点にする", () => {
+  const registered = registerPathOperators(OperatorRegistry.create());
+  assert(registered.ok);
+
+  const result = ContentStreamInterpreter.execute({
+    data: encode("10 10 100 50 re h 120 60 140 80 v"),
+    registry: registered.value,
+  });
+
+  assert(result.ok);
+  expect(result.value.warnings).toEqual([]);
+  const current = GraphicsStateStack.current(
+    result.value.context.graphicsStateStack,
+  );
+  expect(current.currentPath.segments).toEqual([
+    PathSegment.rect(10, 10, 100, 50),
+    PathSegment.close(),
+    PathSegment.curveTo(10, 10, 120, 60, 140, 80),
+  ]);
 });

--- a/packages/core/src/content-stream/operators/path/path-operators/index.ts
+++ b/packages/core/src/content-stream/operators/path/path-operators/index.ts
@@ -11,6 +11,8 @@ import { lHandler } from "../l";
 import { mHandler } from "../m";
 import { reHandler } from "../re";
 import { strokeHandler } from "../stroke";
+import { vHandler } from "../v";
+import { yHandler } from "../y";
 
 export { cHandler } from "../c";
 export { fillHandler } from "../fill";
@@ -20,11 +22,15 @@ export { lHandler } from "../l";
 export { mHandler } from "../m";
 export { reHandler } from "../re";
 export { strokeHandler } from "../stroke";
+export { vHandler } from "../v";
+export { yHandler } from "../y";
 
 const PATH_OPERATORS: ReadonlyArray<readonly [string, OperatorHandler]> = [
   ["m", mHandler],
   ["l", lHandler],
   ["c", cHandler],
+  ["v", vHandler],
+  ["y", yHandler],
   ["h", hHandler],
   ["re", reHandler],
   ["S", strokeHandler],
@@ -33,7 +39,7 @@ const PATH_OPERATORS: ReadonlyArray<readonly [string, OperatorHandler]> = [
 ];
 
 /**
- * Path operator (m / l / c / h / re / S / f / B) を OperatorRegistry に
+ * Path operator (m / l / c / v / y / h / re / S / f / B) を OperatorRegistry に
  * 一括登録するヘルパ。
  *
  * fail-fast: いずれかの register が Err を返した時点で reduce 内 flatMap が

--- a/packages/core/src/content-stream/operators/path/v/__tests__/v.basic.test.ts
+++ b/packages/core/src/content-stream/operators/path/v/__tests__/v.basic.test.ts
@@ -1,0 +1,273 @@
+import { assert, expect, test } from "vitest";
+import type { PdfObject } from "../../../../../pdf/types/pdf-types/index";
+import {
+  CurrentPath,
+  GraphicsState,
+  GraphicsStateStack,
+} from "../../../../graphics-state/index";
+import { PathSegment } from "../../../../graphics-state/path-segment";
+import { MarkedContentStack } from "../../../../marked-content/stack";
+import { OperandStack } from "../../../../operand-stack/index";
+import type { OperatorHandlerContext } from "../../../../operator-registry/index";
+import { mHandler } from "../../m/index";
+import { vHandler } from "../index";
+
+const real = (value: number): PdfObject => ({ type: "real", value });
+const int = (value: number): PdfObject => ({ type: "integer", value });
+
+const buildContext = (operands: PdfObject[]): OperatorHandlerContext => {
+  const operandStack = OperandStack.create();
+  for (const operand of operands) {
+    OperandStack.push(operandStack, operand);
+  }
+  const graphicsStateStack = GraphicsStateStack.create();
+  return {
+    operandStack,
+    graphicsStateStack,
+    markedContentStack: MarkedContentStack.create(),
+  };
+};
+
+const buildContextWithSegments = (
+  segments: PathSegment[],
+  operands: PdfObject[] = [],
+): OperatorHandlerContext => {
+  const operandStack = OperandStack.create();
+  for (const operand of operands) {
+    OperandStack.push(operandStack, operand);
+  }
+  const initialState = GraphicsState.create();
+  let path = initialState.currentPath;
+  for (const segment of segments) {
+    path = CurrentPath.append(path, segment);
+  }
+  const seededState = GraphicsState.update(initialState, { currentPath: path });
+  const graphicsStateStack = GraphicsStateStack.replaceCurrent(
+    GraphicsStateStack.create(),
+    seededState,
+  );
+  return {
+    operandStack,
+    graphicsStateStack,
+    markedContentStack: MarkedContentStack.create(),
+  };
+};
+
+const buildOperandStack = (operands: PdfObject[]): OperandStack => {
+  const operandStack = OperandStack.create();
+  for (const operand of operands) {
+    OperandStack.push(operandStack, operand);
+  }
+  return operandStack;
+};
+
+test("`0 0 m 110 210 120 220 v` は current point を第1制御点にして曲線を追加する", () => {
+  const ctx = buildContextWithSegments(
+    [PathSegment.moveTo(0, 0)],
+    [real(110), real(210), real(120), real(220)],
+  );
+
+  const result = vHandler(ctx);
+
+  assert(result.ok);
+  const current = GraphicsStateStack.current(result.value.graphicsStateStack);
+  expect(current.currentPath.segments).toEqual([
+    PathSegment.moveTo(0, 0),
+    PathSegment.curveTo(0, 0, 110, 210, 120, 220),
+  ]);
+});
+
+test("既存 currentPath を保持し、元の segments を変更せずに曲線を追加する", () => {
+  const ctx = buildContextWithSegments(
+    [PathSegment.moveTo(10, 20), PathSegment.lineTo(30, 40)],
+    [real(100), real(200), real(300), real(400)],
+  );
+  const before = GraphicsStateStack.current(ctx.graphicsStateStack);
+  const beforeSegments = before.currentPath.segments;
+
+  const result = vHandler(ctx);
+
+  assert(result.ok);
+  const current = GraphicsStateStack.current(result.value.graphicsStateStack);
+  expect(current.currentPath.segments).toEqual([
+    PathSegment.moveTo(10, 20),
+    PathSegment.lineTo(30, 40),
+    PathSegment.curveTo(30, 40, 100, 200, 300, 400),
+  ]);
+  expect(before.currentPath.segments).toBe(beforeSegments);
+  expect(beforeSegments).toEqual([
+    PathSegment.moveTo(10, 20),
+    PathSegment.lineTo(30, 40),
+  ]);
+});
+
+test("`mHandler(100,200)` の後の v は m の座標を第1制御点にする", () => {
+  const moveResult = mHandler(buildContext([real(100), real(200)]));
+  assert(moveResult.ok);
+  const operandStack = buildOperandStack([
+    real(110),
+    real(210),
+    real(120),
+    real(220),
+  ]);
+
+  const result = vHandler({
+    operandStack,
+    graphicsStateStack: moveResult.value.graphicsStateStack,
+    markedContentStack: MarkedContentStack.create(),
+  });
+
+  assert(result.ok);
+  const current = GraphicsStateStack.current(result.value.graphicsStateStack);
+  expect(current.currentPath.segments).toEqual([
+    PathSegment.moveTo(100, 200),
+    PathSegment.curveTo(100, 200, 110, 210, 120, 220),
+  ]);
+});
+
+test("末尾 curveTo の終点を v の第1制御点にする", () => {
+  const ctx = buildContextWithSegments(
+    [PathSegment.moveTo(10, 20), PathSegment.curveTo(30, 40, 50, 60, 70, 80)],
+    [real(100), real(200), real(300), real(400)],
+  );
+
+  const result = vHandler(ctx);
+
+  assert(result.ok);
+  const current = GraphicsStateStack.current(result.value.graphicsStateStack);
+  expect(current.currentPath.segments.at(-1)).toEqual(
+    PathSegment.curveTo(70, 80, 100, 200, 300, 400),
+  );
+});
+
+test("末尾 close の後は subpath 開始点を v の第1制御点にする", () => {
+  const ctx = buildContextWithSegments(
+    [
+      PathSegment.moveTo(10, 20),
+      PathSegment.lineTo(30, 40),
+      PathSegment.close(),
+    ],
+    [real(100), real(200), real(300), real(400)],
+  );
+
+  const result = vHandler(ctx);
+
+  assert(result.ok);
+  const current = GraphicsStateStack.current(result.value.graphicsStateStack);
+  expect(current.currentPath.segments.at(-1)).toEqual(
+    PathSegment.curveTo(10, 20, 100, 200, 300, 400),
+  );
+});
+
+test("末尾 rect の左下を v の第1制御点にする", () => {
+  const ctx = buildContextWithSegments(
+    [PathSegment.rect(10, 20, 100, 50)],
+    [real(100), real(200), real(300), real(400)],
+  );
+
+  const result = vHandler(ctx);
+
+  assert(result.ok);
+  const current = GraphicsStateStack.current(result.value.graphicsStateStack);
+  expect(current.currentPath.segments.at(-1)).toEqual(
+    PathSegment.curveTo(10, 20, 100, 200, 300, 400),
+  );
+});
+
+test("v を連続適用すると2個目の第1制御点は1個目の終点になる", () => {
+  const firstContext = buildContextWithSegments(
+    [PathSegment.moveTo(10, 20)],
+    [real(100), real(200), real(300), real(400)],
+  );
+  const firstResult = vHandler(firstContext);
+  assert(firstResult.ok);
+  const secondOperandStack = buildOperandStack([
+    real(500),
+    real(600),
+    real(700),
+    real(800),
+  ]);
+
+  const secondResult = vHandler({
+    operandStack: secondOperandStack,
+    graphicsStateStack: firstResult.value.graphicsStateStack,
+    markedContentStack: MarkedContentStack.create(),
+  });
+
+  assert(secondResult.ok);
+  const current = GraphicsStateStack.current(
+    secondResult.value.graphicsStateStack,
+  );
+  expect(current.currentPath.segments).toEqual([
+    PathSegment.moveTo(10, 20),
+    PathSegment.curveTo(10, 20, 100, 200, 300, 400),
+    PathSegment.curveTo(300, 400, 500, 600, 700, 800),
+  ]);
+});
+
+test("integer と real の operand を混在させても数値として格納する", () => {
+  const ctx = buildContextWithSegments(
+    [PathSegment.moveTo(0, 0)],
+    [int(110), real(210.5), int(120), real(220.25)],
+  );
+
+  const result = vHandler(ctx);
+
+  assert(result.ok);
+  const current = GraphicsStateStack.current(result.value.graphicsStateStack);
+  expect(current.currentPath.segments.at(-1)).toEqual(
+    PathSegment.curveTo(0, 0, 110, 210.5, 120, 220.25),
+  );
+});
+
+test("成功時に operand stack を使い切り、入力と同一参照を返す", () => {
+  const ctx = buildContextWithSegments(
+    [PathSegment.moveTo(0, 0)],
+    [real(1), real(2), real(3), real(4)],
+  );
+
+  const result = vHandler(ctx);
+
+  assert(result.ok);
+  expect(OperandStack.depth(result.value.operandStack)).toBe(0);
+  expect(result.value.operandStack).toBe(ctx.operandStack);
+});
+
+test("成功時に ctm と graphics state の線属性は不変", () => {
+  const ctx = buildContextWithSegments(
+    [PathSegment.moveTo(0, 0)],
+    [real(1), real(2), real(3), real(4)],
+  );
+  const before = GraphicsStateStack.current(ctx.graphicsStateStack);
+
+  const result = vHandler(ctx);
+
+  assert(result.ok);
+  const after = GraphicsStateStack.current(result.value.graphicsStateStack);
+  expect(after.ctm).toEqual(before.ctm);
+  expect(after.lineWidth).toBe(before.lineWidth);
+  expect(after.lineCap).toBe(before.lineCap);
+  expect(after.lineJoin).toBe(before.lineJoin);
+  expect(after.miterLimit).toBe(before.miterLimit);
+});
+
+test.each([
+  { label: "0", value: 0 },
+  { label: "negative", value: -1.5 },
+  { label: "NaN", value: Number.NaN },
+  { label: "Positive Infinity", value: Number.POSITIVE_INFINITY },
+  { label: "Negative Infinity", value: Number.NEGATIVE_INFINITY },
+])("境界値 $label を v の y3 に渡してもそのまま格納する", ({ value }) => {
+  const ctx = buildContextWithSegments(
+    [PathSegment.moveTo(0, 0)],
+    [real(100), real(200), real(300), real(value)],
+  );
+
+  const result = vHandler(ctx);
+
+  assert(result.ok);
+  const current = GraphicsStateStack.current(result.value.graphicsStateStack);
+  expect(current.currentPath.segments.at(-1)).toEqual(
+    PathSegment.curveTo(0, 0, 100, 200, 300, value),
+  );
+});

--- a/packages/core/src/content-stream/operators/path/v/__tests__/v.error.test.ts
+++ b/packages/core/src/content-stream/operators/path/v/__tests__/v.error.test.ts
@@ -1,0 +1,155 @@
+import { assert, expect, test } from "vitest";
+import type { PdfObject } from "../../../../../pdf/types/pdf-types/index";
+import {
+  CurrentPath,
+  GraphicsStateStack,
+} from "../../../../graphics-state/index";
+import { MarkedContentStack } from "../../../../marked-content/stack";
+import { OperandStack } from "../../../../operand-stack/index";
+import type { OperatorHandlerContext } from "../../../../operator-registry/index";
+import { vHandler } from "../index";
+
+const real = (value: number): PdfObject => ({ type: "real", value });
+
+const buildContext = (operands: PdfObject[]): OperatorHandlerContext => {
+  const operandStack = OperandStack.create();
+  for (const operand of operands) {
+    OperandStack.push(operandStack, operand);
+  }
+  return {
+    operandStack,
+    graphicsStateStack: GraphicsStateStack.create(),
+    markedContentStack: MarkedContentStack.create(),
+  };
+};
+
+test.each([
+  { label: "0 個", count: 0 },
+  { label: "1 個", count: 1 },
+  { label: "2 個", count: 2 },
+  { label: "3 個", count: 3 },
+])("operand $label のとき OPERATOR_OPERAND_MISSING を返す", ({ count }) => {
+  const operands: PdfObject[] = Array.from({ length: count }, () => real(1));
+  const ctx = buildContext(operands);
+
+  const result = vHandler(ctx);
+
+  assert(!result.ok);
+  assert(result.error.code === "OPERATOR_OPERAND_MISSING");
+  expect(result.error.operatorName).toBe("v");
+  expect(result.error.required).toBe(4);
+  expect(result.error.actual).toBe(count);
+  expect(result.error.message).toBe(
+    `Operator 'v' requires 4 operand(s), got ${count}`,
+  );
+});
+
+test.each([
+  { label: "null", operand: { type: "null" } satisfies PdfObject },
+  {
+    label: "name",
+    operand: { type: "name", value: "Foo" } satisfies PdfObject,
+  },
+  {
+    label: "boolean",
+    operand: { type: "boolean", value: true } satisfies PdfObject,
+  },
+  {
+    label: "string",
+    operand: {
+      type: "string",
+      value: new Uint8Array([0x61]),
+      encoding: "literal",
+    } satisfies PdfObject,
+  },
+  {
+    label: "array",
+    operand: { type: "array", elements: [] } satisfies PdfObject,
+  },
+  {
+    label: "dictionary",
+    operand: { type: "dictionary", entries: new Map() } satisfies PdfObject,
+  },
+  {
+    label: "indirect-ref",
+    operand: {
+      type: "indirect-ref",
+      objectNumber: 1,
+      generationNumber: 0,
+    } satisfies PdfObject,
+  },
+  {
+    label: "stream",
+    operand: {
+      type: "stream",
+      dictionary: { type: "dictionary", entries: new Map() },
+      data: new Uint8Array(),
+    } satisfies PdfObject,
+  },
+])("top operand が $label のとき TYPE_MISMATCH を返す", ({
+  label,
+  operand,
+}) => {
+  const ctx = buildContext([real(100), real(200), real(300), operand]);
+
+  const result = vHandler(ctx);
+
+  assert(!result.ok);
+  assert(result.error.code === "OPERATOR_OPERAND_TYPE_MISMATCH");
+  expect(result.error.operatorName).toBe("v");
+  expect(result.error.expected).toBe("number");
+  expect(result.error.actual).toBe(label);
+  expect(result.error.message).toBe(
+    `Operator 'v' expected number operand, got ${label}`,
+  );
+  expect(OperandStack.depth(ctx.operandStack)).toBe(3);
+});
+
+test("最下位 operand が boolean のとき TYPE_MISMATCH を返し全4個を消費する", () => {
+  const bottom: PdfObject = { type: "boolean", value: true };
+  const ctx = buildContext([bottom, real(200), real(300), real(400)]);
+
+  const result = vHandler(ctx);
+
+  assert(!result.ok);
+  assert(result.error.code === "OPERATOR_OPERAND_TYPE_MISMATCH");
+  expect(result.error.operatorName).toBe("v");
+  expect(result.error.actual).toBe("boolean");
+  expect(OperandStack.depth(ctx.operandStack)).toBe(0);
+});
+
+test("中間 operand の型不一致では部分消費を復元しない", () => {
+  const middle: PdfObject = { type: "name", value: "Foo" };
+  const ctx = buildContext([real(100), real(200), middle, real(400)]);
+
+  const result = vHandler(ctx);
+
+  assert(!result.ok);
+  assert(result.error.code === "OPERATOR_OPERAND_TYPE_MISMATCH");
+  expect(result.error.actual).toBe("name");
+  expect(OperandStack.depth(ctx.operandStack)).toBe(2);
+});
+
+test("current point 未確立のとき OPERATOR_PATH_NO_CURRENT_POINT を返す", () => {
+  const ctx = buildContext([real(100), real(200), real(300), real(400)]);
+
+  const result = vHandler(ctx);
+
+  assert(!result.ok);
+  assert(result.error.code === "OPERATOR_PATH_NO_CURRENT_POINT");
+  expect(result.error.operatorName).toBe("v");
+  expect(result.error.message).toBe(
+    "Operator 'v' requires a current point established by a prior 'm' or 're'",
+  );
+});
+
+test("current point 未確立時も path は空のまま、operand stack は復元しない", () => {
+  const ctx = buildContext([real(100), real(200), real(300), real(400)]);
+
+  const result = vHandler(ctx);
+
+  assert(!result.ok);
+  const current = GraphicsStateStack.current(ctx.graphicsStateStack);
+  expect(CurrentPath.isEmpty(current.currentPath)).toBe(true);
+  expect(OperandStack.depth(ctx.operandStack)).toBe(0);
+});

--- a/packages/core/src/content-stream/operators/path/v/index.ts
+++ b/packages/core/src/content-stream/operators/path/v/index.ts
@@ -1,0 +1,101 @@
+import type { PdfError } from "../../../../pdf/errors/index";
+import { err, ok } from "../../../../utils/result/index";
+import {
+  CurrentPath,
+  GraphicsState,
+  GraphicsStateStack,
+} from "../../../graphics-state/index";
+import { PathSegment } from "../../../graphics-state/path-segment";
+import { OperandStack } from "../../../operand-stack/index";
+import type {
+  OperatorHandler,
+  OperatorHandlerContext,
+} from "../../../operator-registry/index";
+import { NumericPdfObject } from "../../graphics-state/numeric-pdf-object";
+
+const OPERATOR_NAME = "v";
+const OPERAND_COUNT = 4;
+
+/**
+ * PDF §8.5.2.2 `v` operator (第 1 制御点 = current point の 3 次 Bezier) のハンドラ。
+ *
+ * operand stack から `x2 y2 x3 y3` の 4 個の数値を pop し、current point `(cx, cy)` を
+ * 第 1 制御点として `PathSegment.curveTo(cx, cy, x2, y2, x3, y3)` を current path の
+ * 末尾に append した新しい GraphicsState を生成する。
+ *
+ * - operand 不足 (< 4) のとき `OPERATOR_OPERAND_MISSING` を返す
+ * - operand に integer / real 以外が混在したとき `OPERATOR_OPERAND_TYPE_MISMATCH` を返す
+ * - current point が未確立の場合 `OPERATOR_PATH_NO_CURRENT_POINT` を返す
+ * - 値域 (`NaN` / `Infinity` / 負値 / 0) は本 handler では検証せずそのまま格納する
+ * - エラー時に operand stack の部分消費は復元しない
+ *
+ * @param context - 実行コンテキスト (operand stack / graphics state stack)
+ * @returns 成功なら更新後コンテキスト、失敗なら PdfError
+ */
+export const vHandler: OperatorHandler = (context: OperatorHandlerContext) => {
+  const popped: NumericPdfObject[] = [];
+  for (let i = 0; i < OPERAND_COUNT; i++) {
+    const result = OperandStack.pop(context.operandStack);
+    if (!result.some) {
+      const error: PdfError = {
+        code: "OPERATOR_OPERAND_MISSING",
+        message: `Operator '${OPERATOR_NAME}' requires ${OPERAND_COUNT} operand(s), got ${i}`,
+        operatorName: OPERATOR_NAME,
+        required: OPERAND_COUNT,
+        actual: i,
+      };
+      return err(error);
+    }
+    const operand = result.value;
+    if (!NumericPdfObject.is(operand)) {
+      const error: PdfError = {
+        code: "OPERATOR_OPERAND_TYPE_MISMATCH",
+        message: `Operator '${OPERATOR_NAME}' expected number operand, got ${operand.type}`,
+        operatorName: OPERATOR_NAME,
+        expected: "number",
+        actual: operand.type,
+      };
+      return err(error);
+    }
+    popped.push(operand);
+  }
+
+  // popped は LIFO 順 [y3, x3, y2, x2]。reverse して PDF 順に戻す
+  const [x2, y2, x3, y3] = popped
+    .slice()
+    .reverse()
+    .map((operand) => operand.value);
+
+  const current = GraphicsStateStack.current(context.graphicsStateStack);
+  const currentPoint = CurrentPath.lastPoint(current.currentPath);
+  if (!currentPoint.some) {
+    const error: PdfError = {
+      code: "OPERATOR_PATH_NO_CURRENT_POINT",
+      message: `Operator '${OPERATOR_NAME}' requires a current point established by a prior 'm' or 're'`,
+      operatorName: OPERATOR_NAME,
+    };
+    return err(error);
+  }
+  const nextPath = CurrentPath.append(
+    current.currentPath,
+    PathSegment.curveTo(
+      currentPoint.value.x,
+      currentPoint.value.y,
+      x2,
+      y2,
+      x3,
+      y3,
+    ),
+  );
+  const next = GraphicsState.update(current, { currentPath: nextPath });
+  const graphicsStateStack = GraphicsStateStack.replaceCurrent(
+    context.graphicsStateStack,
+    next,
+  );
+
+  return ok({
+    operandStack: context.operandStack,
+    graphicsStateStack,
+    markedContentStack: context.markedContentStack,
+  });
+};

--- a/packages/core/src/content-stream/operators/path/y/__tests__/y.basic.test.ts
+++ b/packages/core/src/content-stream/operators/path/y/__tests__/y.basic.test.ts
@@ -1,0 +1,228 @@
+import { assert, expect, test } from "vitest";
+import type { PdfObject } from "../../../../../pdf/types/pdf-types/index";
+import {
+  CurrentPath,
+  GraphicsState,
+  GraphicsStateStack,
+} from "../../../../graphics-state/index";
+import { PathSegment } from "../../../../graphics-state/path-segment";
+import { MarkedContentStack } from "../../../../marked-content/stack";
+import { OperandStack } from "../../../../operand-stack/index";
+import type { OperatorHandlerContext } from "../../../../operator-registry/index";
+import { yHandler } from "../index";
+
+const real = (value: number): PdfObject => ({ type: "real", value });
+const int = (value: number): PdfObject => ({ type: "integer", value });
+
+const buildContextWithSegments = (
+  segments: PathSegment[],
+  operands: PdfObject[] = [],
+): OperatorHandlerContext => {
+  const operandStack = OperandStack.create();
+  for (const operand of operands) {
+    OperandStack.push(operandStack, operand);
+  }
+  const initialState = GraphicsState.create();
+  let path = initialState.currentPath;
+  for (const segment of segments) {
+    path = CurrentPath.append(path, segment);
+  }
+  const seededState = GraphicsState.update(initialState, { currentPath: path });
+  const graphicsStateStack = GraphicsStateStack.replaceCurrent(
+    GraphicsStateStack.create(),
+    seededState,
+  );
+  return {
+    operandStack,
+    graphicsStateStack,
+    markedContentStack: MarkedContentStack.create(),
+  };
+};
+
+const buildOperandStack = (operands: PdfObject[]): OperandStack => {
+  const operandStack = OperandStack.create();
+  for (const operand of operands) {
+    OperandStack.push(operandStack, operand);
+  }
+  return operandStack;
+};
+
+test("`0 0 m 110 210 120 220 y` は第2制御点を終点にして曲線を追加する", () => {
+  const ctx = buildContextWithSegments(
+    [PathSegment.moveTo(0, 0)],
+    [real(110), real(210), real(120), real(220)],
+  );
+
+  const result = yHandler(ctx);
+
+  assert(result.ok);
+  const current = GraphicsStateStack.current(result.value.graphicsStateStack);
+  expect(current.currentPath.segments).toEqual([
+    PathSegment.moveTo(0, 0),
+    PathSegment.curveTo(110, 210, 120, 220, 120, 220),
+  ]);
+});
+
+test("y の第2制御点は常に終点と同じ x3 / y3 になる", () => {
+  const ctx = buildContextWithSegments(
+    [PathSegment.moveTo(10, 20)],
+    [real(100), real(200), real(300), real(400)],
+  );
+
+  const result = yHandler(ctx);
+
+  assert(result.ok);
+  const current = GraphicsStateStack.current(result.value.graphicsStateStack);
+  expect(current.currentPath.segments[1]).toEqual(
+    PathSegment.curveTo(100, 200, 300, 400, 300, 400),
+  );
+});
+
+test("current point の座標が異なっても同じ operand から同じ曲線を生成する", () => {
+  const firstResult = yHandler(
+    buildContextWithSegments(
+      [PathSegment.moveTo(0, 0)],
+      [real(100), real(200), real(300), real(400)],
+    ),
+  );
+  const secondResult = yHandler(
+    buildContextWithSegments(
+      [PathSegment.moveTo(900, 800)],
+      [real(100), real(200), real(300), real(400)],
+    ),
+  );
+
+  assert(firstResult.ok);
+  assert(secondResult.ok);
+  const firstCurrent = GraphicsStateStack.current(
+    firstResult.value.graphicsStateStack,
+  );
+  const secondCurrent = GraphicsStateStack.current(
+    secondResult.value.graphicsStateStack,
+  );
+  expect(firstCurrent.currentPath.segments[1]).toEqual(
+    secondCurrent.currentPath.segments[1],
+  );
+});
+
+test("既存 currentPath を保持し、元の segments を変更せずに曲線を追加する", () => {
+  const ctx = buildContextWithSegments(
+    [PathSegment.moveTo(10, 20), PathSegment.lineTo(30, 40)],
+    [real(100), real(200), real(300), real(400)],
+  );
+  const before = GraphicsStateStack.current(ctx.graphicsStateStack);
+  const beforeSegments = before.currentPath.segments;
+
+  const result = yHandler(ctx);
+
+  assert(result.ok);
+  const current = GraphicsStateStack.current(result.value.graphicsStateStack);
+  expect(current.currentPath.segments).toEqual([
+    PathSegment.moveTo(10, 20),
+    PathSegment.lineTo(30, 40),
+    PathSegment.curveTo(100, 200, 300, 400, 300, 400),
+  ]);
+  expect(before.currentPath.segments).toBe(beforeSegments);
+  expect(beforeSegments).toEqual([
+    PathSegment.moveTo(10, 20),
+    PathSegment.lineTo(30, 40),
+  ]);
+});
+
+test("y を連続適用すると2個の曲線を順に append する", () => {
+  const firstContext = buildContextWithSegments(
+    [PathSegment.moveTo(10, 20)],
+    [real(100), real(200), real(300), real(400)],
+  );
+  const firstResult = yHandler(firstContext);
+  assert(firstResult.ok);
+  const secondOperandStack = buildOperandStack([
+    real(500),
+    real(600),
+    real(700),
+    real(800),
+  ]);
+
+  const secondResult = yHandler({
+    operandStack: secondOperandStack,
+    graphicsStateStack: firstResult.value.graphicsStateStack,
+    markedContentStack: MarkedContentStack.create(),
+  });
+
+  assert(secondResult.ok);
+  const current = GraphicsStateStack.current(
+    secondResult.value.graphicsStateStack,
+  );
+  expect(current.currentPath.segments).toEqual([
+    PathSegment.moveTo(10, 20),
+    PathSegment.curveTo(100, 200, 300, 400, 300, 400),
+    PathSegment.curveTo(500, 600, 700, 800, 700, 800),
+  ]);
+});
+
+test("integer と real の operand を混在させても数値として格納する", () => {
+  const ctx = buildContextWithSegments(
+    [PathSegment.moveTo(0, 0)],
+    [int(110), real(210.5), int(120), real(220.25)],
+  );
+
+  const result = yHandler(ctx);
+
+  assert(result.ok);
+  const current = GraphicsStateStack.current(result.value.graphicsStateStack);
+  expect(current.currentPath.segments[1]).toEqual(
+    PathSegment.curveTo(110, 210.5, 120, 220.25, 120, 220.25),
+  );
+});
+
+test("成功時に operand stack を使い切り、入力と同一参照を返す", () => {
+  const ctx = buildContextWithSegments(
+    [PathSegment.moveTo(0, 0)],
+    [real(1), real(2), real(3), real(4)],
+  );
+
+  const result = yHandler(ctx);
+
+  assert(result.ok);
+  expect(OperandStack.depth(result.value.operandStack)).toBe(0);
+  expect(result.value.operandStack).toBe(ctx.operandStack);
+});
+
+test("成功時に ctm と graphics state の線属性は不変", () => {
+  const ctx = buildContextWithSegments(
+    [PathSegment.moveTo(0, 0)],
+    [real(1), real(2), real(3), real(4)],
+  );
+  const before = GraphicsStateStack.current(ctx.graphicsStateStack);
+
+  const result = yHandler(ctx);
+
+  assert(result.ok);
+  const after = GraphicsStateStack.current(result.value.graphicsStateStack);
+  expect(after.ctm).toEqual(before.ctm);
+  expect(after.lineWidth).toBe(before.lineWidth);
+  expect(after.lineCap).toBe(before.lineCap);
+  expect(after.lineJoin).toBe(before.lineJoin);
+  expect(after.miterLimit).toBe(before.miterLimit);
+});
+
+test.each([
+  { label: "0", value: 0 },
+  { label: "negative", value: -1.5 },
+  { label: "NaN", value: Number.NaN },
+  { label: "Positive Infinity", value: Number.POSITIVE_INFINITY },
+  { label: "Negative Infinity", value: Number.NEGATIVE_INFINITY },
+])("境界値 $label を y の y3 に渡してもそのまま格納する", ({ value }) => {
+  const ctx = buildContextWithSegments(
+    [PathSegment.moveTo(0, 0)],
+    [real(100), real(200), real(300), real(value)],
+  );
+
+  const result = yHandler(ctx);
+
+  assert(result.ok);
+  const current = GraphicsStateStack.current(result.value.graphicsStateStack);
+  expect(current.currentPath.segments[1]).toEqual(
+    PathSegment.curveTo(100, 200, 300, value, 300, value),
+  );
+});

--- a/packages/core/src/content-stream/operators/path/y/__tests__/y.error.test.ts
+++ b/packages/core/src/content-stream/operators/path/y/__tests__/y.error.test.ts
@@ -1,0 +1,155 @@
+import { assert, expect, test } from "vitest";
+import type { PdfObject } from "../../../../../pdf/types/pdf-types/index";
+import {
+  CurrentPath,
+  GraphicsStateStack,
+} from "../../../../graphics-state/index";
+import { MarkedContentStack } from "../../../../marked-content/stack";
+import { OperandStack } from "../../../../operand-stack/index";
+import type { OperatorHandlerContext } from "../../../../operator-registry/index";
+import { yHandler } from "../index";
+
+const real = (value: number): PdfObject => ({ type: "real", value });
+
+const buildContext = (operands: PdfObject[]): OperatorHandlerContext => {
+  const operandStack = OperandStack.create();
+  for (const operand of operands) {
+    OperandStack.push(operandStack, operand);
+  }
+  return {
+    operandStack,
+    graphicsStateStack: GraphicsStateStack.create(),
+    markedContentStack: MarkedContentStack.create(),
+  };
+};
+
+test.each([
+  { label: "0 個", count: 0 },
+  { label: "1 個", count: 1 },
+  { label: "2 個", count: 2 },
+  { label: "3 個", count: 3 },
+])("operand $label のとき OPERATOR_OPERAND_MISSING を返す", ({ count }) => {
+  const operands: PdfObject[] = Array.from({ length: count }, () => real(1));
+  const ctx = buildContext(operands);
+
+  const result = yHandler(ctx);
+
+  assert(!result.ok);
+  assert(result.error.code === "OPERATOR_OPERAND_MISSING");
+  expect(result.error.operatorName).toBe("y");
+  expect(result.error.required).toBe(4);
+  expect(result.error.actual).toBe(count);
+  expect(result.error.message).toBe(
+    `Operator 'y' requires 4 operand(s), got ${count}`,
+  );
+});
+
+test.each([
+  { label: "null", operand: { type: "null" } satisfies PdfObject },
+  {
+    label: "name",
+    operand: { type: "name", value: "Foo" } satisfies PdfObject,
+  },
+  {
+    label: "boolean",
+    operand: { type: "boolean", value: true } satisfies PdfObject,
+  },
+  {
+    label: "string",
+    operand: {
+      type: "string",
+      value: new Uint8Array([0x61]),
+      encoding: "literal",
+    } satisfies PdfObject,
+  },
+  {
+    label: "array",
+    operand: { type: "array", elements: [] } satisfies PdfObject,
+  },
+  {
+    label: "dictionary",
+    operand: { type: "dictionary", entries: new Map() } satisfies PdfObject,
+  },
+  {
+    label: "indirect-ref",
+    operand: {
+      type: "indirect-ref",
+      objectNumber: 1,
+      generationNumber: 0,
+    } satisfies PdfObject,
+  },
+  {
+    label: "stream",
+    operand: {
+      type: "stream",
+      dictionary: { type: "dictionary", entries: new Map() },
+      data: new Uint8Array(),
+    } satisfies PdfObject,
+  },
+])("top operand が $label のとき TYPE_MISMATCH を返す", ({
+  label,
+  operand,
+}) => {
+  const ctx = buildContext([real(100), real(200), real(300), operand]);
+
+  const result = yHandler(ctx);
+
+  assert(!result.ok);
+  assert(result.error.code === "OPERATOR_OPERAND_TYPE_MISMATCH");
+  expect(result.error.operatorName).toBe("y");
+  expect(result.error.expected).toBe("number");
+  expect(result.error.actual).toBe(label);
+  expect(result.error.message).toBe(
+    `Operator 'y' expected number operand, got ${label}`,
+  );
+  expect(OperandStack.depth(ctx.operandStack)).toBe(3);
+});
+
+test("最下位 operand が boolean のとき TYPE_MISMATCH を返し全4個を消費する", () => {
+  const bottom: PdfObject = { type: "boolean", value: true };
+  const ctx = buildContext([bottom, real(200), real(300), real(400)]);
+
+  const result = yHandler(ctx);
+
+  assert(!result.ok);
+  assert(result.error.code === "OPERATOR_OPERAND_TYPE_MISMATCH");
+  expect(result.error.operatorName).toBe("y");
+  expect(result.error.actual).toBe("boolean");
+  expect(OperandStack.depth(ctx.operandStack)).toBe(0);
+});
+
+test("中間 operand の型不一致では部分消費を復元しない", () => {
+  const middle: PdfObject = { type: "name", value: "Foo" };
+  const ctx = buildContext([real(100), real(200), middle, real(400)]);
+
+  const result = yHandler(ctx);
+
+  assert(!result.ok);
+  assert(result.error.code === "OPERATOR_OPERAND_TYPE_MISMATCH");
+  expect(result.error.actual).toBe("name");
+  expect(OperandStack.depth(ctx.operandStack)).toBe(2);
+});
+
+test("current point 未確立のとき座標を使わなくても PATH_NO_CURRENT_POINT を返す", () => {
+  const ctx = buildContext([real(100), real(200), real(300), real(400)]);
+
+  const result = yHandler(ctx);
+
+  assert(!result.ok);
+  assert(result.error.code === "OPERATOR_PATH_NO_CURRENT_POINT");
+  expect(result.error.operatorName).toBe("y");
+  expect(result.error.message).toBe(
+    "Operator 'y' requires a current point established by a prior 'm' or 're'",
+  );
+});
+
+test("current point 未確立時も path は空のまま、operand stack は復元しない", () => {
+  const ctx = buildContext([real(100), real(200), real(300), real(400)]);
+
+  const result = yHandler(ctx);
+
+  assert(!result.ok);
+  const current = GraphicsStateStack.current(ctx.graphicsStateStack);
+  expect(CurrentPath.isEmpty(current.currentPath)).toBe(true);
+  expect(OperandStack.depth(ctx.operandStack)).toBe(0);
+});

--- a/packages/core/src/content-stream/operators/path/y/index.ts
+++ b/packages/core/src/content-stream/operators/path/y/index.ts
@@ -1,0 +1,96 @@
+import type { PdfError } from "../../../../pdf/errors/index";
+import { err, ok } from "../../../../utils/result/index";
+import {
+  CurrentPath,
+  GraphicsState,
+  GraphicsStateStack,
+} from "../../../graphics-state/index";
+import { PathSegment } from "../../../graphics-state/path-segment";
+import { OperandStack } from "../../../operand-stack/index";
+import type {
+  OperatorHandler,
+  OperatorHandlerContext,
+} from "../../../operator-registry/index";
+import { NumericPdfObject } from "../../graphics-state/numeric-pdf-object";
+
+const OPERATOR_NAME = "y";
+const OPERAND_COUNT = 4;
+
+/**
+ * PDF §8.5.2.3 `y` operator (第 2 制御点 = 終点の 3 次 Bezier) のハンドラ。
+ *
+ * operand stack から `x1 y1 x3 y3` の 4 個の数値を pop し、
+ * `PathSegment.curveTo(x1, y1, x3, y3, x3, y3)` を current path の末尾に append した
+ * 新しい GraphicsState を生成する。
+ *
+ * current point の座標値は使わないが、§8.5.2.3 上 current point の確立は必須である。
+ *
+ * - operand 不足 (< 4) のとき `OPERATOR_OPERAND_MISSING` を返す
+ * - operand に integer / real 以外が混在したとき `OPERATOR_OPERAND_TYPE_MISMATCH` を返す
+ * - current point が未確立の場合 `OPERATOR_PATH_NO_CURRENT_POINT` を返す
+ * - 値域 (`NaN` / `Infinity` / 負値 / 0) は本 handler では検証せずそのまま格納する
+ * - エラー時に operand stack の部分消費は復元しない
+ *
+ * @param context - 実行コンテキスト (operand stack / graphics state stack)
+ * @returns 成功なら更新後コンテキスト、失敗なら PdfError
+ */
+export const yHandler: OperatorHandler = (context: OperatorHandlerContext) => {
+  const popped: NumericPdfObject[] = [];
+  for (let i = 0; i < OPERAND_COUNT; i++) {
+    const result = OperandStack.pop(context.operandStack);
+    if (!result.some) {
+      const error: PdfError = {
+        code: "OPERATOR_OPERAND_MISSING",
+        message: `Operator '${OPERATOR_NAME}' requires ${OPERAND_COUNT} operand(s), got ${i}`,
+        operatorName: OPERATOR_NAME,
+        required: OPERAND_COUNT,
+        actual: i,
+      };
+      return err(error);
+    }
+    const operand = result.value;
+    if (!NumericPdfObject.is(operand)) {
+      const error: PdfError = {
+        code: "OPERATOR_OPERAND_TYPE_MISMATCH",
+        message: `Operator '${OPERATOR_NAME}' expected number operand, got ${operand.type}`,
+        operatorName: OPERATOR_NAME,
+        expected: "number",
+        actual: operand.type,
+      };
+      return err(error);
+    }
+    popped.push(operand);
+  }
+
+  // popped は LIFO 順 [y3, x3, y1, x1]。reverse して PDF 順に戻す
+  const [x1, y1, x3, y3] = popped
+    .slice()
+    .reverse()
+    .map((operand) => operand.value);
+
+  const current = GraphicsStateStack.current(context.graphicsStateStack);
+  const currentPoint = CurrentPath.lastPoint(current.currentPath);
+  if (!currentPoint.some) {
+    const error: PdfError = {
+      code: "OPERATOR_PATH_NO_CURRENT_POINT",
+      message: `Operator '${OPERATOR_NAME}' requires a current point established by a prior 'm' or 're'`,
+      operatorName: OPERATOR_NAME,
+    };
+    return err(error);
+  }
+  const nextPath = CurrentPath.append(
+    current.currentPath,
+    PathSegment.curveTo(x1, y1, x3, y3, x3, y3),
+  );
+  const next = GraphicsState.update(current, { currentPath: nextPath });
+  const graphicsStateStack = GraphicsStateStack.replaceCurrent(
+    context.graphicsStateStack,
+    next,
+  );
+
+  return ok({
+    operandStack: context.operandStack,
+    graphicsStateStack,
+    markedContentStack: context.markedContentStack,
+  });
+};


### PR DESCRIPTION
## 概要

PDF content stream の `v` / `y` を実装し、current point の導出ロジックを `CurrentPath.lastPoint` に集約します。

## 変更内容

### 🎯 変更の種類

- [x] ✨ 新機能
- [x] ♻️ リファクタリング
- [x] 🧪 テスト追加・修正
- [ ] 🐛 バグ修正
- [ ] 📚 ドキュメント更新
- [ ] ⚡ パフォーマンス改善
- [ ] 🔧 設定変更

### 📝 詳細な変更内容

#### 追加された機能・修正

- `CurrentPath.lastPoint(path)` を追加し、empty / moveTo / lineTo / curveTo / rect / close の current point 判定を一元化
- `v` operator を追加（current point を第 1 制御点として `x2 y2 x3 y3 v` を処理）
- `y` operator を追加（第 2 制御点を終点として `x1 y1 x3 y3 y` を処理）
- `c` operator の current point 判定を `lastPoint` 経由へ変更
- path operator registry に `v` / `y` を登録
- close 後の current point で `rect` を subpath の起点として扱うケースを検証

#### 変更されたファイル

- `packages/core/src/content-stream/graphics-state/current-path/index.ts`
- `packages/core/src/content-stream/operators/path/c/index.ts`
- `packages/core/src/content-stream/operators/path/v/index.ts`
- `packages/core/src/content-stream/operators/path/y/index.ts`
- `packages/core/src/content-stream/operators/path/path-operators/index.ts`
- `packages/core/src/content-stream/**/__tests__/*`（lastPoint、v/y、registry のテスト）

#### 削除されたファイル

- なし

## 📊 システム図

```mermaid
flowchart TD
  Operands[PDF operands: v / y] --> Handler[vHandler / yHandler]
  Handler --> LastPoint{CurrentPath.lastPoint}
  LastPoint -->|Some current point| Curve[Append CurveToSegment]
  LastPoint -->|None| Error[OPERATOR_PATH_NO_CURRENT_POINT]
  Curve --> Registry[PATH_OPERATORS registry]
```

## 📋 関連 Issue

- Closes #488

## 🧪 テスト

### テスト実行方法

```bash
pnpm --filter @pdfmod/core test
pnpm --filter @pdfmod/core build
pnpm --filter @pdfmod/core typecheck
```

### テスト項目

- [x] Unit tests
- [x] Integration tests
- [ ] E2E tests（対象外）
- [x] Typecheck / build

### 結果

- `pnpm --filter @pdfmod/core test`: 295 test files、3667 tests passed
- `pnpm --filter @pdfmod/core build`: 成功
- `pnpm --filter @pdfmod/core typecheck`: 成功
- 変更対象ファイルの Biome / Oxlint チェック: 成功
- 既存の `c.basic.test.ts` は変更せず、green を確認

## 🔍 レビューポイント

- `lastPoint` の `close` 処理が `moveTo` と `rect` の両方を subpath 起点として扱うこと
- `v` / `y` が current point 未設定時に `OPERATOR_PATH_NO_CURRENT_POINT` を返すこと
- `y` の第 2 制御点が終点と同じ座標になること
- 既存の `c` operator の挙動が変わっていないこと

## ⚠️ 破壊的変更

- なし

## ✅ チェックリスト

- [x] 実装内容をセルフレビュー済み
- [x] テストが成功している
- [x] 既存テストを意図せず変更していない
- [x] 関連 Issue をリンクした
- [x] 破壊的変更の有無を明記した