### PR TITLE
🔧 [Config]: devcontainer の git 設定をホストの .gitconfig-shared マウントに切り替える

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,12 +3,6 @@
   "dockerComposeFile": "docker-compose.yml",
   "service": "app",
   "workspaceFolder": "/workspace",
-  "containerEnv": {
-    "GIT_AUTHOR_NAME": "${localEnv:GIT_AUTHOR_NAME}",
-    "GIT_AUTHOR_EMAIL": "${localEnv:GIT_AUTHOR_EMAIL}",
-    "GIT_COMMITTER_NAME": "${localEnv:GIT_COMMITTER_NAME}",
-    "GIT_COMMITTER_EMAIL": "${localEnv:GIT_COMMITTER_EMAIL}"
-  },
   "customizations": {
     "vscode": {
       "extensions": [
@@ -26,6 +20,7 @@
     }
   },
   "mounts": [
+    "source=${localEnv:HOME}/.gitconfig-shared,target=/home/vscode/.gitconfig,type=bind,consistency=cached",
     "source=${localEnv:HOME}/.config/gh,target=/home/vscode/.config/gh,type=bind,readonly"
   ],
   "initializeCommand": "curl -fsSL https://gist.githubusercontent.com/DIO0550/9030208a4e92984e9a1369f61ca8605e/raw/initialize-command.sh | bash",


### PR DESCRIPTION
## 概要

devcontainer の git 設定の持ち込み方を、環境変数の転送からホストの `~/.gitconfig-shared` の bind mount へ切り替える。

## 変更内容

### 🎯 変更の種類

- [x] 🔧 設定変更 (Configuration)

### 📝 詳細な変更内容

#### 削除

`containerEnv` による環境変数転送:

```json
"containerEnv": {
  "GIT_AUTHOR_NAME": "${localEnv:GIT_AUTHOR_NAME}",
  "GIT_AUTHOR_EMAIL": "${localEnv:GIT_AUTHOR_EMAIL}",
  "GIT_COMMITTER_NAME": "${localEnv:GIT_COMMITTER_NAME}",
  "GIT_COMMITTER_EMAIL": "${localEnv:GIT_COMMITTER_EMAIL}"
}
```

#### 追加

`mounts` に 1 行:

```json
"source=${localEnv:HOME}/.gitconfig-shared,target=/home/vscode/.gitconfig,type=bind,consistency=cached"
```

## 🧭 意思決定と経緯

### 背景

環境変数による転送は、ホスト側で 4 つの変数を export していることが前提になる。未設定のまま起動するとコンテナ内の git がコミット時に identity 不明で落ちるが、原因が `devcontainer.json` 側にあることに気づきにくい。また転送できるのは author / committer の identity だけで、エイリアスや `core.*` の設定は引き継がれない。

### なぜこの方針か

gitconfig ファイルそのものをマウントする方式にした。identity 以外の設定もまとめて引き継げ、ホスト側でファイルを 1 つ用意すれば済むため、転送すべき設定が増えるたびに `devcontainer.json` を編集する必要がなくなる。

既に `~/.config/gh` を同じ bind mount 方式で持ち込んでおり、ホストの開発者設定の持ち込み方が 1 つに揃う。

### 影響とトレードオフ

**ホストに `~/.gitconfig-shared` が存在することが新たな前提になる。** 無い状態で起動すると Docker が同名のディレクトリを作り、コンテナ内の git が gitconfig を読めなくなる。

ホストの `~/.gitconfig` を直接マウントせず別名にしているのは、コンテナ側の書き込みがホストの個人設定へ波及するのを避けるため。ただし `gh` の設定と違い `readonly` にしていないので、コンテナ内から `git config` で書き込むと共有ファイルには反映される。

## 📋 関連 Issue

なし

## 🧪 テスト

### テスト項目

- [x] 手動テスト (Manual testing)

### テスト結果

本 PR の作成に使っているコンテナが、この設定変更を適用した状態で稼働しており、`git commit` / `git push` が正常に動作している。

## 🔍 レビューポイント

- `~/.gitconfig-shared` をホスト側に用意する手順を、README や `initializeCommand` のスクリプトに追記する必要があるか（現状は前提が暗黙）
- `readonly` を付けずコンテナからの書き込みを許すかどうか

## ⚠️ 破壊的変更

- [ ] この変更は既存の API に破壊的変更を含みます

API の変更ではないが、**既存の開発環境には作業が必要**。この PR をマージ後に devcontainer を再ビルドする際、ホストに `~/.gitconfig-shared` が無いと git の identity が設定されない状態になる。

## ✅ チェックリスト

- [x] コードレビューの準備ができている
- [x] コミットメッセージが適切な形式で書かれている
- [x] セルフレビューを実施した
- [x] 意思決定と経緯を記載した

🤖 Generated with [Claude Code](https://claude.com/claude-code)
