### PR TITLE
✨ [New Feature]: #581 PDFヘッダ検出とオフセット原点補正を実装

### DIFF
--- a/rust/crates/core/src/byte_offset.rs
+++ b/rust/crates/core/src/byte_offset.rs
@@ -27,6 +27,14 @@ impl ByteOffset {
     pub fn value(&self) -> u64 {
         self.0
     }
+
+    /// 2 つのオフセットを加算する。オーバーフローする場合は `None`。
+    ///
+    /// ヘッダがファイル先頭にない PDF で、xref の記録値を実位置へ補正する用途を想定する。
+    #[must_use]
+    pub fn checked_add(self, other: ByteOffset) -> Option<ByteOffset> {
+        self.0.checked_add(other.0).map(ByteOffset::new)
+    }
 }
 
 impl From<u64> for ByteOffset {

--- a/rust/crates/core/src/byte_offset.rs
+++ b/rust/crates/core/src/byte_offset.rs
@@ -86,6 +86,31 @@ mod tests {
     use std::collections::HashSet;
 
     #[test]
+    fn checked_add_values_in_range_returns_sum() {
+        // 通常範囲の 2 オフセットを加算すると合計値を返すことを確認する
+        assert_eq!(
+            ByteOffset::new(37).checked_add(ByteOffset::new(500)),
+            Some(ByteOffset::new(537))
+        );
+    }
+
+    #[test]
+    fn checked_add_boundary_values_returns_expected_option() {
+        // 境界値の加算とオーバーフローを安全に判定できることを確認する
+        let cases = [
+            (0, 0, Some(ByteOffset::new(0))),
+            (u64::MAX, 0, Some(ByteOffset::new(u64::MAX))),
+            (u64::MAX, 1, None),
+        ];
+        for (left, right, expected) in cases {
+            assert_eq!(
+                ByteOffset::new(left).checked_add(ByteOffset::new(right)),
+                expected
+            );
+        }
+    }
+
+    #[test]
     fn new_then_value_roundtrips() {
         // 代表値（0 / 1 / 42 / u64::MAX）を new で包んで value で取り出すと、生成時の値と一致することを確認する
         for n in [0, 1, 42, u64::MAX] {

--- a/rust/crates/core/src/error/pdf_error_code.rs
+++ b/rust/crates/core/src/error/pdf_error_code.rs
@@ -24,6 +24,10 @@ pub enum PdfErrorCode {
     InvalidNumber,
     /// PDF の構文規則に違反する入力を検出した。
     InvalidSyntax,
+    /// ファイルヘッダ `%PDF-x.y` が期待どおりに見つからない。
+    InvalidHeader,
+    /// ヘッダの版表記が ISO 32000 の規定する版ではない。
+    UnsupportedVersion,
 }
 
 /// バリアントごとに人間可読な英語短文を返す。文言は `std::io::ErrorKind` の
@@ -38,6 +42,8 @@ impl fmt::Display for PdfErrorCode {
             PdfErrorCode::UnexpectedToken => "unexpected token",
             PdfErrorCode::InvalidNumber => "invalid number",
             PdfErrorCode::InvalidSyntax => "invalid syntax",
+            PdfErrorCode::InvalidHeader => "invalid header",
+            PdfErrorCode::UnsupportedVersion => "unsupported version",
         };
         f.write_str(text)
     }

--- a/rust/crates/core/src/error/pdf_error_code.rs
+++ b/rust/crates/core/src/error/pdf_error_code.rs
@@ -67,12 +67,14 @@ mod tests {
 
     #[test]
     fn all_distinct_variants_are_mutually_not_equal() {
-        // 4 バリアントを総当たりで比較し、同一インデックスのみ等価・他は非等価であることを確認する
+        // 6 バリアントを総当たりで比較し、同一インデックスのみ等価・他は非等価であることを確認する
         let variants = [
             PdfErrorCode::UnexpectedEof,
             PdfErrorCode::UnexpectedToken,
             PdfErrorCode::InvalidNumber,
             PdfErrorCode::InvalidSyntax,
+            PdfErrorCode::InvalidHeader,
+            PdfErrorCode::UnsupportedVersion,
         ];
         for (i, a) in variants.iter().enumerate() {
             for (j, b) in variants.iter().enumerate() {
@@ -101,6 +103,8 @@ mod tests {
         assert!(format!("{:?}", PdfErrorCode::UnexpectedToken).contains("UnexpectedToken"));
         assert!(format!("{:?}", PdfErrorCode::InvalidNumber).contains("InvalidNumber"));
         assert!(format!("{:?}", PdfErrorCode::InvalidSyntax).contains("InvalidSyntax"));
+        assert!(format!("{:?}", PdfErrorCode::InvalidHeader).contains("InvalidHeader"));
+        assert!(format!("{:?}", PdfErrorCode::UnsupportedVersion).contains("UnsupportedVersion"));
     }
 
     #[test]
@@ -131,5 +135,20 @@ mod tests {
     fn display_invalid_syntax() {
         // InvalidSyntax の Display 出力が "invalid syntax" になることを確認する
         assert_eq!(format!("{}", PdfErrorCode::InvalidSyntax), "invalid syntax");
+    }
+
+    #[test]
+    fn display_invalid_header() {
+        // InvalidHeader の Display 出力が期待する短文になることを確認する
+        assert_eq!(format!("{}", PdfErrorCode::InvalidHeader), "invalid header");
+    }
+
+    #[test]
+    fn display_unsupported_version() {
+        // UnsupportedVersion の Display 出力が期待する短文になることを確認する
+        assert_eq!(
+            format!("{}", PdfErrorCode::UnsupportedVersion),
+            "unsupported version"
+        );
     }
 }

--- a/rust/crates/core/src/file.rs
+++ b/rust/crates/core/src/file.rs
@@ -1,0 +1,9 @@
+//! PDF の物理ファイル構造（ヘッダ・xref・トレイラ）を扱うモジュール。
+//!
+//! ISO 32000-1:2008 §7.5（`docs/specs/02_file_structure.md`）に対応する。
+//! 本ファイルはサブモジュールの mod 宣言のみを持つファサード。
+//! 現時点ではヘッダ解析（`header`）とバージョン（`version`）のみを提供し、
+//! startxref / xref テーブル / トレイラは後続の Issue で追加する。
+
+pub mod header;
+pub mod version;

--- a/rust/crates/core/src/file/header.rs
+++ b/rust/crates/core/src/file/header.rs
@@ -1,0 +1,183 @@
+//! PDF ファイルヘッダ `%PDF-x.y` の検出と、オフセット原点の確定を担うモジュール
+//! （`docs/specs/02_file_structure.md` §2）。
+//!
+//! xref が記録するバイトオフセットは `%PDF-` の位置を原点とするため、版だけでなく
+//! 原点そのものと、任意のバイナリファイルインジケータの有無を返す。
+
+use crate::byte_offset::ByteOffset;
+use crate::error::pdf_error::PdfError;
+use crate::error::pdf_error_code::PdfErrorCode;
+use crate::file::version::PdfVersion;
+use crate::lexer::byte_kind::ByteKind;
+use crate::lexer::eol::EolKind;
+
+/// ヘッダのシグネチャ。この直後に版表記が続く。
+const SIGNATURE: &[u8] = b"%PDF-";
+/// `%PDF-` を探す走査上限（ファイル先頭からのバイト数）。
+///
+/// PDF 仕様の規定ではなく、前置きバイトを許容する Adobe 実装ノート由来の慣行値。
+/// TypeScript 実装の `HEADER_SCAN_LIMIT` と同値にして受理範囲を揃える。
+const SCAN_LIMIT: usize = 1024;
+/// 版表記として読み取る最大バイト数（`"1.7"` は 3 バイト。異常入力での暴走を防ぐ上限）。
+const VERSION_MAX_LEN: usize = 8;
+/// バイナリファイルインジケータと判定する高ビットバイトの最小個数
+/// （`docs/specs/02_file_structure.md` §2.3）。
+const BINARY_INDICATOR_MIN_HIGH_BYTES: usize = 4;
+/// 行末の判定に使う CR バイト。
+const CR: u8 = 0x0D;
+/// 行末の判定に使う LF バイト。
+const LF: u8 = 0x0A;
+/// コメント行の開始バイト `%`。
+const PERCENT: u8 = b'%';
+
+/// 解析済みの PDF ファイルヘッダ。
+///
+/// 版・オフセット原点・バイナリインジケータの有無を保持する。値ラッパであり `Copy`。
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[must_use]
+pub struct PdfHeader {
+    version: PdfVersion,
+    origin: ByteOffset,
+    has_binary_indicator: bool,
+}
+
+impl PdfHeader {
+    /// 入力バイト列の先頭 1024 バイト以内から PDF ヘッダを解析する。
+    ///
+    /// # Errors
+    ///
+    /// - `InvalidHeader`: 走査範囲内に `%PDF-` が見つからない
+    /// - `UnexpectedEof`: `%PDF-` の直後で版表記が読めない
+    /// - `UnsupportedVersion`: 版表記が形式不正、または ISO 未規定
+    pub fn parse(input: &[u8]) -> Result<PdfHeader, PdfError> {
+        let origin = find_signature(input).ok_or_else(|| {
+            PdfError::new(PdfErrorCode::InvalidHeader)
+                .with_message("%PDF- signature not found within the first 1024 bytes")
+        })?;
+        let version_start = origin + SIGNATURE.len();
+        let version_bytes = read_version_bytes(input, version_start);
+        let position = ByteOffset::new(version_start as u64);
+        if version_bytes.is_empty() {
+            return Err(PdfError::new(PdfErrorCode::UnexpectedEof)
+                .with_position(position)
+                .with_message("input ended before the version could be read"));
+        }
+        let version = PdfVersion::from_bytes(version_bytes).ok_or_else(|| {
+            PdfError::new(PdfErrorCode::UnsupportedVersion)
+                .with_position(position)
+                .with_message(format!(
+                    "unsupported version {}",
+                    String::from_utf8_lossy(version_bytes)
+                ))
+        })?;
+        let after_version = version_start + version_bytes.len();
+        Ok(PdfHeader {
+            version,
+            origin: ByteOffset::new(origin as u64),
+            has_binary_indicator: has_binary_indicator(input, after_version),
+        })
+    }
+
+    /// ヘッダが宣言する PDF バージョンを返す。
+    ///
+    /// カタログの `/Version` による上書き（§2.2）は適用していない暫定値。
+    pub fn version(&self) -> PdfVersion {
+        self.version
+    }
+
+    /// オフセット原点（`%PDF-` の開始位置）を返す。
+    ///
+    /// 通常の PDF では 0。前置きバイトがある PDF では正の値になる。
+    pub fn origin(&self) -> ByteOffset {
+        self.origin
+    }
+
+    /// ヘッダ直後にバイナリファイルインジケータ行があったかを返す。
+    ///
+    /// インジケータは任意要素であり、無くてもヘッダとしては正当（§2.3）。
+    #[must_use]
+    pub fn has_binary_indicator(&self) -> bool {
+        self.has_binary_indicator
+    }
+
+    /// xref に記録されたオフセットを、ファイル先頭基準の実オフセットへ補正する。
+    ///
+    /// 記録値は `%PDF-` を原点とするため、原点を加算した位置が実際の読み取り位置になる。
+    /// 加算が `u64` を超える場合（壊れた xref）は `None`。
+    #[must_use]
+    pub fn resolve_offset(&self, recorded: ByteOffset) -> Option<ByteOffset> {
+        self.origin.checked_add(recorded)
+    }
+}
+
+/// 先頭 `SCAN_LIMIT` バイト以内から `%PDF-` の開始位置を探す。
+///
+/// シグネチャ全体が走査範囲に収まっている必要がある（範囲を跨ぐ位置では検出しない）。
+/// 入力が `SIGNATURE` より短い場合、`windows` は空イテレータとなり `None` を返す。
+fn find_signature(input: &[u8]) -> Option<usize> {
+    let limit = input.len().min(SCAN_LIMIT);
+    input[..limit]
+        .windows(SIGNATURE.len())
+        .position(|window| window == SIGNATURE)
+}
+
+/// `start` から版表記のバイト列を切り出す。
+///
+/// ホワイトスペース（EOL を含む）で終端し、最大 `VERSION_MAX_LEN` バイトで打ち切る。
+/// `start` が入力長を超える場合は空スライスを返す（呼び出し側が EOF として扱う）。
+fn read_version_bytes(input: &[u8], start: usize) -> &[u8] {
+    let end = input.len().min(start.saturating_add(VERSION_MAX_LEN));
+    let Some(candidate) = input.get(start..end) else {
+        return &[];
+    };
+    let len = candidate
+        .iter()
+        .position(|&byte| ByteKind::is_whitespace(byte))
+        .unwrap_or(candidate.len());
+    &candidate[..len]
+}
+
+/// `pos` 以降で最初の EOL を跨いだ、次の行の先頭位置を返す。
+///
+/// EOL の手前にホワイトスペース（スペース・タブなど）が挟まっていても跨ぐ。
+/// EOL に達する前に非ホワイトスペースのバイトへ当たった場合、および入力が
+/// 尽きた場合は `None`（＝次の行が無い）。位置の加算は `checked_add` で行い、
+/// いかなる入力でも panic しない。
+fn next_line_start(input: &[u8], pos: usize) -> Option<usize> {
+    let mut cursor = pos;
+    loop {
+        if let Some(eol) = EolKind::at(input, cursor) {
+            return cursor.checked_add(eol.byte_len());
+        }
+        if !ByteKind::is_whitespace(*input.get(cursor)?) {
+            return None;
+        }
+        cursor = cursor.checked_add(1)?;
+    }
+}
+
+/// 版表記の直後の行がバイナリファイルインジケータかどうかを判定する。
+///
+/// ヘッダ行の EOL（LF / CR / CRLF を 1 改行として）を 1 つ跨いだ次の行が `%` で始まり、
+/// 行末までに高ビットバイト（0x80 以上 = 非 ASCII）を 4 個以上含めば真。
+/// 次の行が無い・次行が `%` で始まらない場合は偽（エラーにはしない）。
+/// 行を跨いで個数を合算はしない（インジケータは 1 行で完結する）。
+fn has_binary_indicator(input: &[u8], after_version: usize) -> bool {
+    let Some(line_start) = next_line_start(input, after_version) else {
+        return false;
+    };
+    if input.get(line_start) != Some(&PERCENT) {
+        return false;
+    }
+    let Some(body) = input.get(line_start.saturating_add(1)..) else {
+        return false;
+    };
+    body.iter()
+        .take_while(|&&byte| byte != CR && byte != LF)
+        .filter(|&&byte| !byte.is_ascii())
+        .count()
+        >= BINARY_INDICATOR_MIN_HIGH_BYTES
+}
+
+#[cfg(test)]
+mod tests;

--- a/rust/crates/core/src/file/header.rs
+++ b/rust/crates/core/src/file/header.rs
@@ -51,8 +51,9 @@ impl PdfHeader {
     /// - `UnsupportedVersion`: 版表記が形式不正、または ISO 未規定
     pub fn parse(input: &[u8]) -> Result<PdfHeader, PdfError> {
         let origin = find_signature(input).ok_or_else(|| {
-            PdfError::new(PdfErrorCode::InvalidHeader)
-                .with_message("%PDF- signature not found within the first 1024 bytes")
+            PdfError::new(PdfErrorCode::InvalidHeader).with_message(format!(
+                "%PDF- signature not found within the first {SCAN_LIMIT} bytes"
+            ))
         })?;
         let version_start = origin + SIGNATURE.len();
         let version_bytes = read_version_bytes(input, version_start);

--- a/rust/crates/core/src/file/header/tests.rs
+++ b/rust/crates/core/src/file/header/tests.rs
@@ -1,0 +1,7 @@
+mod binary_indicator;
+mod malformed_signature;
+mod malformed_version;
+mod parse_error;
+mod parse_origin;
+mod parse_version;
+mod resolve_offset;

--- a/rust/crates/core/src/file/header/tests/binary_indicator.rs
+++ b/rust/crates/core/src/file/header/tests/binary_indicator.rs
@@ -1,0 +1,104 @@
+use crate::file::header::PdfHeader;
+
+fn has_indicator(input: &[u8]) -> bool {
+    PdfHeader::parse(input)
+        .expect("header should parse")
+        .has_binary_indicator()
+}
+
+#[test]
+fn has_binary_indicator_standard_line_returns_true() {
+    // Acrobat 形式の高ビットバイト 4 個を持つコメント行を検出することを確認する
+    assert!(has_indicator(b"%PDF-1.7\n%\xE2\xE3\xCF\xD3\n"));
+}
+
+#[test]
+fn has_binary_indicator_missing_line_returns_false() {
+    // インジケータがなくても解析でき false を返すことを確認する
+    assert!(!has_indicator(b"%PDF-1.7\n1 0 obj\n"));
+}
+
+#[test]
+fn has_binary_indicator_four_high_bytes_returns_true() {
+    // 高ビットバイトが下限ちょうど 4 個なら true になることを確認する
+    assert!(has_indicator(b"%PDF-1.7\n%\x80\x80\x80\x80\n"));
+}
+
+#[test]
+fn has_binary_indicator_three_high_bytes_returns_false() {
+    // 高ビットバイトが 3 個だけなら false になることを確認する
+    assert!(!has_indicator(b"%PDF-1.7\n%\x80\x80\x80\n"));
+}
+
+#[test]
+fn has_binary_indicator_ascii_comment_returns_false() {
+    // ASCII のみの通常コメントをインジケータと誤認しないことを確認する
+    assert!(!has_indicator(b"%PDF-1.7\n%Produced by X\n"));
+}
+
+#[test]
+fn has_binary_indicator_header_without_eol_returns_false() {
+    // ヘッダ行に EOL がなくても panic せず false になることを確認する
+    assert!(!has_indicator(b"%PDF-1.7"));
+}
+
+#[test]
+fn has_binary_indicator_eol_variants_returns_true() {
+    // LF・CR・CRLF の各 EOL でインジケータを検出できることを確認する
+    let inputs = [
+        b"%PDF-1.7\n%\xE2\xE3\xCF\xD3\n".as_slice(),
+        b"%PDF-1.7\r%\xE2\xE3\xCF\xD3\r",
+        b"%PDF-1.7\r\n%\xE2\xE3\xCF\xD3\r\n",
+    ];
+    for input in inputs {
+        assert!(has_indicator(input));
+    }
+}
+
+#[test]
+fn has_binary_indicator_empty_comment_returns_false() {
+    // パーセント記号だけの空コメント行は false になることを確認する
+    assert!(!has_indicator(b"%PDF-1.7\n%\n"));
+}
+
+#[test]
+fn has_binary_indicator_indented_comment_returns_false() {
+    // 行頭が空白でインデントされたコメントを検出しないことを確認する
+    assert!(!has_indicator(b"%PDF-1.7\n %\xE2\xE3\xCF\xD3\n"));
+}
+
+#[test]
+fn has_binary_indicator_after_empty_line_returns_false() {
+    // 空行を挟んだ後方のコメント行を検出しないことを確認する
+    assert!(!has_indicator(b"%PDF-1.7\n\n%\xE2\xE3\xCF\xD3\n"));
+}
+
+#[test]
+fn has_binary_indicator_split_across_lines_returns_false() {
+    // 高ビットバイトを複数行にまたがって合算しないことを確認する
+    assert!(!has_indicator(b"%PDF-1.7\n%\x80\x80\n%\x80\x80\n"));
+}
+
+#[test]
+fn has_binary_indicator_non_comment_line_returns_false() {
+    // 高ビットバイトがあっても行頭がパーセントでなければ false になることを確認する
+    assert!(!has_indicator(b"%PDF-1.7\n1 0 obj\x80\x80\x80\x80\n"));
+}
+
+#[test]
+fn has_binary_indicator_line_without_eol_returns_true() {
+    // インジケータ行が入力末尾まで続いても高ビットバイトを数えることを確認する
+    assert!(has_indicator(b"%PDF-1.7\n%\xE2\xE3\xCF\xD3"));
+}
+
+#[test]
+fn has_binary_indicator_space_before_eol_returns_true() {
+    // 版の後の空白を跨いで次行のインジケータを検出することを確認する
+    assert!(has_indicator(b"%PDF-1.7 \n%\xE2\xE3\xCF\xD3\n"));
+}
+
+#[test]
+fn has_binary_indicator_word_before_eol_returns_false() {
+    // 版の後に非空白語があれば次行探索を打ち切ることを確認する
+    assert!(!has_indicator(b"%PDF-1.7 junk\n%\xE2\xE3\xCF\xD3\n"));
+}

--- a/rust/crates/core/src/file/header/tests/malformed_signature.rs
+++ b/rust/crates/core/src/file/header/tests/malformed_signature.rs
@@ -1,0 +1,65 @@
+use crate::error::pdf_error_code::PdfErrorCode;
+use crate::file::header::PdfHeader;
+
+fn assert_invalid_header(input: &[u8]) {
+    let error = PdfHeader::parse(input).expect_err("signature should be rejected");
+    assert_eq!(error.code(), PdfErrorCode::InvalidHeader);
+}
+
+#[test]
+fn parse_lowercase_signature_returns_invalid_header() {
+    // 小文字のシグネチャを厳密一致として拒否することを確認する
+    assert_invalid_header(b"%pdf-1.7\n");
+}
+
+#[test]
+fn parse_signature_with_space_instead_of_hyphen_returns_invalid_header() {
+    // ハイフンが空白になったシグネチャを拒否することを確認する
+    assert_invalid_header(b"%PDF 1.7\n");
+}
+
+#[test]
+fn parse_signature_without_hyphen_returns_invalid_header() {
+    // ハイフンの欠けたシグネチャを EOL の有無にかかわらず拒否することを確認する
+    for input in [b"%PDF\n".as_slice(), b"%PDF"] {
+        assert_invalid_header(input);
+    }
+}
+
+#[test]
+fn parse_signature_without_percent_returns_invalid_header() {
+    // 先頭のパーセント記号が欠けたシグネチャを拒否することを確認する
+    assert_invalid_header(b"PDF-1.7\n");
+}
+
+#[test]
+fn parse_signature_with_space_after_percent_returns_invalid_header() {
+    // パーセント記号の直後に空白があるシグネチャを拒否することを確認する
+    assert_invalid_header(b"% PDF-1.7\n");
+}
+
+#[test]
+fn parse_png_signature_returns_invalid_header() {
+    // PNG のバイナリヘッダを PDF と誤認しないことを確認する
+    assert_invalid_header(b"\x89PNG\r\n\x1A\nrest");
+}
+
+#[test]
+fn parse_short_inputs_returns_invalid_header() {
+    // シグネチャ長未満の入力が panic せず拒否されることを確認する
+    for input in [b"%PDF".as_slice(), b"%", b""] {
+        assert_invalid_header(input);
+    }
+}
+
+#[test]
+fn parse_nul_filled_input_returns_invalid_header() {
+    // NUL だけの入力を PDF と誤認しないことを確認する
+    assert_invalid_header(&[0; 100]);
+}
+
+#[test]
+fn parse_high_bit_filled_input_returns_invalid_header() {
+    // 高ビットバイトだけの長大な入力を走査上限内で拒否することを確認する
+    assert_invalid_header(&[0xFF; 2000]);
+}

--- a/rust/crates/core/src/file/header/tests/malformed_version.rs
+++ b/rust/crates/core/src/file/header/tests/malformed_version.rs
@@ -1,0 +1,82 @@
+use crate::byte_offset::ByteOffset;
+use crate::error::pdf_error_code::PdfErrorCode;
+use crate::file::header::PdfHeader;
+
+fn assert_error_code(input: &[u8], expected: PdfErrorCode) {
+    let error = PdfHeader::parse(input).expect_err("version should be rejected");
+    assert_eq!(error.code(), expected);
+}
+
+#[test]
+fn parse_empty_version_returns_unexpected_eof() {
+    // ハイフン直後が EOL の空版を UnexpectedEof と分類することを確認する
+    assert_error_code(b"%PDF-\n", PdfErrorCode::UnexpectedEof);
+}
+
+#[test]
+fn parse_whitespace_before_version_returns_unexpected_eof() {
+    // ハイフン直後が空白またはタブなら空版として分類することを確認する
+    for input in [b"%PDF- 1.7\n".as_slice(), b"%PDF-\t1.7\n"] {
+        assert_error_code(input, PdfErrorCode::UnexpectedEof);
+    }
+}
+
+#[test]
+fn parse_double_hyphen_returns_unsupported_version() {
+    // 二重ハイフンの版表記を UnsupportedVersion と分類することを確認する
+    assert_error_code(b"%PDF--1.7\n", PdfErrorCode::UnsupportedVersion);
+}
+
+#[test]
+fn parse_zero_padded_version_returns_unsupported_version() {
+    // ゼロ埋めされた版表記を UnsupportedVersion と分類することを確認する
+    assert_error_code(b"%PDF-01.7\n", PdfErrorCode::UnsupportedVersion);
+}
+
+#[test]
+fn parse_wrong_version_separators_returns_unsupported_version() {
+    // ピリオド以外の版区切りを UnsupportedVersion と分類することを確認する
+    for input in [b"%PDF-1,7\n".as_slice(), b"%PDF-1-7\n"] {
+        assert_error_code(input, PdfErrorCode::UnsupportedVersion);
+    }
+}
+
+#[test]
+fn parse_delimiter_after_version_returns_unsupported_version() {
+    // 版の直後のデリミタでは読み取りを終端しないことを確認する
+    assert_error_code(b"%PDF-1.7/Type\n", PdfErrorCode::UnsupportedVersion);
+}
+
+#[test]
+fn parse_comment_after_version_returns_unsupported_version() {
+    // 版の直後のコメント記号では読み取りを終端しないことを確認する
+    assert_error_code(b"%PDF-1.7%comment\n", PdfErrorCode::UnsupportedVersion);
+}
+
+#[test]
+fn parse_eol_inside_version_returns_unsupported_version() {
+    // 版の途中の EOL で切り出された不完全な表記を拒否することを確認する
+    assert_error_code(b"%PDF-1.\r7\n", PdfErrorCode::UnsupportedVersion);
+}
+
+#[test]
+fn parse_signature_at_limit_without_version_returns_eof_position() {
+    // 上限内のシグネチャ直後で終端した場合の位置が 1024 になることを確認する
+    let mut input = vec![b'x'; 1019];
+    input.extend_from_slice(b"%PDF-");
+    let error = PdfHeader::parse(&input).expect_err("missing version");
+    assert_eq!(error.code(), PdfErrorCode::UnexpectedEof);
+    assert_eq!(error.position(), Some(ByteOffset::new(1024)));
+}
+
+#[test]
+fn parse_non_utf8_version_returns_unsupported_version() {
+    // 非 UTF-8 の版表記を panic せず拒否することを確認する
+    assert_error_code(b"%PDF-\xFF\xFE\n", PdfErrorCode::UnsupportedVersion);
+}
+
+#[test]
+fn parse_full_width_version_returns_unsupported_version() {
+    // 全角の版表記を読み取り上限内で拒否することを確認する
+    assert_error_code("%PDF-１．７\n".as_bytes(), PdfErrorCode::UnsupportedVersion);
+}

--- a/rust/crates/core/src/file/header/tests/parse_error.rs
+++ b/rust/crates/core/src/file/header/tests/parse_error.rs
@@ -1,0 +1,116 @@
+use crate::byte_offset::ByteOffset;
+use crate::error::pdf_error_code::PdfErrorCode;
+use crate::file::header::PdfHeader;
+
+#[test]
+fn parse_empty_input_returns_invalid_header_without_position() {
+    // 空入力が位置なしの InvalidHeader になることを確認する
+    let error = PdfHeader::parse(b"").expect_err("not a pdf");
+    assert_eq!(error.code(), PdfErrorCode::InvalidHeader);
+    assert_eq!(error.position(), None);
+}
+
+#[test]
+fn parse_non_pdf_returns_invalid_header() {
+    // PDF でないテキストが InvalidHeader になることを確認する
+    let error = PdfHeader::parse(b"not a pdf at all").expect_err("not a pdf");
+    assert_eq!(error.code(), PdfErrorCode::InvalidHeader);
+}
+
+#[test]
+fn parse_signature_far_beyond_limit_returns_invalid_header() {
+    // 2000 バイトの前置き後のシグネチャが検出されないことを確認する
+    let mut input = vec![b'x'; 2000];
+    input.extend_from_slice(b"%PDF-1.7\n");
+    let error = PdfHeader::parse(&input).expect_err("signature outside limit");
+    assert_eq!(error.code(), PdfErrorCode::InvalidHeader);
+}
+
+#[test]
+fn parse_unsupported_version_returns_version_position() {
+    // 未サポート版のエラー位置が版表記の開始位置 5 になることを確認する
+    let error = PdfHeader::parse(b"%PDF-1.9\n").expect_err("invalid version");
+    assert_eq!(error.position(), Some(ByteOffset::new(5)));
+}
+
+#[test]
+fn parse_unsupported_version_message_contains_actual_version() {
+    // 未サポート版のメッセージに実際の版表記が含まれることを確認する
+    let error = PdfHeader::parse(b"%PDF-1.9\n").expect_err("invalid version");
+    assert!(error
+        .message()
+        .is_some_and(|message| message.contains("unsupported version 1.9")));
+}
+
+#[test]
+fn parse_truncated_signature_returns_invalid_header() {
+    // 1 バイト足りないシグネチャが InvalidHeader になることを確認する
+    let error = PdfHeader::parse(b"%PDF").expect_err("truncated signature");
+    assert_eq!(error.code(), PdfErrorCode::InvalidHeader);
+}
+
+#[test]
+fn parse_non_utf8_version_returns_unsupported_version() {
+    // 非 UTF-8 の版表記が panic せず UnsupportedVersion になることを確認する
+    let error = PdfHeader::parse(b"%PDF-\xFF\xFE\n").expect_err("invalid version");
+    assert_eq!(error.code(), PdfErrorCode::UnsupportedVersion);
+}
+
+#[test]
+fn parse_prefixed_unsupported_version_returns_absolute_position() {
+    // 前置き付き入力のエラー位置がファイル先頭基準の 42 になることを確認する
+    let mut input = vec![b'x'; 37];
+    input.extend_from_slice(b"%PDF-1.9\n");
+    let error = PdfHeader::parse(&input).expect_err("invalid version");
+    assert_eq!(error.position(), Some(ByteOffset::new(42)));
+}
+
+#[test]
+fn parse_missing_version_returns_version_start_position() {
+    // 版がない入力のエラー位置がシグネチャ直後の 5 になることを確認する
+    let error = PdfHeader::parse(b"%PDF-").expect_err("missing version");
+    assert_eq!(error.position(), Some(ByteOffset::new(5)));
+}
+
+#[test]
+fn parse_missing_signature_message_mentions_scan_limit() {
+    // シグネチャ未検出のメッセージが走査上限 1024 に言及することを確認する
+    let error = PdfHeader::parse(b"not a pdf").expect_err("not a pdf");
+    assert!(error
+        .message()
+        .is_some_and(|message| message.contains("1024")));
+}
+
+#[test]
+fn parse_non_utf8_version_message_uses_replacement_character() {
+    // 非 UTF-8 の版表記が置換文字を含むメッセージへ安全に変換されることを確認する
+    let error = PdfHeader::parse(b"%PDF-\xFF\xFE\n").expect_err("invalid version");
+    assert!(error
+        .message()
+        .is_some_and(|message| message.contains('\u{FFFD}')));
+}
+
+#[test]
+fn parse_error_codes_are_mutually_distinct() {
+    // 3 種のヘッダ解析エラーコードを呼び出し側で区別できることを確認する
+    let codes = [
+        PdfHeader::parse(b"").expect_err("not a pdf").code(),
+        PdfHeader::parse(b"%PDF-")
+            .expect_err("missing version")
+            .code(),
+        PdfHeader::parse(b"%PDF-1.9\n")
+            .expect_err("invalid version")
+            .code(),
+    ];
+    assert_eq!(
+        codes,
+        [
+            PdfErrorCode::InvalidHeader,
+            PdfErrorCode::UnexpectedEof,
+            PdfErrorCode::UnsupportedVersion,
+        ]
+    );
+    assert_ne!(codes[0], codes[1]);
+    assert_ne!(codes[0], codes[2]);
+    assert_ne!(codes[1], codes[2]);
+}

--- a/rust/crates/core/src/file/header/tests/parse_error.rs
+++ b/rust/crates/core/src/file/header/tests/parse_error.rs
@@ -1,3 +1,4 @@
+use super::super::SCAN_LIMIT;
 use crate::byte_offset::ByteOffset;
 use crate::error::pdf_error_code::PdfErrorCode;
 use crate::file::header::PdfHeader;
@@ -74,11 +75,10 @@ fn parse_missing_version_returns_version_start_position() {
 
 #[test]
 fn parse_missing_signature_message_mentions_scan_limit() {
-    // シグネチャ未検出のメッセージが走査上限 1024 に言及することを確認する
+    // シグネチャ未検出のメッセージが設定された走査上限に言及することを確認する
     let error = PdfHeader::parse(b"not a pdf").expect_err("not a pdf");
-    assert!(error
-        .message()
-        .is_some_and(|message| message.contains("1024")));
+    let expected = format!("%PDF- signature not found within the first {SCAN_LIMIT} bytes");
+    assert_eq!(error.message(), Some(expected.as_str()));
 }
 
 #[test]

--- a/rust/crates/core/src/file/header/tests/parse_origin.rs
+++ b/rust/crates/core/src/file/header/tests/parse_origin.rs
@@ -1,0 +1,49 @@
+use crate::byte_offset::ByteOffset;
+use crate::error::pdf_error_code::PdfErrorCode;
+use crate::file::header::PdfHeader;
+use crate::file::version::PdfVersion;
+
+fn with_prefix(prefix_len: usize, body: &[u8]) -> Vec<u8> {
+    let mut input = vec![b'x'; prefix_len];
+    input.extend_from_slice(body);
+    input
+}
+
+#[test]
+fn origin_header_at_start_returns_zero() {
+    // ファイル先頭のシグネチャが原点 0 になることを確認する
+    let header = PdfHeader::parse(b"%PDF-1.7\n").expect("valid header");
+    assert_eq!(header.origin(), ByteOffset::new(0));
+}
+
+#[test]
+fn origin_header_after_prefix_returns_prefix_length() {
+    // 37 バイトの前置き後にあるシグネチャが原点 37 になることを確認する
+    let input = with_prefix(37, b"%PDF-1.7\n");
+    let header = PdfHeader::parse(&input).expect("valid prefixed header");
+    assert_eq!(header.origin(), ByteOffset::new(37));
+}
+
+#[test]
+fn origin_signature_ending_at_scan_limit_is_found() {
+    // 5 バイトのシグネチャ全体が走査上限内なら検出されることを確認する
+    let input = with_prefix(1019, b"%PDF-1.7\n");
+    let header = PdfHeader::parse(&input).expect("valid boundary header");
+    assert_eq!(header.origin(), ByteOffset::new(1019));
+}
+
+#[test]
+fn origin_signature_crossing_scan_limit_is_rejected() {
+    // シグネチャが走査上限を 1 バイト跨ぐと検出されないことを確認する
+    let input = with_prefix(1020, b"%PDF-1.7\n");
+    let error = PdfHeader::parse(&input).expect_err("signature outside limit");
+    assert_eq!(error.code(), PdfErrorCode::InvalidHeader);
+}
+
+#[test]
+fn origin_multiple_signatures_uses_first() {
+    // 複数のシグネチャがある場合に最初の版と原点を採用することを確認する
+    let header = PdfHeader::parse(b"%PDF-1.4\njunk%PDF-1.7\n").expect("valid header");
+    assert_eq!(header.origin(), ByteOffset::new(0));
+    assert_eq!(header.version(), PdfVersion::V1_4);
+}

--- a/rust/crates/core/src/file/header/tests/parse_version.rs
+++ b/rust/crates/core/src/file/header/tests/parse_version.rs
@@ -1,0 +1,75 @@
+use crate::error::pdf_error_code::PdfErrorCode;
+use crate::file::header::PdfHeader;
+use crate::file::version::PdfVersion;
+
+fn with_prefix(prefix_len: usize, body: &[u8]) -> Vec<u8> {
+    let mut input = vec![b'x'; prefix_len];
+    input.extend_from_slice(body);
+    input
+}
+
+#[test]
+fn parse_standard_header_returns_version() {
+    // 標準的な PDF ヘッダから 1.7 を取得できることを確認する
+    let header = PdfHeader::parse(b"%PDF-1.7\n").expect("valid header");
+    assert_eq!(header.version(), PdfVersion::V1_7);
+}
+
+#[test]
+fn parse_all_eol_kinds_returns_same_version() {
+    // LF・CR・CRLF の各改行で同じ版を取得できることを確認する
+    for input in [b"%PDF-1.7\n".as_slice(), b"%PDF-1.7\r", b"%PDF-1.7\r\n"] {
+        let header = PdfHeader::parse(input).expect("valid header");
+        assert_eq!(header.version(), PdfVersion::V1_7);
+    }
+}
+
+#[test]
+fn parse_header_without_eol_returns_version() {
+    // EOL がない極小ヘッダからも版を取得できることを確認する
+    let header = PdfHeader::parse(b"%PDF-1.7").expect("valid header");
+    assert_eq!(header.version(), PdfVersion::V1_7);
+}
+
+#[test]
+fn parse_version_followed_by_space_returns_version() {
+    // 版の直後のスペースで読み取りを終端できることを確認する
+    let header = PdfHeader::parse(b"%PDF-1.7 extra").expect("valid header");
+    assert_eq!(header.version(), PdfVersion::V1_7);
+}
+
+#[test]
+fn parse_unsupported_version_returns_error() {
+    // ISO 未規定版が UnsupportedVersion になることを確認する
+    let error = PdfHeader::parse(b"%PDF-1.9\n").expect_err("invalid version");
+    assert_eq!(error.code(), PdfErrorCode::UnsupportedVersion);
+}
+
+#[test]
+fn parse_missing_version_returns_unexpected_eof() {
+    // シグネチャ直後で入力が尽きると UnexpectedEof になることを確認する
+    let error = PdfHeader::parse(b"%PDF-").expect_err("missing version");
+    assert_eq!(error.code(), PdfErrorCode::UnexpectedEof);
+}
+
+#[test]
+fn parse_version_over_maximum_length_returns_error() {
+    // 8 バイトを超える版表記が上限で打ち切られて拒否されることを確認する
+    let error = PdfHeader::parse(b"%PDF-123456789\n").expect_err("invalid version");
+    assert_eq!(error.code(), PdfErrorCode::UnsupportedVersion);
+}
+
+#[test]
+fn parse_version_beyond_scan_limit_returns_version() {
+    // シグネチャが範囲内なら版表記が 1024 バイト以降でも読めることを確認する
+    let input = with_prefix(1019, b"%PDF-1.7\n");
+    let header = PdfHeader::parse(&input).expect("valid boundary header");
+    assert_eq!(header.version(), PdfVersion::V1_7);
+}
+
+#[test]
+fn parse_version_terminated_by_nul_returns_version() {
+    // PDF のホワイトスペースである NUL が版表記を終端することを確認する
+    let header = PdfHeader::parse(b"%PDF-1.7\0").expect("valid header");
+    assert_eq!(header.version(), PdfVersion::V1_7);
+}

--- a/rust/crates/core/src/file/header/tests/resolve_offset.rs
+++ b/rust/crates/core/src/file/header/tests/resolve_offset.rs
@@ -1,0 +1,62 @@
+use crate::byte_offset::ByteOffset;
+use crate::file::header::PdfHeader;
+
+fn header_with_origin(origin: usize) -> PdfHeader {
+    let mut input = vec![b'x'; origin];
+    input.extend_from_slice(b"%PDF-1.7\n");
+    PdfHeader::parse(&input).expect("valid header")
+}
+
+#[test]
+fn resolve_offset_zero_origin_returns_recorded_value() {
+    // 原点 0 では記録オフセットがそのまま実位置になることを確認する
+    let header = header_with_origin(0);
+    assert_eq!(
+        header.resolve_offset(ByteOffset::new(500)),
+        Some(ByteOffset::new(500))
+    );
+}
+
+#[test]
+fn resolve_offset_prefixed_origin_adds_origin() {
+    // 原点 37 では記録値 500 が実位置 537 になることを確認する
+    let header = header_with_origin(37);
+    assert_eq!(
+        header.resolve_offset(ByteOffset::new(500)),
+        Some(ByteOffset::new(537))
+    );
+}
+
+#[test]
+fn resolve_offset_zero_recorded_returns_origin() {
+    // 記録値 0 がオフセット原点そのものへ補正されることを確認する
+    let header = header_with_origin(0);
+    assert_eq!(
+        header.resolve_offset(ByteOffset::new(0)),
+        Some(ByteOffset::new(0))
+    );
+}
+
+#[test]
+fn resolve_offset_overflow_returns_none() {
+    // 原点が正のとき u64::MAX の記録値が wrap せず None になることを確認する
+    let header = header_with_origin(1);
+    assert_eq!(header.resolve_offset(ByteOffset::new(u64::MAX)), None);
+}
+
+#[test]
+fn resolve_offset_sum_at_u64_max_returns_some() {
+    // 加算結果がちょうど u64::MAX なら成功することを確認する
+    let header = header_with_origin(37);
+    assert_eq!(
+        header.resolve_offset(ByteOffset::new(u64::MAX - 37)),
+        Some(ByteOffset::new(u64::MAX))
+    );
+}
+
+#[test]
+fn resolve_offset_sum_one_past_u64_max_returns_none() {
+    // 加算結果が u64::MAX を 1 超えると None になることを確認する
+    let header = header_with_origin(37);
+    assert_eq!(header.resolve_offset(ByteOffset::new(u64::MAX - 36)), None);
+}

--- a/rust/crates/core/src/file/version.rs
+++ b/rust/crates/core/src/file/version.rs
@@ -1,0 +1,79 @@
+//! PDF のバージョン `x.y` を表す `PdfVersion` を定義するモジュール。
+//!
+//! ISO 32000-1:2008 が 1.0〜1.7 を、ISO 32000-2:2020 が 2.0 を規定する
+//! （`docs/specs/02_file_structure.md` §2.1）。それ以外の版は受理しない。
+
+use std::fmt;
+
+/// PDF のバージョン。ISO が規定する 9 種のみを表現できる。
+///
+/// バリアントの宣言順が版の昇順と一致するため、導出した順序比較がそのまま版の
+/// 新旧比較になる。カタログの `/Version` による上書き判定は後続フェーズで実装する。
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[must_use]
+pub enum PdfVersion {
+    /// PDF 1.0（ISO 32000-1）。
+    V1_0,
+    /// PDF 1.1（ISO 32000-1）。
+    V1_1,
+    /// PDF 1.2（ISO 32000-1）。
+    V1_2,
+    /// PDF 1.3（ISO 32000-1）。
+    V1_3,
+    /// PDF 1.4（ISO 32000-1）。
+    V1_4,
+    /// PDF 1.5（ISO 32000-1）。
+    V1_5,
+    /// PDF 1.6（ISO 32000-1）。
+    V1_6,
+    /// PDF 1.7（ISO 32000-1）。
+    V1_7,
+    /// PDF 2.0（ISO 32000-2）。
+    V2_0,
+}
+
+impl PdfVersion {
+    /// バージョン表記のバイト列（`b"1.7"` など）から `PdfVersion` を得る。
+    ///
+    /// ISO が規定しない版・形式不正は `None` を返す。
+    pub fn from_bytes(bytes: &[u8]) -> Option<PdfVersion> {
+        match bytes {
+            b"1.0" => Some(PdfVersion::V1_0),
+            b"1.1" => Some(PdfVersion::V1_1),
+            b"1.2" => Some(PdfVersion::V1_2),
+            b"1.3" => Some(PdfVersion::V1_3),
+            b"1.4" => Some(PdfVersion::V1_4),
+            b"1.5" => Some(PdfVersion::V1_5),
+            b"1.6" => Some(PdfVersion::V1_6),
+            b"1.7" => Some(PdfVersion::V1_7),
+            b"2.0" => Some(PdfVersion::V2_0),
+            _ => None,
+        }
+    }
+
+    /// `"1.7"` のような版表記を返す。
+    #[must_use]
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            PdfVersion::V1_0 => "1.0",
+            PdfVersion::V1_1 => "1.1",
+            PdfVersion::V1_2 => "1.2",
+            PdfVersion::V1_3 => "1.3",
+            PdfVersion::V1_4 => "1.4",
+            PdfVersion::V1_5 => "1.5",
+            PdfVersion::V1_6 => "1.6",
+            PdfVersion::V1_7 => "1.7",
+            PdfVersion::V2_0 => "2.0",
+        }
+    }
+}
+
+/// 版表記のみを出力する（`"1.7"`。`%PDF-` などの装飾は付けない）。
+impl fmt::Display for PdfVersion {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Display::fmt(self.as_str(), f)
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/rust/crates/core/src/file/version/tests.rs
+++ b/rust/crates/core/src/file/version/tests.rs
@@ -1,0 +1,3 @@
+mod display;
+mod from_bytes;
+mod ordering;

--- a/rust/crates/core/src/file/version/tests/display.rs
+++ b/rust/crates/core/src/file/version/tests/display.rs
@@ -1,0 +1,44 @@
+use super::super::PdfVersion;
+
+const VERSIONS: [(PdfVersion, &str); 9] = [
+    (PdfVersion::V1_0, "1.0"),
+    (PdfVersion::V1_1, "1.1"),
+    (PdfVersion::V1_2, "1.2"),
+    (PdfVersion::V1_3, "1.3"),
+    (PdfVersion::V1_4, "1.4"),
+    (PdfVersion::V1_5, "1.5"),
+    (PdfVersion::V1_6, "1.6"),
+    (PdfVersion::V1_7, "1.7"),
+    (PdfVersion::V2_0, "2.0"),
+];
+
+#[test]
+fn as_str_all_versions_returns_version_text() {
+    // 9 バリアントすべてが対応する版表記を返すことを確認する
+    for (version, expected) in VERSIONS {
+        assert_eq!(version.as_str(), expected);
+    }
+}
+
+#[test]
+fn display_version_returns_undecorated_text() {
+    // Display がシグネチャなどを付けず版表記だけを返すことを確認する
+    assert_eq!(format!("{}", PdfVersion::V1_7), "1.7");
+}
+
+#[test]
+fn display_width_specifier_is_preserved() {
+    // Display の幅と右寄せ指定が内部文字列へ委譲されることを確認する
+    assert_eq!(format!("{:>6}", PdfVersion::V1_7), "   1.7");
+}
+
+#[test]
+fn as_str_then_from_bytes_roundtrips_all_versions() {
+    // 9 バリアントを表記へ変換して再解析すると元の版へ戻ることを確認する
+    for (version, _) in VERSIONS {
+        assert_eq!(
+            PdfVersion::from_bytes(version.as_str().as_bytes()),
+            Some(version)
+        );
+    }
+}

--- a/rust/crates/core/src/file/version/tests/from_bytes.rs
+++ b/rust/crates/core/src/file/version/tests/from_bytes.rs
@@ -1,0 +1,107 @@
+use super::super::PdfVersion;
+
+const VERSIONS: [(&[u8], PdfVersion); 9] = [
+    (b"1.0", PdfVersion::V1_0),
+    (b"1.1", PdfVersion::V1_1),
+    (b"1.2", PdfVersion::V1_2),
+    (b"1.3", PdfVersion::V1_3),
+    (b"1.4", PdfVersion::V1_4),
+    (b"1.5", PdfVersion::V1_5),
+    (b"1.6", PdfVersion::V1_6),
+    (b"1.7", PdfVersion::V1_7),
+    (b"2.0", PdfVersion::V2_0),
+];
+
+#[test]
+fn from_bytes_pdf_1_7_returns_v1_7() {
+    // 一般的な 1.7 の表記が V1_7 に解決されることを確認する
+    assert_eq!(PdfVersion::from_bytes(b"1.7"), Some(PdfVersion::V1_7));
+}
+
+#[test]
+fn from_bytes_supported_versions_returns_corresponding_variants() {
+    // ISO が規定する 9 版すべてが対応するバリアントに解決されることを確認する
+    for (bytes, expected) in VERSIONS {
+        assert_eq!(PdfVersion::from_bytes(bytes), Some(expected));
+    }
+}
+
+#[test]
+fn from_bytes_allowlist_boundaries_returns_variants() {
+    // allowlist の最古版と最新版がともに受理されることを確認する
+    assert_eq!(PdfVersion::from_bytes(b"1.0"), Some(PdfVersion::V1_0));
+    assert_eq!(PdfVersion::from_bytes(b"2.0"), Some(PdfVersion::V2_0));
+}
+
+#[test]
+fn from_bytes_unsupported_versions_returns_none() {
+    // ISO 未規定の版がいずれも拒否されることを確認する
+    for bytes in [b"1.8".as_slice(), b"3.0", b"0.9"] {
+        assert_eq!(PdfVersion::from_bytes(bytes), None);
+    }
+}
+
+#[test]
+fn from_bytes_malformed_versions_returns_none() {
+    // 形式が壊れた版表記がいずれも拒否されることを確認する
+    for bytes in [b"17".as_slice(), b"1.", b".7", b"x.y"] {
+        assert_eq!(PdfVersion::from_bytes(bytes), None);
+    }
+}
+
+#[test]
+fn from_bytes_empty_returns_none() {
+    // 空バイト列が panic せず拒否されることを確認する
+    assert_eq!(PdfVersion::from_bytes(b""), None);
+}
+
+#[test]
+fn from_bytes_extra_characters_returns_none() {
+    // 余分な桁や前後の空白を含む表記が完全一致として受理されないことを確認する
+    for bytes in [b"1.70".as_slice(), b" 1.7", b"1.7 "] {
+        assert_eq!(PdfVersion::from_bytes(bytes), None);
+    }
+}
+
+#[test]
+fn from_bytes_zero_padded_versions_returns_none() {
+    // ゼロ埋めされた版表記が拒否されることを確認する
+    for bytes in [b"01.7".as_slice(), b"1.07"] {
+        assert_eq!(PdfVersion::from_bytes(bytes), None);
+    }
+}
+
+#[test]
+fn from_bytes_wrong_separators_returns_none() {
+    // ピリオド以外の区切りを使った表記が拒否されることを確認する
+    for bytes in [b"1,7".as_slice(), b"1-7", b"1_7"] {
+        assert_eq!(PdfVersion::from_bytes(bytes), None);
+    }
+}
+
+#[test]
+fn from_bytes_full_width_version_returns_none() {
+    // 全角の版表記が panic せず拒否されることを確認する
+    assert_eq!(PdfVersion::from_bytes("１．７".as_bytes()), None);
+}
+
+#[test]
+fn from_bytes_binary_bytes_returns_none() {
+    // 制御バイトと非 UTF-8 バイト列が panic せず拒否されることを確認する
+    for bytes in [b"\0\0\0".as_slice(), b"\xFF\xFE"] {
+        assert_eq!(PdfVersion::from_bytes(bytes), None);
+    }
+}
+
+#[test]
+fn from_bytes_long_input_returns_none() {
+    // 256 バイトの長大な入力が拒否されることを確認する
+    let bytes = [b'1'; 256];
+    assert_eq!(PdfVersion::from_bytes(&bytes), None);
+}
+
+#[test]
+fn from_bytes_version_with_eol_returns_none() {
+    // EOL を含む版表記が完全一致として受理されないことを確認する
+    assert_eq!(PdfVersion::from_bytes(b"1.7\n"), None);
+}

--- a/rust/crates/core/src/file/version/tests/ordering.rs
+++ b/rust/crates/core/src/file/version/tests/ordering.rs
@@ -1,0 +1,39 @@
+use super::super::PdfVersion;
+
+#[test]
+fn ordering_same_major_newer_version_is_greater() {
+    // 同一メジャー版では新しいマイナー版の方が大きいことを確認する
+    assert!(PdfVersion::V1_4 < PdfVersion::V1_7);
+}
+
+#[test]
+fn ordering_across_major_versions_is_supported() {
+    // PDF 2.0 が PDF 1.7 より大きいことを確認する
+    assert!(PdfVersion::V1_7 < PdfVersion::V2_0);
+}
+
+#[test]
+fn ordering_all_versions_matches_declaration_order() {
+    // 9 版すべての隣接ペアが昇順になることを確認する
+    let versions = [
+        PdfVersion::V1_0,
+        PdfVersion::V1_1,
+        PdfVersion::V1_2,
+        PdfVersion::V1_3,
+        PdfVersion::V1_4,
+        PdfVersion::V1_5,
+        PdfVersion::V1_6,
+        PdfVersion::V1_7,
+        PdfVersion::V2_0,
+    ];
+    for pair in versions.windows(2) {
+        assert!(pair[0] < pair[1]);
+    }
+}
+
+#[test]
+fn ordering_same_version_is_equal_and_not_less() {
+    // 同一版同士は等価で一方が小さくならないことを確認する
+    assert_eq!(PdfVersion::V1_7, PdfVersion::V1_7);
+    assert!(!(PdfVersion::V1_7 < PdfVersion::V1_7));
+}

--- a/rust/crates/core/src/lib.rs
+++ b/rust/crates/core/src/lib.rs
@@ -8,11 +8,12 @@
 //! - **外部 crate 依存ゼロ**。Rust 標準ライブラリ (`std`) のみを使う。
 //! - **`Result` / `Option` は std のものをそのまま使う**（自作しない）。
 //!
-//! byte_offset / error / lexer / object / parser の各モジュールは実装済み。
-//! xref / trailer など、PDF ファイル構造を扱う後続モジュールは今後の PR で追加する。
+//! byte_offset / error / file / lexer / object / parser の各モジュールは実装済み。
+//! `file` は現時点でヘッダ解析のみを提供し、xref / trailer など残りの構造は後続 PR で追加する。
 
 pub mod byte_offset;
 pub mod error;
+pub mod file;
 pub mod lexer;
 pub mod object;
 pub mod parser;


### PR DESCRIPTION
## 概要

Rust版 `pdfmod-core` にPDFファイルヘッダ解析を追加しました。先頭1024バイト以内から `%PDF-x.y` を検出し、PDFバージョン、xrefオフセットの原点、バイナリインジケータの有無を返します。

## 変更内容

### 🎯 変更の種類

- [ ] 🐛 バグ修正 (Bug fix)
- [x] ✨ 新機能 (New feature)
- [ ] ♻️ リファクタリング (Refactoring)
- [ ] 🎨 UI/UX 改善 (UI/UX improvement)
- [ ] 🐎 パフォーマンス改善 (Performance improvement)
- [x] 🚨 テスト追加/修正 (Tests)
- [x] 📖 ドキュメント更新 (Documentation)
- [ ] 🔧 設定変更 (Configuration)
- [ ] 🗑️ 削除 (Removal)

### 📝 詳細な変更内容

#### 追加された機能・修正

- ISO規定のPDF 1.0〜1.7 / 2.0のみを表現する `PdfVersion` を追加
- `%PDF-` シグネチャを先頭1024バイト以内から探索する `PdfHeader::parse` を追加
- 前置きバイトを考慮したオフセット原点と `resolve_offset` を追加
- ヘッダ直後のバイナリファイルインジケータ判定を追加
- `InvalidHeader` / `UnsupportedVersion` エラーコードを追加
- `ByteOffset::checked_add` による安全なオフセット加算を追加
- 正常系・境界値・異常入力を含む91テストケースを実装

#### 変更されたファイル

- `rust/crates/core/src/file.rs` と `file/` 配下を新設
- `byte_offset.rs` に安全な加算APIを追加
- `pdf_error_code.rs` にヘッダ解析用エラーを追加
- `lib.rs` から `file` モジュールを公開

#### 削除されたファイル・機能

- なし

## 📊 システム図

```mermaid
flowchart TD
    Input[入力バイト列] --> Signature[先頭1024バイトから %PDF- を探索]:::new
    Signature -->|未検出| InvalidHeader[InvalidHeader]:::new
    Signature -->|検出| VersionBytes[最大8バイトの版表記を切り出す]:::new
    VersionBytes -->|空| UnexpectedEof[UnexpectedEof]
    VersionBytes --> Version[PdfVersion allowlist照合]:::new
    Version -->|未対応| Unsupported[UnsupportedVersion]:::new
    Version -->|対応| Indicator[次行のバイナリインジケータ判定]:::new
    Indicator --> Header[PdfHeader: version / origin / indicator]:::new
    Header --> Resolve[origin.checked_add recorded offset]:::new

    classDef new fill:#ffe4b5,stroke:#d97706,stroke-width:2px
```

## 📋 関連 Issue

- Closes #581

## 🧪 テスト

### テスト実行方法

```bash
cd rust
cargo test
cargo clippy --all-targets -- -D warnings
cargo fmt --check
```

### テスト項目

- [x] 単体テスト (Unit tests)
- [x] 統合テスト相当の実PDF読み取り確認
- [ ] E2E テスト (End-to-end tests)
- [x] 手動テスト (Manual testing)

### テスト結果

- `cargo test`: 1303 passed / 0 failed
- `cargo clippy --all-targets -- -D warnings`: 成功
- `cargo fmt --check`: 成功
- 一時PDFを `std::fs::read` で読み、version / origin / binary indicatorを確認

## 🔍 レビューポイント

- `%PDF-` 全体が先頭1024バイトに収まる場合のみ検出する境界条件
- xref記録値をヘッダ原点からファイル先頭基準へ補正する `resolve_offset`
- バージョン終端をPDFホワイトスペースのみに限定した異常入力の分類
- バイナリインジケータをヘッダ直後の1行だけで判定する点

## ⚠️ 破壊的変更

- [ ] この変更は既存の API に破壊的変更を含みます

## 📚 追加情報

### 参考資料

- `docs/specs/02_file_structure.md`
- ISO 32000-1:2008 §7.5
- ISO 32000-2:2020

### 注意事項

- カタログ `/Version` によるヘッダバージョン上書きは後続フェーズの対象です。
- `version()` / `origin()` は戻り値型自体が `#[must_use]` のため、Clippyの重複警告を避けてメソッド側の属性を省略しています。

## ✅ チェックリスト

- [x] コードレビューの準備ができている
- [x] テストが正常に実行される
- [x] 公開APIのドキュメントが更新されている
- [x] コミットメッセージが適切な形式で書かれている
- [x] 関連する Issue が `Closes #581` でLinkedされている
- [x] セルフレビューを実施した
- [x] 破壊的変更がないことを確認した

## 🤝 レビュアーへのお願い

- 走査上限境界とエラー分類が後続のObjectResolverで利用しやすい形になっているかご確認ください。