### PR TITLE
✨ [New Feature]: #489 add paint variant path handlers

### DIFF
--- a/packages/core/src/content-stream/graphics-state/current-path/__tests__/current-path.basic.test.ts
+++ b/packages/core/src/content-stream/graphics-state/current-path/__tests__/current-path.basic.test.ts
@@ -1,4 +1,4 @@
-import { expect, test } from "vitest";
+import { assert, expect, test } from "vitest";
 import { CurrentPath } from "../../current-path";
 import { PathSegment } from "../../path-segment";
 
@@ -45,6 +45,91 @@ test("CurrentPath.isEmpty(append(empty, seg)) は false を返す", () => {
   expect(CurrentPath.isEmpty(next)).toBe(false);
 });
 
+test("moveTo 済み path に closeSubpath を適用すると close segment が付く", () => {
+  const path = CurrentPath.append(
+    CurrentPath.empty(),
+    PathSegment.moveTo(0, 0),
+  );
+
+  const closed = CurrentPath.closeSubpath(path);
+
+  expect(closed.segments).toEqual([
+    PathSegment.moveTo(0, 0),
+    PathSegment.close(),
+  ]);
+});
+
+test("moveTo → lineTo 済み path に closeSubpath を適用できる", () => {
+  const path = CurrentPath.append(
+    CurrentPath.append(CurrentPath.empty(), PathSegment.moveTo(0, 0)),
+    PathSegment.lineTo(10, 10),
+  );
+  const closed = CurrentPath.closeSubpath(path);
+
+  expect(closed.segments).toEqual([
+    PathSegment.moveTo(0, 0),
+    PathSegment.lineTo(10, 10),
+    PathSegment.close(),
+  ]);
+});
+test("rect 済み path に closeSubpath を適用できる", () => {
+  const path = CurrentPath.append(
+    CurrentPath.empty(),
+    PathSegment.rect(10, 10, 100, 50),
+  );
+  const closed = CurrentPath.closeSubpath(path);
+
+  expect(closed.segments).toEqual([
+    PathSegment.rect(10, 10, 100, 50),
+    PathSegment.close(),
+  ]);
+});
+
+test("closeSubpath を適用しても元の path は mutate されない", () => {
+  const path = CurrentPath.append(
+    CurrentPath.empty(),
+    PathSegment.moveTo(0, 0),
+  );
+  const beforeSegments = path.segments;
+  const closed = CurrentPath.closeSubpath(path);
+
+  expect(path.segments).toEqual([PathSegment.moveTo(0, 0)]);
+  expect(closed.segments).not.toBe(beforeSegments);
+});
+
+test("空 path に closeSubpath を適用しても close は追加されない", () => {
+  const path = CurrentPath.empty();
+  const closed = CurrentPath.closeSubpath(path);
+
+  expect(closed).toBe(path);
+  expect(closed.segments).toEqual([]);
+  expect(CurrentPath.isEmpty(closed)).toBe(true);
+});
+test("closeSubpath を連続適用すると close segment が 2 つ並ぶ", () => {
+  const path = CurrentPath.append(
+    CurrentPath.empty(),
+    PathSegment.moveTo(0, 0),
+  );
+  const firstClosed = CurrentPath.closeSubpath(path);
+  const secondClosed = CurrentPath.closeSubpath(firstClosed);
+
+  expect(secondClosed.segments).toEqual([
+    PathSegment.moveTo(0, 0),
+    PathSegment.close(),
+    PathSegment.close(),
+  ]);
+});
+test("closeSubpath 後も lastPoint は subpath 開始点を返す", () => {
+  const path = CurrentPath.append(
+    CurrentPath.empty(),
+    PathSegment.rect(10, 10, 100, 50),
+  );
+  const closed = CurrentPath.closeSubpath(path);
+  const lastPoint = CurrentPath.lastPoint(closed);
+
+  assert(lastPoint.some);
+  expect(lastPoint.value).toEqual({ x: 10, y: 10 });
+});
 test("連続 append は順序を保持する", () => {
   const moveTo = PathSegment.moveTo(1, 2);
   const lineTo = PathSegment.lineTo(3, 4);

--- a/packages/core/src/content-stream/graphics-state/current-path/index.ts
+++ b/packages/core/src/content-stream/graphics-state/current-path/index.ts
@@ -123,4 +123,21 @@ export const CurrentPath = {
       segments: [...segments, moveTo],
     } as unknown as CurrentPath;
   },
+  /**
+   * `h` / `s` / `b` / `b*` operator (ISO 32000-1:2008 §8.5.2, §8.5.3) の
+   * subpath close を表す `PathSegment.close()` を末尾に追加する。
+   *
+   * 空 path の場合は close を追加せず `path` をそのまま返す。無条件に append
+   * すると `isEmpty` が false に転じ、後続の `l` / `c` が依拠する
+   * `NO_CURRENT_POINT` 不変条件が崩れるため。
+   *
+   * @param path - 元の `CurrentPath` (変更されない)
+   * @returns close を追加した新規 `CurrentPath`。空 path なら `path` 自身
+   */
+  closeSubpath(path: CurrentPath): CurrentPath {
+    if (CurrentPath.isEmpty(path)) {
+      return path;
+    }
+    return CurrentPath.append(path, PathSegment.close());
+  },
 } as const;

--- a/packages/core/src/content-stream/operators/path/close-fill-stroke-even-odd/__tests__/close-fill-stroke-even-odd.basic.test.ts
+++ b/packages/core/src/content-stream/operators/path/close-fill-stroke-even-odd/__tests__/close-fill-stroke-even-odd.basic.test.ts
@@ -1,0 +1,167 @@
+import { assert, expect, test } from "vitest";
+import type { PdfObject } from "../../../../../pdf/types/pdf-types/index";
+import {
+  CurrentPath,
+  GraphicsState,
+  GraphicsStateStack,
+  Matrix,
+} from "../../../../graphics-state/index";
+import { PathSegment } from "../../../../graphics-state/path-segment";
+import { MarkedContentStack } from "../../../../marked-content/stack";
+import { OperandStack } from "../../../../operand-stack/index";
+import type { OperatorHandlerContext } from "../../../../operator-registry/index";
+import { closeFillStrokeHandler } from "../../close-fill-stroke";
+import { fillStrokeEvenOddHandler } from "../../fill-stroke-even-odd";
+import { hHandler } from "../../h";
+import { closeFillStrokeEvenOddHandler } from "../index";
+
+const real = (value: number): PdfObject => ({ type: "real", value });
+
+const buildContext = (operands: PdfObject[]): OperatorHandlerContext => {
+  const operandStack = OperandStack.create();
+  for (const operand of operands) {
+    OperandStack.push(operandStack, operand);
+  }
+  return {
+    operandStack,
+    graphicsStateStack: GraphicsStateStack.create(),
+    markedContentStack: MarkedContentStack.create(),
+  };
+};
+
+const buildContextWithSegments = (
+  segments: PathSegment[],
+  operands: PdfObject[] = [],
+): OperatorHandlerContext => {
+  const operandStack = OperandStack.create();
+  for (const operand of operands) {
+    OperandStack.push(operandStack, operand);
+  }
+  const initialState = GraphicsState.create();
+  let path = initialState.currentPath;
+  for (const segment of segments) {
+    path = CurrentPath.append(path, segment);
+  }
+  const seededState = GraphicsState.update(initialState, { currentPath: path });
+  const graphicsStateStack = GraphicsStateStack.replaceCurrent(
+    GraphicsStateStack.create(),
+    seededState,
+  );
+  return {
+    operandStack,
+    graphicsStateStack,
+    markedContentStack: MarkedContentStack.create(),
+  };
+};
+
+const buildContextWithGraphicsState = (
+  state: GraphicsState,
+  operands: PdfObject[] = [],
+): OperatorHandlerContext => {
+  const operandStack = OperandStack.create();
+  for (const operand of operands) {
+    OperandStack.push(operandStack, operand);
+  }
+  const graphicsStateStack = GraphicsStateStack.replaceCurrent(
+    GraphicsStateStack.create(),
+    state,
+  );
+  return {
+    operandStack,
+    graphicsStateStack,
+    markedContentStack: MarkedContentStack.create(),
+  };
+};
+
+test("m l 済み path に b* を実行すると currentPath が空になる", () => {
+  const context = buildContextWithSegments([
+    PathSegment.moveTo(100, 100),
+    PathSegment.lineTo(200, 200),
+  ]);
+
+  const result = closeFillStrokeEvenOddHandler(context);
+
+  assert(result.ok);
+  expect(
+    CurrentPath.isEmpty(
+      GraphicsStateStack.current(result.value.graphicsStateStack).currentPath,
+    ),
+  ).toBe(true);
+});
+
+test("b* は h + B* と同値", () => {
+  const context = buildContextWithSegments([
+    PathSegment.moveTo(100, 100),
+    PathSegment.lineTo(200, 200),
+  ]);
+
+  const closeFillStrokeResult = closeFillStrokeEvenOddHandler(context);
+  const closeThenFillStrokeResult = hHandler(context);
+
+  assert(closeFillStrokeResult.ok);
+  assert(closeThenFillStrokeResult.ok);
+  const expectedResult = fillStrokeEvenOddHandler(
+    closeThenFillStrokeResult.value,
+  );
+  assert(expectedResult.ok);
+  expect(
+    GraphicsStateStack.current(closeFillStrokeResult.value.graphicsStateStack),
+  ).toEqual(
+    GraphicsStateStack.current(expectedResult.value.graphicsStateStack),
+  );
+});
+
+test("closeFillStrokeHandler とは別の関数実体である", () => {
+  expect(closeFillStrokeEvenOddHandler).not.toBe(closeFillStrokeHandler);
+});
+
+test("operand を pop しない", () => {
+  const context = buildContextWithSegments(
+    [PathSegment.moveTo(100, 100), PathSegment.lineTo(200, 200)],
+    [real(1), real(2)],
+  );
+  const depthBefore = OperandStack.depth(context.operandStack);
+  const peekBefore = OperandStack.peek(context.operandStack);
+
+  const result = closeFillStrokeEvenOddHandler(context);
+
+  assert(result.ok);
+  expect(result.value.operandStack).toBe(context.operandStack);
+  expect(OperandStack.depth(result.value.operandStack)).toBe(depthBefore);
+  const peekAfter = OperandStack.peek(result.value.operandStack);
+  assert(peekBefore.some);
+  assert(peekAfter.some);
+  expect(peekAfter.value).toEqual(real(2));
+});
+
+test("空 path への b* は no-op で graphicsStateStack を同一参照に保つ", () => {
+  const context = buildContext([]);
+
+  const result = closeFillStrokeEvenOddHandler(context);
+
+  assert(result.ok);
+  expect(result.value.graphicsStateStack).toBe(context.graphicsStateStack);
+});
+
+test("currentPath 以外の graphics state を保持する", () => {
+  const baseState = GraphicsState.create();
+  const path = CurrentPath.append(
+    CurrentPath.append(baseState.currentPath, PathSegment.moveTo(100, 100)),
+    PathSegment.lineTo(200, 200),
+  );
+  const seededCtm = Matrix.create(2, 0, 0, 3, 10, 20);
+  const seededState = GraphicsState.update(baseState, {
+    currentPath: path,
+    ctm: seededCtm,
+    lineWidth: 5,
+  });
+  const context = buildContextWithGraphicsState(seededState);
+
+  const result = closeFillStrokeEvenOddHandler(context);
+
+  assert(result.ok);
+  const after = GraphicsStateStack.current(result.value.graphicsStateStack);
+  expect(after.currentPath.segments).toEqual([]);
+  expect(after.ctm).toBe(seededCtm);
+  expect(after.lineWidth).toBe(5);
+});

--- a/packages/core/src/content-stream/operators/path/close-fill-stroke-even-odd/index.ts
+++ b/packages/core/src/content-stream/operators/path/close-fill-stroke-even-odd/index.ts
@@ -1,0 +1,33 @@
+import type {
+  OperatorHandler,
+  OperatorHandlerContext,
+} from "../../../operator-registry/index";
+import { closeSubpathContext } from "../close-subpath";
+import { fillStrokeEvenOddHandler } from "../fill-stroke-even-odd";
+
+/**
+ * PDF §8.5.3 `b*` operator (close, fill and stroke the path; even-odd rule) の
+ * ハンドラ。
+ *
+ * `h` + `B*` と等価。current path の末尾に `PathSegment.close()` を append して
+ * から `fillStrokeEvenOddHandler` に委譲する。委譲先を `fillStrokeHandler` では
+ * なく even-odd 版にすることで、委譲チェーン上も fill rule が一貫する。
+ * fill rule は operator 種別で表現するため state には書き込まない。
+ *
+ * clipping: 将来 `W` / `W*` が設定する pendingClip の適用は本 handler では
+ * 行わない。pendingClip の適用ロジックは別 issue (W/W*) で、本 handler を含む
+ * path finalization operator (`S` / `s` / `f` / `F` / `f*` / `B` / `B*` / `b` /
+ * `b*` / `n`) に注入する。`n` は paint しないが `W n` で clip を確定させるため
+ * 対象に含む。
+ *
+ * - operand 数: 0 (operand stack を一切参照しない)
+ * - current path が空の場合は close を append せず、委譲先が no-op で返す
+ * - currentPath 以外の graphics state は変更しない
+ * - 本 handler では PdfError を返さない (常に ok)
+ *
+ * @param context - 実行コンテキスト (operand stack / graphics state stack)
+ * @returns 更新後コンテキスト (常に ok)
+ */
+export const closeFillStrokeEvenOddHandler: OperatorHandler = (
+  context: OperatorHandlerContext,
+) => fillStrokeEvenOddHandler(closeSubpathContext(context));

--- a/packages/core/src/content-stream/operators/path/close-fill-stroke/__tests__/close-fill-stroke.basic.test.ts
+++ b/packages/core/src/content-stream/operators/path/close-fill-stroke/__tests__/close-fill-stroke.basic.test.ts
@@ -1,0 +1,168 @@
+import { assert, expect, test } from "vitest";
+import type { PdfObject } from "../../../../../pdf/types/pdf-types/index";
+import {
+  CurrentPath,
+  GraphicsState,
+  GraphicsStateStack,
+  Matrix,
+} from "../../../../graphics-state/index";
+import { PathSegment } from "../../../../graphics-state/path-segment";
+import { MarkedContentStack } from "../../../../marked-content/stack";
+import { OperandStack } from "../../../../operand-stack/index";
+import type { OperatorHandlerContext } from "../../../../operator-registry/index";
+import { fillStrokeHandler } from "../../fill-stroke";
+import { hHandler } from "../../h";
+import { closeFillStrokeHandler } from "../index";
+
+const real = (value: number): PdfObject => ({ type: "real", value });
+
+const buildContext = (operands: PdfObject[]): OperatorHandlerContext => {
+  const operandStack = OperandStack.create();
+  for (const operand of operands) {
+    OperandStack.push(operandStack, operand);
+  }
+  return {
+    operandStack,
+    graphicsStateStack: GraphicsStateStack.create(),
+    markedContentStack: MarkedContentStack.create(),
+  };
+};
+
+const buildContextWithSegments = (
+  segments: PathSegment[],
+  operands: PdfObject[] = [],
+): OperatorHandlerContext => {
+  const operandStack = OperandStack.create();
+  for (const operand of operands) {
+    OperandStack.push(operandStack, operand);
+  }
+  const initialState = GraphicsState.create();
+  let path = initialState.currentPath;
+  for (const segment of segments) {
+    path = CurrentPath.append(path, segment);
+  }
+  const seededState = GraphicsState.update(initialState, { currentPath: path });
+  const graphicsStateStack = GraphicsStateStack.replaceCurrent(
+    GraphicsStateStack.create(),
+    seededState,
+  );
+  return {
+    operandStack,
+    graphicsStateStack,
+    markedContentStack: MarkedContentStack.create(),
+  };
+};
+
+test("m l 済み path に b を実行すると currentPath が空になる", () => {
+  const context = buildContextWithSegments([
+    PathSegment.moveTo(100, 100),
+    PathSegment.lineTo(200, 100),
+    PathSegment.lineTo(200, 200),
+  ]);
+
+  const result = closeFillStrokeHandler(context);
+
+  assert(result.ok);
+  expect(
+    CurrentPath.isEmpty(
+      GraphicsStateStack.current(result.value.graphicsStateStack).currentPath,
+    ),
+  ).toBe(true);
+});
+
+test("b は h + B と同値", () => {
+  const context = buildContextWithSegments([
+    PathSegment.moveTo(100, 100),
+    PathSegment.lineTo(200, 100),
+    PathSegment.lineTo(200, 200),
+  ]);
+
+  const closeFillStrokeResult = closeFillStrokeHandler(context);
+  const closeThenFillStrokeResult = hHandler(context);
+
+  assert(closeFillStrokeResult.ok);
+  assert(closeThenFillStrokeResult.ok);
+  const expectedResult = fillStrokeHandler(closeThenFillStrokeResult.value);
+  assert(expectedResult.ok);
+  expect(
+    GraphicsStateStack.current(closeFillStrokeResult.value.graphicsStateStack),
+  ).toEqual(
+    GraphicsStateStack.current(expectedResult.value.graphicsStateStack),
+  );
+});
+
+test("operand を pop しない", () => {
+  const context = buildContextWithSegments(
+    [PathSegment.moveTo(100, 100), PathSegment.lineTo(200, 100)],
+    [real(1), real(2)],
+  );
+  const depthBefore = OperandStack.depth(context.operandStack);
+  const peekBefore = OperandStack.peek(context.operandStack);
+
+  const result = closeFillStrokeHandler(context);
+
+  assert(result.ok);
+  expect(result.value.operandStack).toBe(context.operandStack);
+  expect(OperandStack.depth(result.value.operandStack)).toBe(depthBefore);
+  const peekAfter = OperandStack.peek(result.value.operandStack);
+  assert(peekBefore.some);
+  assert(peekAfter.some);
+  expect(peekAfter.value).toEqual(real(2));
+});
+
+test("空 path への b は no-op で graphicsStateStack を同一参照に保つ", () => {
+  const context = buildContext([]);
+
+  const result = closeFillStrokeHandler(context);
+
+  assert(result.ok);
+  expect(result.value.graphicsStateStack).toBe(context.graphicsStateStack);
+});
+
+test("入力 context の currentPath を mutate しない", () => {
+  const context = buildContextWithSegments([
+    PathSegment.moveTo(100, 100),
+    PathSegment.lineTo(200, 100),
+  ]);
+  const beforePath = GraphicsStateStack.current(
+    context.graphicsStateStack,
+  ).currentPath;
+
+  const result = closeFillStrokeHandler(context);
+
+  assert(result.ok);
+  expect(beforePath.segments).toEqual([
+    PathSegment.moveTo(100, 100),
+    PathSegment.lineTo(200, 100),
+  ]);
+  expect(result.value.graphicsStateStack).not.toBe(context.graphicsStateStack);
+});
+
+test("q 済みの saved graphics state を保持する", () => {
+  const savedState = GraphicsState.update(GraphicsState.create(), {
+    ctm: Matrix.create(2, 0, 0, 3, 10, 20),
+    lineWidth: 5,
+  });
+  const savedStack = GraphicsStateStack.save(
+    GraphicsStateStack.replaceCurrent(GraphicsStateStack.create(), savedState),
+  );
+  const currentPath = CurrentPath.append(
+    savedState.currentPath,
+    PathSegment.moveTo(0, 0),
+  );
+  const currentState = GraphicsState.update(savedState, {
+    currentPath,
+  });
+  const stack = GraphicsStateStack.replaceCurrent(savedStack, currentState);
+  const context: OperatorHandlerContext = {
+    operandStack: OperandStack.create(),
+    graphicsStateStack: stack,
+    markedContentStack: MarkedContentStack.create(),
+  };
+
+  const result = closeFillStrokeHandler(context);
+  assert(result.ok);
+  const restored = GraphicsStateStack.restore(result.value.graphicsStateStack);
+
+  expect(GraphicsStateStack.current(restored.stack)).toEqual(savedState);
+});

--- a/packages/core/src/content-stream/operators/path/close-fill-stroke/index.ts
+++ b/packages/core/src/content-stream/operators/path/close-fill-stroke/index.ts
@@ -1,0 +1,36 @@
+import type {
+  OperatorHandler,
+  OperatorHandlerContext,
+} from "../../../operator-registry/index";
+import { closeSubpathContext } from "../close-subpath";
+import { fillStrokeHandler } from "../fill-stroke";
+
+/**
+ * PDF §8.5.3 `b` operator (close, fill and stroke the path;
+ * nonzero winding number rule) のハンドラ。
+ *
+ * `h` + `B` と等価。current path の末尾に `PathSegment.close()` を append して
+ * から `fillStrokeHandler` に委譲する。fill rule (nonzero winding / even-odd) は
+ * state ではなく operator 種別 (`B` / `B*` / `b` / `b*`) で表現する。
+ *
+ * clipping: 将来 `W` / `W*` が設定する pendingClip の適用は本 handler では
+ * 行わない。pendingClip の適用ロジックは別 issue (W/W*) で、本 handler を含む
+ * path finalization operator (`S` / `s` / `f` / `F` / `f*` / `B` / `B*` / `b` /
+ * `b*` / `n`) に注入する。`n` は paint しないが `W n` で clip を確定させるため
+ * 対象に含む。
+ *
+ * 命名: PDF 仕様上の大文字 `B` (fill+stroke) と小文字 `b`
+ * (close-and-fill-stroke) は別 operator のため semantic 名
+ * `close-fill-stroke` を使う。
+ *
+ * - operand 数: 0 (operand stack を一切参照しない)
+ * - current path が空の場合は close を append せず、委譲先が no-op で返す
+ * - currentPath 以外の graphics state は変更しない
+ * - 本 handler では PdfError を返さない (常に ok)
+ *
+ * @param context - 実行コンテキスト (operand stack / graphics state stack)
+ * @returns 更新後コンテキスト (常に ok)
+ */
+export const closeFillStrokeHandler: OperatorHandler = (
+  context: OperatorHandlerContext,
+) => fillStrokeHandler(closeSubpathContext(context));

--- a/packages/core/src/content-stream/operators/path/close-stroke/__tests__/close-stroke.basic.test.ts
+++ b/packages/core/src/content-stream/operators/path/close-stroke/__tests__/close-stroke.basic.test.ts
@@ -1,0 +1,212 @@
+import { assert, expect, test } from "vitest";
+import type { PdfObject } from "../../../../../pdf/types/pdf-types/index";
+import {
+  CurrentPath,
+  GraphicsState,
+  GraphicsStateStack,
+  LineCap,
+  LineJoin,
+  Matrix,
+} from "../../../../graphics-state/index";
+import { PathSegment } from "../../../../graphics-state/path-segment";
+import { MarkedContentStack } from "../../../../marked-content/stack";
+import { OperandStack } from "../../../../operand-stack/index";
+import type { OperatorHandlerContext } from "../../../../operator-registry/index";
+import { hHandler } from "../../h";
+import { strokeHandler } from "../../stroke";
+import { closeStrokeHandler } from "../index";
+
+const real = (value: number): PdfObject => ({ type: "real", value });
+
+const buildContext = (operands: PdfObject[]): OperatorHandlerContext => {
+  const operandStack = OperandStack.create();
+  for (const operand of operands) {
+    OperandStack.push(operandStack, operand);
+  }
+  return {
+    operandStack,
+    graphicsStateStack: GraphicsStateStack.create(),
+    markedContentStack: MarkedContentStack.create(),
+  };
+};
+
+const buildContextWithSegments = (
+  segments: PathSegment[],
+  operands: PdfObject[] = [],
+): OperatorHandlerContext => {
+  const operandStack = OperandStack.create();
+  for (const operand of operands) {
+    OperandStack.push(operandStack, operand);
+  }
+  const initialState = GraphicsState.create();
+  let path = initialState.currentPath;
+  for (const segment of segments) {
+    path = CurrentPath.append(path, segment);
+  }
+  const seededState = GraphicsState.update(initialState, { currentPath: path });
+  const graphicsStateStack = GraphicsStateStack.replaceCurrent(
+    GraphicsStateStack.create(),
+    seededState,
+  );
+  return {
+    operandStack,
+    graphicsStateStack,
+    markedContentStack: MarkedContentStack.create(),
+  };
+};
+
+const buildContextWithGraphicsState = (
+  state: GraphicsState,
+  operands: PdfObject[] = [],
+): OperatorHandlerContext => {
+  const operandStack = OperandStack.create();
+  for (const operand of operands) {
+    OperandStack.push(operandStack, operand);
+  }
+  const graphicsStateStack = GraphicsStateStack.replaceCurrent(
+    GraphicsStateStack.create(),
+    state,
+  );
+  return {
+    operandStack,
+    graphicsStateStack,
+    markedContentStack: MarkedContentStack.create(),
+  };
+};
+
+test("m l 済み path に s を実行すると currentPath が空になる", () => {
+  const context = buildContextWithSegments([
+    PathSegment.moveTo(100, 100),
+    PathSegment.lineTo(200, 200),
+  ]);
+
+  const result = closeStrokeHandler(context);
+
+  assert(result.ok);
+  expect(
+    CurrentPath.isEmpty(
+      GraphicsStateStack.current(result.value.graphicsStateStack).currentPath,
+    ),
+  ).toBe(true);
+});
+
+test("s は h + S と同値", () => {
+  const context = buildContextWithSegments([
+    PathSegment.moveTo(100, 100),
+    PathSegment.lineTo(200, 200),
+  ]);
+
+  const closeStrokeResult = closeStrokeHandler(context);
+  const closeThenStrokeResult = hHandler(context);
+
+  assert(closeStrokeResult.ok);
+  assert(closeThenStrokeResult.ok);
+  const expectedResult = strokeHandler(closeThenStrokeResult.value);
+  assert(expectedResult.ok);
+  expect(
+    GraphicsStateStack.current(closeStrokeResult.value.graphicsStateStack),
+  ).toEqual(
+    GraphicsStateStack.current(expectedResult.value.graphicsStateStack),
+  );
+});
+
+test("operand を pop しない", () => {
+  const context = buildContextWithSegments(
+    [PathSegment.moveTo(100, 100), PathSegment.lineTo(200, 200)],
+    [real(1), real(2)],
+  );
+  const depthBefore = OperandStack.depth(context.operandStack);
+  const peekBefore = OperandStack.peek(context.operandStack);
+
+  const result = closeStrokeHandler(context);
+
+  assert(result.ok);
+  expect(result.value.operandStack).toBe(context.operandStack);
+  expect(OperandStack.depth(result.value.operandStack)).toBe(depthBefore);
+  const peekAfter = OperandStack.peek(result.value.operandStack);
+  assert(peekBefore.some);
+  assert(peekAfter.some);
+  expect(peekAfter.value).toEqual(real(2));
+});
+
+test("currentPath 以外の graphics state を保持する", () => {
+  const baseState = GraphicsState.create();
+  const path = CurrentPath.append(
+    CurrentPath.append(baseState.currentPath, PathSegment.moveTo(100, 100)),
+    PathSegment.lineTo(200, 200),
+  );
+  const seededCtm = Matrix.create(2, 0, 0, 3, 10, 20);
+  const seededLineCap = LineCap.create(1);
+  const seededLineJoin = LineJoin.create(2);
+  const seededState = GraphicsState.update(baseState, {
+    currentPath: path,
+    ctm: seededCtm,
+    lineWidth: 3.5,
+    lineCap: seededLineCap,
+    lineJoin: seededLineJoin,
+    miterLimit: 8,
+  });
+  const context = buildContextWithGraphicsState(seededState);
+
+  const result = closeStrokeHandler(context);
+
+  assert(result.ok);
+  const after = GraphicsStateStack.current(result.value.graphicsStateStack);
+  expect(after.currentPath.segments).toEqual([]);
+  expect(after.ctm).toBe(seededCtm);
+  expect(after.lineWidth).toBe(3.5);
+  expect(after.lineCap).toBe(seededLineCap);
+  expect(after.lineJoin).toBe(seededLineJoin);
+  expect(after.miterLimit).toBe(8);
+});
+
+test("空 path への s は no-op で graphicsStateStack を同一参照に保つ", () => {
+  const context = buildContext([]);
+
+  const result = closeStrokeHandler(context);
+
+  assert(result.ok);
+  expect(result.value.graphicsStateStack).toBe(context.graphicsStateStack);
+  expect(
+    CurrentPath.isEmpty(
+      GraphicsStateStack.current(result.value.graphicsStateStack).currentPath,
+    ),
+  ).toBe(true);
+});
+
+test("s を連続実行すると 2 回目は no-op で成功する", () => {
+  const context = buildContextWithSegments([
+    PathSegment.moveTo(100, 100),
+    PathSegment.lineTo(200, 200),
+  ]);
+
+  const first = closeStrokeHandler(context);
+  assert(first.ok);
+  const second = closeStrokeHandler(first.value);
+
+  assert(second.ok);
+  expect(
+    CurrentPath.isEmpty(
+      GraphicsStateStack.current(second.value.graphicsStateStack).currentPath,
+    ),
+  ).toBe(true);
+});
+
+test("入力 context の currentPath を mutate しない", () => {
+  const context = buildContextWithSegments([
+    PathSegment.moveTo(100, 100),
+    PathSegment.lineTo(200, 200),
+  ]);
+  const beforePath = GraphicsStateStack.current(
+    context.graphicsStateStack,
+  ).currentPath;
+
+  const result = closeStrokeHandler(context);
+
+  assert(result.ok);
+  expect(beforePath.segments).toEqual([
+    PathSegment.moveTo(100, 100),
+    PathSegment.lineTo(200, 200),
+  ]);
+  expect(result.value.graphicsStateStack).not.toBe(context.graphicsStateStack);
+});

--- a/packages/core/src/content-stream/operators/path/close-stroke/index.ts
+++ b/packages/core/src/content-stream/operators/path/close-stroke/index.ts
@@ -1,0 +1,44 @@
+import type {
+  OperatorHandler,
+  OperatorHandlerContext,
+} from "../../../operator-registry/index";
+import { closeSubpathContext } from "../close-subpath";
+import { strokeHandler } from "../stroke";
+
+/**
+ * PDF §8.5.3 `s` operator (close the subpath, then stroke it) のハンドラ。
+ *
+ * `h` + `S` と等価 (ISO 32000-1:2008 §8.5.3)。current path の末尾に
+ * `PathSegment.close()` を append してから `strokeHandler` に委譲し、
+ * paint 側で current path を `CurrentPath.empty()` にリセットする。
+ * `s` は引数を取らないため operand stack に値が残っていても
+ * pop / 検証 / clear のいずれも行わず、同一参照のまま返す。
+ *
+ * close 動作は `closeSubpathContext` 経由で state に反映するが、直後に
+ * paint が path を消費するため GraphicsState 上には残らない。将来 paint
+ * handler に renderer フックを差し込んだ時点で close 済みの path が渡る。
+ * fill rule (nonzero winding / even-odd) は handler 種別で表現するため state
+ * には書き込まない。`s` は fill を行わないため fill rule を持たない。
+ *
+ * clipping: 将来 `W` / `W*` が設定する pendingClip の適用は本 handler では
+ * 行わない。pendingClip の適用ロジックは別 issue (W/W*) で、本 handler を含む
+ * path finalization operator (`S` / `s` / `f` / `F` / `f*` / `B` / `B*` / `b` /
+ * `b*` / `n`) に注入する。`n` は paint しないが `W n` で clip を確定させるため
+ * 対象に含む。
+ *
+ * 命名: PDF 仕様上の大文字 `S` (stroke) と小文字 `s` (close-and-stroke) は
+ * 別 operator のため、letter ディレクトリではなく semantic 名 `close-stroke` を使う。
+ *
+ * - operand 数: 0 (operand stack を一切参照しない)
+ * - current path が空の場合は close を append せず、委譲先が no-op で
+ *   同一 operandStack / graphicsStateStack 参照を含む context を返す
+ * - ctm / lineWidth / lineCap / lineJoin / miterLimit など
+ *   currentPath 以外の graphics state は変更しない
+ * - 本 handler では PdfError を返さない (常に ok)
+ *
+ * @param context - 実行コンテキスト (operand stack / graphics state stack)
+ * @returns 更新後コンテキスト (常に ok)
+ */
+export const closeStrokeHandler: OperatorHandler = (
+  context: OperatorHandlerContext,
+) => strokeHandler(closeSubpathContext(context));

--- a/packages/core/src/content-stream/operators/path/close-subpath/__tests__/close-subpath.basic.test.ts
+++ b/packages/core/src/content-stream/operators/path/close-subpath/__tests__/close-subpath.basic.test.ts
@@ -1,0 +1,177 @@
+import { assert, expect, test } from "vitest";
+import type { PdfObject } from "../../../../../pdf/types/pdf-types/index";
+import {
+  CurrentPath,
+  GraphicsState,
+  GraphicsStateStack,
+  LineCap,
+  LineJoin,
+  Matrix,
+} from "../../../../graphics-state/index";
+import { PathSegment } from "../../../../graphics-state/path-segment";
+import { MarkedContentStack } from "../../../../marked-content/stack";
+import { OperandStack } from "../../../../operand-stack/index";
+import type { OperatorHandlerContext } from "../../../../operator-registry/index";
+import { closeSubpathContext } from "../index";
+
+const real = (value: number): PdfObject => ({ type: "real", value });
+
+const buildContext = (operands: PdfObject[]): OperatorHandlerContext => {
+  const operandStack = OperandStack.create();
+  for (const operand of operands) {
+    OperandStack.push(operandStack, operand);
+  }
+  return {
+    operandStack,
+    graphicsStateStack: GraphicsStateStack.create(),
+    markedContentStack: MarkedContentStack.create(),
+  };
+};
+
+const buildContextWithSegments = (
+  segments: PathSegment[],
+): OperatorHandlerContext => {
+  const operandStack = OperandStack.create();
+  const initialState = GraphicsState.create();
+  let path = initialState.currentPath;
+  for (const segment of segments) {
+    path = CurrentPath.append(path, segment);
+  }
+  const seededState = GraphicsState.update(initialState, { currentPath: path });
+  const graphicsStateStack = GraphicsStateStack.replaceCurrent(
+    GraphicsStateStack.create(),
+    seededState,
+  );
+  return {
+    operandStack,
+    graphicsStateStack,
+    markedContentStack: MarkedContentStack.create(),
+  };
+};
+
+const buildContextWithGraphicsState = (
+  state: GraphicsState,
+  operands: PdfObject[] = [],
+): OperatorHandlerContext => {
+  const operandStack = OperandStack.create();
+  for (const operand of operands) {
+    OperandStack.push(operandStack, operand);
+  }
+  const graphicsStateStack = GraphicsStateStack.replaceCurrent(
+    GraphicsStateStack.create(),
+    state,
+  );
+  return {
+    operandStack,
+    graphicsStateStack,
+    markedContentStack: MarkedContentStack.create(),
+  };
+};
+
+test("m 済み context に適用すると currentPath に close が付く", () => {
+  const context = buildContextWithSegments([PathSegment.moveTo(0, 0)]);
+
+  const closed = closeSubpathContext(context);
+
+  const current = GraphicsStateStack.current(closed.graphicsStateStack);
+  expect(current.currentPath.segments).toEqual([
+    PathSegment.moveTo(0, 0),
+    PathSegment.close(),
+  ]);
+});
+test("currentPath 以外の graphics state を保持する", () => {
+  const baseState = GraphicsState.create();
+  const path = CurrentPath.append(
+    baseState.currentPath,
+    PathSegment.moveTo(0, 0),
+  );
+  const seededCtm = Matrix.create(2, 0, 0, 3, 10, 20);
+  const seededLineCap = LineCap.create(2);
+  const seededLineJoin = LineJoin.create(2);
+  const seededState = GraphicsState.update(baseState, {
+    currentPath: path,
+    ctm: seededCtm,
+    lineWidth: 5,
+    lineCap: seededLineCap,
+    lineJoin: seededLineJoin,
+    miterLimit: 20,
+  });
+  const context = buildContextWithGraphicsState(seededState);
+
+  const closed = closeSubpathContext(context);
+
+  const after = GraphicsStateStack.current(closed.graphicsStateStack);
+  expect(after.currentPath.segments).toEqual([
+    PathSegment.moveTo(0, 0),
+    PathSegment.close(),
+  ]);
+  expect(after.ctm).toBe(seededCtm);
+  expect(after.lineWidth).toBe(5);
+  expect(after.lineCap).toBe(seededLineCap);
+  expect(after.lineJoin).toBe(seededLineJoin);
+  expect(after.miterLimit).toBe(20);
+});
+
+test("operand stack を pop せず同一参照を返す", () => {
+  const context = buildContext([real(1), real(2)]);
+  const depthBefore = OperandStack.depth(context.operandStack);
+  const peekBefore = OperandStack.peek(context.operandStack);
+
+  const closed = closeSubpathContext(context);
+
+  expect(closed.operandStack).toBe(context.operandStack);
+  expect(OperandStack.depth(closed.operandStack)).toBe(depthBefore);
+  const peekAfter = OperandStack.peek(closed.operandStack);
+  assert(peekBefore.some);
+  assert(peekAfter.some);
+  expect(peekAfter.value).toEqual(real(2));
+});
+
+test("空 path では引数 context を同一参照で返す", () => {
+  const context = buildContext([]);
+  const closed = closeSubpathContext(context);
+
+  expect(closed).toBe(context);
+  expect(closed.graphicsStateStack).toBe(context.graphicsStateStack);
+});
+
+test("入力 context の currentPath を mutate しない", () => {
+  const context = buildContextWithSegments([PathSegment.moveTo(0, 0)]);
+  const beforePath = GraphicsStateStack.current(
+    context.graphicsStateStack,
+  ).currentPath;
+
+  const closed = closeSubpathContext(context);
+
+  expect(beforePath.segments).toEqual([PathSegment.moveTo(0, 0)]);
+  expect(closed.graphicsStateStack).not.toBe(context.graphicsStateStack);
+});
+
+test("q 済みの saved graphics state を保持する", () => {
+  const savedState = GraphicsState.update(GraphicsState.create(), {
+    ctm: Matrix.create(2, 0, 0, 3, 10, 20),
+    lineWidth: 5,
+  });
+  const savedStack = GraphicsStateStack.save(
+    GraphicsStateStack.replaceCurrent(GraphicsStateStack.create(), savedState),
+  );
+  const currentPath = CurrentPath.append(
+    savedState.currentPath,
+    PathSegment.moveTo(0, 0),
+  );
+  const currentState = GraphicsState.update(savedState, {
+    currentPath,
+  });
+  const stack = GraphicsStateStack.replaceCurrent(savedStack, currentState);
+  const context: OperatorHandlerContext = {
+    operandStack: OperandStack.create(),
+    graphicsStateStack: stack,
+    markedContentStack: MarkedContentStack.create(),
+  };
+
+  const closed = closeSubpathContext(context);
+
+  const restored = GraphicsStateStack.restore(closed.graphicsStateStack);
+
+  expect(GraphicsStateStack.current(restored.stack)).toEqual(savedState);
+});

--- a/packages/core/src/content-stream/operators/path/close-subpath/index.ts
+++ b/packages/core/src/content-stream/operators/path/close-subpath/index.ts
@@ -1,0 +1,42 @@
+import {
+  CurrentPath,
+  GraphicsState,
+  GraphicsStateStack,
+} from "../../../graphics-state/index";
+import type { OperatorHandlerContext } from "../../../operator-registry/index";
+
+/**
+ * current path の subpath を close した新しい実行コンテキストを返す。
+ *
+ * `h` / `s` / `b` / `b*` が共用する内部ヘルパで、operator handler ではない
+ * (`PATH_OPERATORS` には登録しない)。
+ *
+ * - current path が空の場合は `context` をそのまま返す (graphicsStateStack も同一参照)。
+ *   空 path に close を append すると `CurrentPath.isEmpty` が false に転じ、
+ *   後続の `l` / `c` が依拠する `NO_CURRENT_POINT` 不変条件が崩れるため
+ * - operandStack / markedContentStack は常に同一参照を引き継ぐ
+ * - currentPath 以外の graphics state は変更しない
+ * - 失敗しないため `Result` は返さない
+ *
+ * @param context - 実行コンテキスト
+ * @returns subpath を close した新しいコンテキスト。空 path なら `context` 自身
+ */
+export const closeSubpathContext = (
+  context: OperatorHandlerContext,
+): OperatorHandlerContext => {
+  const current = GraphicsStateStack.current(context.graphicsStateStack);
+  if (CurrentPath.isEmpty(current.currentPath)) {
+    return context;
+  }
+  const next = GraphicsState.update(current, {
+    currentPath: CurrentPath.closeSubpath(current.currentPath),
+  });
+  return {
+    operandStack: context.operandStack,
+    graphicsStateStack: GraphicsStateStack.replaceCurrent(
+      context.graphicsStateStack,
+      next,
+    ),
+    markedContentStack: context.markedContentStack,
+  };
+};

--- a/packages/core/src/content-stream/operators/path/close-subpath/index.ts
+++ b/packages/core/src/content-stream/operators/path/close-subpath/index.ts
@@ -13,7 +13,7 @@ import type { OperatorHandlerContext } from "../../../operator-registry/index";
  *
  * - current path が空の場合は `context` をそのまま返す (graphicsStateStack も同一参照)。
  *   空 path に close を append すると `CurrentPath.isEmpty` が false に転じ、
- *   後続の `l` / `c` が依拠する `NO_CURRENT_POINT` 不変条件が崩れるため
+ *   後続の `l` / `c` が依拠する `NO_CURRENT_POINT` 不変条件が崩れるため。
  * - operandStack / markedContentStack は常に同一参照を引き継ぐ
  * - currentPath 以外の graphics state は変更しない
  * - 失敗しないため `Result` は返さない

--- a/packages/core/src/content-stream/operators/path/end-path/__tests__/end-path.basic.test.ts
+++ b/packages/core/src/content-stream/operators/path/end-path/__tests__/end-path.basic.test.ts
@@ -1,0 +1,195 @@
+import { assert, expect, test } from "vitest";
+import type { PdfObject } from "../../../../../pdf/types/pdf-types/index";
+import {
+  CurrentPath,
+  GraphicsState,
+  GraphicsStateStack,
+  LineCap,
+  LineJoin,
+  Matrix,
+} from "../../../../graphics-state/index";
+import { PathSegment } from "../../../../graphics-state/path-segment";
+import { MarkedContentStack } from "../../../../marked-content/stack";
+import { OperandStack } from "../../../../operand-stack/index";
+import type { OperatorHandlerContext } from "../../../../operator-registry/index";
+import { fillHandler } from "../../fill";
+import { fillStrokeHandler } from "../../fill-stroke";
+import { strokeHandler } from "../../stroke";
+import { endPathHandler } from "../index";
+
+const real = (value: number): PdfObject => ({ type: "real", value });
+
+const buildContext = (operands: PdfObject[]): OperatorHandlerContext => {
+  const operandStack = OperandStack.create();
+  for (const operand of operands) {
+    OperandStack.push(operandStack, operand);
+  }
+  return {
+    operandStack,
+    graphicsStateStack: GraphicsStateStack.create(),
+    markedContentStack: MarkedContentStack.create(),
+  };
+};
+
+const buildContextWithSegments = (
+  segments: PathSegment[],
+  operands: PdfObject[] = [],
+): OperatorHandlerContext => {
+  const operandStack = OperandStack.create();
+  for (const operand of operands) {
+    OperandStack.push(operandStack, operand);
+  }
+  const initialState = GraphicsState.create();
+  let path = initialState.currentPath;
+  for (const segment of segments) {
+    path = CurrentPath.append(path, segment);
+  }
+  const seededState = GraphicsState.update(initialState, { currentPath: path });
+  const graphicsStateStack = GraphicsStateStack.replaceCurrent(
+    GraphicsStateStack.create(),
+    seededState,
+  );
+  return {
+    operandStack,
+    graphicsStateStack,
+    markedContentStack: MarkedContentStack.create(),
+  };
+};
+
+const buildContextWithGraphicsState = (
+  state: GraphicsState,
+  operands: PdfObject[] = [],
+): OperatorHandlerContext => {
+  const operandStack = OperandStack.create();
+  for (const operand of operands) {
+    OperandStack.push(operandStack, operand);
+  }
+  const graphicsStateStack = GraphicsStateStack.replaceCurrent(
+    GraphicsStateStack.create(),
+    state,
+  );
+  return {
+    operandStack,
+    graphicsStateStack,
+    markedContentStack: MarkedContentStack.create(),
+  };
+};
+
+test("re 済み path に n を実行すると currentPath が空になる", () => {
+  const context = buildContextWithSegments([
+    PathSegment.rect(100, 100, 300, 400),
+  ]);
+
+  const result = endPathHandler(context);
+
+  assert(result.ok);
+  expect(
+    CurrentPath.isEmpty(
+      GraphicsStateStack.current(result.value.graphicsStateStack).currentPath,
+    ),
+  ).toBe(true);
+});
+
+test("m l close 済みの閉じた path も n で破棄できる", () => {
+  const context = buildContextWithSegments([
+    PathSegment.moveTo(0, 0),
+    PathSegment.lineTo(10, 10),
+    PathSegment.close(),
+  ]);
+
+  const result = endPathHandler(context);
+
+  assert(result.ok);
+  expect(
+    CurrentPath.isEmpty(
+      GraphicsStateStack.current(result.value.graphicsStateStack).currentPath,
+    ),
+  ).toBe(true);
+});
+
+test("fillHandler / strokeHandler / fillStrokeHandler とは別の関数実体である", () => {
+  expect(endPathHandler).not.toBe(fillHandler);
+  expect(endPathHandler).not.toBe(strokeHandler);
+  expect(endPathHandler).not.toBe(fillStrokeHandler);
+});
+
+test("operand を pop しない", () => {
+  const context = buildContextWithSegments(
+    [PathSegment.rect(100, 100, 300, 400)],
+    [real(1), real(2)],
+  );
+  const depthBefore = OperandStack.depth(context.operandStack);
+  const peekBefore = OperandStack.peek(context.operandStack);
+
+  const result = endPathHandler(context);
+
+  assert(result.ok);
+  expect(result.value.operandStack).toBe(context.operandStack);
+  expect(OperandStack.depth(result.value.operandStack)).toBe(depthBefore);
+  const peekAfter = OperandStack.peek(result.value.operandStack);
+  assert(peekBefore.some);
+  assert(peekAfter.some);
+  expect(peekAfter.value).toEqual(real(2));
+});
+
+test("空 path への n は no-op で graphicsStateStack を同一参照に保つ", () => {
+  const context = buildContext([]);
+
+  const result = endPathHandler(context);
+
+  assert(result.ok);
+  expect(result.value.graphicsStateStack).toBe(context.graphicsStateStack);
+  expect(
+    CurrentPath.isEmpty(
+      GraphicsStateStack.current(result.value.graphicsStateStack).currentPath,
+    ),
+  ).toBe(true);
+});
+
+test("graphics state の全フィールドを保持する", () => {
+  const baseState = GraphicsState.create();
+  const path = CurrentPath.append(
+    baseState.currentPath,
+    PathSegment.rect(100, 100, 300, 400),
+  );
+  const seededCtm = Matrix.create(2, 0, 0, 3, 10, 20);
+  const seededLineCap = LineCap.create(2);
+  const seededLineJoin = LineJoin.create(2);
+  const seededState = GraphicsState.update(baseState, {
+    currentPath: path,
+    ctm: seededCtm,
+    lineWidth: 5,
+    lineCap: seededLineCap,
+    lineJoin: seededLineJoin,
+    miterLimit: 20,
+  });
+  const context = buildContextWithGraphicsState(seededState);
+
+  const result = endPathHandler(context);
+
+  assert(result.ok);
+  const after = GraphicsStateStack.current(result.value.graphicsStateStack);
+  expect(after.currentPath.segments).toEqual([]);
+  expect(after.ctm).toBe(seededCtm);
+  expect(after.lineWidth).toBe(5);
+  expect(after.lineCap).toBe(seededLineCap);
+  expect(after.lineJoin).toBe(seededLineJoin);
+  expect(after.miterLimit).toBe(20);
+});
+
+test("n を連続実行しても 2 回目は no-op で成功する", () => {
+  const context = buildContextWithSegments([
+    PathSegment.rect(100, 100, 300, 400),
+  ]);
+
+  const first = endPathHandler(context);
+  assert(first.ok);
+  const second = endPathHandler(first.value);
+
+  assert(second.ok);
+  expect(
+    CurrentPath.isEmpty(
+      GraphicsStateStack.current(second.value.graphicsStateStack).currentPath,
+    ),
+  ).toBe(true);
+});

--- a/packages/core/src/content-stream/operators/path/end-path/index.ts
+++ b/packages/core/src/content-stream/operators/path/end-path/index.ts
@@ -1,0 +1,62 @@
+import { ok } from "../../../../utils/result/index";
+import {
+  CurrentPath,
+  GraphicsState,
+  GraphicsStateStack,
+} from "../../../graphics-state/index";
+import type {
+  OperatorHandler,
+  OperatorHandlerContext,
+} from "../../../operator-registry/index";
+
+/**
+ * PDF §8.5.3 `n` operator (end the path object without filling or stroking) の
+ * ハンドラ。
+ *
+ * operand を pop せず、current path を `CurrentPath.empty()` にリセットした
+ * 新しい GraphicsState を生成する (ISO 32000-1:2008 §8.5.3)。塗りも線描も
+ * 行わないため、`f` / `S` / `B` と state 更新は同じでも別 handler 実体として
+ * 定義する (委譲すると将来 renderer フック導入時に誤って描画してしまう)。
+ *
+ * fill rule (nonzero winding / even-odd) は paint handler の種別で表現するため
+ * state には書き込まない。`n` は paint を行わないため fill rule を持たない。
+ * clipping: 主用途は `W n` / `W* n` によるクリッピングパスの確定
+ * (ISO 32000-1:2008 §8.5.4, `docs/specs/05_content_streams.md` §4.3)。
+ * pendingClip の適用ロジックは別 issue (W/W*) で、本 handler を含む path
+ * finalization operator (`S` / `s` / `f` / `F` / `f*` / `B` / `B*` / `b` /
+ * `b*` / `n`) に注入する。本 issue では path の消費のみを行う。
+ *
+ * - operand 数: 0 (operand stack を一切参照しない)
+ * - current path が空の場合は no-op で同一 operandStack / graphicsStateStack
+ *   参照を含む新 context を返す
+ * - ctm / lineWidth / lineCap / lineJoin / miterLimit など
+ *   currentPath 以外の graphics state は変更しない
+ * - 本 handler では PdfError を返さない (常に ok)
+ *
+ * @param context - 実行コンテキスト (operand stack / graphics state stack)
+ * @returns 更新後コンテキスト (常に ok)
+ */
+export const endPathHandler: OperatorHandler = (
+  context: OperatorHandlerContext,
+) => {
+  const current = GraphicsStateStack.current(context.graphicsStateStack);
+  if (CurrentPath.isEmpty(current.currentPath)) {
+    return ok({
+      operandStack: context.operandStack,
+      graphicsStateStack: context.graphicsStateStack,
+      markedContentStack: context.markedContentStack,
+    });
+  }
+  const next = GraphicsState.update(current, {
+    currentPath: CurrentPath.empty(),
+  });
+  const graphicsStateStack = GraphicsStateStack.replaceCurrent(
+    context.graphicsStateStack,
+    next,
+  );
+  return ok({
+    operandStack: context.operandStack,
+    graphicsStateStack,
+    markedContentStack: context.markedContentStack,
+  });
+};

--- a/packages/core/src/content-stream/operators/path/fill-even-odd/__tests__/fill-even-odd.basic.test.ts
+++ b/packages/core/src/content-stream/operators/path/fill-even-odd/__tests__/fill-even-odd.basic.test.ts
@@ -1,0 +1,159 @@
+import { assert, expect, test } from "vitest";
+import type { PdfObject } from "../../../../../pdf/types/pdf-types/index";
+import {
+  CurrentPath,
+  GraphicsState,
+  GraphicsStateStack,
+  Matrix,
+} from "../../../../graphics-state/index";
+import { PathSegment } from "../../../../graphics-state/path-segment";
+import { MarkedContentStack } from "../../../../marked-content/stack";
+import { OperandStack } from "../../../../operand-stack/index";
+import type { OperatorHandlerContext } from "../../../../operator-registry/index";
+import { fillHandler } from "../../fill";
+import { fillEvenOddHandler } from "../index";
+
+const real = (value: number): PdfObject => ({ type: "real", value });
+
+const buildContext = (operands: PdfObject[]): OperatorHandlerContext => {
+  const operandStack = OperandStack.create();
+  for (const operand of operands) {
+    OperandStack.push(operandStack, operand);
+  }
+  return {
+    operandStack,
+    graphicsStateStack: GraphicsStateStack.create(),
+    markedContentStack: MarkedContentStack.create(),
+  };
+};
+
+const buildContextWithSegments = (
+  segments: PathSegment[],
+  operands: PdfObject[] = [],
+): OperatorHandlerContext => {
+  const operandStack = OperandStack.create();
+  for (const operand of operands) {
+    OperandStack.push(operandStack, operand);
+  }
+  const initialState = GraphicsState.create();
+  let path = initialState.currentPath;
+  for (const segment of segments) {
+    path = CurrentPath.append(path, segment);
+  }
+  const seededState = GraphicsState.update(initialState, { currentPath: path });
+  const graphicsStateStack = GraphicsStateStack.replaceCurrent(
+    GraphicsStateStack.create(),
+    seededState,
+  );
+  return {
+    operandStack,
+    graphicsStateStack,
+    markedContentStack: MarkedContentStack.create(),
+  };
+};
+
+const buildContextWithGraphicsState = (
+  state: GraphicsState,
+  operands: PdfObject[] = [],
+): OperatorHandlerContext => {
+  const operandStack = OperandStack.create();
+  for (const operand of operands) {
+    OperandStack.push(operandStack, operand);
+  }
+  const graphicsStateStack = GraphicsStateStack.replaceCurrent(
+    GraphicsStateStack.create(),
+    state,
+  );
+  return {
+    operandStack,
+    graphicsStateStack,
+    markedContentStack: MarkedContentStack.create(),
+  };
+};
+
+test("m l 済み path に f* を実行すると currentPath が空になる", () => {
+  const context = buildContextWithSegments([
+    PathSegment.moveTo(100, 100),
+    PathSegment.lineTo(200, 200),
+  ]);
+
+  const result = fillEvenOddHandler(context);
+
+  assert(result.ok);
+  expect(
+    CurrentPath.isEmpty(
+      GraphicsStateStack.current(result.value.graphicsStateStack).currentPath,
+    ),
+  ).toBe(true);
+});
+
+test("fillHandler と同じ state 更新結果になる", () => {
+  const context = buildContextWithSegments([
+    PathSegment.moveTo(100, 100),
+    PathSegment.lineTo(200, 200),
+  ]);
+
+  const evenOddResult = fillEvenOddHandler(context);
+  const nonzeroResult = fillHandler(context);
+
+  assert(evenOddResult.ok);
+  assert(nonzeroResult.ok);
+  expect(
+    GraphicsStateStack.current(evenOddResult.value.graphicsStateStack),
+  ).toEqual(GraphicsStateStack.current(nonzeroResult.value.graphicsStateStack));
+});
+
+test("fillHandler とは別の関数実体である", () => {
+  expect(fillEvenOddHandler).not.toBe(fillHandler);
+});
+
+test("operand を pop しない", () => {
+  const context = buildContextWithSegments(
+    [PathSegment.moveTo(100, 100), PathSegment.lineTo(200, 200)],
+    [real(1), real(2)],
+  );
+  const depthBefore = OperandStack.depth(context.operandStack);
+  const peekBefore = OperandStack.peek(context.operandStack);
+
+  const result = fillEvenOddHandler(context);
+
+  assert(result.ok);
+  expect(result.value.operandStack).toBe(context.operandStack);
+  expect(OperandStack.depth(result.value.operandStack)).toBe(depthBefore);
+  const peekAfter = OperandStack.peek(result.value.operandStack);
+  assert(peekBefore.some);
+  assert(peekAfter.some);
+  expect(peekAfter.value).toEqual(real(2));
+});
+
+test("空 path への f* は no-op で graphicsStateStack を同一参照に保つ", () => {
+  const context = buildContext([]);
+
+  const result = fillEvenOddHandler(context);
+
+  assert(result.ok);
+  expect(result.value.graphicsStateStack).toBe(context.graphicsStateStack);
+});
+
+test("currentPath 以外の graphics state を保持する", () => {
+  const baseState = GraphicsState.create();
+  const path = CurrentPath.append(
+    CurrentPath.append(baseState.currentPath, PathSegment.moveTo(100, 100)),
+    PathSegment.lineTo(200, 200),
+  );
+  const seededCtm = Matrix.create(2, 0, 0, 3, 10, 20);
+  const seededState = GraphicsState.update(baseState, {
+    currentPath: path,
+    ctm: seededCtm,
+    lineWidth: 5,
+  });
+  const context = buildContextWithGraphicsState(seededState);
+
+  const result = fillEvenOddHandler(context);
+
+  assert(result.ok);
+  const after = GraphicsStateStack.current(result.value.graphicsStateStack);
+  expect(after.currentPath.segments).toEqual([]);
+  expect(after.ctm).toBe(seededCtm);
+  expect(after.lineWidth).toBe(5);
+});

--- a/packages/core/src/content-stream/operators/path/fill-even-odd/index.ts
+++ b/packages/core/src/content-stream/operators/path/fill-even-odd/index.ts
@@ -1,0 +1,35 @@
+import type {
+  OperatorHandler,
+  OperatorHandlerContext,
+} from "../../../operator-registry/index";
+import { fillHandler } from "../fill";
+
+/**
+ * PDF §8.5.3 `f*` operator (fill the path, even-odd rule) のハンドラ。
+ *
+ * state 更新は `f` と同一 (current path を `CurrentPath.empty()` にリセット)
+ * のため `fillHandler` に委譲する。fill rule (nonzero winding / even-odd) は
+ * state ではなく operator 種別で表現するため、`fillHandler` の別名 export に
+ * せず**別の関数実体**として定義する。registry 上で `f` と `f*` が別 handler
+ * に対応することが fill rule の唯一の表現。ただしこの区別は registry の
+ * マッピングまでで、委譲後の `fillHandler` 内部には届かない。renderer 実装時に
+ * は本 handler が委譲をやめ、fill rule を明示引数で受ける共通 paint 関数を
+ * 呼ぶ形へ変更する必要がある (別 issue)。
+ *
+ * clipping: 将来 `W` / `W*` が設定する pendingClip の適用は本 handler では
+ * 行わない。pendingClip の適用ロジックは別 issue (W/W*) で、本 handler を含む
+ * path finalization operator (`S` / `s` / `f` / `F` / `f*` / `B` / `B*` / `b` /
+ * `b*` / `n`) に注入する。`n` は paint しないが `W n` で clip を確定させるため
+ * 対象に含む。
+ *
+ * - operand 数: 0 (operand stack を一切参照しない)
+ * - current path が空の場合は委譲先が no-op で返す
+ * - currentPath 以外の graphics state は変更しない
+ * - 本 handler では PdfError を返さない (常に ok)
+ *
+ * @param context - 実行コンテキスト (operand stack / graphics state stack)
+ * @returns 更新後コンテキスト (常に ok)
+ */
+export const fillEvenOddHandler: OperatorHandler = (
+  context: OperatorHandlerContext,
+) => fillHandler(context);

--- a/packages/core/src/content-stream/operators/path/fill-stroke-even-odd/__tests__/fill-stroke-even-odd.basic.test.ts
+++ b/packages/core/src/content-stream/operators/path/fill-stroke-even-odd/__tests__/fill-stroke-even-odd.basic.test.ts
@@ -1,0 +1,157 @@
+import { assert, expect, test } from "vitest";
+import type { PdfObject } from "../../../../../pdf/types/pdf-types/index";
+import {
+  CurrentPath,
+  GraphicsState,
+  GraphicsStateStack,
+  LineJoin,
+} from "../../../../graphics-state/index";
+import { PathSegment } from "../../../../graphics-state/path-segment";
+import { MarkedContentStack } from "../../../../marked-content/stack";
+import { OperandStack } from "../../../../operand-stack/index";
+import type { OperatorHandlerContext } from "../../../../operator-registry/index";
+import { fillStrokeHandler } from "../../fill-stroke";
+import { fillStrokeEvenOddHandler } from "../index";
+
+const real = (value: number): PdfObject => ({ type: "real", value });
+
+const buildContext = (operands: PdfObject[]): OperatorHandlerContext => {
+  const operandStack = OperandStack.create();
+  for (const operand of operands) {
+    OperandStack.push(operandStack, operand);
+  }
+  return {
+    operandStack,
+    graphicsStateStack: GraphicsStateStack.create(),
+    markedContentStack: MarkedContentStack.create(),
+  };
+};
+
+const buildContextWithSegments = (
+  segments: PathSegment[],
+  operands: PdfObject[] = [],
+): OperatorHandlerContext => {
+  const operandStack = OperandStack.create();
+  for (const operand of operands) {
+    OperandStack.push(operandStack, operand);
+  }
+  const initialState = GraphicsState.create();
+  let path = initialState.currentPath;
+  for (const segment of segments) {
+    path = CurrentPath.append(path, segment);
+  }
+  const seededState = GraphicsState.update(initialState, { currentPath: path });
+  const graphicsStateStack = GraphicsStateStack.replaceCurrent(
+    GraphicsStateStack.create(),
+    seededState,
+  );
+  return {
+    operandStack,
+    graphicsStateStack,
+    markedContentStack: MarkedContentStack.create(),
+  };
+};
+
+const buildContextWithGraphicsState = (
+  state: GraphicsState,
+  operands: PdfObject[] = [],
+): OperatorHandlerContext => {
+  const operandStack = OperandStack.create();
+  for (const operand of operands) {
+    OperandStack.push(operandStack, operand);
+  }
+  const graphicsStateStack = GraphicsStateStack.replaceCurrent(
+    GraphicsStateStack.create(),
+    state,
+  );
+  return {
+    operandStack,
+    graphicsStateStack,
+    markedContentStack: MarkedContentStack.create(),
+  };
+};
+
+test("re 済み path に B* を実行すると currentPath が空になる", () => {
+  const context = buildContextWithSegments([
+    PathSegment.rect(100, 100, 200, 150),
+  ]);
+
+  const result = fillStrokeEvenOddHandler(context);
+
+  assert(result.ok);
+  expect(
+    CurrentPath.isEmpty(
+      GraphicsStateStack.current(result.value.graphicsStateStack).currentPath,
+    ),
+  ).toBe(true);
+});
+
+test("fillStrokeHandler と同じ state 更新結果になる", () => {
+  const context = buildContextWithSegments([
+    PathSegment.rect(100, 100, 200, 150),
+  ]);
+
+  const evenOddResult = fillStrokeEvenOddHandler(context);
+  const nonzeroResult = fillStrokeHandler(context);
+
+  assert(evenOddResult.ok);
+  assert(nonzeroResult.ok);
+  expect(
+    GraphicsStateStack.current(evenOddResult.value.graphicsStateStack),
+  ).toEqual(GraphicsStateStack.current(nonzeroResult.value.graphicsStateStack));
+});
+
+test("fillStrokeHandler とは別の関数実体である", () => {
+  expect(fillStrokeEvenOddHandler).not.toBe(fillStrokeHandler);
+});
+
+test("operand を pop しない", () => {
+  const context = buildContextWithSegments(
+    [PathSegment.rect(100, 100, 200, 150)],
+    [real(1), real(2)],
+  );
+  const depthBefore = OperandStack.depth(context.operandStack);
+  const peekBefore = OperandStack.peek(context.operandStack);
+
+  const result = fillStrokeEvenOddHandler(context);
+
+  assert(result.ok);
+  expect(result.value.operandStack).toBe(context.operandStack);
+  expect(OperandStack.depth(result.value.operandStack)).toBe(depthBefore);
+  const peekAfter = OperandStack.peek(result.value.operandStack);
+  assert(peekBefore.some);
+  assert(peekAfter.some);
+  expect(peekAfter.value).toEqual(real(2));
+});
+
+test("空 path への B* は no-op で graphicsStateStack を同一参照に保つ", () => {
+  const context = buildContext([]);
+
+  const result = fillStrokeEvenOddHandler(context);
+
+  assert(result.ok);
+  expect(result.value.graphicsStateStack).toBe(context.graphicsStateStack);
+});
+
+test("miterLimit / lineJoin を保持する", () => {
+  const baseState = GraphicsState.create();
+  const path = CurrentPath.append(
+    baseState.currentPath,
+    PathSegment.rect(100, 100, 200, 150),
+  );
+  const seededLineJoin = LineJoin.create(2);
+  const seededState = GraphicsState.update(baseState, {
+    currentPath: path,
+    lineJoin: seededLineJoin,
+    miterLimit: 8,
+  });
+  const context = buildContextWithGraphicsState(seededState);
+
+  const result = fillStrokeEvenOddHandler(context);
+
+  assert(result.ok);
+  const after = GraphicsStateStack.current(result.value.graphicsStateStack);
+  expect(after.currentPath.segments).toEqual([]);
+  expect(after.lineJoin).toBe(seededLineJoin);
+  expect(after.miterLimit).toBe(8);
+});

--- a/packages/core/src/content-stream/operators/path/fill-stroke-even-odd/index.ts
+++ b/packages/core/src/content-stream/operators/path/fill-stroke-even-odd/index.ts
@@ -1,0 +1,31 @@
+import type {
+  OperatorHandler,
+  OperatorHandlerContext,
+} from "../../../operator-registry/index";
+import { fillStrokeHandler } from "../fill-stroke";
+
+/**
+ * PDF §8.5.3 `B*` operator (fill the path, then stroke it; even-odd rule) の
+ * ハンドラ。
+ *
+ * state 更新は `B` と同一のため `fillStrokeHandler` に委譲する。fill rule は
+ * state ではなく operator 種別で表現するため、別名 export にせず**別の関数実体**
+ * として定義する。fill と stroke の合成順序も renderer 側の責務。
+ *
+ * clipping: 将来 `W` / `W*` が設定する pendingClip の適用は本 handler では
+ * 行わない。pendingClip の適用ロジックは別 issue (W/W*) で、本 handler を含む
+ * path finalization operator (`S` / `s` / `f` / `F` / `f*` / `B` / `B*` / `b` /
+ * `b*` / `n`) に注入する。`n` は paint しないが `W n` で clip を確定させるため
+ * 対象に含む。
+ *
+ * - operand 数: 0 (operand stack を一切参照しない)
+ * - current path が空の場合は委譲先が no-op で返す
+ * - currentPath 以外の graphics state は変更しない
+ * - 本 handler では PdfError を返さない (常に ok)
+ *
+ * @param context - 実行コンテキスト (operand stack / graphics state stack)
+ * @returns 更新後コンテキスト (常に ok)
+ */
+export const fillStrokeEvenOddHandler: OperatorHandler = (
+  context: OperatorHandlerContext,
+) => fillStrokeHandler(context);

--- a/packages/core/src/content-stream/operators/path/fill-stroke/index.ts
+++ b/packages/core/src/content-stream/operators/path/fill-stroke/index.ts
@@ -18,12 +18,14 @@ import type {
  * operand stack に値が残っていても pop / 検証 / clear のいずれも行わず、
  * 同一参照のまま返す。
  *
- * fill rule (nonzero winding / even-odd) と close 動作は operator 種別
- * (`B` / `B*` / `b` / `b*`) で表現するため state には書き込まない。
- * また fill と stroke の合成順序 (`B` では fill → stroke) も renderer 側の
+ * fill rule (nonzero winding / even-odd) は operator 種別 (`B` / `B*`) で
+ * 表現するため state には書き込まない。一方 close 動作 (`b` / `b*`) は
+ * 呼び出し側の handler が `closeSubpathContext` で current path に
+ * `PathSegment.close()` を append してから本 handler に委譲する形で表現する。
+ * また fill と stroke の合成順序 (`B` では fill → stroke) は renderer 側の
  * 責務であり、本 handler は path リセットのみを担当する。実際のラスタライズは
  * ライブラリのスコープ外で、ピクセル描画は将来 renderer 側が operator 種別から
- * fill rule / close 動作 / fill+stroke の合成順序を解釈する。
+ * fill rule / fill+stroke の合成順序を解釈する。
  *
  * 命名: PDF 仕様上の大文字 `B` (fill+stroke) と小文字 `b` (close-and-fill-stroke)
  * は別 operator のため、letter ディレクトリではなく semantic 名 `fill-stroke` を使う。

--- a/packages/core/src/content-stream/operators/path/h/index.ts
+++ b/packages/core/src/content-stream/operators/path/h/index.ts
@@ -1,21 +1,17 @@
 import { ok } from "../../../../utils/result/index";
-import {
-  CurrentPath,
-  GraphicsState,
-  GraphicsStateStack,
-} from "../../../graphics-state/index";
-import { PathSegment } from "../../../graphics-state/path-segment";
 import type {
   OperatorHandler,
   OperatorHandlerContext,
 } from "../../../operator-registry/index";
+import { closeSubpathContext } from "../close-subpath";
 
 /**
  * PDF §8.5.2 `h` operator (close subpath) のハンドラ。
  *
  * operand を pop せず、current path の末尾に `PathSegment.close()` を
  * append した新しい GraphicsState を生成する (ISO 32000-1:2008 §8.5.2)。
- * `h` は引数を取らないオペレータのため、operand stack に値が残っていても
+ * close 処理そのものは `s` / `b` / `b*` と共通のため `closeSubpathContext`
+ * に集約している。`h` は引数を取らないオペレータのため、operand stack に値が
  * pop / 検証 / clear のいずれも行わず、同一参照のまま返す。
  *
  * - operand 数: 0 (operand stack を一切参照しない)
@@ -30,23 +26,10 @@ import type {
  * @returns 更新後コンテキスト (常に ok)
  */
 export const hHandler: OperatorHandler = (context: OperatorHandlerContext) => {
-  const current = GraphicsStateStack.current(context.graphicsStateStack);
-  if (CurrentPath.isEmpty(current.currentPath)) {
-    return ok({
-      operandStack: context.operandStack,
-      graphicsStateStack: context.graphicsStateStack,
-      markedContentStack: context.markedContentStack,
-    });
-  }
-  const nextPath = CurrentPath.append(current.currentPath, PathSegment.close());
-  const next = GraphicsState.update(current, { currentPath: nextPath });
-  const graphicsStateStack = GraphicsStateStack.replaceCurrent(
-    context.graphicsStateStack,
-    next,
-  );
+  const closed = closeSubpathContext(context);
   return ok({
-    operandStack: context.operandStack,
-    graphicsStateStack,
-    markedContentStack: context.markedContentStack,
+    operandStack: closed.operandStack,
+    graphicsStateStack: closed.graphicsStateStack,
+    markedContentStack: closed.markedContentStack,
   });
 };

--- a/packages/core/src/content-stream/operators/path/h/index.ts
+++ b/packages/core/src/content-stream/operators/path/h/index.ts
@@ -12,7 +12,7 @@ import { closeSubpathContext } from "../close-subpath";
  * append した新しい GraphicsState を生成する (ISO 32000-1:2008 §8.5.2)。
  * close 処理そのものは `s` / `b` / `b*` と共通のため `closeSubpathContext`
  * に集約している。`h` は引数を取らないオペレータのため、operand stack に値が
- * pop / 検証 / clear のいずれも行わず、同一参照のまま返す。
+ * 残っていても pop / 検証 / clear のいずれも行わず、同一参照のまま返す。
  *
  * - operand 数: 0 (operand stack を一切参照しない)
  * - current path が空 (current point 未確立) の場合は no-op で同一 context を返す。

--- a/packages/core/src/content-stream/operators/path/path-operators/__tests__/path-operators.basic.test.ts
+++ b/packages/core/src/content-stream/operators/path/path-operators/__tests__/path-operators.basic.test.ts
@@ -5,7 +5,13 @@ import {
 } from "../../../../operator-registry/index";
 import {
   cHandler,
+  closeFillStrokeEvenOddHandler,
+  closeFillStrokeHandler,
+  closeStrokeHandler,
+  endPathHandler,
+  fillEvenOddHandler,
   fillHandler,
+  fillStrokeEvenOddHandler,
   fillStrokeHandler,
   hHandler,
   lHandler,
@@ -26,8 +32,15 @@ test.each<readonly [string, OperatorHandler]>([
   ["h", hHandler],
   ["re", reHandler],
   ["S", strokeHandler],
+  ["s", closeStrokeHandler],
   ["f", fillHandler],
+  ["F", fillHandler],
+  ["f*", fillEvenOddHandler],
   ["B", fillStrokeHandler],
+  ["B*", fillStrokeEvenOddHandler],
+  ["b", closeFillStrokeHandler],
+  ["b*", closeFillStrokeEvenOddHandler],
+  ["n", endPathHandler],
 ])("registerPathOperators は %s に対応する handler を登録する", (name, expectedHandler) => {
   const result = registerPathOperators(OperatorRegistry.create());
   assert(result.ok);
@@ -35,4 +48,48 @@ test.each<readonly [string, OperatorHandler]>([
   const looked = OperatorRegistry.lookup(result.value, name);
   assert(looked.some);
   expect(looked.value).toBe(expectedHandler);
+});
+
+test("F は f と同じ fillHandler 実体で引ける", () => {
+  const result = registerPathOperators(OperatorRegistry.create());
+  assert(result.ok);
+
+  const fill = OperatorRegistry.lookup(result.value, "f");
+  const alias = OperatorRegistry.lookup(result.value, "F");
+  assert(fill.some);
+  assert(alias.some);
+  expect(alias.value).toBe(fill.value);
+  expect(alias.value).toBe(fillHandler);
+});
+
+test("f と f* は lookup の value が別 handler 実体である", () => {
+  const result = registerPathOperators(OperatorRegistry.create());
+  assert(result.ok);
+
+  const nonzero = OperatorRegistry.lookup(result.value, "f");
+  const evenOdd = OperatorRegistry.lookup(result.value, "f*");
+  assert(nonzero.some);
+  assert(evenOdd.some);
+  expect(nonzero.value).not.toBe(evenOdd.value);
+});
+
+test("B と B* は lookup の value が別 handler 実体である", () => {
+  const result = registerPathOperators(OperatorRegistry.create());
+  assert(result.ok);
+
+  const nonzero = OperatorRegistry.lookup(result.value, "B");
+  const evenOdd = OperatorRegistry.lookup(result.value, "B*");
+  assert(nonzero.some);
+  assert(evenOdd.some);
+  expect(nonzero.value).not.toBe(evenOdd.value);
+});
+
+test("closeSubpathContext は operator 名として登録されない", () => {
+  const result = registerPathOperators(OperatorRegistry.create());
+  assert(result.ok);
+
+  const kebab = OperatorRegistry.lookup(result.value, "close-subpath");
+  const camel = OperatorRegistry.lookup(result.value, "closeSubpath");
+  expect(kebab.some).toBe(false);
+  expect(camel.some).toBe(false);
 });

--- a/packages/core/src/content-stream/operators/path/path-operators/__tests__/path-operators.error.test.ts
+++ b/packages/core/src/content-stream/operators/path/path-operators/__tests__/path-operators.error.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, assert, expect, test, vi } from "vitest";
 import { OperatorRegistry } from "../../../../operator-registry/index";
 import {
+  endPathHandler,
   lHandler,
   mHandler,
   registerPathOperators,
@@ -58,7 +59,7 @@ test("l のみ事前登録済みなら配列順序で l に到達した時点で
   expect(result.error.operatorName).toBe("l");
 });
 
-test("m 重複時、後続 operator (l/c/h/re/S/f/B) への register は呼ばれない", () => {
+test("m 重複時、後続 operator (l/c/v/y/h/re/S/s/f/F/f*/B/B*/b/b*/n) への register は呼ばれない", () => {
   const seed = OperatorRegistry.register(
     OperatorRegistry.create(),
     "m",
@@ -75,7 +76,7 @@ test("m 重複時、後続 operator (l/c/h/re/S/f/B) への register は呼ば�
   expect(calledNames).toEqual(["m"]);
 });
 
-test("l 重複時、配列順で m は成功 → l で短絡し c/h/re/S/f/B は呼ばれない", () => {
+test("l 重複時、配列順で m は成功 → l で短絡し c/v/y/h/re/S/s/f/F/f*/B/B*/b/b*/n は呼ばれない", () => {
   const seed = OperatorRegistry.register(
     OperatorRegistry.create(),
     "l",
@@ -90,4 +91,19 @@ test("l 重複時、配列順で m は成功 → l で短絡し c/h/re/S/f/B は
 
   const calledNames = registerSpy.mock.calls.map((call) => call[1]);
   expect(calledNames).toEqual(["m", "l"]);
+});
+
+test("n が登録済みなら OPERATOR_ALREADY_REGISTERED の Err を返す", () => {
+  const seed = OperatorRegistry.register(
+    OperatorRegistry.create(),
+    "n",
+    endPathHandler,
+  );
+  assert(seed.ok);
+
+  const result = registerPathOperators(seed.value);
+
+  assert(!result.ok);
+  assert(result.error.code === "OPERATOR_ALREADY_REGISTERED");
+  expect(result.error.operatorName).toBe("n");
 });

--- a/packages/core/src/content-stream/operators/path/path-operators/__tests__/path-operators.integration.test.ts
+++ b/packages/core/src/content-stream/operators/path/path-operators/__tests__/path-operators.integration.test.ts
@@ -117,3 +117,213 @@ test("re h の後の v は rect の subpath 開始点を第1制御点にする",
     PathSegment.curveTo(10, 10, 120, 60, 140, 80),
   ]);
 });
+
+test("100 100 m 200 200 l s が warning なく完走する", () => {
+  const registered = registerPathOperators(OperatorRegistry.create());
+  assert(registered.ok);
+
+  const result = ContentStreamInterpreter.execute({
+    data: encode("100 100 m 200 200 l s"),
+    registry: registered.value,
+  });
+
+  assert(result.ok);
+  expect(result.value.warnings).toEqual([]);
+  const current = GraphicsStateStack.current(
+    result.value.context.graphicsStateStack,
+  );
+  expect(CurrentPath.isEmpty(current.currentPath)).toBe(true);
+});
+
+test("100 100 300 400 re f* が warning なく完走する", () => {
+  const registered = registerPathOperators(OperatorRegistry.create());
+  assert(registered.ok);
+
+  const result = ContentStreamInterpreter.execute({
+    data: encode("100 100 300 400 re f*"),
+    registry: registered.value,
+  });
+
+  assert(result.ok);
+  expect(result.value.warnings).toEqual([]);
+  expect(
+    CurrentPath.isEmpty(
+      GraphicsStateStack.current(result.value.context.graphicsStateStack)
+        .currentPath,
+    ),
+  ).toBe(true);
+});
+
+test("100 100 300 400 re F が warning なく完走する", () => {
+  const registered = registerPathOperators(OperatorRegistry.create());
+  assert(registered.ok);
+
+  const result = ContentStreamInterpreter.execute({
+    data: encode("100 100 300 400 re F"),
+    registry: registered.value,
+  });
+
+  assert(result.ok);
+  expect(result.value.warnings).toEqual([]);
+  expect(
+    CurrentPath.isEmpty(
+      GraphicsStateStack.current(result.value.context.graphicsStateStack)
+        .currentPath,
+    ),
+  ).toBe(true);
+});
+
+test("100 100 300 400 re B* が warning なく完走する", () => {
+  const registered = registerPathOperators(OperatorRegistry.create());
+  assert(registered.ok);
+
+  const result = ContentStreamInterpreter.execute({
+    data: encode("100 100 300 400 re B*"),
+    registry: registered.value,
+  });
+
+  assert(result.ok);
+  expect(result.value.warnings).toEqual([]);
+  expect(
+    CurrentPath.isEmpty(
+      GraphicsStateStack.current(result.value.context.graphicsStateStack)
+        .currentPath,
+    ),
+  ).toBe(true);
+});
+
+test("100 100 m 200 200 l b が warning なく完走する", () => {
+  const registered = registerPathOperators(OperatorRegistry.create());
+  assert(registered.ok);
+
+  const result = ContentStreamInterpreter.execute({
+    data: encode("100 100 m 200 200 l b"),
+    registry: registered.value,
+  });
+
+  assert(result.ok);
+  expect(result.value.warnings).toEqual([]);
+  expect(
+    CurrentPath.isEmpty(
+      GraphicsStateStack.current(result.value.context.graphicsStateStack)
+        .currentPath,
+    ),
+  ).toBe(true);
+});
+
+test("100 100 m 200 200 l b* が warning なく完走する", () => {
+  const registered = registerPathOperators(OperatorRegistry.create());
+  assert(registered.ok);
+
+  const result = ContentStreamInterpreter.execute({
+    data: encode("100 100 m 200 200 l b*"),
+    registry: registered.value,
+  });
+
+  assert(result.ok);
+  expect(result.value.warnings).toEqual([]);
+  expect(
+    CurrentPath.isEmpty(
+      GraphicsStateStack.current(result.value.context.graphicsStateStack)
+        .currentPath,
+    ),
+  ).toBe(true);
+});
+
+test("100 100 300 400 re n が warning なく完走する", () => {
+  const registered = registerPathOperators(OperatorRegistry.create());
+  assert(registered.ok);
+
+  const result = ContentStreamInterpreter.execute({
+    data: encode("100 100 300 400 re n"),
+    registry: registered.value,
+  });
+
+  assert(result.ok);
+  expect(result.value.warnings).toEqual([]);
+  expect(
+    CurrentPath.isEmpty(
+      GraphicsStateStack.current(result.value.context.graphicsStateStack)
+        .currentPath,
+    ),
+  ).toBe(true);
+});
+
+test("s と h S が同じ GraphicsState になる", () => {
+  const registered = registerPathOperators(OperatorRegistry.create());
+  assert(registered.ok);
+
+  const closeStrokeResult = ContentStreamInterpreter.execute({
+    data: encode("100 100 m 200 200 l s"),
+    registry: registered.value,
+  });
+  const closeThenStrokeResult = ContentStreamInterpreter.execute({
+    data: encode("100 100 m 200 200 l h S"),
+    registry: registered.value,
+  });
+
+  assert(closeStrokeResult.ok);
+  assert(closeThenStrokeResult.ok);
+  expect(
+    GraphicsStateStack.current(
+      closeStrokeResult.value.context.graphicsStateStack,
+    ),
+  ).toEqual(
+    GraphicsStateStack.current(
+      closeThenStrokeResult.value.context.graphicsStateStack,
+    ),
+  );
+});
+
+test("f* / B* / b* が 1 token として読まれる", () => {
+  const registered = registerPathOperators(OperatorRegistry.create());
+  assert(registered.ok);
+
+  const result = ContentStreamInterpreter.execute({
+    data: encode(
+      "100 100 300 400 re f* 100 100 300 400 re B* 100 100 m 200 200 l b*",
+    ),
+    registry: registered.value,
+  });
+
+  assert(result.ok);
+  expect(result.value.warnings).toEqual([]);
+  expect(
+    CurrentPath.isEmpty(
+      GraphicsStateStack.current(result.value.context.graphicsStateStack)
+        .currentPath,
+    ),
+  ).toBe(true);
+});
+
+test("paint 後に path 構築を再開できる", () => {
+  const registered = registerPathOperators(OperatorRegistry.create());
+  assert(registered.ok);
+
+  const result = ContentStreamInterpreter.execute({
+    data: encode("100 100 m n 300 300 m 400 400 l f"),
+    registry: registered.value,
+  });
+
+  assert(result.ok);
+  expect(result.value.warnings).toEqual([]);
+  expect(
+    CurrentPath.isEmpty(
+      GraphicsStateStack.current(result.value.context.graphicsStateStack)
+        .currentPath,
+    ),
+  ).toBe(true);
+});
+
+test("7つのpaint variantsを並べても UNKNOWN_OPERATOR warning が出ない", () => {
+  const registered = registerPathOperators(OperatorRegistry.create());
+  assert(registered.ok);
+
+  const result = ContentStreamInterpreter.execute({
+    data: encode("100 100 m 200 200 l s f* F B* b b* n"),
+    registry: registered.value,
+  });
+
+  assert(result.ok);
+  expect(result.value.warnings).toEqual([]);
+});

--- a/packages/core/src/content-stream/operators/path/path-operators/index.ts
+++ b/packages/core/src/content-stream/operators/path/path-operators/index.ts
@@ -4,8 +4,14 @@ import { flatMap, ok } from "../../../../utils/result/index";
 import type { OperatorHandler } from "../../../operator-registry/index";
 import { OperatorRegistry } from "../../../operator-registry/index";
 import { cHandler } from "../c";
+import { closeFillStrokeHandler } from "../close-fill-stroke";
+import { closeFillStrokeEvenOddHandler } from "../close-fill-stroke-even-odd";
+import { closeStrokeHandler } from "../close-stroke";
+import { endPathHandler } from "../end-path";
 import { fillHandler } from "../fill";
+import { fillEvenOddHandler } from "../fill-even-odd";
 import { fillStrokeHandler } from "../fill-stroke";
+import { fillStrokeEvenOddHandler } from "../fill-stroke-even-odd";
 import { hHandler } from "../h";
 import { lHandler } from "../l";
 import { mHandler } from "../m";
@@ -15,8 +21,14 @@ import { vHandler } from "../v";
 import { yHandler } from "../y";
 
 export { cHandler } from "../c";
+export { closeFillStrokeHandler } from "../close-fill-stroke";
+export { closeFillStrokeEvenOddHandler } from "../close-fill-stroke-even-odd";
+export { closeStrokeHandler } from "../close-stroke";
+export { endPathHandler } from "../end-path";
 export { fillHandler } from "../fill";
+export { fillEvenOddHandler } from "../fill-even-odd";
 export { fillStrokeHandler } from "../fill-stroke";
+export { fillStrokeEvenOddHandler } from "../fill-stroke-even-odd";
 export { hHandler } from "../h";
 export { lHandler } from "../l";
 export { mHandler } from "../m";
@@ -34,13 +46,23 @@ const PATH_OPERATORS: ReadonlyArray<readonly [string, OperatorHandler]> = [
   ["h", hHandler],
   ["re", reHandler],
   ["S", strokeHandler],
+  ["s", closeStrokeHandler],
   ["f", fillHandler],
+  ["F", fillHandler],
+  ["f*", fillEvenOddHandler],
   ["B", fillStrokeHandler],
+  ["B*", fillStrokeEvenOddHandler],
+  ["b", closeFillStrokeHandler],
+  ["b*", closeFillStrokeEvenOddHandler],
+  ["n", endPathHandler],
 ];
 
 /**
- * Path operator (m / l / c / v / y / h / re / S / f / B) を OperatorRegistry に
- * 一括登録するヘルパ。
+ * Path operator (m / l / c / v / y / h / re / S / s / f / F / f* / B / B* /
+ * b / b* / n) を OperatorRegistry に一括登録するヘルパ。
+ *
+ * `F` は `f` の互換 alias (ISO 32000-1:2008 §8.5.3) のため、専用 handler を
+ * 作らず `fillHandler` を 2 つの名前で登録する。
  *
  * fail-fast: いずれかの register が Err を返した時点で reduce 内 flatMap が
  * 短絡し、後続 operator の register は呼ばれない。


### PR DESCRIPTION
## 概要

Closes #489

PDF path paint variant operators を実装し、registry と interpreter から利用できるようにしました。

## 変更の種類

- ✨ 新機能
- ♻️ 共通の subpath close 処理を整理
- 🧪 単体・registry・interpreter テストを追加

## 主な変更

- `s` / `f*` / `F` / `B*` / `b` / `b*` / `n` を登録
- `CurrentPath.closeSubpath` と `closeSubpathContext` を追加
- `h` / `s` / `b` / `b*` の close 処理を共通化
- fill rule は handler 種別で表現し、pending clip は W/W* の別Issueに委譲
- `F` は `fillHandler` と同一実体、その他の fill rule variant は別 handler 実体

## 処理フロー

```mermaid
flowchart LR
  Registry[PATH_OPERATORS] --> Variant[Paint variant handler]
  Variant --> Close[closeSubpathContext]
  Close --> Paint[fill / stroke / fill-stroke handler]
  Paint --> Reset[currentPath reset]
```

## テスト

- `pnpm --filter @pdfmod/core test`
- `pnpm --filter @pdfmod/core build`
- `pnpm lint`
- 変更対象範囲の Biome / Oxlint

## レビューポイント

- close variant が `h` + paint と同値になること
- operand stack と currentPath 以外の graphics state を変更しないこと
- registry の handler identity（`F` alias、fill rule variants）
- `f*` / `B*` / `b*` が単一 token として解釈されること
